### PR TITLE
🎨 Palette: Enhance WebServer accessibility and toggle feedback

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
@@ -56,6 +56,9 @@ class WebServerHtmlTest {
         assertTrue("Missing aria-label for fileSelector", html.contains("aria-label=\"Select configuration file\""))
         assertTrue("Missing aria-label for editor", html.contains("aria-label=\"Configuration editor\""))
 
+        // Verify aria-live
+        assertTrue("Missing aria-live for keyboxStatus", html.contains("id=\"keyboxStatus\" aria-live=\"polite\""))
+
         // Verify save button ID
         assertTrue("Missing id for saveBtn", html.contains("id=\"saveBtn\""))
 
@@ -65,5 +68,9 @@ class WebServerHtmlTest {
         // Verify Toast logic exists
         assertTrue("Missing toast CSS class", html.contains(".toast {"))
         assertTrue("Missing showToast function", html.contains("function showToast(msg, type)"))
+
+        // Verify toggle logic
+        assertTrue("Missing disabled logic in toggle", html.contains("el.disabled = true;"))
+        assertTrue("Missing showToast logic in toggle", html.contains("showToast('Setting updated', 'success');"))
     }
 }


### PR DESCRIPTION
Implemented micro-UX improvements in the embedded WebServer:
- Added `aria-live="polite"` to the keybox status element to ensure screen readers announce status changes.
- Refactored the `toggle()` JavaScript function to provide immediate visual feedback (disabling the checkbox and reducing opacity) during network requests.
- Added toast notifications for success and failure states in the toggle action.
- Implemented state reversion logic to uncheck/check the box if the server request fails, preventing "lying UI".
- Updated `WebServerHtmlTest` to verify the presence of these new accessibility attributes and logic.

---
*PR created automatically by Jules for task [11817690437137883214](https://jules.google.com/task/11817690437137883214) started by @tryigit*