### PR TITLE
🎨 Palette: Warn on unsaved changes in Editor

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -599,6 +599,14 @@ class WebServer(
                     }
                 });
             });
+
+            // Init Editor
+            currentFile = document.getElementById('fileSelector').value;
+            await loadFile();
+            document.getElementById('fileEditor').addEventListener('input', () => {
+                editorDirty = true;
+                document.getElementById('saveBtn').innerText = 'SAVE FILE *';
+            });
         }
 
         async function toggle(setting) {
@@ -724,10 +732,23 @@ class WebServer(
             setTimeout(() => window.location.reload(), 1000);
         }
 
+        let editorDirty = false;
+        let currentFile = '';
+
         async function loadFile() {
-            const f = document.getElementById('fileSelector').value;
+            const sel = document.getElementById('fileSelector');
+            const f = sel.value;
+            if (editorDirty && currentFile && currentFile !== f) {
+                if (!confirm('You have unsaved changes. Discard them?')) {
+                    sel.value = currentFile;
+                    return;
+                }
+            }
+            currentFile = f;
             const res = await fetch(getAuthUrl('/api/file?filename=' + f));
             document.getElementById('fileEditor').value = await res.text();
+            editorDirty = false;
+            document.getElementById('saveBtn').innerText = 'SAVE FILE';
         }
 
         async function saveFile() {
@@ -738,6 +759,8 @@ class WebServer(
                  body: new URLSearchParams({ filename: f, content: c })
              });
              showToast('File Saved');
+             editorDirty = false;
+             document.getElementById('saveBtn').innerText = 'SAVE FILE';
         }
 
         async function fetchBetaNow() {


### PR DESCRIPTION
Implemented a micro-UX improvement to the Configuration Editor in the WebUI.
Previously, switching files in the dropdown would immediately overwrite the editor content, causing data loss if the user had unsaved changes. Additionally, the editor was empty on load despite the dropdown showing a selection.

Changes:
1.  **State Tracking**: Added `editorDirty` variable to track if the textarea content has changed.
2.  **Visual Feedback**: Added an event listener to the textarea to mark the state as dirty and append `*` to the "SAVE FILE" button.
3.  **Navigation Protection**: Modified `loadFile()` to check `editorDirty`. If dirty, it confirms with the user. If the user cancels, the dropdown selection is reverted.
4.  **Initialization**: The `init()` function now explicitly calls `loadFile()` to populate the editor with the default selected file.

Verified with Playwright script ensuring the dirty state triggers correctly, the confirmation dialog appears, and cancelling/accepting works as intended. Kotlin unit tests passed.

---
*PR created automatically by Jules for task [2291252205555096434](https://jules.google.com/task/2291252205555096434) started by @tryigit*