### PR TITLE
🛡️ Sentinel: [HIGH] Fix ambiguous CRL parsing in KeyboxVerifier

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -86,24 +86,26 @@ object KeyboxVerifier {
             val decStr = keys.next()
             var added = false
 
-            // Try treating as Hex (literal)
-            if (decStr.matches(Regex("^[0-9a-fA-F]+$"))) {
-                try {
-                    val hexStr = java.math.BigInteger(decStr, 16).toString(16).lowercase()
-                    set.add(hexStr)
-                    added = true
-                } catch (e: Exception) {
-                    // Should not happen due to regex check, but safety first
-                }
-            }
-
-            // Try treating as Decimal
+            // Try treating as Decimal first (Spec compliant)
             try {
                 val hexStr = java.math.BigInteger(decStr).toString(16).lowercase()
                 set.add(hexStr)
                 added = true
             } catch (e: Exception) {
-                // Not a valid decimal
+                // Not a valid decimal, fall back to Hex
+            }
+
+            if (!added) {
+                // Try treating as Hex (literal) as fallback
+                if (decStr.matches(Regex("^[0-9a-fA-F]+$"))) {
+                    try {
+                        val hexStr = java.math.BigInteger(decStr, 16).toString(16).lowercase()
+                        set.add(hexStr)
+                        added = true
+                    } catch (e: Exception) {
+                        // Should not happen due to regex check, but safety first
+                    }
+                }
             }
 
             if (!added) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierBugTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierBugTest.kt
@@ -1,0 +1,47 @@
+package cleveres.tricky.cleverestech.util
+
+import cleveres.tricky.cleverestech.Logger
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.BeforeClass
+import org.junit.Test
+
+class KeyboxVerifierBugTest {
+
+    companion object {
+        @JvmStatic
+        @BeforeClass
+        fun setup() {
+             Logger.setImpl(object : Logger.LogImpl {
+                override fun d(tag: String, msg: String) {}
+                override fun e(tag: String, msg: String) { println("E/$tag: $msg") }
+                override fun e(tag: String, msg: String, t: Throwable?) { println("E/$tag: $msg") }
+                override fun i(tag: String, msg: String) {}
+            })
+        }
+    }
+
+    @Test
+    fun testParseCrlDecimalAmbiguity() {
+        // CRL entry "10" (Decimal 10).
+        // This corresponds to Hex "a".
+        // It should NOT correspond to Hex "10" (Decimal 16).
+
+        val json = """
+        {
+          "entries": {
+            "10": { "status": "REVOKED" }
+          }
+        }
+        """.trimIndent()
+
+        val revoked = KeyboxVerifier.parseCrl(json)
+        println("Revoked Set: $revoked")
+
+        // Should contain "a" (Decimal 10)
+        assertTrue("Should revoke decimal 10 (hex 'a')", revoked.contains("a"))
+
+        // Should NOT contain "10" (Decimal 16)
+        assertFalse("Should NOT revoke decimal 16 (hex '10')", revoked.contains("10"))
+    }
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierRegressionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierRegressionTest.kt
@@ -28,7 +28,7 @@ class KeyboxVerifierReproTest {
         assertTrue("Set should contain '1e240' (Decimal interpretation)", revoked.contains("1e240"))
 
         // 123456 (Hex) -> 123456.
-        // This is the Ambiguous Hex interpretation. We now include this to prevent false negatives (fail-closed).
-        assertTrue("Set should contain '123456' (Ambiguous Hex interpretation)", revoked.contains("123456"))
+        // This is the Ambiguous Hex interpretation. We should NOT include this as it causes false positives.
+        assertFalse("Set should NOT contain '123456' (Ambiguous Hex interpretation)", revoked.contains("123456"))
     }
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Ambiguous parsing of CRL keys allowed denial of service (revocation) of valid keys.
- The `KeyboxVerifier` incorrectly interpreted decimal numeric strings (e.g., "10") as both decimal (10) and hexadecimal (16) values.
- This caused valid certificates with serial numbers matching the hex interpretation (e.g., serial 16) to be falsely flagged as revoked if the decimal equivalent (e.g., serial 10) was present in the CRL.
🎯 Impact: Users with valid keyboxes could be falsely told their keys are revoked, leading to unnecessary replacement or service disruption (False Positives).
🔧 Fix: Refactored `KeyboxVerifier.parseCrl` to prioritize Decimal parsing (standard compliance). It only falls back to Hex parsing if the key is not a valid decimal string.
✅ Verification: Added `KeyboxVerifierBugTest` to confirm that decimal string "10" does NOT revoke hex serial "10". Updated regression tests to reflect correct behavior.

---
*PR created automatically by Jules for task [16867970228340861164](https://jules.google.com/task/16867970228340861164) started by @tryigit*