### PR TITLE
Fix C++ warnings and enable unit tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           packages: ''
 
+      - name: Run Unit Tests
+        run: ./gradlew testDebugUnitTest
+
       - name: Build with Gradle
         run: |
           ./gradlew zipRelease

--- a/module/src/main/cpp/binder/include/binder/Parcel.h
+++ b/module/src/main/cpp/binder/include/binder/Parcel.h
@@ -27,6 +27,8 @@ namespace android {
         class Status {};
     }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-private-field"
     class Parcel {
     public:
 
@@ -184,6 +186,7 @@ namespace android {
 
         size_t mReserved;
     };
+#pragma clang diagnostic pop
 
 } // namespace android
 

--- a/module/src/main/cpp/binder/include/utils/String16.h
+++ b/module/src/main/cpp/binder/include/utils/String16.h
@@ -18,6 +18,8 @@
 #define ANDROID_STRING16_H
 
 namespace android {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-private-field"
     class String16 {
     public:
         String16();
@@ -33,6 +35,7 @@ namespace android {
     private:
         const char16_t *mString;
     };
+#pragma clang diagnostic pop
 
 
 }  // namespace android

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/CertHackTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/CertHackTest.java
@@ -9,10 +9,22 @@ import cleveres.tricky.cleverestech.Logger;
 public class CertHackTest {
 
     private static final String EC_KEY = "-----BEGIN EC PRIVATE KEY-----\n" +
-            "MHcCAQEEIBN+UV4uBUNLhszEC84F0PYJ+KUJMTbdUgfbMbG/ayq0oAoGCCqGSM49\n" +
-            "AwEHoUQDQgAEWXMGzZNcUHT4he/QEGCA8WB5LPVSJzpu0Bbqgkk5b3TmzlW0Emqu\n" +
-            "SboYcnWjC9j+RpY0LhI22LR4U5AaFuklSw==\n" +
+            "MHcCAQEEIAcPs+YkQGT6EDkaEH6Z9StSR7mQuKnh49K0DVqB/ZxYoAoGCCqGSM49\n" +
+            "AwEHoUQDQgAEzi23gXvUATkDmPcNPgsqe24eWmSIfuteSk8S5wJxs4ABt+O6QGAO\n" +
+            "XHqvCjNpJSbUxgz3SZefi8TWWQ1t32G/1w==\n" +
             "-----END EC PRIVATE KEY-----";
+
+    private static final String TEST_CERT = "-----BEGIN CERTIFICATE-----\n" +
+            "MIIBfTCCASOgAwIBAgIUBZ47iWGUbx00hmWBPTYkakbXnigwCgYIKoZIzj0EAwIw\n" +
+            "FDESMBAGA1UEAwwJVGVzdCBDZXJ0MB4XDTI2MDEyOTIxNTI0M1oXDTI3MDEyNDIx\n" +
+            "NTI0M1owFDESMBAGA1UEAwwJVGVzdCBDZXJ0MFkwEwYHKoZIzj0CAQYIKoZIzj0D\n" +
+            "AQcDQgAEzi23gXvUATkDmPcNPgsqe24eWmSIfuteSk8S5wJxs4ABt+O6QGAOXHqv\n" +
+            "CjNpJSbUxgz3SZefi8TWWQ1t32G/16NTMFEwHQYDVR0OBBYEFCwifKyDaNaHtKvx\n" +
+            "m+0eLn/LZoTaMB8GA1UdIwQYMBaAFCwifKyDaNaHtKvxm+0eLn/LZoTaMA8GA1Ud\n" +
+            "EwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIgT+CWCLXuIN5XY0c3mFN1p1FM\n" +
+            "1KAiK9pMwjbHYxNxDmYCIQDXriCpaafMnkJIqGb8UsI5XlkQD0soXYP7hd9ymW/t\n" +
+            "qg==\n" +
+            "-----END CERTIFICATE-----";
 
     @Test
     public void testReadFromXml() {
@@ -31,7 +43,8 @@ public class CertHackTest {
                 "<Key algorithm=\"ecdsa\">\n" +
                 "<PrivateKey>\n" + EC_KEY + "\n</PrivateKey>\n" +
                 "<CertificateChain>\n" +
-                "<NumberOfCertificates>0</NumberOfCertificates>\n" +
+                "<NumberOfCertificates>1</NumberOfCertificates>\n" +
+                "<Certificate>\n" + TEST_CERT + "\n</Certificate>\n" +
                 "</CertificateChain>\n" +
                 "</Key>\n" +
                 "</Keybox>\n" +
@@ -39,6 +52,6 @@ public class CertHackTest {
 
         CertHack.readFromXml(new StringReader(xml));
 
-        assertTrue(CertHack.canHack());
+        assertTrue("Keybox should be loaded", CertHack.canHack());
     }
 }


### PR DESCRIPTION
Suppressed unused private field warnings in Parcel.h and String16.h using pragmas to clean up build logs while maintaining ABI compatibility.
Updated CertHackTest to include a valid EC key and certificate chain, ensuring robust verification of keybox XML parsing logic.
Added `./gradlew testDebugUnitTest` to the GitHub Actions build workflow to automate testing.

---
*PR created automatically by Jules for task [6434252431211286981](https://jules.google.com/task/6434252431211286981) started by @tryigit*