### PR TITLE
Refactor: Rename TrickyStore to CleveresTricky and standardize paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 **Advanced Keystore and Attestation Spoofing Module for Android**
 
-*Formerly TrickyStore*
-
 **Requires Android 12+**
 
 ## Features
@@ -83,7 +81,7 @@ ro.boot.verifiedbootstate=green
 ro.boot.flash.locked=1
 ```
 
-For Magisk users without Zygisk, remove `/data/adb/modules/cleveres_tricky/zygisk`.
+For Magisk users without Zygisk, remove `/data/adb/modules/cleverestricky/zygisk`.
 
 ### Device Templates
 
@@ -136,13 +134,13 @@ Fetches latest Pixel Beta/Canary fingerprints from Google servers.
 **Manual execution:**
 ```bash
 # Random device
-sh /data/adb/modules/cleveres_tricky/autopif.sh
+sh /data/adb/modules/cleverestricky/autopif.sh
 
 # Specific device
-sh /data/adb/modules/cleveres_tricky/autopif.sh --device husky
+sh /data/adb/modules/cleverestricky/autopif.sh --device husky
 
 # List devices
-sh /data/adb/modules/cleveres_tricky/autopif.sh --list
+sh /data/adb/modules/cleverestricky/autopif.sh --list
 ```
 
 **Background updates (24 hour interval, battery optimized):**
@@ -174,16 +172,14 @@ Special values:
 - `no` disables patching for that component
 - `prop` keeps system prop consistent
 
-**TrickyStore sync:**
+**Security Patch sync:**
 ```bash
 # Enable sync
-sh /data/adb/modules/cleveres_tricky/security_patch.sh --enable
+sh /data/adb/modules/cleverestricky/security_patch.sh --enable
 
 # Disable sync
