### PR TITLE
🔧 Bugfix: Ambiguous CRL key parsing in KeyboxVerifier

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -86,19 +86,8 @@ object KeyboxVerifier {
             val decStr = keys.next()
             var added = false
 
-            // Try treating as Decimal
-            try {
-                val hexStr = java.math.BigInteger(decStr).toString(16).lowercase()
-                set.add(hexStr)
-                added = true
-            } catch (e: Exception) {
-                // Not a valid decimal
-            }
-
-            // Try treating as Hex (literal) ONLY if decimal parsing failed.
-            // This prevents false positives where a decimal string (e.g. "10")
-            // is interpreted as hex (0x10 = 16) in addition to decimal (10 = 0xA).
-            if (!added && decStr.matches(Regex("^[0-9a-fA-F]+$"))) {
+            // Try treating as Hex (literal)
+            if (decStr.matches(Regex("^[0-9a-fA-F]+$"))) {
                 try {
                     val hexStr = java.math.BigInteger(decStr, 16).toString(16).lowercase()
                     set.add(hexStr)
@@ -106,6 +95,15 @@ object KeyboxVerifier {
                 } catch (e: Exception) {
                     // Should not happen due to regex check, but safety first
                 }
+            }
+
+            // Try treating as Decimal
+            try {
+                val hexStr = java.math.BigInteger(decStr).toString(16).lowercase()
+                set.add(hexStr)
+                added = true
+            } catch (e: Exception) {
+                // Not a valid decimal
             }
 
             if (!added) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierRegressionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierRegressionTest.kt
@@ -28,8 +28,7 @@ class KeyboxVerifierReproTest {
         assertTrue("Set should contain '1e240' (Decimal interpretation)", revoked.contains("1e240"))
 
         // 123456 (Hex) -> 123456.
-        // This is the Ambiguous Hex interpretation. We used to include this, but it causes false positives.
-        // We now AssertFalse.
-        assertFalse("Set should NOT contain '123456' (Ambiguous Hex interpretation)", revoked.contains("123456"))
+        // This is the Ambiguous Hex interpretation. We now include this to prevent false negatives (fail-closed).
+        assertTrue("Set should contain '123456' (Ambiguous Hex interpretation)", revoked.contains("123456"))
     }
 }


### PR DESCRIPTION
Fixes a potential security bypass where revoked certificates with ambiguous serial numbers (valid as both decimal and hex strings, e.g., "10") were not correctly identified as revoked. The fix ensures that such keys are interpreted as *both* decimal and hexadecimal values when populating the revocation set.

---
*PR created automatically by Jules for task [7096657282340622465](https://jules.google.com/task/7096657282340622465) started by @tryigit*