### PR TITLE
🛡️ Sentinel: Fix XXE vulnerability in XMLParser

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/Logger.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Logger.kt
@@ -45,6 +45,11 @@ object Logger {
     }
 
     @JvmStatic
+    fun d(tag: String, msg: String) {
+        impl.d(tag, msg)
+    }
+
+    @JvmStatic
     inline fun d(msg: () -> String) {
         if (isDebugEnabled()) {
             d(msg())
@@ -57,13 +62,28 @@ object Logger {
     }
 
     @JvmStatic
+    fun e(tag: String, msg: String) {
+        impl.e(tag, msg)
+    }
+
+    @JvmStatic
     fun e(msg: String, t: Throwable?) {
         impl.e(TAG, msg, t)
     }
 
     @JvmStatic
+    fun e(tag: String, msg: String, t: Throwable?) {
+        impl.e(tag, msg, t)
+    }
+
+    @JvmStatic
     fun i(msg: String) {
         impl.i(TAG, msg)
+    }
+
+    @JvmStatic
+    fun i(tag: String, msg: String) {
+        impl.i(tag, msg)
     }
 
     @JvmStatic

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/XMLParser.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/XMLParser.java
@@ -37,6 +37,14 @@ public class XMLParser {
         XmlPullParserFactory xmlFactoryObject = XmlPullParserFactory.newInstance();
         XmlPullParser parser = xmlFactoryObject.newPullParser();
         parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, false);
+        try {
+            parser.setFeature(XmlPullParser.FEATURE_PROCESS_DOCDECL, false);
+        } catch (Exception ignored) {
+            // Ignore if feature not supported (though it should be for security)
+        }
+        try {
+            parser.setFeature(XmlPullParser.FEATURE_VALIDATION, false);
+        } catch (Exception ignored) {}
         parser.setInput(reader);
 
         Element currentElement = null;

--- a/service/src/test/java/cleveres/tricky/cleverestech/RkpInterceptorTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/RkpInterceptorTest.kt
@@ -22,9 +22,9 @@ class RkpInterceptorTest {
         Logger.setImpl(object : Logger.LogImpl {
             override fun d(tag: String, msg: String) = println("D/$tag: $msg")
             override fun e(tag: String, msg: String) = println("E/$tag: $msg")
-            override fun e(tag: String, msg: String, t: Throwable) {
+            override fun e(tag: String, msg: String, t: Throwable?) {
                 println("E/$tag: $msg")
-                t.printStackTrace()
+                t?.printStackTrace()
             }
             override fun i(tag: String, msg: String) = println("I/$tag: $msg")
         })

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/XXETest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/XXETest.java
@@ -1,0 +1,39 @@
+package cleveres.tricky.cleverestech.keystore;
+
+import org.junit.Test;
+import java.io.StringReader;
+import static org.junit.Assert.fail;
+import org.xmlpull.v1.XmlPullParserException;
+
+public class XXETest {
+
+    @Test
+    public void testDTDRejected() throws Exception {
+        String xml = "<!DOCTYPE foo [ <!ENTITY x \"Hello\"> ]><root>&x;</root>";
+
+        try {
+            XMLParser parser = new XMLParser(new StringReader(xml));
+
+            // Try to access content. If it succeeds and resolves 'x', it's vulnerable.
+            try {
+                String text = parser.obtainPath("root").get("text");
+                if ("Hello".equals(text)) {
+                     fail("DTD was processed! Vulnerable to XXE.");
+                }
+            } catch (Exception ignored) {}
+
+            // It should fail either at construction or when accessing the unresolved entity.
+            // If it didn't resolve 'x', it will throw XmlPullParserException("unresolved: &x;")
+            // If it rejected DOCTYPE, it will throw XmlPullParserException("docdecl not permitted")
+
+            fail("Should have thrown XmlPullParserException due to DTD declaration or unresolved entity");
+        } catch (XmlPullParserException e) {
+            // Expected
+        } catch (Exception e) {
+             if (e.getCause() instanceof XmlPullParserException) {
+                 return;
+             }
+             throw e;
+        }
+    }
+}


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix XXE Vulnerability in XMLParser

**Vulnerability:**
The `XMLParser` class used `XmlPullParser` without explicitly disabling DTD processing (`FEATURE_PROCESS_DOCDECL`). While KXml2 (Android's default parser) often ignores DTDs by default, relying on defaults is insecure. A malicious `keybox.xml` (if injected) could potentially exploit XXE to read local files or cause Denial of Service.

**Fix:**
- Explicitly set `FEATURE_PROCESS_DOCDECL` and `FEATURE_VALIDATION` to `false` in `XMLParser.java`.
- Wrapped in `try-catch` to ensure compatibility with parsers that might not support these features (though they should).

**Verification:**
- Added `XXETest.java` which attempts to parse an XML with a DOCTYPE declaration. It asserts that the parser throws an exception (either due to disallowed DTD or unresolved entity if DTD was ignored), preventing the attack.
- Fixed unrelated build errors in `Logger.kt` (missing overloads) and `RkpInterceptorTest.kt` (interface mismatch) to ensure the test suite runs correctly.

**Impact:**
Prevents potential XXE attacks, hardening the module against malicious configuration files.

---
*PR created automatically by Jules for task [7074055687317055472](https://jules.google.com/task/7074055687317055472) started by @tryigit*