### PR TITLE
Add keybox polling and fix CMake warnings

### DIFF
--- a/module/src/main/cpp/CMakeLists.txt
+++ b/module/src/main/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.28...3.31)
 project(trick_store)
 
 find_package(cxx REQUIRED CONFIG)

--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -310,6 +310,7 @@ object Config {
             updateKeyBox(keybox)
         }
         ConfigObserver.startWatching()
+        keyboxPoller?.stop()
         keyboxPoller = FilePoller(File(root, KEYBOX_FILE), 5000) {
             Logger.i("Detected keybox change via polling")
             updateKeyBox(it)

--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -119,6 +119,8 @@ object Config {
         Logger.e("failed to update target files", it)
     }
 
+    private var keyboxPoller: FilePoller? = null
+
     // Stream file content to avoid large String allocation and explicit GC
     private fun updateKeyBox(f: File?) = runCatching {
         if (f == null) {
@@ -126,6 +128,7 @@ object Config {
         } else {
             f.bufferedReader().use { CertHack.readFromXml(it) }
         }
+        keyboxPoller?.updateLastModified()
     }.onFailure {
         Logger.e("failed to update keybox", it)
     }
@@ -307,6 +310,11 @@ object Config {
             updateKeyBox(keybox)
         }
         ConfigObserver.startWatching()
+        keyboxPoller = FilePoller(File(root, KEYBOX_FILE), 5000) {
+            Logger.i("Detected keybox change via polling")
+            updateKeyBox(it)
+        }
+        keyboxPoller?.start()
     }
 
     private var iPm: IPackageManager? = null

--- a/service/src/main/java/cleveres/tricky/cleverestech/FilePoller.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/FilePoller.kt
@@ -1,0 +1,58 @@
+package cleveres.tricky.cleverestech
+
+import java.io.File
+import kotlin.concurrent.thread
+
+class FilePoller(
+    private val file: File,
+    private val intervalMs: Long = 5000,
+    private val onModified: (File) -> Unit
+) {
+    @Volatile
+    private var isRunning = false
+    @Volatile
+    private var lastModified: Long = 0
+
+    init {
+        if (file.exists()) {
+            lastModified = file.lastModified()
+        }
+    }
+
+    fun start() {
+        if (isRunning) return
+        isRunning = true
+        thread(start = true, isDaemon = true, name = "FilePoller-${file.name}") {
+            while (isRunning) {
+                try {
+                    Thread.sleep(intervalMs)
+                    if (file.exists()) {
+                        val currentModified = file.lastModified()
+                        if (currentModified > lastModified) {
+                            lastModified = currentModified
+                            onModified(file)
+                        }
+                    } else {
+                        // Reset if file deleted? Or keep lastModified?
+                        // If deleted and recreated, lastModified checks should handle it if new time > old time.
+                        // Usually specific logic needed? For now, keep simple.
+                    }
+                } catch (e: InterruptedException) {
+                    break
+                }
+            }
+        }
+    }
+
+    fun stop() {
+        isRunning = false
+    }
+
+    fun updateLastModified() {
+         if (file.exists()) {
+            lastModified = file.lastModified()
+        } else {
+            lastModified = 0
+        }
+    }
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/FilePollerTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/FilePollerTest.kt
@@ -1,0 +1,104 @@
+package cleveres.tricky.cleverestech
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class FilePollerTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var testFile: File
+    private lateinit var poller: FilePoller
+    private val intervalMs = 100L
+
+    @Before
+    fun setUp() {
+        testFile = tempFolder.newFile("test_poller.txt")
+        testFile.writeText("initial")
+    }
+
+    @After
+    fun tearDown() {
+        if (::poller.isInitialized) {
+            poller.stop()
+        }
+    }
+
+    @Test
+    fun testModificationDetected() {
+        val latch = CountDownLatch(1)
+        var callbackFile: File? = null
+
+        poller = FilePoller(testFile, intervalMs) {
+            callbackFile = it
+            latch.countDown()
+        }
+        poller.start()
+
+        // Wait a bit to ensure poller started and read initial state
+        Thread.sleep(intervalMs * 2)
+
+        // Modify file
+        // Ensure lastModified changes (some FS have 1s resolution)
+        val oldTime = testFile.lastModified()
+        var newTime = oldTime
+        while (newTime <= oldTime) {
+            Thread.sleep(100)
+            testFile.writeText("modified")
+            testFile.setLastModified(System.currentTimeMillis())
+            newTime = testFile.lastModified()
+        }
+
+        assertTrue("Callback should be invoked", latch.await(2, TimeUnit.SECONDS))
+        assertEquals(testFile, callbackFile)
+    }
+
+    @Test
+    fun testNoFalsePositives() {
+        val latch = CountDownLatch(1)
+        poller = FilePoller(testFile, intervalMs) {
+            latch.countDown()
+        }
+        poller.start()
+
+        Thread.sleep(intervalMs * 3)
+        // Should not have triggered
+        assertEquals(1, latch.count)
+    }
+
+    @Test
+    fun testUpdateLastModifiedPreventsTrigger() {
+        val latch = CountDownLatch(1)
+        poller = FilePoller(testFile, intervalMs) {
+            latch.countDown()
+        }
+        poller.start()
+
+        Thread.sleep(intervalMs * 2)
+
+        // Modify file
+        testFile.writeText("modified")
+        val t = System.currentTimeMillis()
+        // Ensure time moves forward
+        if (t <= testFile.lastModified()) Thread.sleep(100)
+        testFile.setLastModified(System.currentTimeMillis())
+
+        // Manually update poller state
+        poller.updateLastModified()
+
+        // Wait for poller to run cycle
+        Thread.sleep(intervalMs * 3)
+
+        // Should NOT trigger because we updated state manually
+        assertEquals(1, latch.count)
+    }
+}


### PR DESCRIPTION
This PR addresses the user's request to ensure `keybox.xml` changes are detected even without the webserver, by adding a polling mechanism. It also fixes build warnings related to CMake version compatibility.

Changes:
1.  **Polling Mechanism:** Implemented `FilePoller` and integrated it into `Config.kt` to poll `keybox.xml` every 5 seconds. This acts as a reliable backup to `FileObserver`.
2.  **Build Fixes:** Updated `CMakeLists.txt` to suppress deprecation warnings.
3.  **Tests:** Added `FilePollerTest` to verify the polling logic.

Testing:
- Ran `./gradlew :service:testDebugUnitTest`. All tests passed, including the new `FilePollerTest`.

---
*PR created automatically by Jules for task [10163994124016147491](https://jules.google.com/task/10163994124016147491) started by @tryigit*