### PR TITLE
Propagate NO_AUTH_REQUIRED tag in SecurityLevelInterceptor

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -123,12 +123,14 @@ class SecurityLevelInterceptor(
         a.keyParameter.value = KeyParameterValue.ecCurve(params.ecCurve)
         a.securityLevel = level
         authorizations.add(a)
-        a = Authorization()
-        a.keyParameter = KeyParameter()
-        a.keyParameter.tag = Tag.NO_AUTH_REQUIRED
-        a.keyParameter.value = KeyParameterValue.boolValue(true) // TODO: copy
-        a.securityLevel = level
-        authorizations.add(a)
+        if (params.isNoAuthRequired) {
+            a = Authorization()
+            a.keyParameter = KeyParameter()
+            a.keyParameter.tag = Tag.NO_AUTH_REQUIRED
+            a.keyParameter.value = KeyParameterValue.boolValue(true)
+            a.securityLevel = level
+            authorizations.add(a)
+        }
         // TODO: ORIGIN
         //OS_VERSION
         //OS_PATCHLEVEL

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -571,6 +571,8 @@ public final class CertHack {
         public int ecCurve;
         public String ecCurveName;
 
+        public boolean isNoAuthRequired = false;
+
         public List<Integer> purpose = new ArrayList<>();
         public List<Integer> digest = new ArrayList<>();
 
@@ -599,6 +601,7 @@ public final class CertHack {
                         ecCurve = p.getEcCurve();
                         ecCurveName = getEcCurveName(ecCurve);
                     }
+                    case Tag.NO_AUTH_REQUIRED -> isNoAuthRequired = true;
                     case Tag.PURPOSE -> {
                         purpose.add(p.getKeyPurpose());
                     }


### PR DESCRIPTION
Implemented logic to conditionally add `NO_AUTH_REQUIRED` authorization in `SecurityLevelInterceptor.kt` based on the original request parameters. Added `isNoAuthRequired` field to `CertHack.KeyGenParameters` to capture this tag during parsing. This resolves a TODO item and ensures correct propagation of security requirements.

---
*PR created automatically by Jules for task [11355406849668560183](https://jules.google.com/task/11355406849668560183) started by @tryigit*