### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unsecured keybox upload permissions

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerSecurityTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerSecurityTest.kt
@@ -1,0 +1,98 @@
+package cleveres.tricky.cleverestech
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import java.nio.charset.StandardCharsets
+
+class WebServerSecurityTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var server: WebServer
+    private lateinit var configDir: File
+
+    // Tracking for permission calls
+    data class PermissionCall(val path: String, val mode: Int)
+    private val permissionCalls = mutableListOf<PermissionCall>()
+
+    @Before
+    fun setUp() {
+        Logger.setImpl(object : Logger.LogImpl {
+            override fun d(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String, t: Throwable?) { t?.printStackTrace() }
+            override fun i(tag: String, msg: String) {}
+        })
+        configDir = tempFolder.newFolder("config")
+        permissionCalls.clear()
+
+        // Inject mock permission setter
+        server = WebServer(0, configDir) { file, mode ->
+            permissionCalls.add(PermissionCall(file.absolutePath, mode))
+        }
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.stop()
+    }
+
+    @Test
+    fun testUploadKeyboxPermissions() {
+        val port = server.listeningPort
+        val token = server.token
+        val url = URL("http://localhost:$port/api/upload_keybox?token=$token")
+
+        val filename = "test_keybox.xml"
+        val content = "<xml>test</xml>"
+
+        // Ensure keyboxes dir does not exist to test mkdirs permission setting
+        val keyboxDir = File(configDir, "keyboxes")
+        if (keyboxDir.exists()) keyboxDir.deleteRecursively()
+
+        val postData = "filename=$filename&content=$content"
+        val postDataBytes = postData.toByteArray(StandardCharsets.UTF_8)
+
+        val conn = url.openConnection() as HttpURLConnection
+        conn.requestMethod = "POST"
+        conn.doOutput = true
+        conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
+        conn.outputStream.write(postDataBytes)
+        conn.outputStream.close()
+
+        val responseCode = conn.responseCode
+        assertEquals(200, responseCode)
+
+        val uploadedFile = File(configDir, "keyboxes/$filename")
+        assertTrue(uploadedFile.exists())
+
+        // Verify permissions calls
+        // 1. Directory creation (if missing) -> 0700 (448)
+        var foundDirChmod = false
+        for (call in permissionCalls) {
+            if (call.path == keyboxDir.absolutePath && call.mode == 448) {
+                foundDirChmod = true
+            }
+        }
+        assertTrue("chmod 0700 should be called on the keyboxes directory", foundDirChmod)
+
+        // 2. File creation -> 0600 (384)
+        var foundFileChmod = false
+        for (call in permissionCalls) {
+            if (call.path == uploadedFile.absolutePath && call.mode == 384) {
+                foundFileChmod = true
+            }
+        }
+        assertTrue("chmod 0600 should be called on the uploaded file", foundFileChmod)
+    }
+}


### PR DESCRIPTION
**Vulnerability Fix:** The `upload_keybox` endpoint previously created the `keyboxes` directory and the uploaded file without explicitly restricting permissions. This could allow other applications on the device to read the private keys if the default umask was permissive.

**Resolution:**
1.  Refactored `WebServer` to accept a `permissionSetter` lambda in the constructor. This allows injecting a mock for testing and defaults to `android.system.Os.chmod` for production.
2.  Updated `upload_keybox` to explicitly call `permissionSetter` with `0700` (rwx------) for the directory and `0600` (rw-------) for the file immediately after creation.
3.  Added `WebServerSecurityTest` to verify the fix by capturing permission setter calls.

**Impact:** Prevents potential leakage of private keys to other apps.
**Testing:** Added new unit test `WebServerSecurityTest` which passes. Existing tests passed.
**Verification:** Code review confirmed the logic addresses the vulnerability and improves testability.

---
*PR created automatically by Jules for task [8876200777529395358](https://jules.google.com/task/8876200777529395358) started by @tryigit*