### PR TITLE
Refactor to cleveres.tricky.cleverestech and add UI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ tasks.register("Delete", Delete::class) {
 
 fun Project.configureBaseExtension() {
     extensions.findByType(AppExtension::class)?.run {
-        namespace = "io.github.a13e300.tricky_store"
+        namespace = "cleveres.tricky.cleverestech"
         compileSdkVersion(androidCompileSdkVersion)
         ndkVersion = androidCompileNdkVersion
         buildToolsVersion = androidBuildToolsVersion
@@ -64,7 +64,7 @@ fun Project.configureBaseExtension() {
     }
 
     extensions.findByType(LibraryExtension::class)?.run {
-        namespace = "io.github.a13e300.tricky_store"
+        namespace = "cleveres.tricky.cleverestech"
         compileSdk = androidCompileSdkVersion
         ndkVersion = androidCompileNdkVersion
         buildToolsVersion = androidBuildToolsVersion

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,15 +4,25 @@ bcpkix-jdk18on = "1.78.1"
 kotlin = "2.0.0"
 annotation = "1.8.0"
 junit = "4.13.2"
+compose-bom = "2024.06.00"
+activity-compose = "1.9.0"
 
 [libraries]
 junit = { module = "junit:junit", version.ref = "junit" }
 annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 bcpkix-jdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bcpkix-jdk18on" }
 cxx = { module = "org.lsposed.libcxx:libcxx", version = "27.0.12077973" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
+androidx-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 
 [plugins]
 agp-app = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 lsplugin-cmaker = { id = "org.lsposed.lsplugin.cmaker", version = "1.2" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/module/template/action.sh
+++ b/module/template/action.sh
@@ -1,0 +1,11 @@
+#!/system/bin/sh
+PKG="cleveres.tricky.cleverestech"
+APK="/data/adb/modules/cleveres_tricky/service.apk"
+
+if ! pm list packages | grep -q "$PKG"; then
+  echo "- Installing CleveresTricky Manager..."
+  pm install -r "$APK"
+fi
+
+echo "- Launching Manager..."
+am start -n "$PKG/.ui.MainActivity"

--- a/module/template/customize.sh
+++ b/module/template/customize.sh
@@ -69,6 +69,8 @@ extract "$ZIPFILE" 'service.apk'     "$MODPATH"
 extract "$ZIPFILE" 'sepolicy.rule'   "$MODPATH"
 extract "$ZIPFILE" 'daemon'          "$MODPATH"
 chmod 755 "$MODPATH/daemon"
+extract "$ZIPFILE" 'action.sh'       "$MODPATH"
+chmod 755 "$MODPATH/action.sh"
 
 mkdir "$MODPATH/zygisk"
 

--- a/module/template/daemon
+++ b/module/template/daemon
@@ -1,3 +1,3 @@
 #!/system/bin/sh
 
-exec /system/bin/app_process -Djava.class.path=./service.apk / --nice-name=TrickyStore io.github.a13e300.tricky_store.MainKt
+exec /system/bin/app_process -Djava.class.path=./service.apk / --nice-name=TrickyStore cleveres.tricky.cleverestech.MainKt

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -5,6 +5,7 @@ import java.security.MessageDigest
 plugins {
     alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.agp.app)
+    alias(libs.plugins.compose.compiler)
 }
 
 val moduleId: String by rootProject.extra
@@ -29,11 +30,11 @@ fun calculateChecksum(variantLowered: String): String {
 }
 
 android {
-    namespace = "io.github.a13e300.tricky_store"
+    namespace = "cleveres.tricky.cleverestech"
     compileSdk = 34
 
     defaultConfig {
-        applicationId = "io.github.a13e300.tricky_store"
+        applicationId = "cleveres.tricky.cleverestech"
     }
 
     buildTypes {
@@ -63,7 +64,8 @@ android {
 
     packaging {
         resources {
-            excludes += "**"
+            excludes += "META-INF/versions/**"
+            excludes += "META-INF/DEPENDENCIES"
         }
     }
 
@@ -74,15 +76,23 @@ android {
 
     buildFeatures {
         buildConfig = true
+        compose = true
     }
-
 }
 
 dependencies {
     compileOnly(project(":stub"))
-    compileOnly(libs.annotation)
+    implementation(libs.annotation)
     implementation(libs.bcpkix.jdk18on)
     testImplementation(libs.junit)
+
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.ui)
+    implementation(libs.androidx.ui.graphics)
+    implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.androidx.material3)
+    implementation(libs.androidx.activity.compose)
+    debugImplementation(libs.androidx.ui.tooling)
 }
 
 afterEvaluate {
@@ -106,7 +116,7 @@ afterEvaluate {
                     commandLine(
                         "adb",
                         "shell",
-                        "su -c 'rm /data/adb/modules/tricky_store/service.apk; mv /data/local/tmp/service.apk /data/adb/modules/tricky_store/'"
+                        "su -c 'rm /data/adb/modules/cleveres_tricky/service.apk; mv /data/local/tmp/service.apk /data/adb/modules/cleveres_tricky/'"
                     )
                 }
             }

--- a/service/proguard-rules.pro
+++ b/service/proguard-rules.pro
@@ -19,11 +19,11 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
--keepclasseswithmembers class io.github.a13e300.tricky_store.MainKt {
+-keepclasseswithmembers class cleveres.tricky.cleverestech.MainKt {
     public static void main(java.lang.String[]);
 }
 
--assumenosideeffects class io.github.a13e300.tricky_store.Logger {
+-assumenosideeffects class cleveres.tricky.cleverestech.Logger {
     public static void d(java.lang.String);
 }
 

--- a/service/src/main/AndroidManifest.xml
+++ b/service/src/main/AndroidManifest.xml
@@ -1,2 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:label="CleveresTricky"
+        android:icon="@android:drawable/sym_def_app_icon"
+        android:theme="@android:style/Theme.DeviceDefault.NoActionBar">
+        <activity
+            android:name=".ui.MainActivity"
+            android:exported="true"
+            android:label="CleveresTricky"
+            android:theme="@android:style/Theme.DeviceDefault.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -1,10 +1,10 @@
-package io.github.a13e300.tricky_store
+package cleveres.tricky.cleverestech
 
 import android.content.pm.IPackageManager
 import android.os.FileObserver
 import android.os.ServiceManager
 import android.system.Os
-import io.github.a13e300.tricky_store.keystore.CertHack
+import cleveres.tricky.cleverestech.keystore.CertHack
 import java.io.File
 
 object Config {

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -1,4 +1,4 @@
-package io.github.a13e300.tricky_store
+package cleveres.tricky.cleverestech
 
 import android.annotation.SuppressLint
 import android.hardware.security.keymint.SecurityLevel
@@ -8,9 +8,9 @@ import android.os.ServiceManager
 import android.system.keystore2.IKeystoreService
 import android.system.keystore2.KeyDescriptor
 import android.system.keystore2.KeyEntryResponse
-import io.github.a13e300.tricky_store.binder.BinderInterceptor
-import io.github.a13e300.tricky_store.keystore.CertHack
-import io.github.a13e300.tricky_store.keystore.Utils
+import cleveres.tricky.cleverestech.binder.BinderInterceptor
+import cleveres.tricky.cleverestech.keystore.CertHack
+import cleveres.tricky.cleverestech.keystore.Utils
 import kotlin.system.exitProcess
 
 @SuppressLint("BlockedPrivateApi")

--- a/service/src/main/java/cleveres/tricky/cleverestech/Logger.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Logger.java
@@ -1,4 +1,4 @@
-package io.github.a13e300.tricky_store;
+package cleveres.tricky.cleverestech;
 
 import android.util.Log;
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
@@ -1,4 +1,4 @@
-package io.github.a13e300.tricky_store
+package cleveres.tricky.cleverestech
 
 import java.security.MessageDigest
 import kotlin.system.exitProcess

--- a/service/src/main/java/cleveres/tricky/cleverestech/PropertyHiderService.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/PropertyHiderService.kt
@@ -1,8 +1,8 @@
-package io.github.a13e300.tricky_store
+package cleveres.tricky.cleverestech
 
 import android.os.Binder
 import android.os.Parcel
-import io.github.a13e300.tricky_store.Config
+import cleveres.tricky.cleverestech.Config
 
 class PropertyHiderService : Binder() {
     companion object {

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -1,4 +1,4 @@
-package io.github.a13e300.tricky_store
+package cleveres.tricky.cleverestech
 
 import android.hardware.security.keymint.KeyParameter
 import android.hardware.security.keymint.KeyParameterValue
@@ -10,10 +10,10 @@ import android.system.keystore2.IKeystoreSecurityLevel
 import android.system.keystore2.KeyDescriptor
 import android.system.keystore2.KeyEntryResponse
 import android.system.keystore2.KeyMetadata
-import io.github.a13e300.tricky_store.binder.BinderInterceptor
-import io.github.a13e300.tricky_store.keystore.CertHack
-import io.github.a13e300.tricky_store.keystore.CertHack.KeyGenParameters
-import io.github.a13e300.tricky_store.keystore.Utils
+import cleveres.tricky.cleverestech.binder.BinderInterceptor
+import cleveres.tricky.cleverestech.keystore.CertHack
+import cleveres.tricky.cleverestech.keystore.CertHack.KeyGenParameters
+import cleveres.tricky.cleverestech.keystore.Utils
 import java.security.KeyPair
 import java.security.cert.Certificate
 import java.util.concurrent.ConcurrentHashMap

--- a/service/src/main/java/cleveres/tricky/cleverestech/Verification.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Verification.kt
@@ -1,4 +1,4 @@
-package io.github.a13e300.tricky_store
+package cleveres.tricky.cleverestech
 
 import java.io.File
 import java.security.MessageDigest

--- a/service/src/main/java/cleveres/tricky/cleverestech/binder/BinderInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/binder/BinderInterceptor.kt
@@ -1,9 +1,9 @@
-package io.github.a13e300.tricky_store.binder
+package cleveres.tricky.cleverestech.binder
 
 import android.os.Binder
 import android.os.IBinder
 import android.os.Parcel
-import io.github.a13e300.tricky_store.Logger
+import cleveres.tricky.cleverestech.Logger
 
 open class BinderInterceptor : Binder() {
     sealed class Result

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -1,4 +1,4 @@
-package io.github.a13e300.tricky_store.keystore;
+package cleveres.tricky.cleverestech.keystore;
 
 import android.content.pm.PackageManager;
 import android.hardware.security.keymint.Algorithm;
@@ -68,9 +68,9 @@ import java.util.Set;
 
 import javax.security.auth.x500.X500Principal;
 
-import io.github.a13e300.tricky_store.Config;
-import io.github.a13e300.tricky_store.Logger;
-import io.github.a13e300.tricky_store.UtilKt;
+import cleveres.tricky.cleverestech.Config;
+import cleveres.tricky.cleverestech.Logger;
+import cleveres.tricky.cleverestech.UtilKt;
 
 public final class CertHack {
     private static final ASN1ObjectIdentifier OID = new ASN1ObjectIdentifier("1.3.6.1.4.1.11129.2.1.17");

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
@@ -1,4 +1,4 @@
-package io.github.a13e300.tricky_store.keystore;
+package cleveres.tricky.cleverestech.keystore;
 
 import android.system.keystore2.KeyEntryResponse;
 import android.system.keystore2.KeyMetadata;

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/XMLParser.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/XMLParser.java
@@ -1,4 +1,4 @@
-package io.github.a13e300.tricky_store.keystore;
+package cleveres.tricky.cleverestech.keystore;
 
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;

--- a/service/src/main/java/cleveres/tricky/cleverestech/ui/MainActivity.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ui/MainActivity.kt
@@ -1,0 +1,245 @@
+package cleveres.tricky.cleverestech.ui
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+
+object RootUtils {
+    private const val CONFIG_DIR = "/data/adb/cleveres_tricky"
+
+    fun exec(command: String): Boolean {
+        return try {
+            val process = Runtime.getRuntime().exec(arrayOf("su", "-c", command))
+            process.waitFor() == 0
+        } catch (e: Exception) {
+            e.printStackTrace()
+            false
+        }
+    }
+
+    fun readFile(filename: String): String {
+        return try {
+            val process = Runtime.getRuntime().exec(arrayOf("su", "-c", "cat $CONFIG_DIR/$filename"))
+            val content = process.inputStream.bufferedReader().use { it.readText() }
+            process.waitFor()
+            content
+        } catch (e: Exception) {
+            e.printStackTrace()
+            ""
+        }
+    }
+
+    fun saveFile(context: Context, filename: String, content: String): Boolean {
+        return try {
+            val tempFile = File(context.cacheDir, filename)
+            tempFile.writeText(content)
+            val path = tempFile.absolutePath
+            val cmd = "cp \"$path\" \"$CONFIG_DIR/$filename\" && chmod 600 \"$CONFIG_DIR/$filename\""
+            exec(cmd)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            false
+        }
+    }
+}
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            TrickyTheme {
+                MainApp()
+            }
+        }
+    }
+}
+
+@Composable
+fun TrickyTheme(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colorScheme = darkColorScheme(
+            primary = Color.White,
+            onPrimary = Color.Black,
+            background = Color.Black,
+            onBackground = Color.White,
+            surface = Color(0xFF121212),
+            onSurface = Color.White
+        ),
+        content = content
+    )
+}
+
+@OptIn(ExperimentalAnimationApi::class)
+@Composable
+fun MainApp() {
+    var screen by remember { mutableStateOf("home") }
+
+    AnimatedContent(
+        targetState = screen,
+        transitionSpec = {
+            fadeIn(animationSpec = tween(300)) togetherWith fadeOut(animationSpec = tween(300))
+        },
+        label = "ScreenTransition"
+    ) { targetScreen ->
+        when (targetScreen) {
+            "home" -> HomeScreen(onNavigate = { screen = it })
+            "config" -> ConfigScreen(onBack = { screen = "home" })
+        }
+    }
+}
+
+@Composable
+fun HomeScreen(onNavigate: (String) -> Unit) {
+    val context = LocalContext.current
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black)
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "CleveresTricky",
+            fontSize = 32.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color.White
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "BETA",
+            fontSize = 16.sp,
+            color = Color.Gray
+        )
+
+        Spacer(modifier = Modifier.height(48.dp))
+
+        MenuButton(text = "Configure Keybox") {
+            onNavigate("config")
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        MenuButton(text = "Join Telegram") {
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://t.me/cleverestech"))
+            context.startActivity(intent)
+        }
+    }
+}
+
+@Composable
+fun MenuButton(text: String, onClick: () -> Unit) {
+    Button(
+        onClick = onClick,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = Color.White,
+            contentColor = Color.Black
+        ),
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp)
+    ) {
+        Text(text = text, fontSize = 18.sp, fontWeight = FontWeight.Medium)
+    }
+}
+
+@Composable
+fun ConfigScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var keyboxContent by remember { mutableStateOf("Loading...") }
+    var isSaving by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.IO) {
+            keyboxContent = RootUtils.readFile("keybox.xml")
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black)
+            .padding(16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Back",
+                color = Color.Gray,
+                modifier = Modifier.clickable { onBack() }
+            )
+            Text(
+                text = "keybox.xml",
+                color = Color.White,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = if (isSaving) "Saving..." else "Save",
+                color = if (isSaving) Color.Gray else Color.White,
+                modifier = Modifier.clickable {
+                    if (!isSaving) {
+                        isSaving = true
+                        scope.launch(Dispatchers.IO) {
+                            val success = RootUtils.saveFile(context, "keybox.xml", keyboxContent)
+                            withContext(Dispatchers.Main) {
+                                isSaving = false
+                                Toast.makeText(context, if (success) "Saved" else "Failed", Toast.LENGTH_SHORT).show()
+                            }
+                        }
+                    }
+                }
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        TextField(
+            value = keyboxContent,
+            onValueChange = { keyboxContent = it },
+            modifier = Modifier
+                .fillMaxSize()
+                .weight(1f),
+            colors = TextFieldDefaults.colors(
+                focusedContainerColor = Color(0xFF121212),
+                unfocusedContainerColor = Color(0xFF121212),
+                focusedTextColor = Color.White,
+                unfocusedTextColor = Color.White,
+                cursorColor = Color.White
+            )
+        )
+    }
+}

--- a/service/src/main/java/cleveres/tricky/cleverestech/util.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util.kt
@@ -1,6 +1,6 @@
 @file:OptIn(ExperimentalStdlibApi::class)
 
-package io.github.a13e300.tricky_store
+package cleveres.tricky.cleverestech
 
 import android.content.pm.IPackageManager
 import android.os.Build

--- a/service/src/test/java/cleveres/tricky/cleverestech/ConfigTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ConfigTest.kt
@@ -1,4 +1,4 @@
-package io.github.a13e300.tricky_store
+package cleveres.tricky.cleverestech
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/ModuleHashTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/ModuleHashTest.java
@@ -1,9 +1,9 @@
-package io.github.a13e300.tricky_store.keystore;
+package cleveres.tricky.cleverestech.keystore;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import io.github.a13e300.tricky_store.Config;
+import cleveres.tricky.cleverestech.Config;
 import java.lang.reflect.Field;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;


### PR DESCRIPTION
This PR refactors the core package to `cleveres.tricky.cleverestech` and introduces a Jetpack Compose-based UI for managing the module configuration (specifically `keybox.xml`). 

Changes include:
- **Refactoring:** Renamed all internal packages and updated build scripts/manifests.
- **UI:** Added `MainActivity` with a "Black and White" theme, smooth animations, and file editing capabilities using root (`su`).
- **Integration:** Added `action.sh` for easy access via module managers.
- **Build Fixes:** Resolved `androidx.annotation` duplicate class issues and Bouncy Castle OSGi metadata conflicts.
- **Deprecated APIs:** Fixed Kotlin animation deprecations.

---
*PR created automatically by Jules for task [13570422910313506799](https://jules.google.com/task/13570422910313506799) started by @tryigit*