### PR TITLE
Fix fail-open vulnerability in KeyboxVerifier CRL parsing

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -67,31 +67,26 @@ object KeyboxVerifier {
     }
 
     fun parseCrl(jsonStr: String): Set<String> {
-        return try {
-            val json = JSONObject(jsonStr)
-            val entries = json.optJSONObject("entries") ?: return emptySet()
+        val json = JSONObject(jsonStr)
+        val entries = json.optJSONObject("entries") ?: throw Exception("CRL missing 'entries' field")
 
-            val set = HashSet<String>(entries.length())
-            val keys = entries.keys()
-            while (keys.hasNext()) {
-                val decStr = keys.next()
-                try {
-                    val hexStr = java.math.BigInteger(decStr).toString(16).lowercase()
-                    set.add(hexStr)
-                } catch (e: Exception) {
-                    // It might be a hex string already (e.g. c3574...)
-                    if (decStr.matches(Regex("^[0-9a-fA-F]+$"))) {
-                        set.add(decStr.lowercase())
-                    } else {
-                        Logger.e("Failed to parse CRL entry key: $decStr")
-                    }
+        val set = HashSet<String>(entries.length())
+        val keys = entries.keys()
+        while (keys.hasNext()) {
+            val decStr = keys.next()
+            try {
+                val hexStr = java.math.BigInteger(decStr).toString(16).lowercase()
+                set.add(hexStr)
+            } catch (e: Exception) {
+                // It might be a hex string already (e.g. c3574...)
+                if (decStr.matches(Regex("^[0-9a-fA-F]+$"))) {
+                    set.add(decStr.lowercase())
+                } else {
+                    Logger.e("Failed to parse CRL entry key: $decStr")
                 }
             }
-            set
-        } catch (e: Exception) {
-            Logger.e("Failed to parse CRL JSON", e)
-            emptySet()
         }
+        return set
     }
 
     private fun checkFile(file: File, revokedSerials: Set<String>): Result {


### PR DESCRIPTION
The `KeyboxVerifier` was failing open when the Certificate Revocation List (CRL) could not be parsed. This meant that if Google's server returned an error page, an empty response, or invalid JSON, the module would silently assume that *no* keys were revoked, giving users a false sense of security.

This fix ensures that parsing errors are propagated, causing the verification process to fail explicitly (returning an ERROR status) rather than silently succeeding. It also adds a regression test suite to cover various parsing scenarios and ensure the fail-closed behavior is maintained.

---
*PR created automatically by Jules for task [1554496185538518939](https://jules.google.com/task/1554496185538518939) started by @tryigit*