### PR TITLE
Fix false positive revocations due to ambiguous CRL parsing

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -86,24 +86,23 @@ object KeyboxVerifier {
             val decStr = keys.next()
             var added = false
 
-            // Try treating as Hex (literal)
-            if (decStr.matches(Regex("^[0-9a-fA-F]+$"))) {
-                try {
+            // Heuristic: If it contains hex characters (a-f), treat as Hex.
+            // Otherwise (only digits), treat as Decimal.
+            // This prevents ambiguity for inputs like "10" (Dec 10 vs Hex 16).
+            val isHex = decStr.any { it in 'a'..'f' || it in 'A'..'F' }
+
+            try {
+                if (isHex) {
                     val hexStr = java.math.BigInteger(decStr, 16).toString(16).lowercase()
                     set.add(hexStr)
                     added = true
-                } catch (e: Exception) {
-                    // Should not happen due to regex check, but safety first
+                } else {
+                    val hexStr = java.math.BigInteger(decStr).toString(16).lowercase()
+                    set.add(hexStr)
+                    added = true
                 }
-            }
-
-            // Try treating as Decimal
-            try {
-                val hexStr = java.math.BigInteger(decStr).toString(16).lowercase()
-                set.add(hexStr)
-                added = true
             } catch (e: Exception) {
-                // Not a valid decimal
+                // Ignore parsing errors
             }
 
             if (!added) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/KeyboxVerifierAmbiguityTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/KeyboxVerifierAmbiguityTest.kt
@@ -1,0 +1,38 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.util.KeyboxVerifier
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KeyboxVerifierAmbiguityTest {
+
+    @Test
+    fun testParseCrlAmbiguity() {
+        // "10" is ambiguous:
+        // - Decimal: 10 -> Hex "a"
+        // - Hex: 0x10 -> Hex "10" (Decimal 16)
+
+        // Google CRL uses decimal strings for numbers.
+        // So "10" means serial number 10 (hex "a").
+        // It should NOT mean serial number 16 (hex "10").
+
+        val json = """
+        {
+          "entries": {
+            "10": "REVOKED"
+          }
+        }
+        """.trimIndent()
+
+        val revoked = KeyboxVerifier.parseCrl(json)
+        println("Revoked: $revoked")
+
+        // Should contain "a" (decimal 10)
+        assertTrue("Should contain 'a' (dec 10)", revoked.contains("a"))
+
+        // Should NOT contain "10" (hex 10 => dec 16)
+        // If it does, then we have a false positive for serial number 16.
+        assertFalse("Should NOT contain '10' (hex interpretation of '10')", revoked.contains("10"))
+    }
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierRegressionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierRegressionTest.kt
@@ -28,7 +28,8 @@ class KeyboxVerifierReproTest {
         assertTrue("Set should contain '1e240' (Decimal interpretation)", revoked.contains("1e240"))
 
         // 123456 (Hex) -> 123456.
-        // This is the Ambiguous Hex interpretation. We now include this to prevent false negatives (fail-closed).
-        assertTrue("Set should contain '123456' (Ambiguous Hex interpretation)", revoked.contains("123456"))
+        // This is the Ambiguous Hex interpretation. We used to include this, but it causes false positives.
+        // We now enforce Decimal interpretation for digit-only strings.
+        assertFalse("Set should NOT contain '123456' (Ambiguous Hex interpretation)", revoked.contains("123456"))
     }
 }


### PR DESCRIPTION
Fixed a bug in `KeyboxVerifier.kt` where numeric strings in the CRL JSON were parsed ambiguously as both Decimal and Hexadecimal. This caused false positives (revoking valid certificates) when the CRL entry was intended as a Decimal serial number but its Hex interpretation collided with a valid certificate.

Implemented a heuristic to treat digit-only strings strictly as Decimal, and strings with hex characters (a-f) as Hexadecimal. Added a regression test `KeyboxVerifierAmbiguityTest.kt` and updated `KeyboxVerifierRegressionTest.kt`.

---
*PR created automatically by Jules for task [13108837804103139463](https://jules.google.com/task/13108837804103139463) started by @tryigit*