### PR TITLE
🎨 Palette: Add file picker for keybox upload

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Journal
+
+## 2026-02-05 - File Picker for Text Content
+**Learning:** Users uploading configuration files (XML/JSON) often have them as files, not clipboard content. Pasting into a textarea is error-prone.
+**Action:** Always provide a "Load from File" button that populates the textarea using FileReader, allowing both file selection and manual editing.

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -348,6 +348,7 @@ class WebServer(
 <!DOCTYPE html>
 <html>
 <head>
+    <meta charset="utf-8">
     <title>CleveresTricky GOD-MODE</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
@@ -478,6 +479,10 @@ class WebServer(
     <div id="keys" class="content">
         <div class="panel">
             <h3>UPLOAD KEYBOX</h3>
+            <input type="file" id="kbFilePicker" style="display:none" onchange="loadFileContent(this)" onclick="this.value = null">
+            <div style="display:flex; gap:10px; margin-bottom:10px;">
+                <button onclick="document.getElementById('kbFilePicker').click()" style="flex:1;">📂 LOAD FROM FILE</button>
+            </div>
             <input type="text" id="kbFilename" placeholder="filename.xml" aria-label="Keybox Filename">
             <textarea id="kbContent" placeholder="Paste XML content..." style="height:100px; margin-top:10px;" aria-label="Keybox Content"></textarea>
             <button onclick="runWithState(this, 'UPLOADING...', uploadKeybox)" style="width:100%; margin-top:10px;">UPLOAD</button>
@@ -778,6 +783,18 @@ class WebServer(
                  body: new URLSearchParams({ filename: f, content: c })
              });
              showToast('Uploaded');
+        }
+
+        function loadFileContent(input) {
+            if (input.files && input.files[0]) {
+                const file = input.files[0];
+                document.getElementById('kbFilename').value = file.name;
+                const reader = new FileReader();
+                reader.onload = (e) => {
+                    document.getElementById('kbContent').value = e.target.result;
+                };
+                reader.readAsText(file);
+            }
         }
 
         function copyFingerprint(btn) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
@@ -80,6 +80,11 @@ class WebServerHtmlTest {
         // Verify toggle logic
         assertTrue("Missing disabled logic in toggle", html.contains("el.disabled = true;"))
 
+        // Verify File Picker
+        assertTrue("Missing file picker input", html.contains("id=\"kbFilePicker\""))
+        assertTrue("Missing load from file button", html.contains("LOAD FROM FILE"))
+        assertTrue("Missing loadFileContent function", html.contains("function loadFileContent(input)"))
+
         // Debugging failure
         val hasToast = html.contains("showToast('SETTING UPDATED')")
         if (!hasToast) {


### PR DESCRIPTION
This PR improves the UX for uploading keybox XML files by allowing users to select a file from their device instead of manually pasting content. It also fixes a potential encoding issue by explicitly setting the charset to UTF-8.

---
*PR created automatically by Jules for task [9160189224015870987](https://jules.google.com/task/9160189224015870987) started by @tryigit*