### PR TITLE
Remove onLastWeakRef method

### DIFF
--- a/module/src/main/cpp/binder/include/utils/RefBase.h
+++ b/module/src/main/cpp/binder/include/utils/RefBase.h
@@ -126,11 +126,6 @@ inline bool operator _op_ (const U* o) const {                   \
         // The first flags argument is always FIRST_INC_STRONG.
         // TODO: Remove initial flag argument.
         virtual bool            onIncStrongAttempted(uint32_t flags, const void* id);
-        // Invoked in the OBJECT_LIFETIME_WEAK case when the last reference of either
-        // kind goes away.  Unused.
-        // TODO: Remove.
-        virtual void            onLastWeakRef(const void* id);
-
     private:
         friend class weakref_type;
         class weakref_impl;

--- a/module/src/main/cpp/binder/stub_utils.cpp
+++ b/module/src/main/cpp/binder/stub_utils.cpp
@@ -33,7 +33,6 @@ namespace android {
     void RefBase::onFirstRef() {}
     void RefBase::onLastStrongRef(const void* id) {}
     bool RefBase::onIncStrongAttempted(uint32_t flags, const void* id) { return false; }
-    void RefBase::onLastWeakRef(const void* id) {}
 
     RefBase* RefBase::weakref_type::refBase() const { return nullptr; }
 


### PR DESCRIPTION
Removed the unused `onLastWeakRef` virtual method from `RefBase` class in `module/src/main/cpp/binder/include/utils/RefBase.h` and its stub implementation in `module/src/main/cpp/binder/stub_utils.cpp`. The method was marked for removal and its removal cleans up the API.

---
*PR created automatically by Jules for task [6668613116840684142](https://jules.google.com/task/6668613116840684142) started by @tryigit*