### PR TITLE
Fix XMLParser data loss on split text nodes

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/XMLParser.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/XMLParser.java
@@ -62,7 +62,11 @@ public class XMLParser {
                     if (currentElement != null && parser.getText() != null) {
                         String text = parser.getText().trim();
                         if (!text.isEmpty()) {
-                            currentElement.text = text;
+                            if (currentElement.text == null) {
+                                currentElement.text = text;
+                            } else {
+                                currentElement.text += text;
+                            }
                         }
                     }
                     break;
@@ -73,8 +77,8 @@ public class XMLParser {
                         if (stack.isEmpty()) {
                             return finished;
                         }
+                        currentElement = stack.get(stack.size() - 1);
                     }
-                    currentElement = null;
                     break;
             }
             eventType = parser.next();

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/XMLParserBugTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/XMLParserBugTest.java
@@ -1,0 +1,18 @@
+package cleveres.tricky.cleverestech.keystore;
+
+import org.junit.Test;
+import java.io.StringReader;
+import static org.junit.Assert.assertEquals;
+
+public class XMLParserBugTest {
+
+    @Test
+    public void testMixedContent() throws Exception {
+        String xml = "<Root><Data>Part1<Inner/>Part2</Data></Root>";
+
+        XMLParser parser = new XMLParser(new StringReader(xml));
+        String extracted = parser.obtainPath("Root.Data").get("text");
+
+        assertEquals("Extracted text content mismatch", "Part1Part2", extracted);
+    }
+}


### PR DESCRIPTION
Fixes a bug where large text nodes or mixed content in XML files (like `keybox.xml`) would be truncated or ignored by the custom `XMLParser`. This ensures robust parsing of certificates and keys even if the parser chunks the input.

---
*PR created automatically by Jules for task [6148220133112901672](https://jules.google.com/task/6148220133112901672) started by @tryigit*