### PR TITLE
Fix CI build, Auto-Release, and Runtime Verification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
     branches: [ "master" ]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -42,10 +45,16 @@ jobs:
         if: success()
         id: prepareArtifact
         run: |
-          releaseName=`ls module/release/Tricky-Store-v*-release.zip | awk -F '(/|.zip)' '{print $3}'` && echo "releaseName=$releaseName" >> $GITHUB_OUTPUT
-          debugName=`ls module/release/Tricky-Store-v*-debug.zip | awk -F '(/|.zip)' '{print $3}'` && echo "debugName=$debugName" >> $GITHUB_OUTPUT
-          unzip module/release/Tricky-Store-v*-release.zip -d module-release
-          unzip module/release/Tricky-Store-v*-debug.zip -d module-debug
+          releasePath=$(ls module/release/*-release.zip)
+          releaseName=$(basename "$releasePath" .zip)
+          echo "releaseName=$releaseName" >> $GITHUB_OUTPUT
+
+          debugPath=$(ls module/release/*-debug.zip)
+          debugName=$(basename "$debugPath" .zip)
+          echo "debugName=$debugName" >> $GITHUB_OUTPUT
+
+          unzip "$releasePath" -d module-release
+          unzip "$debugPath" -d module-debug
 
       - name: Upload release
         uses: actions/upload-artifact@v4
@@ -64,3 +73,51 @@ jobs:
         with:
           name: release-mappings
           path: "./service/build/outputs/mapping/release"
+
+      - name: Check for Release
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+        id: check_release
+        run: |
+          VERSION=$(grep 'val verName by extra' build.gradle.kts | cut -d'"' -f2)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists."
+            echo "create_release=false" >> $GITHUB_OUTPUT
+          else
+            echo "Tag v$VERSION does not exist."
+            echo "create_release=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Tag
+        if: steps.check_release.outputs.create_release == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${{ env.VERSION }}"
+          git push origin "v${{ env.VERSION }}"
+
+      - name: Generate Changelog
+        if: steps.check_release.outputs.create_release == 'true'
+        id: changelog
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 "v${{ env.VERSION }}^" 2>/dev/null || echo "")
+          if [ -z "$PREV_TAG" ]; then
+            CHANGELOG=$(git log --pretty=format:"* %s (%h)" "v${{ env.VERSION }}")
+          else
+            CHANGELOG=$(git log --pretty=format:"* %s (%h)" "$PREV_TAG..v${{ env.VERSION }}")
+          fi
+
+          echo "changelog<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create Release
+        if: steps.check_release.outputs.create_release == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: "v${{ env.VERSION }}"
+          name: "Release v${{ env.VERSION }}"
+          body: ${{ steps.changelog.outputs.changelog }}
+          files: |
+            module/release/*-release.zip
+            module/release/*-debug.zip

--- a/module/template/customize.sh
+++ b/module/template/customize.sh
@@ -78,15 +78,18 @@ if [ "$ARCH" = "x64" ]; then
   extract "$ZIPFILE" "lib/x86_64/libinject.so" "$MODPATH" true
   extract "$ZIPFILE" "lib/x86_64/libtszygisk.so" "$MODPATH/zygisk" true
   mv "$MODPATH/zygisk/libtszygisk.so" "$MODPATH/zygisk/x86_64.so"
+  [ -f "$MODPATH/zygisk/libtszygisk.so.sha256" ] && mv "$MODPATH/zygisk/libtszygisk.so.sha256" "$MODPATH/zygisk/x86_64.so.sha256"
 else
   ui_print "- Extracting arm64 libraries"
   extract "$ZIPFILE" "lib/arm64-v8a/lib$SONAME.so" "$MODPATH" true
   extract "$ZIPFILE" "lib/arm64-v8a/libinject.so" "$MODPATH" true
   extract "$ZIPFILE" "lib/arm64-v8a/libtszygisk.so" "$MODPATH/zygisk" true
   mv "$MODPATH/zygisk/libtszygisk.so" "$MODPATH/zygisk/arm64-v8a.so"
+  [ -f "$MODPATH/zygisk/libtszygisk.so.sha256" ] && mv "$MODPATH/zygisk/libtszygisk.so.sha256" "$MODPATH/zygisk/arm64-v8a.so.sha256"
 fi
 
 mv "$MODPATH/libinject.so" "$MODPATH/inject"
+[ -f "$MODPATH/libinject.so.sha256" ] && mv "$MODPATH/libinject.so.sha256" "$MODPATH/inject.sha256"
 chmod 755 "$MODPATH/inject"
 
 CONFIG_DIR=/data/adb/cleveres_tricky

--- a/module/template/verify.sh
+++ b/module/template/verify.sh
@@ -22,16 +22,16 @@ extract() {
   hash_path=""
   if [ $junk_paths = true ]; then
     file_path="$dir/$(basename "$file")"
-    hash_path="$TMPDIR_FOR_VERIFY/$(basename "$file").sha256"
+    hash_path="$dir/$(basename "$file").sha256"
   else
     file_path="$dir/$file"
-    hash_path="$TMPDIR_FOR_VERIFY/$file.sha256"
+    hash_path="$dir/$file.sha256"
   fi
 
   unzip $opts "$zip" "$file" -d "$dir" >&2
   [ -f "$file_path" ] || abort_verify "$file not exists"
 
-  unzip $opts "$zip" "$file.sha256" -d "$TMPDIR_FOR_VERIFY" >&2
+  unzip $opts "$zip" "$file.sha256" -d "$dir" >&2
   [ -f "$hash_path" ] || abort_verify "$file.sha256 not exists"
 
   (echo "$(cat "$hash_path")  $file_path" | sha256sum -c -s -) || abort_verify "Failed to verify $file"

--- a/service/src/main/java/io/github/a13e300/tricky_store/Main.kt
+++ b/service/src/main/java/io/github/a13e300/tricky_store/Main.kt
@@ -5,6 +5,7 @@ import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {
     Logger.i("Welcome to TrickyStore!")
+    Verification.check()
     while (true) {
         if (!KeystoreInterceptor.tryRunKeystoreInterceptor()) {
             Thread.sleep(1000)

--- a/service/src/main/java/io/github/a13e300/tricky_store/Verification.kt
+++ b/service/src/main/java/io/github/a13e300/tricky_store/Verification.kt
@@ -1,0 +1,52 @@
+package io.github.a13e300.tricky_store
+
+import java.io.File
+import java.security.MessageDigest
+import kotlin.system.exitProcess
+
+object Verification {
+    private const val MODULE_PATH = "/data/adb/modules/cleveres_tricky"
+    private val IGNORED_FILES = setOf("disable", "remove", "update", "system.prop", "sepolicy.rule")
+
+    fun check() {
+        val root = File(MODULE_PATH)
+        if (!root.exists()) {
+            Logger.e("Module directory not found: $MODULE_PATH")
+            return
+        }
+
+        root.walk().forEach { file ->
+            if (file.isDirectory) return@forEach
+            // Skip checksum files themselves
+            if (file.name.endsWith(".sha256")) return@forEach
+            // Skip ignored files
+            if (file.parentFile?.absolutePath == root.absolutePath && IGNORED_FILES.contains(file.name)) return@forEach
+
+            val checksumFile = File(file.path + ".sha256")
+            if (!checksumFile.exists()) {
+                fail("Missing checksum for file: ${file.path}")
+            }
+
+            val expected = checksumFile.readText().trim()
+            val actual = calculateChecksum(file)
+            if (!expected.equals(actual, ignoreCase = true)) {
+                fail("Checksum mismatch for file: ${file.path}. Expected $expected, got $actual")
+            }
+        }
+        Logger.i("Module verification passed.")
+    }
+
+    private fun calculateChecksum(file: File): String {
+        val md = MessageDigest.getInstance("SHA-256")
+        file.forEachBlock { buffer, bytesRead ->
+            md.update(buffer, 0, bytesRead)
+        }
+        return md.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    private fun fail(reason: String) {
+        Logger.e("Verification failed: $reason")
+        File(MODULE_PATH, "disable").createNewFile()
+        exitProcess(1)
+    }
+}


### PR DESCRIPTION
This PR addresses the build error in CI/CD, implements automated releases when the version number changes, and adds a checksum verification mechanism for the installed Magisk module files.

1.  **CI Fix**: The artifact path in `build.yml` was updated to match the actual output filename pattern `*-release.zip`, fixing the "No zipfiles found" error.
2.  **Auto-Release**: Added logic to `build.yml` to check if a Git tag exists for the current version. If not, it creates a tag, generates a changelog, and creates a GitHub Release.
3.  **Runtime Verification**:
    *   Created `Verification.kt` in the `service` module.
    *   It checks files in `/data/adb/modules/cleveres_tricky` against their `.sha256` checksums at startup.
    *   If verification fails, it creates a `disable` file and exits.
4.  **Checksum Installation**:
    *   Modified `verify.sh` to extract `.sha256` files to the target directory.
    *   Modified `customize.sh` to rename/move `.sha256` files whenever their corresponding files are renamed/moved.
    *   This ensures that the runtime verification has the necessary data to work.

---
*PR created automatically by Jules for task [9111975162308541749](https://jules.google.com/task/9111975162308541749) started by @tryigit*