### PR TITLE
fix(test): Resolve RkpInterceptorTest failure due to DeviceInfo size change

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/RkpInterceptorTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/RkpInterceptorTest.kt
@@ -149,7 +149,7 @@ class RkpInterceptorTest {
         
         assertNotNull("deviceInfo should not be null", deviceInfo)
         assertTrue("deviceInfo should have content", deviceInfo!!.isNotEmpty())
-        assertEquals("should start with CBOR map header", 0xAA.toByte(), deviceInfo[0])
+        assertEquals("should start with CBOR map header", 0xAB.toByte(), deviceInfo[0])
         
         // check that it contains expected values
         val content = String(deviceInfo, Charsets.UTF_8)


### PR DESCRIPTION
Resolved a build failure in `service:testDebugUnitTest` where `RkpInterceptorTest.testDeviceInfoCborGeneration` was failing with an assertion error.

The test was asserting that the generated CBOR `DeviceInfo` map started with `0xAA` (indicating a map of 10 elements). However, the implementation of `CertHack.createDeviceInfoCbor` now constructs a map with 11 elements (including `security_level` and `fused`), resulting in a header of `0xAB`.

Updated the test expectation to match the current implementation. Validated the fix by running `./gradlew :service:testDebugUnitTest`.

---
*PR created automatically by Jules for task [12160077836241092498](https://jules.google.com/task/12160077836241092498) started by @tryigit*