### PR TITLE
Implement callback to old interceptor

### DIFF
--- a/module/src/main/cpp/binder_interceptor.cpp
+++ b/module/src/main/cpp/binder_interceptor.cpp
@@ -360,8 +360,10 @@ BinderInterceptor::onTransact(uint32_t code, const android::Parcel &data, androi
             if (it == items.end() || it->first != t) {
                 it = items.emplace_hint(it, t, InterceptItem{});
                 it->second.target = t;
+            } else if (it->second.interceptor != nullptr && it->second.interceptor != interceptor) {
+                Parcel data, reply;
+                it->second.interceptor->transact(INTERCEPTOR_REPLACED, data, &reply, IBinder::FLAG_ONEWAY);
             }
-            // TODO: send callback to old interceptor
             it->second.interceptor = interceptor;
             return OK;
         }

--- a/module/src/main/cpp/binder_interceptor.h
+++ b/module/src/main/cpp/binder_interceptor.h
@@ -31,7 +31,8 @@ private:
     };
     enum { // These were likely intended to be scoped to functions or private
         PRE_TRANSACT = 1,
-        POST_TRANSACT
+        POST_TRANSACT,
+        INTERCEPTOR_REPLACED = 3
     };
     enum { // These were likely intended to be scoped to functions or private
         SKIP = 1,

--- a/service/src/main/java/cleveres/tricky/cleverestech/binder/BinderInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/binder/BinderInterceptor.kt
@@ -74,6 +74,7 @@ open class BinderInterceptor : Binder() {
 
     open fun onPreTransact(target: IBinder, code: Int, flags: Int, callingUid: Int, callingPid: Int, data: Parcel): Result = Skip
     open fun onPostTransact(target: IBinder, code: Int, flags: Int, callingUid: Int, callingPid: Int, data: Parcel, reply: Parcel?, resultCode: Int): Result = Skip
+    open fun onInterceptorReplaced() {}
 
     override fun onTransact(code: Int, data: Parcel, reply: Parcel?, flags: Int): Boolean {
         val result = when (code) {
@@ -118,6 +119,10 @@ open class BinderInterceptor : Binder() {
                     theData.recycle()
                     theReply?.recycle()
                 }
+            }
+            3 -> { // INTERCEPTOR_REPLACED
+                onInterceptorReplaced()
+                Skip
             }
             else -> return super.onTransact(code, data, reply, flags)
         }

--- a/service/src/test/java/android/os/Parcel.java
+++ b/service/src/test/java/android/os/Parcel.java
@@ -1,14 +1,24 @@
 package android.os;
 
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.LinkedList;
+
 public class Parcel {
+    public static final AtomicInteger obtainCount = new AtomicInteger(0);
+
     public static Parcel obtain() {
+        obtainCount.incrementAndGet();
         return new Parcel();
+    }
+
+    public static void resetStats() {
+        obtainCount.set(0);
     }
 
     public void recycle() {}
 
     public int dataSize() {
-        return 100; // Simulated size
+        return items.size() * 4; // Mock size
     }
 
     public void writeNoException() {}
@@ -22,4 +32,48 @@ public class Parcel {
     public void writeTypedObject(Parcelable val, int parcelableFlags) {}
 
     public void enforceInterface(String interfaceName) {}
+
+    private LinkedList<Object> items = new LinkedList<>();
+
+    // Write methods
+    public void writeInt(int val) { items.add(val); }
+    public void writeLong(long val) { items.add(val); }
+    public void writeStrongBinder(IBinder val) { items.add(val); }
+
+    // Read methods
+    public int readInt() {
+        if (items.isEmpty()) return 0;
+        Object o = items.poll();
+        if (o instanceof Integer) return (Integer) o;
+        return 0;
+    }
+    public long readLong() {
+        if (items.isEmpty()) return 0;
+        Object o = items.poll();
+        if (o instanceof Long) return (Long) o;
+        return 0;
+    }
+    public IBinder readStrongBinder() {
+        if (items.isEmpty()) return null;
+        Object o = items.poll();
+        if (o instanceof IBinder) return (IBinder) o;
+        return null;
+    }
+
+    // Test helper methods
+    public void pushInt(int val) { writeInt(val); }
+    public void pushLong(long val) { writeLong(val); }
+    public void pushBinder(IBinder val) { writeStrongBinder(val); }
+
+    public void setDataPosition(int pos) {}
+    public int dataPosition() { return 0; }
+
+    public void appendFrom(Parcel parcel, int offset, int length) {
+        // In a real implementation this would copy bytes.
+        // For our mock, we can just copy items if any, or do nothing.
+        // BinderInterceptor logic copies from 'data' to 'theData'.
+        // The test doesn't populate 'data' with payload items, just header items.
+        // So we can leave this empty or just copy everything (which might be nothing if we consumed everything).
+        this.items.addAll(parcel.items);
+    }
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/binder/BinderInterceptorTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/binder/BinderInterceptorTest.kt
@@ -105,4 +105,24 @@ class BinderInterceptorTest {
         // 2. theReply obtained (sz2 != 0)
         assertEquals(2, Parcel.obtainCount.get())
     }
+
+    @Test
+    fun testOnInterceptorReplaced() {
+        val replaced = java.util.concurrent.atomic.AtomicBoolean(false)
+        val interceptor = object : BinderInterceptor() {
+            override fun onInterceptorReplaced() {
+                replaced.set(true)
+            }
+        }
+
+        val data = Parcel.obtain()
+        val reply = Parcel.obtain()
+
+        interceptor.transact(3, data, reply, 0)
+
+        assertEquals(true, replaced.get())
+
+        data.recycle()
+        reply.recycle()
+    }
 }


### PR DESCRIPTION
This change implements the TODO "send callback to old interceptor" in `binder_interceptor.cpp`. 
When a new interceptor is registered for a target that already has one, the old interceptor receives a one-way transaction with code 3 (`INTERCEPTOR_REPLACED`).
The Kotlin `BinderInterceptor` class now has an `onInterceptorReplaced` method that can be overridden to handle this event.
Unit tests were added and the Parcel mock was improved to support the tests.

---
*PR created automatically by Jules for task [4256987978460739158](https://jules.google.com/task/4256987978460739158) started by @tryigit*