### PR TITLE
Fix KeyboxVerifier ignoring hex serial numbers in CRL

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -79,7 +79,12 @@ object KeyboxVerifier {
                     val hexStr = java.math.BigInteger(decStr).toString(16).lowercase()
                     set.add(hexStr)
                 } catch (e: Exception) {
-                    Logger.e("Failed to parse CRL entry key: $decStr")
+                    // It might be a hex string already (e.g. c3574...)
+                    if (decStr.matches(Regex("^[0-9a-fA-F]+$"))) {
+                        set.add(decStr.lowercase())
+                    } else {
+                        Logger.e("Failed to parse CRL entry key: $decStr")
+                    }
                 }
             }
             set

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierTest.kt
@@ -30,4 +30,28 @@ class KeyboxVerifierTest {
         assertTrue("Should contain 5cb838f1fe157a85 but got $revoked", revoked.contains("5cb838f1fe157a85"))
         assertTrue("Should contain 3039 but got $revoked", revoked.contains("3039"))
     }
+
+    @Test
+    fun testParseCrl_WithHexStrings() {
+        // CRL containing both Decimal and Hex keys
+        // "6681152659205225093" -> 5cb838f1fe157a85 (Decimal)
+        // "c35747a084470c3135aeefe2b8d40cd6" -> (Hex)
+        val json = """
+        {
+          "entries": {
+            "6681152659205225093" : {
+              "status": "REVOKED"
+            },
+            "c35747a084470c3135aeefe2b8d40cd6" : {
+              "status": "REVOKED"
+            }
+          }
+        }
+        """.trimIndent()
+
+        val revoked = KeyboxVerifier.parseCrl(json)
+
+        assertTrue("Should contain decimal-converted key", revoked.contains("5cb838f1fe157a85"))
+        assertTrue("Should contain hex key", revoked.contains("c35747a084470c3135aeefe2b8d40cd6"))
+    }
 }


### PR DESCRIPTION
The `KeyboxVerifier` failed to parse revocation entries from Google's CRL when the serial numbers were represented as hexadecimal strings in the JSON keys. The existing code strictly attempted to parse keys as decimal integers using `BigInteger`, which threw `NumberFormatException` for hex strings (e.g., "c3..."), causing them to be silently ignored.

This change introduces a fallback mechanism in `parseCrl`. If decimal parsing fails, the code now checks if the string is a valid hexadecimal string (using a regex). If valid, it is normalized to lowercase and added to the set of revoked serials. This ensures that the verifier correctly identifies all revoked certificates, regardless of the serial number format used in the CRL.

A regression test case `testParseCrl_WithHexStrings` has been added to `KeyboxVerifierTest.kt` to verify that both decimal and hexadecimal keys are parsed correctly.

---
*PR created automatically by Jules for task [449887887373433786](https://jules.google.com/task/449887887373433786) started by @tryigit*