### PR TITLE
🎨 Palette: Add Copy Fingerprint button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-02 - Custom Tab Component Accessibility
 **Learning:** Custom tab implementations using `div` elements are invisible to screen readers and keyboard users unless explicitly managed with ARIA roles (`tablist`, `tab`, `aria-selected`) and `keydown` handlers.
 **Action:** Always check custom navigation components for keyboard accessibility (Enter/Space support) and proper ARIA roles.
+
+## 2026-02-03 - Mobile Text Selection
+**Learning:** Selecting long technical strings (like fingerprints) inside `div` elements is often frustrating on mobile touch interfaces due to imprecise cursors.
+**Action:** Always provide a dedicated "Copy" button for long, non-editable text fields to improve usability.

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -405,7 +405,10 @@ class WebServer(
                 <div class="row"><span>Model:</span> <b id="pModel"></b></div>
                 <div class="row"><span>Manufacturer:</span> <span id="pManuf"></span></div>
                 <div class="row"><span>Security Patch:</span> <span id="pPatch"></span></div>
-                <div style="font-size:0.7em; color:#666; word-break:break-all;" id="pFing"></div>
+                <div class="row" style="margin-top: 5px; align-items: flex-start;">
+                    <div style="font-size:0.7em; color:#666; word-break:break-all; padding-right: 10px;" id="pFing"></div>
+                    <button onclick="copyFingerprint()" style="padding: 4px 8px; font-size: 0.7em; white-space: nowrap;" aria-label="Copy fingerprint">COPY</button>
+                </div>
             </div>
 
             <div class="row" style="margin-top:15px;">
@@ -734,6 +737,17 @@ class WebServer(
                  body: new URLSearchParams({ filename: f, content: c })
              });
              showToast('Uploaded');
+        }
+
+        function copyFingerprint() {
+             const text = document.getElementById('pFing').innerText;
+             if (text) {
+                 navigator.clipboard.writeText(text).then(() => {
+                     showToast('COPIED TO CLIPBOARD');
+                 }).catch(() => {
+                     showToast('COPY FAILED');
+                 });
+             }
         }
 
         async function verifyKeyboxes() {

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
@@ -69,6 +69,10 @@ class WebServerHtmlTest {
         assertTrue("Missing toast CSS class", html.contains(".toast {"))
         assertTrue("Missing showToast function", html.contains("function showToast(msg)"))
 
+        // Verify Copy Fingerprint button
+        assertTrue("Missing Copy button for fingerprint", html.contains("onclick=\"copyFingerprint()\""))
+        assertTrue("Missing copyFingerprint function", html.contains("function copyFingerprint()"))
+
         // Verify toggle logic
         assertTrue("Missing disabled logic in toggle", html.contains("el.disabled = true;"))
 


### PR DESCRIPTION
Added a "COPY" button next to the device fingerprint in the WebUI to improve usability, especially on mobile devices where selecting long strings is difficult. This change involves modifying the embedded HTML in `WebServer.kt` and adding a corresponding JavaScript function. Also updated `WebServerHtmlTest.kt` to verify the new feature.

---
*PR created automatically by Jules for task [16158894362812480757](https://jules.google.com/task/16158894362812480757) started by @tryigit*