### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix race condition in token file creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The internal configuration web server (`WebServer`) was initialized using `NanoHTTPD(port)`, which defaults to binding on all network interfaces (`0.0.0.0`). This exposed the sensitive configuration API and token auth to the local network (e.g., Wi-Fi).
 **Learning:** Embedded web servers often default to promiscuous binding. For local IPC or configuration tools, explicit binding to loopback (`127.0.0.1`) is mandatory.
 **Prevention:** Always explicitly specify the hostname/IP when initializing network listeners for local services (e.g., `NanoHTTPD("127.0.0.1", port)`).
+
+## 2024-05-23 - Race Condition in Token File Creation
+**Vulnerability:** The `web_port` file containing the authentication token was being created in the configuration directory before the directory's permissions were restricted to `0700`. This created a window where the directory and the token file could be world-readable.
+**Learning:** Even if you change file permissions immediately after creation, there is a race condition window. Securing the parent directory *before* creating sensitive files inside it is a more robust way to prevent access.
+**Prevention:** Always ensure the parent directory has restrictive permissions (e.g., `0700`) before writing sensitive files into it. Use `Os.chmod` immediately after directory creation.

--- a/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
@@ -1,5 +1,6 @@
 package cleveres.tricky.cleverestech
 
+import android.system.Os
 import java.io.File
 import java.security.MessageDigest
 import kotlin.system.exitProcess
@@ -18,6 +19,12 @@ fun main(args: Array<String>) {
         Logger.i("Web server started on port $port")
         val portFile = File(configDir, "web_port")
         if (!configDir.exists()) configDir.mkdirs()
+        // Secure directory before writing sensitive file
+        try {
+            Os.chmod(configDir.absolutePath, 448) // 0700
+        } catch (t: Throwable) {
+            Logger.e("failed to set permissions for config dir", t)
+        }
         portFile.writeText("$port|$token")
         portFile.setReadable(false, false) // Clear all
         portFile.setReadable(true, true) // Owner only (0600)


### PR DESCRIPTION
This PR addresses a race condition vulnerability in `Main.kt`. 

**The Issue:**
The `web_port` file, which contains the sensitive authentication token for the web server, was being created in the configuration directory (`/data/adb/cleverestricky`) *before* the directory's permissions were explicitly restricted. This created a time window where, if the directory was created with default permissions (e.g., via `mkdirs` respecting a default umask), the file could be readable by other applications on the device.

**The Fix:**
I have inserted a call to `Os.chmod(configDir.absolutePath, 448)` (which corresponds to `0700` permissions) immediately after ensuring the directory exists and *before* writing the `web_port` file. This ensures the directory is secure before any sensitive data is placed inside it.

**Verification:**
- Verified that `android.system.Os` is available (as the module runs in an Android environment).
- Verified `Config.kt` uses the same approach (`Os.chmod` with `448`).
- Ran `./gradlew testDebugUnitTest` and confirmed all tests pass.
- Added a `SENTINEL` journal entry documenting the fix.

---
*PR created automatically by Jules for task [1187310664911850682](https://jules.google.com/task/1187310664911850682) started by @tryigit*