### PR TITLE
God-Mode Evolution: App Attest Bypass & Dynamic Build Templates

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -151,6 +151,37 @@ object Config {
     @Volatile
     private var buildVars: Map<String, String> = emptyMap()
 
+    private val templates = mapOf(
+        "pixel8pro" to mapOf(
+            "MANUFACTURER" to "Google",
+            "MODEL" to "Pixel 8 Pro",
+            "FINGERPRINT" to "google/husky/husky:14/AP1A.240405.002/11480754:user/release-keys",
+            "BRAND" to "google",
+            "PRODUCT" to "husky",
+            "DEVICE" to "husky",
+            "RELEASE" to "14",
+            "ID" to "AP1A.240405.002",
+            "INCREMENTAL" to "11480754",
+            "TYPE" to "user",
+            "TAGS" to "release-keys",
+            "SECURITY_PATCH" to "2024-04-05"
+        ),
+        "xiaomi14" to mapOf(
+            "MANUFACTURER" to "Xiaomi",
+            "MODEL" to "23127PN0CG",
+            "FINGERPRINT" to "Xiaomi/houji_global/houji:14/UKQ1.230804.001/V816.0.4.0.UNCMIXM:user/release-keys",
+            "BRAND" to "Xiaomi",
+            "PRODUCT" to "houji_global",
+            "DEVICE" to "houji",
+            "RELEASE" to "14",
+            "ID" to "UKQ1.230804.001",
+            "INCREMENTAL" to "V816.0.4.0.UNCMIXM",
+            "TYPE" to "user",
+            "TAGS" to "release-keys",
+            "SECURITY_PATCH" to "2024-03-01"
+        )
+    )
+
     fun getBuildVar(key: String): String? {
         return buildVars[key]
     }
@@ -162,7 +193,13 @@ object Config {
                 if (line.isNotBlank() && !line.startsWith("#")) {
                     val parts = line.split("=", limit = 2)
                     if (parts.size == 2) {
-                        newVars[parts[0].trim()] = parts[1].trim()
+                        val key = parts[0].trim()
+                        val value = parts[1].trim()
+                        if (key == "TEMPLATE") {
+                            templates[value.lowercase()]?.let { newVars.putAll(it) }
+                        } else {
+                            newVars[key] = value
+                        }
                     }
                 }
             }

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -52,9 +52,9 @@ class SecurityLevelInterceptor(
                 // val entropy = data.createByteArray()
                 val kgp = KeyGenParameters(params)
                 if (kgp.attestationChallenge != null) {
-                    // if (attestationKeyDescriptor != null) {
-                    //    Logger.e("warn: attestation key not supported now")
-                    // } else {
+                    if (attestationKeyDescriptor != null) {
+                        Logger.e("intercept attestation key request alias=${attestationKeyDescriptor.alias}")
+                    }
                     val pair = CertHack.generateKeyPair(callingUid, keyDescriptor, kgp)
                         ?: return@runCatching
                     val response = buildResponse(pair.second, kgp, keyDescriptor, callingUid)
@@ -63,7 +63,6 @@ class SecurityLevelInterceptor(
                     p.writeNoException()
                     p.writeTypedObject(response.metadata, 0)
                     return OverrideReply(0, p)
-                    // }
                 }
             }.onFailure {
                 Logger.e("parse key gen request", it)


### PR DESCRIPTION
This evolution introduces two major "God-Mode" features to TrickyStore:

1.  **App Attest Key Interception & Bypass**:
    Android 12+ introduced the ability for apps to request an "App Attest Key" to sign their keys, which can be used to pin keys or verify the chain locally, potentially detecting spoofing.
    We now intercept this request in `SecurityLevelInterceptor`. Instead of failing or respecting the request (which would break our chain), we log the attempt and *intentionally ignore* the requested attest key. We proceed to sign the generated key with our own spoofed Keybox (Google Root). This ensures the attestation result is always valid and rooted to Google, satisfying server-side checks like Play Integrity, even if the app tries to isolate itself.

2.  **Dynamic Build Templates**:
    Added a template engine to `Config.kt`. Users can now simply add `TEMPLATE=pixel8pro` or `TEMPLATE=xiaomi14` to their `spoof_build_vars` file.
    The module will automatically populate the correct `MANUFACTURER`, `MODEL`, `FINGERPRINT`, `SECURITY_PATCH`, etc., for that device.
    User-defined values in the same file take precedence (last-one-wins logic), allowing for easy customization on top of templates.

**Verification:**
- `./gradlew clean` -> Success
- `./gradlew assembleRelease` -> Success
- `./gradlew build` -> Success
- `./gradlew test` -> Success
- `./gradlew zipRelease` -> Success
- Validated that `attestationKeyDescriptor` handling builds correctly and logic flow is sound.
- Validated that `Config.kt` template logic correctly merges maps.

---
*PR created automatically by Jules for task [2832397376120590486](https://jules.google.com/task/2832397376120590486) started by @tryigit*