### PR TITLE
Fix KeyboxVerifier ignoring legacy keybox.xml

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -262,7 +262,7 @@ class WebServer(
 
         if (uri == "/api/verify_keyboxes" && method == Method.POST) {
              try {
-                val results = KeyboxVerifier.verify(File(configDir, "keyboxes"))
+                val results = KeyboxVerifier.verify(configDir)
                 val json = createKeyboxVerificationJson(results)
                 return newFixedLengthResponse(Response.Status.OK, "application/json", json)
              } catch(e: Exception) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxAutoCleaner.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxAutoCleaner.kt
@@ -22,7 +22,7 @@ object KeyboxAutoCleaner {
         if (!toggleFile.exists()) return
 
         Logger.i("AutoCleaner: Starting daily revocation check...")
-        val results = KeyboxVerifier.verify(keyboxDir)
+        val results = KeyboxVerifier.verify(configDir)
         var revokedCount = 0
 
         if (!revokedDir.exists()) revokedDir.mkdirs()
@@ -30,7 +30,7 @@ object KeyboxAutoCleaner {
         for (res in results) {
             if (res.status == KeyboxVerifier.Status.REVOKED || res.status == KeyboxVerifier.Status.INVALID) {
                 Logger.i("AutoCleaner: Keybox ${res.filename} is ${res.status}. Moving to revoked.")
-                val file = File(keyboxDir, res.filename)
+                val file = res.file
                 val target = File(revokedDir, res.filename)
                 if (file.exists()) {
                     try {

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerJsonTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerJsonTest.kt
@@ -2,6 +2,7 @@ package cleveres.tricky.cleverestech
 
 import cleveres.tricky.cleverestech.util.KeyboxVerifier
 import org.json.JSONArray
+import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.fail
@@ -16,7 +17,7 @@ class WebServerJsonTest {
         // Resulting "filename": "hack", "injected": "true", "x": "" ...
         val payload = "hack\", \"injected\": \"true\", \"x\": \""
         val results = listOf(
-            KeyboxVerifier.Result(payload, KeyboxVerifier.Status.INVALID, "Bad")
+            KeyboxVerifier.Result(File("dummy"), payload, KeyboxVerifier.Status.INVALID, "Bad")
         )
         val json = WebServer.createKeyboxVerificationJson(results)
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierLegacyTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierLegacyTest.kt
@@ -1,0 +1,53 @@
+package cleveres.tricky.cleverestech.util
+
+import org.junit.Test
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class KeyboxVerifierLegacyTest {
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun testVerify_FindsLegacyAndJukebox() {
+        val root = tempFolder.root
+        val keyboxesDir = File(root, "keyboxes")
+        keyboxesDir.mkdirs()
+
+        // Legacy file in root
+        File(root, "keybox.xml").writeText("<invalid></invalid>")
+
+        // Jukebox file
+        File(keyboxesDir, "jukebox.xml").writeText("<invalid></invalid>")
+
+        // Mock CRL
+        val crlFetcher = { emptySet<String>() }
+
+        // Simulate WebUI call: pointing to "keyboxes" dir, but we want it to find legacy too.
+        // Or rather, we will change WebUI to pass 'root' and KeyboxVerifier to be smart.
+        // But for now, let's call verify with 'keyboxesDir' and see it fail to find legacy.
+        // Actually, if we change the call signature in WebUI, we are changing the contract.
+        // If I pass 'root' to verify(), existing code finds 'keybox.xml' but ignores 'keyboxes/jukebox.xml' (non-recursive).
+
+        // So let's test verify(root).
+        val results = KeyboxVerifier.verify(root, crlFetcher)
+
+        // Expectation: It should find BOTH.
+        val foundLegacy = results.any { it.filename == "keybox.xml" }
+        val foundJukebox = results.any { it.filename == "jukebox.xml" }
+
+        // Current behavior: finds legacy, misses jukebox (because listFiles is non-recursive).
+        // Or if we simulate WebUI call: verify(keyboxesDir)
+        // Current behavior: misses legacy, finds jukebox.
+
+        // Since I can only call it once per test effectively (or multiple times),
+        // I want to prove that NO single call currently satisfies the requirement.
+
+        // Let's stick to the "smart verifier" plan where we pass 'root' (configDir).
+
+        assertTrue("Should find legacy keybox.xml", foundLegacy)
+        assertTrue("Should find jukebox.xml inside keyboxes/", foundJukebox)
+    }
+}


### PR DESCRIPTION
This PR fixes a bug where `KeyboxVerifier` and `KeyboxAutoCleaner` ignored the legacy `keybox.xml` file located in the root configuration directory, only scanning the `keyboxes/` subdirectory. This left legacy configurations unverified and vulnerable to revocation without notification.

Changes:
- Modified `KeyboxVerifier.verify` to accept `configDir` instead of `keyboxDir` and check both locations.
- Updated `KeyboxVerifier.Result` to include the `File` object for robust file handling.
- Updated `WebServer` and `KeyboxAutoCleaner` to use the new API.
- Added `KeyboxVerifierLegacyTest` to verify the fix.
- Updated `WebServerJsonTest` to match the API change.

---
*PR created automatically by Jules for task [9560596239561448808](https://jules.google.com/task/9560596239561448808) started by @tryigit*