### PR TITLE
UX: Add empty state to App Config table

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -614,6 +614,21 @@ class WebServer(
         function renderAppTable() {
             const tbody = document.querySelector('#appTable tbody');
             tbody.innerHTML = '';
+
+            if (appRules.length === 0) {
+                const tr = document.createElement('tr');
+                const td = document.createElement('td');
+                td.colSpan = 4;
+                td.style.textAlign = 'center';
+                td.style.padding = '20px';
+                td.style.color = '#888';
+                td.style.fontStyle = 'italic';
+                td.innerText = 'No active rules. Add a package above.';
+                tr.appendChild(td);
+                tbody.appendChild(tr);
+                return;
+            }
+
             appRules.forEach((rule, idx) => {
                 const tr = document.createElement('tr');
 


### PR DESCRIPTION
🎨 Palette Improvement: Empty State for App Config

**What:** Added a clear, centered "No active rules" message to the App Config table when no rules are present.
**Why:** Users were presented with an empty table header with no feedback, which could be confusing or look broken.
**Accessibility:** The message uses high-contrast gray text and is clearly legible.
**Verification:**
- Verified with Playwright (screenshot included in previous steps).
- Ran project tests (`./gradlew :service:test`) successfully.

---
*PR created automatically by Jules for task [16435946984711161686](https://jules.google.com/task/16435946984711161686) started by @tryigit*