### PR TITLE
🔧 Bugfix: Fix KeyboxVerifier syntax and enforce strict CRL parsing

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -77,37 +77,35 @@ object KeyboxVerifier {
     }
 
     fun parseCrl(jsonStr: String): Set<String> {
-        return try {
-            val json = JSONObject(jsonStr)
-            val entries = json.optJSONObject("entries") ?: return emptySet()
+        val json = JSONObject(jsonStr)
+        val entries = json.getJSONObject("entries")
 
-            val set = HashSet<String>(entries.length())
-            val keys = entries.keys()
-            while (keys.hasNext()) {
-                val decStr = keys.next()
-                var added = false
+        val set = HashSet<String>(entries.length())
+        val keys = entries.keys()
+        while (keys.hasNext()) {
+            val decStr = keys.next()
+            var added = false
 
-                // Try treating as Decimal
-                try {
-                    val hexStr = java.math.BigInteger(decStr).toString(16).lowercase()
-                    set.add(hexStr)
-                    added = true
-                } catch (e: Exception) {
-                    // Not a valid decimal
-                }
+            // Try treating as Decimal
+            try {
+                val hexStr = java.math.BigInteger(decStr).toString(16).lowercase()
+                set.add(hexStr)
+                added = true
+            } catch (e: Exception) {
+                // Not a valid decimal
+            }
 
-                // Try treating as Hex (literal)
-                // If it matches hex pattern, add it too.
-                // This covers cases where a hex string was purely numeric (e.g. "123456")
-                // which would have been consumed by the decimal block above but transformed incorrectly.
-                if (decStr.matches(Regex("^[0-9a-fA-F]+$"))) {
-                    set.add(decStr.lowercase())
-                    added = true
-                }
+            // Try treating as Hex (literal)
+            // If it matches hex pattern, add it too.
+            // This covers cases where a hex string was purely numeric (e.g. "123456")
+            // which would have been consumed by the decimal block above but transformed incorrectly.
+            if (decStr.matches(Regex("^[0-9a-fA-F]+$"))) {
+                set.add(decStr.lowercase())
+                added = true
+            }
 
-                if (!added) {
-                    Logger.e("Failed to parse CRL entry key: $decStr")
-                }
+            if (!added) {
+                Logger.e("Failed to parse CRL entry key: $decStr")
             }
         }
         return set


### PR DESCRIPTION
Fixed a compilation error in `KeyboxVerifier.kt` caused by a missing `catch` block. Also updated the JSON parsing logic to be strict (Fail Closed) regarding missing "entries" fields, matching the behavior expected by existing unit tests. Safety is ensured as the caller `fetchCrl` catches and logs these exceptions.

---
*PR created automatically by Jules for task [3627711496987901987](https://jules.google.com/task/3627711496987901987) started by @tryigit*