### PR TITLE
Fix CI release versioning and Config thread safety

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         id: check_release
         run: |
-          VERSION=$(grep 'val verName by extra' build.gradle.kts | cut -d'"' -f2)
+          VERSION=$(grep 'val verName by extra' build.gradle.kts | cut -d'"' -f2 | sed 's/^v//')
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           if git rev-parse "v$VERSION" >/dev/null 2>&1; then
             echo "Tag v$VERSION already exists."

--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -19,10 +19,13 @@ object Config {
         "ro.oem_unlock_supported" to "0"
     )
 
-    private val hackPackages = mutableSetOf<String>()
-    private val generatePackages = mutableSetOf<String>()
+    @Volatile
+    private var hackPackages: Set<String> = emptySet()
+    @Volatile
+    private var generatePackages: Set<String> = emptySet()
     private var isGlobalMode = false
     private var isTeeBrokenMode = false
+    @Volatile
     private var moduleHash: ByteArray? = null
 
     fun getModuleHash(): ByteArray? = moduleHash
@@ -44,15 +47,15 @@ object Config {
     }
 
     private fun updateTargetPackages(f: File?) = runCatching {
-        hackPackages.clear()
-        generatePackages.clear()
         if (isGlobalMode) {
+            hackPackages = emptySet()
+            generatePackages = emptySet()
             Logger.i("Global mode is enabled, skipping updateTargetPackages execution.")
             return@runCatching
         }
         val (h, g) = parsePackages(f?.readLines() ?: emptyList(), isTeeBrokenMode)
-        hackPackages.addAll(h)
-        generatePackages.addAll(g)
+        hackPackages = h
+        generatePackages = g
         Logger.i("update hack packages: $hackPackages, generate packages=$generatePackages")
     }.onFailure {
         Logger.e("failed to update target files", it)


### PR DESCRIPTION
This pull request fixes a critical issue in the CI/CD pipeline where release tags were being created with a double 'v' prefix (e.g., `vv1.0.3`), causing the release check to fail and triggering a new release on every push. It also addresses a potential crash and race condition in `Config.kt` by ensuring thread-safe access to configuration properties using `@Volatile` and immutable sets.

---
*PR created automatically by Jules for task [10449850881181526097](https://jules.google.com/task/10449850881181526097) started by @tryigit*