### PR TITLE
⚡ Optimize BinderInterceptor Parcel Allocation

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/binder/BinderInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/binder/BinderInterceptor.kt
@@ -101,7 +101,7 @@ open class BinderInterceptor : Binder() {
                 val callingPid = data.readInt()
                 val resultCode = data.readInt()
                 val theData = Parcel.obtain()
-                val theReply = Parcel.obtain()
+                var theReply: Parcel? = null
                 try {
                     val sz = data.readLong().toInt()
                     theData.appendFrom(data, data.dataPosition(), sz)
@@ -109,13 +109,14 @@ open class BinderInterceptor : Binder() {
                     data.setDataPosition(data.dataPosition() + sz)
                     val sz2 = data.readLong().toInt()
                     if (sz2 != 0) {
+                        theReply = Parcel.obtain()
                         theReply.appendFrom(data, data.dataPosition(), sz2)
                         theReply.setDataPosition(0)
                     }
-                    onPostTransact(target, theCode, theFlags, callingUid, callingPid, theData, if (sz2 == 0) null else theReply, resultCode)
+                    onPostTransact(target, theCode, theFlags, callingUid, callingPid, theData, theReply, resultCode)
                 } finally {
                     theData.recycle()
-                    theReply.recycle()
+                    theReply?.recycle()
                 }
             }
             else -> return super.onTransact(code, data, reply, flags)

--- a/service/src/test/java/android/os/Binder.java
+++ b/service/src/test/java/android/os/Binder.java
@@ -1,0 +1,20 @@
+package android.os;
+
+public class Binder implements IBinder {
+    public boolean onTransact(int code, Parcel data, Parcel reply, int flags) {
+        return false;
+    }
+
+    public void attachInterface(IInterface owner, String descriptor) {}
+    public String getInterfaceDescriptor() { return null; }
+    public boolean pingBinder() { return true; }
+    public boolean isBinderAlive() { return true; }
+    public IInterface queryLocalInterface(String descriptor) { return null; }
+    public void dump(java.io.FileDescriptor fd, String[] args) {}
+    public void dumpAsync(java.io.FileDescriptor fd, String[] args) {}
+    public boolean transact(int code, Parcel data, Parcel reply, int flags) throws RemoteException {
+        return onTransact(code, data, reply, flags);
+    }
+    public void linkToDeath(DeathRecipient recipient, int flags) {}
+    public boolean unlinkToDeath(DeathRecipient recipient, int flags) { return true; }
+}

--- a/service/src/test/java/android/os/IBinder.java
+++ b/service/src/test/java/android/os/IBinder.java
@@ -1,2 +1,9 @@
 package android.os;
-public interface IBinder {}
+
+public interface IBinder {
+    public boolean transact(int code, Parcel data, Parcel reply, int flags) throws RemoteException;
+
+    public interface DeathRecipient {
+        public void binderDied();
+    }
+}

--- a/service/src/test/java/android/os/IInterface.java
+++ b/service/src/test/java/android/os/IInterface.java
@@ -1,0 +1,5 @@
+package android.os;
+
+public interface IInterface {
+    public IBinder asBinder();
+}

--- a/service/src/test/java/android/os/Parcel.java
+++ b/service/src/test/java/android/os/Parcel.java
@@ -1,0 +1,51 @@
+package android.os;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class Parcel {
+    public static final AtomicInteger obtainCount = new AtomicInteger(0);
+
+    private Queue<Object> data = new LinkedList<>();
+    private int dataPosition = 0;
+
+    public static void resetStats() {
+        obtainCount.set(0);
+    }
+
+    public static Parcel obtain() {
+        obtainCount.incrementAndGet();
+        return new Parcel();
+    }
+
+    public void recycle() { }
+
+    // Test helpers
+    public void pushLong(long l) { data.add(l); }
+    public void pushInt(int i) { data.add(i); }
+    public void pushBinder(IBinder b) { data.add(b); }
+
+    public int readInt() {
+        Object o = data.poll();
+        return o instanceof Integer ? (Integer)o : 0;
+    }
+    public long readLong() {
+        Object o = data.poll();
+        return o instanceof Long ? (Long)o : 0L;
+    }
+    public IBinder readStrongBinder() {
+        Object o = data.poll();
+        return o instanceof IBinder ? (IBinder)o : new Binder();
+    }
+
+    public void writeInt(int i) {}
+    public void writeLong(long l) {}
+    public void writeStrongBinder(IBinder b) {}
+
+    public int dataPosition() { return dataPosition; }
+    public void setDataPosition(int pos) { dataPosition = pos; }
+
+    public void appendFrom(Parcel other, int start, int length) {}
+    public int dataSize() { return 0; }
+}

--- a/service/src/test/java/android/util/Log.java
+++ b/service/src/test/java/android/util/Log.java
@@ -1,8 +1,8 @@
 package android.util;
 
 public class Log {
-    public static int d(String tag, String msg) { System.out.println("D/" + tag + ": " + msg); return 0; }
-    public static int i(String tag, String msg) { System.out.println("I/" + tag + ": " + msg); return 0; }
-    public static int e(String tag, String msg) { System.err.println("E/" + tag + ": " + msg); return 0; }
-    public static int e(String tag, String msg, Throwable tr) { System.err.println("E/" + tag + ": " + msg); tr.printStackTrace(); return 0; }
+    public static int d(String tag, String msg) { return 0; }
+    public static int e(String tag, String msg) { return 0; }
+    public static int e(String tag, String msg, Throwable tr) { return 0; }
+    public static int i(String tag, String msg) { return 0; }
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/binder/BinderInterceptorTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/binder/BinderInterceptorTest.kt
@@ -1,0 +1,108 @@
+package cleveres.tricky.cleverestech.binder
+
+import android.os.Binder
+import android.os.IBinder
+import android.os.Parcel
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class BinderInterceptorTest {
+
+    @Before
+    fun setup() {
+        Parcel.resetStats()
+    }
+
+    @Test
+    fun testOnTransactPostTransact_ZeroSz2_ReducesObtain() {
+        val interceptor = object : BinderInterceptor() {
+            override fun onPostTransact(
+                target: IBinder,
+                code: Int,
+                flags: Int,
+                callingUid: Int,
+                callingPid: Int,
+                data: Parcel,
+                reply: Parcel?,
+                resultCode: Int
+            ): Result {
+                return BinderInterceptor.Continue
+            }
+        }
+
+        val data = Parcel.obtain()
+        // Setup data for POST_TRANSACT (code 2)
+        // val target = data.readStrongBinder()
+        data.pushBinder(Binder())
+        // val theCode = data.readInt()
+        data.pushInt(0)
+        // val theFlags = data.readInt()
+        data.pushInt(0)
+        // val callingUid = data.readInt()
+        data.pushInt(1000)
+        // val callingPid = data.readInt()
+        data.pushInt(100)
+        // val resultCode = data.readInt()
+        data.pushInt(0)
+
+        // val sz = data.readLong().toInt()
+        data.pushLong(10L) // sz = 10
+
+        // val sz2 = data.readLong().toInt()
+        data.pushLong(0L) // sz2 = 0
+
+        val reply = Parcel.obtain()
+
+        // Reset stats before calling onTransact to count calls inside it
+        Parcel.resetStats()
+
+        interceptor.transact(2, data, reply, 0)
+
+        // In unoptimized code:
+        // 1. val theData = Parcel.obtain()
+        // 2. val theReply = Parcel.obtain()
+        // Total 2 calls.
+
+        // After optimization, if sz2 is 0, it should be 1 call.
+        assertEquals(1, Parcel.obtainCount.get())
+    }
+
+    @Test
+    fun testOnTransactPostTransact_NonZeroSz2_AllocatesTwo() {
+        val interceptor = object : BinderInterceptor() {
+            override fun onPostTransact(
+                target: IBinder,
+                code: Int,
+                flags: Int,
+                callingUid: Int,
+                callingPid: Int,
+                data: Parcel,
+                reply: Parcel?,
+                resultCode: Int
+            ): Result {
+                return BinderInterceptor.Continue
+            }
+        }
+
+        val data = Parcel.obtain()
+        // Setup data for POST_TRANSACT (code 2)
+        data.pushBinder(Binder())
+        data.pushInt(0)
+        data.pushInt(0)
+        data.pushInt(1000)
+        data.pushInt(100)
+        data.pushInt(0)
+        data.pushLong(10L) // sz = 10
+        data.pushLong(5L)  // sz2 = 5 (non-zero)
+
+        val reply = Parcel.obtain()
+
+        Parcel.resetStats()
+        interceptor.transact(2, data, reply, 0)
+
+        // 1. theData obtained
+        // 2. theReply obtained (sz2 != 0)
+        assertEquals(2, Parcel.obtainCount.get())
+    }
+}


### PR DESCRIPTION
💡 **What:** Optimized `BinderInterceptor.kt` to lazy-initialize `theReply` Parcel only when `sz2` is non-zero.
🎯 **Why:** Previously, `theReply` was allocated unconditionally via `Parcel.obtain()` even when it was not used (when `sz2 == 0`). This caused unnecessary overhead in the high-throughput IPC interceptor path.
📊 **Measured Improvement:** Verified via unit tests with mocks (`BinderInterceptorTest`) that `Parcel.obtain()` calls are reduced from 2 to 1 when `sz2 == 0`.


---
*PR created automatically by Jules for task [6083374665898053104](https://jules.google.com/task/6083374665898053104) started by @tryigit*