### PR TITLE
Fix ambiguous CRL parsing in KeyboxVerifier

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -86,24 +86,24 @@ object KeyboxVerifier {
             val decStr = keys.next()
             var added = false
 
-            // Try treating as Hex (literal)
-            if (decStr.matches(Regex("^[0-9a-fA-F]+$"))) {
+            if (decStr.matches(Regex("^[0-9]+$"))) {
+                // Strictly Decimal (digits only)
+                try {
+                    val hexStr = java.math.BigInteger(decStr).toString(16).lowercase()
+                    set.add(hexStr)
+                    added = true
+                } catch (e: Exception) {
+                    // Not a valid decimal
+                }
+            } else if (decStr.matches(Regex("^[0-9a-fA-F]+$"))) {
+                // Hex (contains letters)
                 try {
                     val hexStr = java.math.BigInteger(decStr, 16).toString(16).lowercase()
                     set.add(hexStr)
                     added = true
                 } catch (e: Exception) {
-                    // Should not happen due to regex check, but safety first
+                    // Should not happen due to regex check
                 }
-            }
-
-            // Try treating as Decimal
-            try {
-                val hexStr = java.math.BigInteger(decStr).toString(16).lowercase()
-                set.add(hexStr)
-                added = true
-            } catch (e: Exception) {
-                // Not a valid decimal
             }
 
             if (!added) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierRegressionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierRegressionTest.kt
@@ -28,7 +28,8 @@ class KeyboxVerifierReproTest {
         assertTrue("Set should contain '1e240' (Decimal interpretation)", revoked.contains("1e240"))
 
         // 123456 (Hex) -> 123456.
-        // This is the Ambiguous Hex interpretation. We now include this to prevent false negatives (fail-closed).
-        assertTrue("Set should contain '123456' (Ambiguous Hex interpretation)", revoked.contains("123456"))
+        // This is the Ambiguous Hex interpretation. We should NOT include this as it causes false positives.
+        // Strings consisting solely of digits are strictly treated as decimal integers.
+        assertFalse("Set should NOT contain '123456' (Ambiguous Hex interpretation)", revoked.contains("123456"))
     }
 }


### PR DESCRIPTION
Fix ambiguous CRL parsing in KeyboxVerifier to prevent false positive revocations.

A bug in `KeyboxVerifier.parseCrl` caused strings consisting solely of digits (e.g., "10") to be parsed twice: once as a Decimal integer (10 -> hex "a") and once as a Hexadecimal literal (16 -> hex "10"). This ambiguity could lead to false positive revocations if a CRL entry meant to be decimal 10 was also interpreted as hex 16, revoking a certificate with serial 0x10.

This change modifies the parsing logic to be mutually exclusive:
- Strings matching `^[0-9]+$` are treated STRICTLY as Decimal.
- Strings matching `^[0-9a-fA-F]+$` (and not caught by the first check, i.e., containing letters) are treated as Hexadecimal.

This aligns with the specified requirement that digit-only strings are strictly decimal.
The regression test `KeyboxVerifierRegressionTest.kt` was updated to assert that the ambiguous hex interpretation is NO LONGER present.

---
*PR created automatically by Jules for task [1920792875592307400](https://jules.google.com/task/1920792875592307400) started by @tryigit*