### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent sensitive data leak in exception logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-01-28 - [Data Leak in XML Parsing Exceptions]
+**Vulnerability:** The application was logging the full `Throwable` object when XML parsing failed. In `XmlPullParserException`, the exception message often contains a snippet of the XML content where the error occurred. Since `keybox.xml` contains private keys, this could leak sensitive data to the logs.
+**Learning:** Standard exception logging (`Logger.e(msg, t)`) is dangerous when processing sensitive data files with parsers that include content in error messages.
+**Prevention:** Catch exceptions during sensitive data parsing and log generic error messages or sanitized exception types (e.g., `t.getClass().getSimpleName()`) instead of the full exception object.

--- a/service/src/main/java/io/github/a13e300/tricky_store/keystore/CertHack.java
+++ b/service/src/main/java/io/github/a13e300/tricky_store/keystore/CertHack.java
@@ -154,7 +154,8 @@ public final class CertHack {
             }
             Logger.i("update " + numberOfKeyboxes + " keyboxes");
         } catch (Throwable t) {
-            Logger.e("Error loading xml file (keyboxes cleared): " + t);
+            // Do not log the exception details as it might contain sensitive data from the keybox file.
+            Logger.e("Error loading xml file (keyboxes cleared).");
         }
     }
 


### PR DESCRIPTION
This PR addresses a security vulnerability where exception logging during sensitive XML parsing could leak private key data.

Changes:
- Modified `service/src/main/java/io/github/a13e300/tricky_store/keystore/CertHack.java` to not log the `Throwable` object in `readFromXml`.

Verification:
- Created a reproduction script (not included in PR) confirming that XML parser exceptions can contain snippets of the input XML.
- Verified that the code change correctly suppresses the exception detail logging.

---
*PR created automatically by Jules for task [14697355079633168618](https://jules.google.com/task/14697355079633168618) started by @tryigit*