### PR TITLE
⚡ Bolt: Use package cache in getPatchLevel to reduce IPC calls

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -375,7 +375,8 @@ object Config {
     fun getPatchLevel(callingUid: Int): Int {
         val defaultLevel = patchLevel
         val patchStr = if (securityPatch.isNotEmpty()) {
-            val pkgName = getPm()?.getPackagesForUid(callingUid)?.firstOrNull()
+            // Use cached getPackages to avoid expensive IPC call
+            val pkgName = getPackages(callingUid).firstOrNull()
             if (pkgName != null) {
                 securityPatch[pkgName] ?: defaultSecurityPatch
             } else {

--- a/service/src/test/java/cleveres/tricky/cleverestech/ConfigPatchLevelTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ConfigPatchLevelTest.kt
@@ -1,0 +1,46 @@
+package cleveres.tricky.cleverestech
+
+import android.content.pm.IPackageManager
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.lang.reflect.Field
+
+class ConfigPatchLevelTest {
+
+    @Test
+    fun testGetPatchLevel_usesPackageName() {
+        // 1. Mock IPackageManager
+        val mockPm = object : IPackageManager {
+             override fun getPackagesForUid(uid: Int): Array<String> {
+                 if (uid == 1001) return arrayOf("com.example.patched")
+                 return emptyArray()
+             }
+        }
+
+        // 2. Inject Mock PM into Config
+        val iPmField = Config::class.java.getDeclaredField("iPm")
+        iPmField.isAccessible = true
+        val originalPm = iPmField.get(Config)
+        iPmField.set(Config, mockPm)
+
+        // 3. Inject Security Patch Map
+        val securityPatchField = Config::class.java.getDeclaredField("securityPatch")
+        securityPatchField.isAccessible = true
+        val originalSecurityPatch = securityPatchField.get(Config)
+
+        val testPatchMap = mapOf("com.example.patched" to "2023-12-05")
+        securityPatchField.set(Config, testPatchMap)
+
+        try {
+            // 4. Verify Patch Level
+            // 2023-12-05 -> 202312
+            val level = Config.getPatchLevel(1001)
+            assertEquals(202312, level)
+
+        } finally {
+            // Restore
+            iPmField.set(Config, originalPm)
+            securityPatchField.set(Config, originalSecurityPatch)
+        }
+    }
+}


### PR DESCRIPTION
**Optimization**
Replaced direct `IPackageManager.getPackagesForUid` call in `Config.getPatchLevel` with `Config.getPackages`, which uses an internal `SynchronizedMap` (LRU cache) to store package names for UIDs.

**Performance Impact**
Reduces IPC calls to `system_server` when querying security patch levels for apps, which is frequently done during key generation and attestation.

**Verification**
Added `ConfigPatchLevelTest` to verify that `getPatchLevel` correctly resolves the package name and patch level using a mocked `IPackageManager`.
Ran all unit tests in `:service` module.

---
*PR created automatically by Jules for task [7807105614303291831](https://jules.google.com/task/7807105614303291831) started by @tryigit*