### PR TITLE
🛡️ Sentinel: [HIGH] Secure WebServer Binding and Auth

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The configuration directory `/data/adb/tricky_store/` and sensitive files like `keybox.xml` (containing private keys) were created with default permissions (likely 755/644), making them readable by any app on the device.
 **Learning:** Default filesystem operations (`mkdir`, `cp`) in Android/Linux usually respect umask (022 for root), resulting in world-readable files. Sensitive data must always have explicit permission hardening.
 **Prevention:** Always use `chmod 700` for directories and `chmod 600` for files containing secrets immediately after creation. Enforce this in both installation scripts (`customize.sh`) and runtime initialization (Java/Kotlin using `Os.chmod`).
+
+## 2024-05-24 - [Unintended Network Exposure of Local Service]
+**Vulnerability:** The internal configuration web server (`WebServer`) was initialized using `NanoHTTPD(port)`, which defaults to binding on all network interfaces (`0.0.0.0`). This exposed the sensitive configuration API and token auth to the local network (e.g., Wi-Fi).
+**Learning:** Embedded web servers often default to promiscuous binding. For local IPC or configuration tools, explicit binding to loopback (`127.0.0.1`) is mandatory.
+**Prevention:** Always explicitly specify the hostname/IP when initializing network listeners for local services (e.g., `NanoHTTPD("127.0.0.1", port)`).

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -3,9 +3,10 @@ package cleveres.tricky.cleverestech
 import cleveres.tricky.cleverestech.keystore.CertHack
 import fi.iki.elonen.NanoHTTPD
 import java.io.File
+import java.security.MessageDigest
 import java.util.UUID
 
-class WebServer(port: Int, private val configDir: File = File("/data/adb/cleverestricky")) : NanoHTTPD(port) {
+class WebServer(port: Int, private val configDir: File = File("/data/adb/cleverestricky")) : NanoHTTPD("127.0.0.1", port) {
 
     val token = UUID.randomUUID().toString()
 
@@ -55,7 +56,7 @@ class WebServer(port: Int, private val configDir: File = File("/data/adb/clevere
 
         // Simple Token Auth
         val requestToken = params["token"]
-        if (requestToken != token) {
+        if (!MessageDigest.isEqual(token.toByteArray(), (requestToken ?: "").toByteArray())) {
              return newFixedLengthResponse(Response.Status.UNAUTHORIZED, "text/plain", "Unauthorized")
         }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The internal WebServer was binding to `0.0.0.0` (all interfaces), potentially exposing the configuration API to the local network. Additionally, the token authentication used a non-constant-time string comparison, theoretically allowing timing attacks.
🎯 Impact: An attacker on the same Wi-Fi network could potentially access sensitive configuration or guess the authentication token.
🔧 Fix:
1. Explicitly bind `NanoHTTPD` to `127.0.0.1` (localhost).
2. Use `MessageDigest.isEqual` for constant-time token comparison.
✅ Verification: Ran unit tests (`ActionTest`), confirmed `WebServer` starts and auth works correctly via localhost.

---
*PR created automatically by Jules for task [8445751347027649606](https://jules.google.com/task/8445751347027649606) started by @tryigit*