### PR TITLE
Add Telegram community stats to WebUI

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/CommunityStatsTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/CommunityStatsTest.kt
@@ -1,0 +1,42 @@
+package cleveres.tricky.cleverestech
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.regex.Pattern
+
+class CommunityStatsTest {
+
+    @Test
+    fun testParseMemberCount() {
+        val html = """
+            <div class="tgme_page_extra">10 026 members, 750 online</div>
+        """.trimIndent()
+
+        val regex = Pattern.compile("tgme_page_extra\">([0-9 ]+) members")
+        val matcher = regex.matcher(html)
+
+        var count = "Unknown"
+        if (matcher.find()) {
+            count = matcher.group(1)?.trim() ?: "Unknown"
+        }
+
+        assertEquals("10 026", count)
+    }
+
+    @Test
+    fun testParseMemberCountNoMatch() {
+        val html = """
+            <div class="something_else">No members here</div>
+        """.trimIndent()
+
+        val regex = Pattern.compile("tgme_page_extra\">([0-9 ]+) members")
+        val matcher = regex.matcher(html)
+
+        var count = "Unknown"
+        if (matcher.find()) {
+            count = matcher.group(1)?.trim() ?: "Unknown"
+        }
+
+        assertEquals("Unknown", count)
+    }
+}


### PR DESCRIPTION
Implemented a mechanism to fetch and display the Telegram community member count in the WebUI.
This involves a backend scraper in `WebServer.kt` that hits the public `t.me/cleverestech` page and parses the member count, exposing it via a new `/api/stats` endpoint.
The WebUI now includes a "COMMUNITY POWERED" section that fetches this data on load.
Added `CommunityStatsTest` to verify the parsing logic.

---
*PR created automatically by Jules for task [16824092490354160776](https://jules.google.com/task/16824092490354160776) started by @tryigit*