### PR TITLE
🎨 Palette: Improve installation UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Installation Script UX
+**Learning:** For root tools/modules without a GUI, the installation script (`customize.sh`) is the primary user interface. Improving messages there provides high value.
+**Action:** Always verify `ui_print` messages in installation scripts to ensure they are helpful and indicate where configuration files are located.

--- a/module/template/customize.sh
+++ b/module/template/customize.sh
@@ -38,7 +38,7 @@ done
 if [ "$support" == "false" ]; then
   abort "! Unsupported platform: $ARCH"
 else
-  ui_print "- Device platform: $ARCH"
+  ui_print "- Device platform: $ARCH (Supported)"
 fi
 
 # check android
@@ -46,7 +46,7 @@ if [ "$API" -lt $MIN_SDK ]; then
   ui_print "! Unsupported sdk: $API"
   abort "! Minimal supported sdk is $MIN_SDK"
 else
-  ui_print "- Device sdk: $API"
+  ui_print "- Device sdk: $API (Supported)"
 fi
 
 ui_print "- Extracting verify.sh"
@@ -105,3 +105,10 @@ if [ ! -f "$CONFIG_DIR/target.txt" ]; then
   extract "$ZIPFILE" 'target.txt' "$TMPDIR"
   mv "$TMPDIR/target.txt" "$CONFIG_DIR/target.txt"
 fi
+
+ui_print "*********************************************************"
+ui_print "  Tricky Store Installed Successfully!"
+ui_print "  "
+ui_print "  Config files are located at:"
+ui_print "  $CONFIG_DIR"
+ui_print "*********************************************************"

--- a/service/src/main/java/io/github/a13e300/tricky_store/Config.kt
+++ b/service/src/main/java/io/github/a13e300/tricky_store/Config.kt
@@ -102,6 +102,8 @@ object Config {
         Logger.i("update build vars: $buildVars")
     }.onFailure {
         Logger.e("failed to update build vars", it)
+    }
+
     @OptIn(ExperimentalStdlibApi::class)
     private fun updateModuleHash(f: File?) = runCatching {
         moduleHash = f?.readText()?.trim()?.hexToByteArray()
@@ -117,6 +119,7 @@ object Config {
     private const val GLOBAL_MODE_FILE = "global_mode"
     private const val TEE_BROKEN_MODE_FILE = "tee_broken_mode"
     private const val SPOOF_BUILD_VARS_FILE = "spoof_build_vars"
+    private const val MODULE_HASH_FILE = "module_hash"
     private val root = File(CONFIG_PATH)
 
     object ConfigObserver : FileObserver(root, CLOSE_WRITE or DELETE or MOVED_FROM or MOVED_TO) {

--- a/service/src/main/java/io/github/a13e300/tricky_store/keystore/CertHack.java
+++ b/service/src/main/java/io/github/a13e300/tricky_store/keystore/CertHack.java
@@ -208,8 +208,8 @@ public final class CertHack {
             if (moduleHashStr != null && !moduleHashStr.isEmpty()) {
                 try {
                     byte[] moduleHashBytes = hexToByteArray(moduleHashStr);
-                    ASN1Encodable moduleHash = new DERTaggedObject(true, 724, new DEROctetString(moduleHashBytes));
-                    vector.add(moduleHash);
+                    ASN1Encodable moduleHashEnc = new DERTaggedObject(true, 724, new DEROctetString(moduleHashBytes));
+                    vector.add(moduleHashEnc);
                 } catch (Exception e) {
                     Logger.e("Failed to inject moduleHash in hackCertificateChain", e);
                 }
@@ -454,9 +454,9 @@ public final class CertHack {
             if (moduleHashStr != null && !moduleHashStr.isEmpty()) {
                 try {
                     byte[] moduleHashBytes = hexToByteArray(moduleHashStr);
-                    ASN1Encodable moduleHash = new DERTaggedObject(true, 724, new DEROctetString(moduleHashBytes));
+                    ASN1Encodable moduleHashEnc = new DERTaggedObject(true, 724, new DEROctetString(moduleHashBytes));
                     List<ASN1Encodable> list = new ArrayList<>(Arrays.asList(teeEnforcedEncodables));
-                    list.add(moduleHash);
+                    list.add(moduleHashEnc);
                     teeEnforcedEncodables = list.toArray(new ASN1Encodable[0]);
                 } catch (Exception e) {
                     Logger.e("Failed to inject moduleHash", e);


### PR DESCRIPTION
🎨 **Palette: Improve installation feedback in customize.sh**

💡 **What:**
- Added "(Supported)" confirmation to platform and SDK checks in `customize.sh`.
- Added a summary block at the end of installation showing success status and the location of configuration files (`/data/adb/tricky_store`).

🎯 **Why:**
- Users installing the module via Magisk/KernelSU often miss where to put config files. This provides immediate, clear feedback.

📸 **Before/After:**
*(CLI Output)*
**Before:**
```
- Installing tricky_store 1.0
- Device platform: arm64
- Device sdk: 34
...
- Adding default target scope
```

**After:**
```
- Installing tricky_store 1.0
- Device platform: arm64 (Supported)
- Device sdk: 34 (Supported)
...
- Adding default target scope
*********************************************************
  Tricky Store Installed Successfully!
  
  Config files are located at:
  /data/adb/tricky_store
*********************************************************
```

🔧 **Fixes:**
- Fixed compilation errors in `Config.kt` (missing brace, missing constant `MODULE_HASH_FILE`).
- Fixed variable shadowing in `CertHack.java`.
- These fixes were necessary to ensure the repo is buildable (`never leave the repo in an unbuildable state`).

---
*PR created automatically by Jules for task [181106051093201157](https://jules.google.com/task/181106051093201157) started by @tryigit*