### PR TITLE
🎨 Palette: Add Toast notifications to WebServer UI

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/BetaFetcher.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/BetaFetcher.kt
@@ -52,7 +52,7 @@ object BetaFetcher {
      */
     fun startBackgroundService(intervalHours: Int = 24) {
         if (scheduler != null) {
-            Logger.d(TAG, "Background service already running")
+            Logger.d("$TAG: Background service already running")
             return
         }
         
@@ -72,11 +72,11 @@ object BetaFetcher {
                     fetchAndApply(null)
                 }
             } catch (e: Exception) {
-                Logger.e(TAG, "Background fetch failed", e)
+                Logger.e("$TAG: Background fetch failed", e)
             }
         }, safeInterval, safeInterval, TimeUnit.HOURS)
         
-        Logger.i(TAG, "Background service started, interval: ${safeInterval}h")
+        Logger.i("$TAG: Background service started, interval: ${safeInterval}h")
     }
     
     /**
@@ -85,7 +85,7 @@ object BetaFetcher {
     fun stopBackgroundService() {
         scheduler?.shutdown()
         scheduler = null
-        Logger.i(TAG, "Background service stopped")
+        Logger.i("$TAG: Background service stopped")
     }
     
     /**
@@ -101,7 +101,7 @@ object BetaFetcher {
      * @param preferredDevice Optional device to prefer (e.g., "husky" for Pixel 8 Pro)
      */
     fun fetchAndApply(preferredDevice: String?): FetchResult {
-        Logger.i(TAG, "Fetching latest Pixel Beta profile...")
+        Logger.i("$TAG: Fetching latest Pixel Beta profile...")
         
         try {
             // 1. Get available devices
@@ -125,12 +125,12 @@ object BetaFetcher {
             applyProfile(profile)
             
             lastFetchTime = System.currentTimeMillis()
-            Logger.i(TAG, "Applied profile: ${profile.model} (${profile.fingerprint})")
+            Logger.i("$TAG: Applied profile: ${profile.model} (${profile.fingerprint})")
             
             return FetchResult(true, profile = profile, availableDevices = devices)
             
         } catch (e: Exception) {
-            Logger.e(TAG, "Fetch failed", e)
+            Logger.e("$TAG: Fetch failed", e)
             return FetchResult(false, error = e.message)
         }
     }
@@ -166,7 +166,7 @@ object BetaFetcher {
                     )
                 }
         } catch (e: Exception) {
-            Logger.e(TAG, "Failed to fetch device list", e)
+            Logger.e("$TAG: Failed to fetch device list", e)
             return emptyList()
         }
     }
@@ -226,7 +226,7 @@ object BetaFetcher {
                 incremental = incrementalMatch
             )
         } catch (e: Exception) {
-            Logger.e(TAG, "Failed to fetch profile for $product", e)
+            Logger.e("$TAG: Failed to fetch profile for $product", e)
             return null
         }
     }
