### PR TITLE
Fix WebServer POST parameter parsing

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -93,11 +93,11 @@ class WebServer(port: Int, private val configDir: File = File("/data/adb/clevere
         if (uri == "/api/save" && method == Method.POST) {
              val map = HashMap<String, String>()
              try { session.parseBody(map) } catch(e:Exception){}
-             val filename = params["filename"]
+             val filename = session.parms["filename"]
              // nanohttpd puts body content in map["postData"] usually, or mix params.
              // When parsing body, map contains temp file paths for uploads, but for form data it puts in parms?
              // Actually parseBody populates map with temp files, and parms with fields.
-             val content = params["content"] // This might be limited in size?
+             val content = session.parms["content"] // This might be limited in size?
              // For large content (keybox), we might need to read from map if it's treated as file?
              // But usually standard form post puts it in parms.
              // Let's assume text/plain body or form-url-encoded.
@@ -118,8 +118,8 @@ class WebServer(port: Int, private val configDir: File = File("/data/adb/clevere
         if (uri == "/api/toggle" && method == Method.POST) {
              val map = HashMap<String, String>()
              try { session.parseBody(map) } catch(e:Exception){}
-             val setting = params["setting"]
-             val value = params["value"]
+             val setting = session.parms["setting"]
+             val value = session.parms["value"]
 
              if (setting != null && value != null) {
                  if (toggleFile(setting, value.toBoolean())) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerPostTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerPostTest.kt
@@ -1,0 +1,69 @@
+package cleveres.tricky.cleverestech
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.Rule
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import java.nio.charset.StandardCharsets
+
+class WebServerPostTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var server: WebServer
+    private lateinit var configDir: File
+
+    @Before
+    fun setUp() {
+        configDir = tempFolder.newFolder("config")
+        server = WebServer(0, configDir)
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.stop()
+    }
+
+    @Test
+    fun testSaveFileWithBodyParams() {
+        val port = server.listeningPort
+        val token = server.token
+        // Only token in URL
+        val saveUrl = URL("http://localhost:$port/api/save?token=$token")
+
+        val conn = saveUrl.openConnection() as HttpURLConnection
+        conn.requestMethod = "POST"
+        conn.doOutput = true
+        conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
+
+        val postData = "filename=keybox.xml&content=BODY_CONTENT"
+        val postDataBytes = postData.toByteArray(StandardCharsets.UTF_8)
+
+        conn.outputStream.use { it.write(postDataBytes) }
+
+        val responseCode = conn.responseCode
+        println("Response Code: $responseCode")
+
+        if (responseCode == 200) {
+            val response = conn.inputStream.bufferedReader().readText()
+            println("Response: $response")
+        } else {
+             val error = conn.errorStream?.bufferedReader()?.readText()
+             println("Error Response: $error")
+        }
+
+        assertEquals(200, responseCode)
+
+        val savedFile = File(configDir, "keybox.xml")
+        assertTrue("File should exist", savedFile.exists())
+        assertEquals("File content mismatch", "BODY_CONTENT", savedFile.readText())
+    }
+}


### PR DESCRIPTION
This PR fixes a bug in `WebServer.kt` where parameters from POST requests (specifically `filename`, `content`, `setting`, `value`) were not being correctly read. 

The issue was that `val params = session.parms` was initialized at the beginning of the `serve` method, before `session.parseBody(map)` was called. For `application/x-www-form-urlencoded` requests, `NanoHTTPD` populates `session.parms` during `parseBody`. As a result, the initial `params` map did not contain the body parameters.

The fix involves accessing `session.parms` directly inside the request handlers for `/api/save` and `/api/toggle`, ensuring that the parameters are read after they have been populated by `parseBody`.

Verified with a new regression test `WebServerPostTest` and existing `ActionTest`.


---
*PR created automatically by Jules for task [11384124530950632315](https://jules.google.com/task/11384124530950632315) started by @tryigit*