### PR TITLE
🔥 God-Mode: KeyMint 4.0 ModuleHash Injection & Android 16 Support

### DIFF
--- a/service/src/main/java/io/github/a13e300/tricky_store/util.kt
+++ b/service/src/main/java/io/github/a13e300/tricky_store/util.kt
@@ -42,6 +42,8 @@ val patchLevelLong by lazy {
 // FIXME
 val osVersion by lazy {
     when (Build.VERSION.SDK_INT) {
+        36 -> 160000
+        35 -> 150000
         Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> 140000
         Build.VERSION_CODES.TIRAMISU -> 130000
         Build.VERSION_CODES.S_V2 -> 120100

--- a/service/src/test/java/android/content/pm/IPackageManager.java
+++ b/service/src/test/java/android/content/pm/IPackageManager.java
@@ -1,0 +1,8 @@
+package android.content.pm;
+public interface IPackageManager {
+    public static abstract class Stub implements android.os.IBinder {
+        public static IPackageManager asInterface(android.os.IBinder obj) { return null; }
+    }
+    // Add methods used by Config if any, but currently getPackagesForUid is used by getPm() -> used by Config.
+    String[] getPackagesForUid(int uid) throws android.os.RemoteException;
+}

--- a/service/src/test/java/android/os/Build.java
+++ b/service/src/test/java/android/os/Build.java
@@ -1,0 +1,14 @@
+package android.os;
+
+public class Build {
+    public static class VERSION {
+        public static int SDK_INT = 34;
+        public static String SECURITY_PATCH = "2024-01-01";
+    }
+    public static class VERSION_CODES {
+        public static int UPSIDE_DOWN_CAKE = 34;
+        public static int TIRAMISU = 33;
+        public static int S_V2 = 32;
+        public static int S = 31;
+    }
+}

--- a/service/src/test/java/android/os/FileObserver.java
+++ b/service/src/test/java/android/os/FileObserver.java
@@ -1,0 +1,13 @@
+package android.os;
+import java.io.File;
+public abstract class FileObserver {
+    public static final int CLOSE_WRITE = 8;
+    public static final int DELETE = 512;
+    public static final int MOVED_FROM = 64;
+    public static final int MOVED_TO = 128;
+
+    public FileObserver(File path, int mask) {}
+    public abstract void onEvent(int event, String path);
+    public void startWatching() {}
+    public void stopWatching() {}
+}

--- a/service/src/test/java/android/os/IBinder.java
+++ b/service/src/test/java/android/os/IBinder.java
@@ -1,0 +1,2 @@
+package android.os;
+public interface IBinder {}

--- a/service/src/test/java/android/os/RemoteException.java
+++ b/service/src/test/java/android/os/RemoteException.java
@@ -1,0 +1,2 @@
+package android.os;
+public class RemoteException extends Exception {}

--- a/service/src/test/java/android/os/ServiceManager.java
+++ b/service/src/test/java/android/os/ServiceManager.java
@@ -1,0 +1,4 @@
+package android.os;
+public class ServiceManager {
+    public static IBinder getService(String name) { return null; }
+}

--- a/service/src/test/java/android/os/SystemProperties.java
+++ b/service/src/test/java/android/os/SystemProperties.java
@@ -1,0 +1,5 @@
+package android.os;
+
+public class SystemProperties {
+    public static String get(String key, String def) { return def; }
+}

--- a/service/src/test/java/android/util/Log.java
+++ b/service/src/test/java/android/util/Log.java
@@ -1,0 +1,8 @@
+package android.util;
+
+public class Log {
+    public static int d(String tag, String msg) { System.out.println("D/" + tag + ": " + msg); return 0; }
+    public static int i(String tag, String msg) { System.out.println("I/" + tag + ": " + msg); return 0; }
+    public static int e(String tag, String msg) { System.err.println("E/" + tag + ": " + msg); return 0; }
+    public static int e(String tag, String msg, Throwable tr) { System.err.println("E/" + tag + ": " + msg); tr.printStackTrace(); return 0; }
+}

--- a/service/src/test/java/io/github/a13e300/tricky_store/keystore/ModuleHashTest.java
+++ b/service/src/test/java/io/github/a13e300/tricky_store/keystore/ModuleHashTest.java
@@ -1,0 +1,117 @@
+package io.github.a13e300.tricky_store.keystore;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import io.github.a13e300.tricky_store.Config;
+import java.lang.reflect.Field;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.security.cert.Certificate;
+import org.bouncycastle.asn1.*;
+import org.bouncycastle.asn1.x509.*;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.asn1.x500.X500Name;
+import java.math.BigInteger;
+import java.util.Date;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import org.junit.Assert;
+import java.util.Collections;
+
+@RunWith(JUnit4.class)
+public class ModuleHashTest {
+
+    static {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    private void setModuleHash(byte[] hash) throws Exception {
+        Field field = Config.class.getDeclaredField("moduleHash");
+        field.setAccessible(true);
+        field.set(Config.INSTANCE, hash);
+    }
+
+    private X509Certificate generateSelfSignedCert(KeyPair kp) throws Exception {
+        X500Name issuer = new X500Name("CN=Test");
+        BigInteger serial = BigInteger.ONE;
+        Date notBefore = new Date();
+        Date notAfter = new Date(System.currentTimeMillis() + 100000);
+
+        X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+            issuer, serial, notBefore, notAfter, issuer, kp.getPublic());
+
+        ASN1EncodableVector keyDesc = new ASN1EncodableVector();
+        keyDesc.add(new ASN1Integer(100)); // version
+        keyDesc.add(new ASN1Enumerated(1)); // security level
+        keyDesc.add(new ASN1Integer(100));
+        keyDesc.add(new ASN1Enumerated(1));
+        keyDesc.add(new DEROctetString(new byte[0])); // challenge
+        keyDesc.add(new DEROctetString(new byte[0])); // uniqueId
+        keyDesc.add(new DERSequence()); // softwareEnforced
+
+        ASN1EncodableVector teeEnforced = new ASN1EncodableVector();
+        // Add RootOfTrust (704)
+        ASN1EncodableVector rootOfTrust = new ASN1EncodableVector();
+        rootOfTrust.add(new DEROctetString(new byte[32])); // key
+        rootOfTrust.add(ASN1Boolean.TRUE);
+        rootOfTrust.add(new ASN1Enumerated(0));
+        rootOfTrust.add(new DEROctetString(new byte[32])); // hash
+        teeEnforced.add(new DERTaggedObject(true, 704, new DERSequence(rootOfTrust)));
+
+        keyDesc.add(new DERSequence(teeEnforced));
+
+        ASN1ObjectIdentifier OID = new ASN1ObjectIdentifier("1.3.6.1.4.1.11129.2.1.17");
+        builder.addExtension(OID, false, new DERSequence(keyDesc));
+
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").build(kp.getPrivate());
+        return new JcaX509CertificateConverter().getCertificate(builder.build(signer));
+    }
+
+    @Test
+    public void testHackCertificateChainWithModuleHash() throws Exception {
+        byte[] expectedHash = new byte[] { (byte)0xDE, (byte)0xAD, (byte)0xBE, (byte)0xEF };
+        setModuleHash(expectedHash);
+
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", "BC");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+
+        X509Certificate cert = generateSelfSignedCert(kp);
+
+        // Inject keybox
+        CertHack.KeyBox keyBox = new CertHack.KeyBox(null, kp, Collections.singletonList(cert));
+        Field keyboxesField = CertHack.class.getDeclaredField("keyboxes");
+        keyboxesField.setAccessible(true);
+        Map<String, CertHack.KeyBox> keyboxes = (Map) keyboxesField.get(null);
+        keyboxes.put("RSA", keyBox);
+
+        Certificate[] chain = new Certificate[] { cert };
+        Certificate[] hackedChain = CertHack.hackCertificateChain(chain);
+
+        X509Certificate hackedCert = (X509Certificate) hackedChain[0];
+        byte[] extBytes = hackedCert.getExtensionValue("1.3.6.1.4.1.11129.2.1.17");
+        ASN1Primitive extStruct = ASN1Primitive.fromByteArray(ASN1OctetString.getInstance(extBytes).getOctets());
+        ASN1Sequence seq = ASN1Sequence.getInstance(extStruct);
+        ASN1Sequence teeEnforced = (ASN1Sequence) seq.getObjectAt(7);
+
+        boolean found = false;
+        for(ASN1Encodable e : teeEnforced) {
+            ASN1TaggedObject t = (ASN1TaggedObject) e;
+            if (t.getTagNo() == 724) {
+                found = true;
+                ASN1OctetString val = (ASN1OctetString) t.getBaseObject();
+                Assert.assertArrayEquals(expectedHash, val.getOctets());
+            }
+        }
+        Assert.assertTrue("ModuleHash tag 724 not found", found);
+    }
+}


### PR DESCRIPTION
- Implemented `moduleHash` (Tag 724) spoofing/injection in KeyStore attestation certificates.
- Added dynamic configuration support via `/data/adb/tricky_store/module_hash`.
- Updated OS version recognition for Android 15 (Vanilla Ice Cream) and 16.
- Added robust unit testing infrastructure with Android framework mocks to verify ASN.1 injection logic.
- Ensures compatibility with upcoming KeyMint 4.0 attestation enforcement.

---
*PR created automatically by Jules for task [453685380867950520](https://jules.google.com/task/453685380867950520) started by @tryigit*