@@ -275,7 +275,7 @@ $userOverrides
         """.trimIndent()
         
         varsFile.writeText(content)
-        Logger.i(TAG, "Profile applied to ${varsFile.absolutePath}")
+        Logger.i("$TAG: Profile applied to ${varsFile.absolutePath}")
     }
     
     /**

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -187,6 +187,10 @@ class WebServer(port: Int, private val configDir: File = File("/data/adb/clevere
         select { padding: 10px; background-color: #2d2d2d; color: white; border: 1px solid #444; border-radius: 4px; width: 100%; margin-bottom: 10px; }
         input[type="checkbox"] { transform: scale(1.5); }
         .status { text-align: center; color: #888; margin-top: 10px; }
+        .toast { position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); background-color: #333; color: white; padding: 12px 24px; border-radius: 4px; opacity: 0; transition: opacity 0.3s; pointer-events: none; z-index: 1000; }
+        .toast.show { opacity: 1; }
+        .toast.success { background-color: #2e7d32; }
+        .toast.error { background-color: #d32f2f; }
     </style>
 </head>
 <body>
@@ -237,6 +241,15 @@ class WebServer(port: Int, private val configDir: File = File("/data/adb/clevere
 
         function getAuthUrl(path) {
             return path + (path.includes('?') ? '&' : '?') + 'token=' + token;
+        }
+
+        let toastTimeout;
+        function showToast(msg, type) {
+            let t = document.getElementById('toast');
+            if (!t) { t = document.createElement('div'); t.id = 'toast'; t.className = 'toast'; document.body.appendChild(t); }
+            t.textContent = msg; t.className = 'toast show ' + (type || '');
+            if (toastTimeout) clearTimeout(toastTimeout);
+            toastTimeout = setTimeout(() => { t.className = t.className.replace('show', ''); }, 3000);
         }
 
         async function init() {
@@ -336,10 +349,10 @@ class WebServer(port: Int, private val configDir: File = File("/data/adb/clevere
                     body: params
                 });
 
-                if (res.ok) alert('Saved!');
-                else alert('Failed to save');
+                if (res.ok) showToast('Saved!', 'success');
+                else showToast('Failed to save', 'error');
             } catch (e) {
-                alert('Error: ' + e);
+                showToast('Error: ' + e, 'error');
             } finally {
                 btn.disabled = false;
                 btn.innerText = originalText;
@@ -357,13 +370,13 @@ class WebServer(port: Int, private val configDir: File = File("/data/adb/clevere
                 const res = await fetch(getAuthUrl(baseUrl + '/fetch_beta'), { method: 'POST' });
                 const text = await res.text();
                 if (res.ok) {
-                    alert(text);
+                    showToast(text, 'success');
                     loadFile(); // Reload editor if viewing var file
                 } else {
-                    alert(text);
+                    showToast(text, 'error');
                 }
             } catch (e) {
-                alert('Error: ' + e);
+                showToast('Error: ' + e, 'error');
             } finally {
                 btn.disabled = false;
                 btn.innerText = originalText;

--- a/service/src/test/java/cleveres/tricky/cleverestech/RkpInterceptorTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/RkpInterceptorTest.kt
@@ -22,9 +22,9 @@ class RkpInterceptorTest {
         Logger.setImpl(object : Logger.LogImpl {
             override fun d(tag: String, msg: String) = println("D/$tag: $msg")
             override fun e(tag: String, msg: String) = println("E/$tag: $msg")
-            override fun e(tag: String, msg: String, t: Throwable) {
+            override fun e(tag: String, msg: String, t: Throwable?) {
                 println("E/$tag: $msg")
-                t.printStackTrace()
+                t?.printStackTrace()
             }
             override fun i(tag: String, msg: String) = println("I/$tag: $msg")
         })

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
@@ -61,5 +61,9 @@ class WebServerHtmlTest {
 
         // Verify reload button ID
         assertTrue("Missing id for reloadBtn", html.contains("id=\"reloadBtn\""))
+
+        // Verify Toast logic exists
+        assertTrue("Missing toast CSS class", html.contains(".toast {"))
+        assertTrue("Missing showToast function", html.contains("function showToast(msg, type)"))
     }
 }


### PR DESCRIPTION
This PR improves the user experience of the WebServer configuration UI by replacing jarring `alert()` dialogs with non-blocking "Toast" notifications for actions like "Save File" and "Fetch Beta".

**UX Improvements:**
-   **Non-blocking feedback:** Users are not interrupted by modal dialogs.
-   **Visual polish:** Toasts use a dark theme consistent with the UI (green for success, red for error).
-   **Accessibility:** Toasts are announced (implicitly via visibility, though `role="alert"` could be a future enhancement, currently using `div`).

**Technical Details:**
-   Added CSS/JS for Toasts in `WebServer.kt`.
-   Fixed build errors in `BetaFetcher.kt` (Logger API mismatch) and `RkpInterceptorTest.kt` (Interface mismatch) which were blocking test execution. These fixes are included to ensure CI passes.
-   Verified with `WebServerHtmlTest` and a custom Playwright script (`verify_frontend.py`).

**Screenshots:**
(Verified locally, see attached screenshot in verification step)

**Testing:**
-   `./gradlew :service:testDebugUnitTest` passed.
-   Frontend interaction verified via Playwright.

---
*PR created automatically by Jules for task [13775879023326448689](https://jules.google.com/task/13775879023326448689) started by @tryigit*