### PR TITLE
🔧 Bugfix: Fix KeyboxVerifier CRL hex parsing

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -99,8 +99,13 @@ object KeyboxVerifier {
             // This prevents false positives where a decimal string (e.g. "10")
             // is interpreted as hex (0x10 = 16) in addition to decimal (10 = 0xA).
             if (!added && decStr.matches(Regex("^[0-9a-fA-F]+$"))) {
-                set.add(decStr.lowercase())
-                added = true
+                try {
+                    val hexStr = java.math.BigInteger(decStr, 16).toString(16).lowercase()
+                    set.add(hexStr)
+                    added = true
+                } catch (e: Exception) {
+                    // Should not happen due to regex check, but safety first
+                }
             }
 
             if (!added) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/KeyboxVerifierReproTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/KeyboxVerifierReproTest.kt
@@ -1,0 +1,33 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.util.KeyboxVerifier
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class KeyboxVerifierReproTest {
+
+    @Test
+    fun testParseCrlWithLeadingZeroHex() {
+        // "0a" is valid hex for 10.
+        // Certificate serial number 10 is converted to "a" (no leading zero) by BigInteger.toString(16).
+        // If CRL contains "0a", it should match "a".
+
+        val json = """
+        {
+          "entries": {
+            "0a": "REVOKED"
+          }
+        }
+        """.trimIndent()
+
+        val revoked = KeyboxVerifier.parseCrl(json)
+
+        // 10 (decimal) -> "a" (hex)
+        val targetSerial = "a"
+
+        println("Revoked Set: $revoked")
+
+        assertTrue("Should contain 'a' but has $revoked", revoked.contains(targetSerial))
+    }
+}


### PR DESCRIPTION
Fixed a bug where CRL entries containing hex strings with leading zeros (e.g. "0a") were not correctly matched against normalized certificate serial numbers (e.g. "a"). Implemented normalization using BigInteger parsing for hex literals.

---
*PR created automatically by Jules for task [15057358799245735174](https://jules.google.com/task/15057358799245735174) started by @tryigit*