### PR TITLE
Fix CborEncoder Canonical Sorting

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/CborEncoder.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/CborEncoder.java
@@ -86,7 +86,14 @@ public class CborEncoder {
                 }
                 // Compare Strings
                 if (k1 instanceof String && k2 instanceof String) {
-                    return ((String) k1).compareTo((String) k2);
+                    String s1 = (String) k1;
+                    String s2 = (String) k2;
+                    byte[] b1 = s1.getBytes(StandardCharsets.UTF_8);
+                    byte[] b2 = s2.getBytes(StandardCharsets.UTF_8);
+                    if (b1.length != b2.length) {
+                        return Integer.compare(b1.length, b2.length);
+                    }
+                    return s1.compareTo(s2);
                 }
                 // Mixed keys: Int < String per standard CBOR canonical rules usually? 
                 // RFC 7049: "If two keys have different types, the one with the lower major type sorts earlier."

--- a/service/src/test/java/cleveres/tricky/cleverestech/CborEncoderTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/CborEncoderTest.kt
@@ -1,0 +1,70 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.util.CborEncoder
+import org.junit.Test
+import java.util.LinkedHashMap
+
+class CborEncoderTest {
+
+    private fun bytesToHex(bytes: ByteArray): String {
+        val sb = StringBuilder()
+        for (b in bytes) {
+            sb.append(String.format("%02x", b))
+        }
+        return sb.toString()
+    }
+
+    @Test
+    fun testCanonicalMapSorting() {
+        // "b" (len 1) vs "aa" (len 2)
+        // Canonical: "b" < "aa"
+        // Java String: "aa" < "b"
+
+        val map = LinkedHashMap<String, Int>()
+        map["aa"] = 1
+        map["b"] = 2
+
+        // Expected Order: "b", "aa"
+        // Encoded:
+        // Map(2) (0xa2)
+        // "b" (0x61 62) -> 2 (0x02)
+        // "aa" (0x62 61 61) -> 1 (0x01)
+        // Hex: a2 61 62 02 62 61 61 01
+
+        val expected = "a261620262616101"
+        val encoded = CborEncoder.encode(map)
+        val encodedHex = bytesToHex(encoded)
+
+        println("Encoded: $encodedHex")
+
+        org.junit.Assert.assertEquals("Expected canonical sort order", expected, encodedHex)
+    }
+
+    @Test
+    fun testCanonicalMapSortingLongerKeys() {
+        // "manufacturer" (12) vs "vb_state" (8)
+        // Canonical: "vb_state" < "manufacturer"
+
+        val map = LinkedHashMap<String, Int>()
+        map["manufacturer"] = 1
+        map["vb_state"] = 2
+
+        // Encoded:
+        // Map(2) (0xa2)
+        // "vb_state" (8 bytes) -> 0x68 + "vb_state" -> 2
+        // "manufacturer" (12 bytes) -> 0x6c + "manufacturer" -> 1
+
+        // 68 76625f7374617465 -> vb_state
+        // 02
+        // 6c 6d616e756661637475726572 -> manufacturer
+        // 01
+
+        val expected = "a26876625f7374617465026c6d616e75666163747572657201"
+        val encoded = CborEncoder.encode(map)
+        val encodedHex = bytesToHex(encoded)
+
+        println("Encoded: $encodedHex")
+
+        org.junit.Assert.assertEquals("Expected shorter key (vb_state) first", expected, encodedHex)
+    }
+}


### PR DESCRIPTION
Fixes a bug in `CborEncoder` where map keys were sorted lexicographically instead of by encoded length as required by RFC 7049 (Canonical CBOR). This is critical for RKP attestation which relies on deterministic encoding for signature verification. Added a regression test covering both short and long keys.

---
*PR created automatically by Jules for task [5888377669829424568](https://jules.google.com/task/5888377669829424568) started by @tryigit*