### PR TITLE
Feat: Add Device Templates & UI Picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Compared to the standard TrickyStore, **CleveresTricky** brings:
 ## Usage
 
 1. Flash this module and reboot.  
-2. For more than DEVICE integrity, put an unrevoked hardware keybox.xml at `/data/adb/cleveres_tricky/keybox.xml` (Optional).
-3. Customize target packages at `/data/adb/cleveres_tricky/target.txt` (Optional).
+2. For more than DEVICE integrity, put an unrevoked hardware keybox.xml at `/data/adb/cleverestricky/keybox.xml` (Optional).
+3. Customize target packages at `/data/adb/cleverestricky/target.txt` (Optional).
 4. Enjoy!  
 
 **All configuration files will take effect immediately.**
@@ -62,7 +62,7 @@ format:
 
 CleveresTricky allows you to spoof ANY system property via Binder interception, making it invisible to standard `getprop` checks from targeted apps.
 
-Create/edit `/data/adb/cleveres_tricky/spoof_build_vars`.
+Create/edit `/data/adb/cleverestricky/spoof_build_vars`.
 
 Example:
 
@@ -86,6 +86,33 @@ ro.boot.flash.locked=1
 
 For Magisk users: if you don't need this feature and zygisk is disabled, please remove or rename the
 folder `/data/adb/modules/cleveres_tricky/zygisk` manually.
+
+## Device Templates
+
+CleveresTricky includes built-in templates for popular devices to make spoofing easier. You can apply these templates via the Web UI or by adding `TEMPLATE=<name>` to your `spoof_build_vars` file.
+
+**Available Templates:**
+*   `pixel8pro` (Google Pixel 8 Pro)
+*   `pixel7pro` (Google Pixel 7 Pro)
+*   `pixel6pro` (Google Pixel 6 Pro)
+*   `xiaomi14` (Xiaomi 14)
+*   `s23ultra` (Samsung Galaxy S23 Ultra)
+*   `oneplus11` (OnePlus 11)
+
+**Usage via Web UI:**
+1.  Open the Web UI.
+2.  Select `spoof_build_vars` from the file selector.
+3.  Choose a device from the "Select a device template..." dropdown.
+4.  Click "Load Template".
+5.  Click "Save File".
+
+**Usage via File:**
+Edit `/data/adb/cleverestricky/spoof_build_vars`:
+```text
+TEMPLATE=pixel7pro
+# You can override specific variables if needed
+MODEL=My Custom Model
+```
 
 ## Support TEE broken devices
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -168,6 +168,34 @@ object Config {
             "TAGS" to "release-keys",
             "SECURITY_PATCH" to "2024-04-05"
         ),
+        "pixel7pro" to mapOf(
+            "MANUFACTURER" to "Google",
+            "MODEL" to "Pixel 7 Pro",
+            "FINGERPRINT" to "google/cheetah/cheetah:14/AP1A.240305.019.A1/11445699:user/release-keys",
+            "BRAND" to "google",
+            "PRODUCT" to "cheetah",
+            "DEVICE" to "cheetah",
+            "RELEASE" to "14",
+            "ID" to "AP1A.240305.019.A1",
+            "INCREMENTAL" to "11445699",
+            "TYPE" to "user",
+            "TAGS" to "release-keys",
+            "SECURITY_PATCH" to "2024-03-05"
+        ),
+        "pixel6pro" to mapOf(
+            "MANUFACTURER" to "Google",
+            "MODEL" to "Pixel 6 Pro",
+            "FINGERPRINT" to "google/raven/raven:13/TQ3A.230901.001/10750268:user/release-keys",
+            "BRAND" to "google",
+            "PRODUCT" to "raven",
+            "DEVICE" to "raven",
+            "RELEASE" to "13",
+            "ID" to "TQ3A.230901.001",
+            "INCREMENTAL" to "10750268",
+            "TYPE" to "user",
+            "TAGS" to "release-keys",
+            "SECURITY_PATCH" to "2023-09-01"
+        ),
         "xiaomi14" to mapOf(
             "MANUFACTURER" to "Xiaomi",
             "MODEL" to "23127PN0CG",
@@ -181,14 +209,46 @@ object Config {
             "TYPE" to "user",
             "TAGS" to "release-keys",
             "SECURITY_PATCH" to "2024-03-01"
+        ),
+        "s23ultra" to mapOf(
+            "MANUFACTURER" to "samsung",
+            "MODEL" to "SM-S918B",
+            "FINGERPRINT" to "samsung/dm3qxxx/dm3q:14/UP1A.231005.007/S918BXXS3BXE0:user/release-keys",
+            "BRAND" to "samsung",
+            "PRODUCT" to "dm3qxxx",
+            "DEVICE" to "dm3q",
+            "RELEASE" to "14",
+            "ID" to "UP1A.231005.007",
+            "INCREMENTAL" to "S918BXXS3BXE0",
+            "TYPE" to "user",
+            "TAGS" to "release-keys",
+            "SECURITY_PATCH" to "2024-05-01"
+        ),
+        "oneplus11" to mapOf(
+            "MANUFACTURER" to "OnePlus",
+            "MODEL" to "CPH2449",
+            "FINGERPRINT" to "OnePlus/CPH2449/OP5554L1:14/UKQ1.230924.001/R.15f1de6-1-1:user/release-keys",
+            "BRAND" to "OnePlus",
+            "PRODUCT" to "CPH2449",
+            "DEVICE" to "OP5554L1",
+            "RELEASE" to "14",
+            "ID" to "UKQ1.230924.001",
+            "INCREMENTAL" to "R.15f1de6-1-1",
+            "TYPE" to "user",
+            "TAGS" to "release-keys",
+            "SECURITY_PATCH" to "2024-04-05"
         )
     )