-sh /data/adb/modules/cleveres_tricky/security_patch.sh --disable
+sh /data/adb/modules/cleverestricky/security_patch.sh --disable
 ```
-
-Supports both standard TrickyStore and James fork formats.
 
 ## Roadmap
 
@@ -199,7 +195,6 @@ Contributions welcome.
 - [BootloaderSpoofer](https://github.com/chiteroman/BootloaderSpoofer)
 - [KeystoreInjection](https://github.com/aviraxp/Zygisk-KeystoreInjection)
 - [LSPosed](https://github.com/LSPosed/LSPosed)
-- TrickyStore
 
 ## Credits
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ val gitCommitCount = "git rev-list HEAD --count".execute().toInt()
 val gitCommitHash = "git rev-parse --verify --short HEAD".execute()
 
 // also the soname
-val moduleId by extra("cleveres_tricky")
+val moduleId by extra("cleverestricky")
 val moduleName by extra("CleveresTricky Beta")
 val author by extra("tryigitx")
 val description by extra("AI Powered trick of keystore. See GitHub for changelog details.")

--- a/module/common/autopif.sh
+++ b/module/common/autopif.sh
@@ -3,7 +3,7 @@
 # Goal: MEETS_STRONG_INTEGRITY
 # Battery-optimized background updates
 
-MODDIR="${MODDIR:-/data/adb/modules/cleveres_tricky}"
+MODDIR="${MODDIR:-/data/adb/modules/cleverestricky}"
 DATADIR="/data/adb/cleverestricky"
 VERSION=$(grep "^version=" "$MODDIR/module.prop" 2>/dev/null | sed 's/version=//g')
 
@@ -185,7 +185,7 @@ EOF
     log "Saved to $output"
 }
 
-# Update security patch for TrickyStore compatibility
+# Update security patch
 update_security_patch() {
     local target="$DATADIR/security_patch.txt"
     

--- a/module/common/security_patch.sh
+++ b/module/common/security_patch.sh
@@ -1,9 +1,9 @@
 #!/system/bin/sh
 # CleveresTricky Security Patch Utility
-# Syncs security patch level with TrickyStore/other modules
+# Syncs security patch level
 
 DATADIR="/data/adb/cleverestricky"
-MODDIR="${MODDIR:-/data/adb/modules/cleveres_tricky}"
+MODDIR="${MODDIR:-/data/adb/modules/cleverestricky}"
 
 # Config flags
 AUTO_FLAG="$DATADIR/auto_security_patch"
@@ -95,47 +95,6 @@ EOF
     log "system.prop written with patch: $patch"
 }
 
-# Sync with TrickyStore if installed
-sync_trickystore() {
-    local ts_mod="/data/adb/modules/tricky_store"
-    
-    if [ ! -d "$ts_mod" ]; then
-        return 0
-    fi
-    
-    log "Syncing with TrickyStore..."
-    
-    # Detect TrickyStore variant
-    local config_file
-    if grep -q "James" "$ts_mod/module.prop" 2>/dev/null; then
-        config_file="/data/adb/tricky_store/devconfig.toml"
-    else
-        config_file="/data/adb/tricky_store/security_patch.txt"
-    fi
-    
-    local patch=$(get_security_patch)
-    local short_patch=$(echo "$patch" | tr -d '-')
-    
-    if [ "$config_file" = "/data/adb/tricky_store/security_patch.txt" ]; then
-        # Standard format
-        mkdir -p "$(dirname "$config_file")"
-        cat > "$config_file" << EOF
-system=$short_patch
-boot=$patch
-vendor=$patch
-EOF
-    elif [ -f "$config_file" ]; then
-        # TOML format (James fork)
-        if grep -q "^securityPatch" "$config_file"; then
-            sed -i "s/^securityPatch.*/securityPatch = \"$patch\"/" "$config_file"
-        else
-            echo "securityPatch = \"$patch\"" >> "$config_file"
-        fi
-    fi
-    
-    log "TrickyStore synced: $patch"
-}
-
 # Main
 main() {
     log "Security Patch Utility"
@@ -162,9 +121,6 @@ main() {
     
     # Write props
     write_system_prop "$SYSTEM_PATCH"
-    
-    # Sync with TrickyStore
-    sync_trickystore
     
     log "Done!"
 }

--- a/module/src/main/cpp/inject/utils.hpp
+++ b/module/src/main/cpp/inject/utils.hpp
@@ -4,7 +4,7 @@
 #include <map>
 #include "lsplt.hpp"
 
-#define LOG_TAG "TrickyStore"
+#define LOG_TAG "CleveresTricky"
 
 #define SYSCALL_IS_ERR(e) (((unsigned long) e) > -4096UL)
 #define SYSCALL_ERR(e) (-(int)(e))

--- a/module/src/main/cpp/logging/include/logging.hpp
+++ b/module/src/main/cpp/logging/include/logging.hpp
@@ -6,7 +6,7 @@
 #include <string>
 
 #ifndef LOG_TAG
-# define LOG_TAG "TrickyStore"
+# define LOG_TAG "CleveresTricky"
 #endif
 
 #ifndef NDEBUG

--- a/module/template/daemon
+++ b/module/template/daemon
@@ -1,3 +1,3 @@
 #!/system/bin/sh
 
-exec /system/bin/app_process -Djava.class.path=./service.apk / --nice-name=TrickyStore cleveres.tricky.cleverestech.MainKt
+exec /system/bin/app_process -Djava.class.path=./service.apk / --nice-name=CleveresTricky cleveres.tricky.cleverestech.MainKt

--- a/module/template/sepolicy.rule
+++ b/module/template/sepolicy.rule
@@ -1,8 +1,8 @@
-# Define a type for the TrickyStore daemon and its executable files
+# Define a type for the CleveresTricky daemon and its executable files
 type tricky_store_daemon;
 type tricky_store_exec, exec_type, file_type, system_file_type;
 
-# Define a type for TrickyStore's data files in /data/adb/tricky_store
+# Define a type for CleveresTricky's data files in /data/adb/cleverestricky
 type tricky_store_data_file, file_type, data_file_type;
 
 # Allow init or zygote to transition the daemon executable to tricky_store_daemon type
@@ -25,8 +25,8 @@ allow tricky_store_daemon keystore_server:process { ptrace };
 allow keystore_server tricky_store_daemon:binder { call transfer };
 allow tricky_store_daemon keystore_server:binder { transfer }; # For replies and C++ calling back to Java interceptors
 
-# Permissions for tricky_store_daemon to read its config files in /data/adb/tricky_store
-# Assumes files in /data/adb/tricky_store are (or can be) labeled tricky_store_data_file.
+# Permissions for tricky_store_daemon to read its config files in /data/adb/cleverestricky
+# Assumes files in /data/adb/cleverestricky are (or can be) labeled tricky_store_data_file.
 # Alternatively, use a broader context like 'adb_data_file' if managed by Magisk that way.
 allow tricky_store_daemon tricky_store_data_file:dir { search read open getattr };
 allow tricky_store_daemon tricky_store_data_file:file { read open getattr };

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -109,7 +109,7 @@ afterEvaluate {
                     commandLine(
                         "adb",
                         "shell",
-                        "su -c 'rm /data/adb/modules/cleveres_tricky/service.apk; mv /data/local/tmp/service.apk /data/adb/modules/cleveres_tricky/'"
+                        "su -c 'rm /data/adb/modules/cleverestricky/service.apk; mv /data/local/tmp/service.apk /data/adb/modules/cleverestricky/'"
                     )
                 }
             }

--- a/service/src/main/java/cleveres/tricky/cleverestech/BetaFetcher.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/BetaFetcher.kt
@@ -52,7 +52,7 @@ object BetaFetcher {
      */
     fun startBackgroundService(intervalHours: Int = 24) {
         if (scheduler != null) {
-            Logger.d(TAG, "Background service already running")
+            Logger.d("[$TAG] Background service already running")
             return
         }
         
@@ -72,11 +72,11 @@ object BetaFetcher {
                     fetchAndApply(null)
                 }
             } catch (e: Exception) {
-                Logger.e(TAG, "Background fetch failed", e)
+                Logger.e("[$TAG] Background fetch failed", e)
             }
         }, safeInterval, safeInterval, TimeUnit.HOURS)
         
-        Logger.i(TAG, "Background service started, interval: ${safeInterval}h")
+        Logger.i("[$TAG] Background service started, interval: ${safeInterval}h")
     }
     
     /**
@@ -85,7 +85,7 @@ object BetaFetcher {
     fun stopBackgroundService() {
         scheduler?.shutdown()
         scheduler = null
-        Logger.i(TAG, "Background service stopped")
+        Logger.i("[$TAG] Background service stopped")
     }
     
     /**
@@ -101,7 +101,7 @@ object BetaFetcher {
      * @param preferredDevice Optional device to prefer (e.g., "husky" for Pixel 8 Pro)
      */
     fun fetchAndApply(preferredDevice: String?): FetchResult {
-        Logger.i(TAG, "Fetching latest Pixel Beta profile...")
+        Logger.i("[$TAG] Fetching latest Pixel Beta profile...")
         
         try {
             // 1. Get available devices
@@ -125,12 +125,12 @@ object BetaFetcher {
             applyProfile(profile)
             
             lastFetchTime = System.currentTimeMillis()
-            Logger.i(TAG, "Applied profile: ${profile.model} (${profile.fingerprint})")
+            Logger.i("[$TAG] Applied profile: ${profile.model} (${profile.fingerprint})")
             
             return FetchResult(true, profile = profile, availableDevices = devices)
             
         } catch (e: Exception) {
-            Logger.e(TAG, "Fetch failed", e)
+            Logger.e("[$TAG] Fetch failed", e)
             return FetchResult(false, error = e.message)
         }
     }
@@ -166,7 +166,7 @@ object BetaFetcher {
                     )
                 }
         } catch (e: Exception) {
-            Logger.e(TAG, "Failed to fetch device list", e)
+            Logger.e("[$TAG] Failed to fetch device list", e)
             return emptyList()
         }
     }
@@ -226,7 +226,7 @@ object BetaFetcher {
                 incremental = incrementalMatch
             )
         } catch (e: Exception) {
-            Logger.e(TAG, "Failed to fetch profile for $product", e)
+            Logger.e("[$TAG] Failed to fetch profile for $product", e)
             return null
         }
     }
@@ -275,7 +275,7 @@ $userOverrides
         """.trimIndent()
         
         varsFile.writeText(content)
-        Logger.i(TAG, "Profile applied to ${varsFile.absolutePath}")
+        Logger.i("[$TAG] Profile applied to ${varsFile.absolutePath}")
     }
     
     /**

--- a/service/src/main/java/cleveres/tricky/cleverestech/Logger.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Logger.kt
@@ -3,7 +3,7 @@ package cleveres.tricky.cleverestech
 import android.util.Log
 
 object Logger {
-    const val TAG = "TrickyStore"
+    const val TAG = "CleveresTricky"
 
     interface LogImpl {
         fun d(tag: String, msg: String)

--- a/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
@@ -6,7 +6,7 @@ import java.security.MessageDigest
 import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {
-    Logger.i("Welcome to TrickyStore!")
+    Logger.i("Welcome to CleveresTricky!")
     Verification.check()
 
     // Start Web Server

--- a/service/src/main/java/cleveres/tricky/cleverestech/Verification.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Verification.kt
@@ -5,7 +5,7 @@ import java.security.MessageDigest
 import kotlin.system.exitProcess
 
 object Verification {
-    private const val MODULE_PATH = "/data/adb/modules/cleveres_tricky"
+    private const val MODULE_PATH = "/data/adb/modules/cleverestricky"
     private val IGNORED_FILES = setOf("disable", "remove", "update", "system.prop", "sepolicy.rule")
 
     var exitProcessImpl: (Int) -> Unit = { exitProcess(it) }

--- a/service/src/test/java/cleveres/tricky/cleverestech/RkpInterceptorTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/RkpInterceptorTest.kt
@@ -22,9 +22,9 @@ class RkpInterceptorTest {
         Logger.setImpl(object : Logger.LogImpl {
             override fun d(tag: String, msg: String) = println("D/$tag: $msg")
             override fun e(tag: String, msg: String) = println("E/$tag: $msg")
-            override fun e(tag: String, msg: String, t: Throwable) {
+            override fun e(tag: String, msg: String, t: Throwable?) {
                 println("E/$tag: $msg")
-                t.printStackTrace()
+                t?.printStackTrace()
             }
             override fun i(tag: String, msg: String) = println("I/$tag: $msg")
         })


### PR DESCRIPTION
This PR addresses the user's request to completely sever ties with the "TrickyStore" repository and standardize the module branding and paths to "CleveresTricky".

Key changes:
1.  **Path Standardization:** The module installation path is now consistently `/data/adb/modules/cleverestricky` (previously mixed with `cleveres_tricky`). The Gradle `moduleId` has been updated to `cleverestricky`.
2.  **Branding Updates:**
    *   `README.md`: Removed "Formerly TrickyStore" and sync instructions.
    *   `Logger.kt`: `TAG` changed from `TrickyStore` to `CleveresTricky`.
    *   `Main.kt`: Welcome message updated.
    *   Native code headers: `LOG_TAG` updated.
    *   Scripts: Comments and output messages updated.
3.  **Functionality Removal:** Removed the `sync_trickystore` logic from `security_patch.sh` as requested.
4.  **Bug Fixes:**
    *   Fixed a compilation error in `BetaFetcher.kt` where `Logger.d/i/e` were called with 2 arguments (tag + msg) instead of 1 (msg). The tag is now prepended to the message.
    *   Fixed a compilation error in `RkpInterceptorTest.kt` where the `Logger.LogImpl` override for `e` did not handle nullable `Throwable?`, causing a signature mismatch.

Verified by running `testDebugUnitTest` which now passes successfully. The build scripts now reference the correct paths for `adb push` and module operations.

---
*PR created automatically by Jules for task [13981905231959016602](https://jules.google.com/task/13981905231959016602) started by @tryigit*