### PR TITLE
Fix CBOR integer key sorting in CborEncoder

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/CborEncoder.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/CborEncoder.java
@@ -66,7 +66,22 @@ public class CborEncoder {
                 Object k2 = e2.getKey();
                 // Compare Integers
                 if (k1 instanceof Integer && k2 instanceof Integer) {
-                    return Integer.compare((Integer) k1, (Integer) k2);
+                    int i1 = (Integer) k1;
+                    int i2 = (Integer) k2;
+                    // Check Major Types: Positive (MT0) < Negative (MT1)
+                    if (i1 >= 0 && i2 < 0) return -1;
+                    if (i1 < 0 && i2 >= 0) return 1;
+
+                    // Same Major Type
+                    if (i1 >= 0) {
+                        // Both positive: 1 < 2
+                        return Integer.compare(i1, i2);
+                    } else {
+                        // Both negative: -1 (0) < -2 (1).
+                        // Java compare(-1, -2) is 1. We want -1.
+                        // So reverse comparison.
+                        return Integer.compare(i2, i1);
+                    }
                 }
                 // Compare Strings
                 if (k1 instanceof String && k2 instanceof String) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/CborEncoderTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/CborEncoderTest.java
@@ -1,0 +1,55 @@
+package cleveres.tricky.cleverestech.util;
+
+import org.junit.Test;
+import java.util.HashMap;
+import java.util.Map;
+import static org.junit.Assert.assertArrayEquals;
+
+public class CborEncoderTest {
+
+    private String bytesToHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : bytes) {
+            sb.append(String.format("%02X", b));
+        }
+        return sb.toString();
+    }
+
+    @Test
+    public void testMapSortingOrder() {
+        // Map { 1: "a", -1: "b" }
+        // CBOR:
+        // 1 (unsigned) -> 0x01
+        // -1 (negative) -> 0x20
+        // Expected order: 1 (Major Type 0) comes before -1 (Major Type 1)
+
+        Map<Integer, String> map = new HashMap<>();
+        map.put(1, "a");
+        map.put(-1, "b");
+
+        byte[] encoded = CborEncoder.encode(map);
+
+        // Expected:
+        // A2       (Map, size 2)
+        // 01       (Key: 1)
+        // 61 61    (Val: "a")
+        // 20       (Key: -1)
+        // 61 62    (Val: "b")
+        byte[] expected = new byte[] {
+            (byte)0xA2,
+            (byte)0x01, (byte)0x61, (byte)0x61,
+            (byte)0x20, (byte)0x61, (byte)0x62
+        };
+
+        // If bug exists (Integer.compare used):
+        // -1 comes before 1
+        // A2
+        // 20       (Key: -1)
+        // 61 62    (Val: "b")
+        // 01       (Key: 1)
+        // 61 61    (Val: "a")
+
+        System.out.println("Encoded: " + bytesToHex(encoded));
+        assertArrayEquals("CBOR Map sorting is incorrect!", expected, encoded);
+    }
+}


### PR DESCRIPTION
Fixed a bug in `CborEncoder` where mixed positive and negative integer keys in a map were sorted incorrectly, violating CBOR Canonicalization rules (RFC 7049/8949). The fix implements a custom comparator that respects Major Type ordering (Positive < Negative) and encoded value ordering. Added a regression test `CborEncoderTest` covering this case.

---
*PR created automatically by Jules for task [5937489815072506950](https://jules.google.com/task/5937489815072506950) started by @tryigit*