### PR TITLE
fix(build): Resolve CborEncoder compilation errors (missing import & method name)

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -42,6 +42,7 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.util.io.pem.PemReader;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
@@ -62,6 +63,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/CborEncoder.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/CborEncoder.java
@@ -35,7 +35,7 @@ public class CborEncoder {
 
     public static void encodeItem(ByteArrayOutputStream os, Object value) throws IOException {
         if (value == null) {
-            writeTypeAndArgument(os, MT_SIMPLE, 22); // null
+            encodeTypeAndLength(os, MT_SIMPLE, 22); // null
         } else if (value instanceof Integer) {
             encodeInteger(os, (Integer) value);
         } else if (value instanceof Long) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/RkpInterceptorTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/RkpInterceptorTest.kt
@@ -38,7 +38,7 @@ class RkpInterceptorTest {
         keyPairGen.initialize(ECGenParameterSpec("secp256r1"))
         val keyPair = keyPairGen.generateKeyPair()
         
-        val macedKey = CertHack.generateMacedPublicKey(keyPair)
+        val macedKey = CertHack.generateMacedPublicKey(keyPair, ByteArray(32))
         
         assertNotNull("macedKey should not be null", macedKey)
         assertTrue("macedKey should have content", macedKey!!.isNotEmpty())
@@ -56,7 +56,7 @@ class RkpInterceptorTest {
         val keys = mutableListOf<ByteArray>()
         repeat(5) {
             val keyPair = keyPairGen.generateKeyPair()
-            val macedKey = CertHack.generateMacedPublicKey(keyPair)
+            val macedKey = CertHack.generateMacedPublicKey(keyPair, ByteArray(32))
             assertNotNull(macedKey)
             keys.add(macedKey!!)
         }
@@ -76,7 +76,7 @@ class RkpInterceptorTest {
         keyPairGen.initialize(ECGenParameterSpec("secp256r1"))
         val keyPair = keyPairGen.generateKeyPair()
         
-        val macedKey = CertHack.generateMacedPublicKey(keyPair)
+        val macedKey = CertHack.generateMacedPublicKey(keyPair, ByteArray(32))
         assertNotNull(macedKey)
         
         val publicKeys = listOf(macedKey!!)
@@ -102,7 +102,7 @@ class RkpInterceptorTest {
         val publicKeys = mutableListOf<ByteArray>()
         repeat(3) {
             val keyPair = keyPairGen.generateKeyPair()
-            val macedKey = CertHack.generateMacedPublicKey(keyPair)
+            val macedKey = CertHack.generateMacedPublicKey(keyPair, ByteArray(32))
             assertNotNull(macedKey)
             publicKeys.add(macedKey!!)
         }
@@ -124,7 +124,7 @@ class RkpInterceptorTest {
         keyPairGen.initialize(ECGenParameterSpec("secp256r1"))
         val keyPair = keyPairGen.generateKeyPair()
         
-        val macedKey = CertHack.generateMacedPublicKey(keyPair)
+        val macedKey = CertHack.generateMacedPublicKey(keyPair, ByteArray(32))
         val deviceInfo = CertHack.createDeviceInfoCbor("google", "Google", "generic", "Pixel", "generic")
         
         // empty challenge should still work
@@ -205,7 +205,7 @@ class RkpInterceptorTest {
         keyPairGen.initialize(ECGenParameterSpec("secp256r1"))
         val keyPair = keyPairGen.generateKeyPair()
         
-        val macedKey = CertHack.generateMacedPublicKey(keyPair)
+        val macedKey = CertHack.generateMacedPublicKey(keyPair, ByteArray(32))
         val deviceInfo = CertHack.createDeviceInfoCbor("google", "Google", "generic", "Pixel", "generic")
         
         // large challenge (1KB)
@@ -250,7 +250,7 @@ class RkpInterceptorTest {
         
         repeat(10) {
             val keyPair = keyPairGen.generateKeyPair()
-            CertHack.generateMacedPublicKey(keyPair)
+            CertHack.generateMacedPublicKey(keyPair, ByteArray(32))
         }
         
         val elapsed = System.currentTimeMillis() - startTime


### PR DESCRIPTION
Resolved compilation errors in `CborEncoder.java` and `CertHack.java` that were causing build failures. 

Specific fixes:
1.  **`CborEncoder.java`**: Replaced `writeTypeAndArgument(os, MT_SIMPLE, 22)` with `encodeTypeAndLength(os, MT_SIMPLE, 22)` as the former method was undefined and the latter is the correct internal method for encoding type and length (used for null value 22).
2.  **`CertHack.java`**: Added missing imports `java.io.ByteArrayOutputStream` and `java.util.LinkedHashMap`.
3.  **`RkpInterceptorTest.kt`**: Updated calls to `CertHack.generateMacedPublicKey` to include the required second argument (`byte[] hmacKey`), using a dummy 32-byte array for testing purposes. This fixes the test compilation errors exposed after fixing the main source build.

Verified that the `service` module compiles and unit tests compile successfully.

---
*PR created automatically by Jules for task [6734345011149824656](https://jules.google.com/task/6734345011149824656) started by @tryigit*