### PR TITLE
⚡ Bolt: Optimize CertHack certificate processing

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -293,11 +293,19 @@ public final class CertHack {
                  }
             }
 
-            X509Certificate leaf = (X509Certificate) certificateFactory.generateCertificate(new ByteArrayInputStream(leafEncoded));
+            // Optimization: Avoid redundant parsing if already X509Certificate
+            X509Certificate leaf;
+            if (caList[0] instanceof X509Certificate) {
+                leaf = (X509Certificate) caList[0];
+            } else {
+                leaf = (X509Certificate) certificateFactory.generateCertificate(new ByteArrayInputStream(leafEncoded));
+            }
+
             byte[] bytes = leaf.getExtensionValue(OID.getId());
             if (bytes == null) return caList;
 
-            X509CertificateHolder leafHolder = new X509CertificateHolder(leaf.getEncoded());
+            // Optimization: Use original encoded bytes to avoid copy/re-encoding
+            X509CertificateHolder leafHolder = new X509CertificateHolder(leafEncoded);
             Extension ext = leafHolder.getExtension(OID);
             ASN1Sequence sequence = ASN1Sequence.getInstance(ext.getExtnValue().getOctets());
             ASN1Encodable[] encodables = sequence.toArray();


### PR DESCRIPTION
⚡ Bolt: Optimize CertHack certificate processing

💡 **What:**
- Added a check to cast `caList[0]` to `X509Certificate` instead of re-parsing it from bytes, if possible.
- Replaced `leaf.getEncoded()` with the original `leafEncoded` byte array when creating `X509CertificateHolder`.

🎯 **Why:**
- `CertificateFactory.generateCertificate` involves expensive ASN.1 parsing.
- `getEncoded()` can involve re-serializing the certificate structure or copying the internal byte array.
- This path is hit for every certificate chain hack (key attestation), so optimizing it reduces latency and memory pressure.

📊 **Impact:**
- Reduces object allocations (no new `X509Certificate` if cast succeeds).
- Reduces CPU cycles spent on ASN.1 parsing.

 microscope **Measurement:**
- Validated with `CertHackOrderTest` which exercises `hackCertificateChain`.
- Verified no regressions with full `./gradlew :service:test` suite.

---
*PR created automatically by Jules for task [9636824282389252391](https://jules.google.com/task/9636824282389252391) started by @tryigit*