### PR TITLE
Fix KeyboxVerifier ignoring ambiguous hex strings in CRL

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -75,16 +75,28 @@ object KeyboxVerifier {
             val keys = entries.keys()
             while (keys.hasNext()) {
                 val decStr = keys.next()
+                var added = false
+
+                // Try treating as Decimal
                 try {
                     val hexStr = java.math.BigInteger(decStr).toString(16).lowercase()
                     set.add(hexStr)
+                    added = true
                 } catch (e: Exception) {
-                    // It might be a hex string already (e.g. c3574...)
-                    if (decStr.matches(Regex("^[0-9a-fA-F]+$"))) {
-                        set.add(decStr.lowercase())
-                    } else {
-                        Logger.e("Failed to parse CRL entry key: $decStr")
-                    }
+                    // Not a valid decimal
+                }
+
+                // Try treating as Hex (literal)
+                // If it matches hex pattern, add it too.
+                // This covers cases where a hex string was purely numeric (e.g. "123456")
+                // which would have been consumed by the decimal block above but transformed incorrectly.
+                if (decStr.matches(Regex("^[0-9a-fA-F]+$"))) {
+                    set.add(decStr.lowercase())
+                    added = true
+                }
+
+                if (!added) {
+                    Logger.e("Failed to parse CRL entry key: $decStr")
                 }
             }
             set

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierRegressionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierRegressionTest.kt
@@ -1,0 +1,33 @@
+package cleveres.tricky.cleverestech.util
+
+import org.junit.Test
+import org.junit.Assert.*
+
+class KeyboxVerifierReproTest {
+    @Test
+    fun testAmbiguousNumericStringInCrl() {
+        // "123456" is a valid hex string (digits only).
+        // If the CRL contains "123456", and it represents a HEX serial number,
+        // the verifier MUST detect it.
+        // Current implementation treats "123456" as Decimal -> 1E240 (Hex).
+        // So it fails to revoke a certificate with actual serial "123456".
+
+        val json = """
+        {
+          "entries": {
+            "123456" : {
+              "status": "REVOKED"
+            }
+          }
+        }
+        """.trimIndent()
+
+        val revoked = KeyboxVerifier.parseCrl(json)
+
+        // If "123456" was meant as Hex, the set should contain "123456".
+        // If "123456" was meant as Decimal, the set should contain "1e240".
+        // To be safe, we should probably support "123456" being in the set if it's a valid hex.
+
+        assertTrue("Set should contain '123456' (treating numeric string as potential Hex)", revoked.contains("123456"))
+    }
+}


### PR DESCRIPTION
Modified `KeyboxVerifier.kt` to parse CRL entries as both Decimal (converted to Hex) and literal Hex strings if they match a hex regex. This prevents a potential security bypass where numeric-only hex strings in the CRL were incorrectly interpreted as large decimal numbers, causing the verifier to miss the revocation.

Added `KeyboxVerifierRegressionTest.kt` to verify the fix.

---
*PR created automatically by Jules for task [14010877378912215845](https://jules.google.com/task/14010877378912215845) started by @tryigit*