### PR TITLE
🛡️ Sentinel: [HIGH] Prevent API access to keybox.xml

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -322,7 +322,7 @@ class WebServer(
     }
 
     private fun isValidFilename(name: String): Boolean {
-        return name in setOf("keybox.xml", "target.txt", "security_patch.txt", "spoof_build_vars", "app_config", "templates.json")
+        return name in setOf("target.txt", "security_patch.txt", "spoof_build_vars", "app_config", "templates.json")
     }
 
     private fun getHtml(): String {

--- a/service/src/test/java/cleveres/tricky/cleverestech/ActionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ActionTest.kt
@@ -118,7 +118,7 @@ class ActionTest {
         val port = server.listeningPort
         val token = server.token
         // Pass params in URL to avoid body parsing issues in test
-        val saveUrl = URL("http://localhost:$port/api/save?token=$token&filename=keybox.xml&content=TEST_CONTENT")
+        val saveUrl = URL("http://localhost:$port/api/save?token=$token&filename=target.txt&content=TEST_CONTENT")
 
         val conn = saveUrl.openConnection() as HttpURLConnection
         conn.requestMethod = "POST"
@@ -128,7 +128,7 @@ class ActionTest {
 
         assertEquals(200, conn.responseCode)
 
-        val savedFile = File(configDir, "keybox.xml")
+        val savedFile = File(configDir, "target.txt")
         assertTrue("File should exist", savedFile.exists())
         assertEquals("File content mismatch", "TEST_CONTENT", savedFile.readText())
     }

--- a/service/src/test/java/cleveres/tricky/cleverestech/SensitiveExposureTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/SensitiveExposureTest.kt
@@ -1,0 +1,59 @@
+package cleveres.tricky.cleverestech
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+
+class SensitiveExposureTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var server: WebServer
+    private lateinit var configDir: File
+
+    @Before
+    fun setUp() {
+        // Suppress logging
+        Logger.setImpl(object : Logger.LogImpl {
+            override fun d(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String, t: Throwable?) { t?.printStackTrace() }
+            override fun i(tag: String, msg: String) {}
+        })
+        configDir = tempFolder.newFolder("config")
+
+        // Create a dummy keybox.xml
+        File(configDir, "keybox.xml").writeText("<secret>data</secret>")
+
+        server = WebServer(0, configDir)
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.stop()
+    }
+
+    @Test
+    fun testKeyboxExposure() {
+        val port = server.listeningPort
+        val token = server.token // Valid token
+        val url = URL("http://localhost:$port/api/file?filename=keybox.xml&token=$token")
+
+        val conn = url.openConnection() as HttpURLConnection
+        conn.requestMethod = "GET"
+
+        val responseCode = conn.responseCode
+
+        // This assertion expects 400 (Bad Request), meaning access is DENIED.
+        // If the vulnerability exists, it will return 200 (OK), failing this test.
+        assertEquals("Should deny access to keybox.xml", 400, responseCode)
+    }
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerPostTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerPostTest.kt
@@ -44,7 +44,7 @@ class WebServerPostTest {
         conn.doOutput = true
         conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
 
-        val postData = "filename=keybox.xml&content=BODY_CONTENT"
+        val postData = "filename=target.txt&content=BODY_CONTENT"
         val postDataBytes = postData.toByteArray(StandardCharsets.UTF_8)
 
         conn.outputStream.use { it.write(postDataBytes) }
@@ -62,7 +62,7 @@ class WebServerPostTest {
 
         assertEquals(200, responseCode)
 
-        val savedFile = File(configDir, "keybox.xml")
+        val savedFile = File(configDir, "target.txt")
         assertTrue("File should exist", savedFile.exists())
         assertEquals("File content mismatch", "BODY_CONTENT", savedFile.readText())
     }


### PR DESCRIPTION
# Sentinel Security Fix

**Vulnerability:** Information Disclosure (Sensitive Data Exposure)
**Severity:** HIGH

**Details:**
The `WebServer` exposed a generic file access endpoint (`/api/file`) that whitelisted `keybox.xml`. This file contains the private keys used for attestation spoofing. Although the endpoint requires a token (generated at startup and stored in a secure file), exposing the private keys via the web interface is unnecessary and increases the risk of leakage (e.g., via browser caching, shoulder surfing, or if the token is compromised).

**Fix:**
Removed `keybox.xml` from the `isValidFilename` whitelist in `WebServer.kt`. The WebUI uses `/api/upload_keybox` for uploading new keys, so generic read/write access to the legacy `keybox.xml` is not required for the UI to function.

**Verification:**
- Added `SensitiveExposureTest.kt` which asserts that requesting `keybox.xml` returns HTTP 400.
- Verified that `ActionTest` and `WebServerPostTest` pass after being updated to use `target.txt`.

---
*PR created automatically by Jules for task [13441742475409191499](https://jules.google.com/task/13441742475409191499) started by @tryigit*