+
+    fun getTemplateNames(): Set<String> {
+        return templates.keys
+    }
 
     fun getBuildVar(key: String): String? {
         return buildVars[key]
     }
 
-    private fun updateBuildVars(f: File?) = runCatching {
+    internal fun updateBuildVars(f: File?) = runCatching {
         val newVars = mutableMapOf<String, String>()
         f?.useLines { lines ->
             lines.forEach { line ->

--- a/service/src/test/java/cleveres/tricky/cleverestech/ConfigTemplateTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ConfigTemplateTest.kt
@@ -1,0 +1,39 @@
+package cleveres.tricky.cleverestech
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+
+class ConfigTemplateTest {
+
+    @Test
+    fun testUpdateBuildVars_withTemplate() {
+        // Create a temporary file
+        val tempFile = File.createTempFile("spoof_build_vars", ".txt")
+        tempFile.deleteOnExit()
+
+        // Write template directive
+        tempFile.writeText("TEMPLATE=pixel7pro")
+
+        // Update Config
+        Config.updateBuildVars(tempFile)
+
+        // Verify
+        assertEquals("Pixel 7 Pro", Config.getBuildVar("MODEL"))
+        assertEquals("google/cheetah/cheetah:14/AP1A.240305.019.A1/11445699:user/release-keys", Config.getBuildVar("FINGERPRINT"))
+    }
+
+    @Test
+    fun testUpdateBuildVars_withOverride() {
+        val tempFile = File.createTempFile("spoof_build_vars_override", ".txt")
+        tempFile.deleteOnExit()
+
+        // Template + Override
+        tempFile.writeText("TEMPLATE=pixel7pro\nMODEL=My Custom Pixel")
+
+        Config.updateBuildVars(tempFile)
+
+        assertEquals("My Custom Pixel", Config.getBuildVar("MODEL"))
+        assertEquals("google", Config.getBuildVar("BRAND"))
+    }
+}


### PR DESCRIPTION
**Weekly Ship Builder 🚢 Delivery**

**Theme:** Device Fingerprint Expansion & UI Upgrade

**User Problem:**
Users previously had to manually research and type complex `build.prop` values (fingerprints) into `spoof_build_vars` to spoof devices. This was error-prone and tedious. The `TEMPLATE` feature existed but was undocumented and limited to 2 devices.

**Improvement:**
1.  **Expanded Templates:** Added built-in support for:
    *   Pixel 7 Pro
    *   Pixel 6 Pro
    *   Samsung Galaxy S23 Ultra
    *   OnePlus 11
2.  **UI Upgrade:** The Web UI now features a "Load Template" dropdown when editing `spoof_build_vars`. Users can select a device and apply it with one click.
3.  **Documentation:** Fully documented the `TEMPLATE` directive and list of supported devices in `README.md`.
4.  **Fix:** Corrected the configuration path in `README.md` (`/data/adb/cleveres_tricky` -> `/data/adb/cleverestricky`) to match the codebase.

**Verification:**
- Added `ConfigTemplateTest.kt` to verify that `TEMPLATE=...` correctly populates build variables.
- Verified Frontend UI using a mock server and Playwright script (verified dropdown appearance, population, and text insertion logic).

**Files Changed:**
- `service/src/main/java/cleveres/tricky/cleverestech/Config.kt`
- `service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt`
- `README.md`
- `service/src/test/java/cleveres/tricky/cleverestech/ConfigTemplateTest.kt` (New)


---
*PR created automatically by Jules for task [4925822577845342772](https://jules.google.com/task/4925822577845342772) started by @tryigit*