### PR TITLE
🎨 Palette: Add loading states to action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-22 - Installation Script UX
 **Learning:** For root tools/modules without a GUI, the installation script (`customize.sh`) is the primary user interface. Improving messages there provides high value.
 **Action:** Always verify `ui_print` messages in installation scripts to ensure they are helpful and indicate where configuration files are located.
+
+## 2024-05-23 - Async Feedback in Embedded WebUI
+**Learning:** Embedded WebUIs often lack native browser feedback. Users may double-submit actions if buttons don't immediately react.
+**Action:** Implement a reusable 'runWithState' pattern in JS to immediately disable buttons and show loading state during async operations.

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -355,7 +355,7 @@ class WebServer(
             <div class="row"><label for="auto_keybox_check">Auto Keybox Check</label><input type="checkbox" id="auto_keybox_check" onchange="toggle('auto_keybox_check')"></div>
             <div class="row" style="margin-top:20px;">
                 <div id="keyboxStatus" aria-live="polite">Loading keys...</div>
-                <button onclick="reloadConfig()" id="reloadBtn">RELOAD CONFIG</button>
+                <button onclick="runWithState(this, 'RELOADING...', reloadConfig)" id="reloadBtn">RELOAD CONFIG</button>
             </div>
         </div>
     </div>
@@ -375,13 +375,13 @@ class WebServer(
             </div>
 
             <div class="row" style="margin-top:15px;">
-                <button onclick="applyTemplateToGlobal()">APPLY GLOBALLY</button>
+                <button onclick="runWithState(this, 'APPLYING...', applyTemplateToGlobal)">APPLY GLOBALLY</button>
                 <button class="primary" onclick="switchTab('apps')">USE IN APP CONFIG</button>
             </div>
         </div>
         <div class="panel">
             <h3>BETA FETCHER</h3>
-            <button onclick="fetchBetaNow()">FETCH LATEST PIXEL BETA</button>
+            <button onclick="runWithState(this, 'FETCHING...', fetchBetaNow)">FETCH LATEST PIXEL BETA</button>
         </div>
     </div>
 
@@ -414,7 +414,7 @@ class WebServer(
                 <tbody></tbody>
             </table>
             <div class="row" style="margin-top:15px; justify-content:flex-end;">
-                <button onclick="saveAppConfig()" class="primary">SAVE CHANGES</button>
+                <button onclick="runWithState(this, 'SAVING...', saveAppConfig)" class="primary">SAVE CHANGES</button>
             </div>
         </div>
     </div>
@@ -425,12 +425,12 @@ class WebServer(
             <h3>UPLOAD KEYBOX</h3>
             <input type="text" id="kbFilename" placeholder="filename.xml" aria-label="Keybox Filename">
             <textarea id="kbContent" placeholder="Paste XML content..." style="height:100px; margin-top:10px;" aria-label="Keybox Content"></textarea>
-            <button onclick="uploadKeybox()" style="width:100%; margin-top:10px;">UPLOAD</button>
+            <button onclick="runWithState(this, 'UPLOADING...', uploadKeybox)" style="width:100%; margin-top:10px;">UPLOAD</button>
         </div>
         <div class="panel">
             <div class="row">
                 <h3>VERIFICATION</h3>
-                <button onclick="verifyKeyboxes()">RUN CHECK</button>
+                <button onclick="runWithState(this, 'CHECKING...', verifyKeyboxes)">RUN CHECK</button>
             </div>
             <div id="verifyResult"></div>
         </div>
@@ -447,7 +447,7 @@ class WebServer(
                 <option value="templates.json">templates.json</option>
             </select>
             <textarea id="fileEditor" style="height:400px; margin-top:10px;" aria-label="Configuration editor"></textarea>
-            <button onclick="saveFile()" style="width:100%; margin-top:10px;" id="saveBtn">SAVE FILE</button>
+            <button onclick="runWithState(this, 'SAVING...', saveFile)" style="width:100%; margin-top:10px;" id="saveBtn">SAVE FILE</button>
         </div>
     </div>
 
@@ -464,6 +464,14 @@ class WebServer(
             t.innerText = msg;
             t.classList.add('show');
             setTimeout(() => t.classList.remove('show'), 3000);
+        }
+
+        async function runWithState(btn, text, task) {
+             const orig = btn.innerText;
+             btn.disabled = true;
+             btn.innerText = text;
+             try { await task(); }
+             finally { btn.disabled = false; btn.innerText = orig; }
         }
 
         function switchTab(id) {


### PR DESCRIPTION
This PR improves the UX of the embedded WebUI by adding immediate visual feedback to action buttons. Previously, buttons like "Fetch Beta" or "Save Config" provided no immediate feedback until the operation completed (via toast), which could lead to user confusion or double-clicking.

Changes:
- Implemented `runWithState(btn, text, task)` in the embedded JavaScript.
- Refactored `onclick` handlers to use this helper.
- Ensures buttons are disabled and show a processing state (e.g., "FETCHING...") while the async task runs.
- Restores button state automatically using `try/finally` blocks.

---
*PR created automatically by Jules for task [3567011668279021741](https://jules.google.com/task/3567011668279021741) started by @tryigit*