### PR TITLE
Fix JSON injection in WebServer /api/config

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -111,22 +111,26 @@ class WebServer(
         }
 
         if (uri == "/api/config" && method == Method.GET) {
-            val config = StringBuilder("{")
-            config.append("\"global_mode\": ${fileExists("global_mode")},")
-            config.append("\"tee_broken_mode\": ${fileExists("tee_broken_mode")},")
-            config.append("\"rkp_bypass\": ${fileExists("rkp_bypass")},")
-            config.append("\"auto_beta\": ${fileExists("auto_beta_fetch")},")
-            config.append("\"auto_keybox_check\": ${fileExists("auto_keybox_check")},")
-            config.append("\"files\": [\"keybox.xml\", \"target.txt\", \"security_patch.txt\", \"spoof_build_vars\", \"app_config\"],")
-            config.append("\"keybox_count\": ${CertHack.getKeyboxCount()},")
-            config.append("\"templates\": [")
-            Config.getTemplateNames().forEachIndexed { index, name ->
-                if (index > 0) config.append(",")
-                config.append("\"$name\"")
+            val json = JSONObject()
+            json.put("global_mode", fileExists("global_mode"))
+            json.put("tee_broken_mode", fileExists("tee_broken_mode"))
+            json.put("rkp_bypass", fileExists("rkp_bypass"))
+            json.put("auto_beta", fileExists("auto_beta_fetch"))
+            json.put("auto_keybox_check", fileExists("auto_keybox_check"))
+            val files = JSONArray()
+            files.put("keybox.xml")
+            files.put("target.txt")
+            files.put("security_patch.txt")
+            files.put("spoof_build_vars")
+            files.put("app_config")
+            json.put("files", files)
+            json.put("keybox_count", CertHack.getKeyboxCount())
+            val templates = JSONArray()
+            Config.getTemplateNames().forEach { name ->
+                templates.put(name)
             }
-            config.append("]")
-            config.append("}")
-            return newFixedLengthResponse(Response.Status.OK, "application/json", config.toString())
+            json.put("templates", templates)
+            return newFixedLengthResponse(Response.Status.OK, "application/json", json.toString())
         }
 
         // NEW: Get Templates List

--- a/service/src/test/java/cleveres/tricky/cleverestech/ActionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ActionTest.kt
@@ -12,6 +12,7 @@ import java.io.File
 import java.io.StringReader
 import java.net.HttpURLConnection
 import java.net.URL
+import org.json.JSONObject
 
 class ActionTest {
 
@@ -88,7 +89,8 @@ class ActionTest {
         println("Config response: $content")
 
         // Initial state: 0 keys
-        assertTrue(content.contains("\"keybox_count\": 0"))
+        val json = JSONObject(content)
+        assertEquals(0, json.getInt("keybox_count"))
     }
 
     @Test
@@ -102,7 +104,8 @@ class ActionTest {
 
         var conn = url.openConnection() as HttpURLConnection
         var content = conn.inputStream.bufferedReader().readText()
-        assertTrue("Should have 1 key", content.contains("\"keybox_count\": 1"))
+        var json = JSONObject(content)
+        assertEquals(1, json.getInt("keybox_count"))
 
         // 2. Invalid XML
         val invalidXml = "<AndroidAttestation><NumberOfKeyboxes>1</NumberOfKeyboxes>INVALID</AndroidAttestation>"
@@ -110,7 +113,8 @@ class ActionTest {
 
         conn = url.openConnection() as HttpURLConnection
         content = conn.inputStream.bufferedReader().readText()
-        assertTrue("Should have 0 keys after invalid XML", content.contains("\"keybox_count\": 0"))
+        json = JSONObject(content)
+        assertEquals(0, json.getInt("keybox_count"))
     }
 
     @Test

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerConfigInjectionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerConfigInjectionTest.kt
@@ -1,0 +1,70 @@
+package cleveres.tricky.cleverestech
+
+import fi.iki.elonen.NanoHTTPD
+import org.json.JSONObject
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.Rule
+import java.io.File
+import java.io.InputStream
+import java.util.UUID
+
+class WebServerConfigInjectionTest {
+
+    @Rule
+    @JvmField
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var webServer: WebServer
+    private lateinit var configDir: File
+
+    @Before
+    fun setUp() {
+        configDir = tempFolder.newFolder("config")
+        File(configDir, "target.txt").createNewFile()
+    }
+
+    @Test
+    fun testApiConfigJsonInjection() {
+        // 1. Create a custom template with a malicious name
+        val maliciousName = "hack\", \"injected\": true, \"dummy\": \""
+        val customTemplatesFile = File(configDir, "custom_templates")
+        customTemplatesFile.writeText("[$maliciousName]\nMODEL=Hack\n")
+
+        // 2. Update Config
+        Config.updateCustomTemplates(customTemplatesFile)
+
+        // 3. Create WebServer
+        webServer = WebServer(8080, configDir)
+
+        // 4. Simulate Request
+        val session = object : NanoHTTPD.IHTTPSession {
+            override fun execute() {}
+            override fun getCookies() = null
+            override fun getHeaders() = emptyMap<String, String>()
+            override fun getInputStream(): InputStream? = null
+            override fun getMethod() = NanoHTTPD.Method.GET
+            override fun getParms() = mapOf("token" to webServer.token)
+            override fun getParameters() = emptyMap<String, List<String>>() // Implemented
+            override fun getQueryParameterString() = ""
+            override fun getUri() = "/api/config"
+            override fun parseBody(files: MutableMap<String, String>?) {}
+            override fun getRemoteIpAddress() = "127.0.0.1"
+            override fun getRemoteHostName() = "localhost"
+        }
+
+        val response = webServer.serve(session)
+        val jsonStr = response.data.bufferedReader().use { it.readText() }
+
+        println("JSON Response: $jsonStr")
+
+        // 5. Verify JSON validity
+        try {
+            JSONObject(jsonStr)
+        } catch (e: Exception) {
+            fail("Vulnerability confirmed: JSON parsing failed due to injection: ${e.message}")
+        }
+    }
+}


### PR DESCRIPTION
Fixed a JSON injection vulnerability in the `/api/config` endpoint by replacing manual string concatenation with `JSONObject` usage. This ensures that template names containing special characters are correctly escaped. Added a regression test `WebServerConfigInjectionTest` and updated `ActionTest` to be more robust.

---
*PR created automatically by Jules for task [7697191841290405890](https://jules.google.com/task/7697191841290405890) started by @tryigit*