### PR TITLE
🛡️ Sentinel: Fix DoS via missing Content-Length

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -115,6 +115,8 @@ class WebServer(
                            return newFixedLengthResponse(Response.Status.BAD_REQUEST, "text/plain", "Payload too large")
                       }
                   } catch (e: Exception) {}
+             } else {
+                 return newFixedLengthResponse(Response.Status.BAD_REQUEST, "text/plain", "Content-Length required")
              }
         }
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/ActionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ActionTest.kt
@@ -127,8 +127,8 @@ class ActionTest {
         val conn = saveUrl.openConnection() as HttpURLConnection
         conn.requestMethod = "POST"
         // Even with empty body, we need doOutput for POST usually, or just length 0.
-        // conn.doOutput = true
-        // conn.outputStream.close()
+        conn.doOutput = true
+        conn.outputStream.close()
 
         assertEquals(200, conn.responseCode)
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerMissingContentLengthTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerMissingContentLengthTest.kt
@@ -1,0 +1,88 @@
+package cleveres.tricky.cleverestech
+
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.net.Socket
+import java.net.SocketTimeoutException
+
+class WebServerMissingContentLengthTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var server: WebServer
+    private lateinit var configDir: File
+
+    @Before
+    fun setUp() {
+        // Use println logger to avoid silencing logs for other tests and to aid debugging
+        Logger.setImpl(object : Logger.LogImpl {
+            override fun d(tag: String, msg: String) { println("D/$tag: $msg") }
+            override fun e(tag: String, msg: String) { println("E/$tag: $msg") }
+            override fun e(tag: String, msg: String, t: Throwable?) { println("E/$tag: $msg"); t?.printStackTrace() }
+            override fun i(tag: String, msg: String) { println("I/$tag: $msg") }
+        })
+        configDir = tempFolder.newFolder("config")
+        server = WebServer(0, configDir)
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.stop()
+    }
+
+    @Test
+    fun testMissingContentLength() {
+        val port = server.listeningPort
+        val token = server.token
+        val socket = Socket("localhost", port)
+        socket.soTimeout = 5000
+
+        val writer = socket.getOutputStream().writer(Charsets.UTF_8)
+        val reader = socket.getInputStream().bufferedReader(Charsets.UTF_8)
+
+        // POST without Content-Length
+        writer.write("POST /api/upload_keybox?token=$token HTTP/1.1\r\n")
+        writer.write("Host: localhost:$port\r\n")
+        // No Content-Length
+        writer.write("Content-Type: application/x-www-form-urlencoded\r\n")
+        writer.write("\r\n")
+
+        // Start streaming data
+        // If server reads forever or accepts huge data, it fails.
+        // We expect it to either fail immediately (if we mandate Content-Length)
+        // or eventually fail if we exceed limit (if it counts bytes).
+
+        val chunk = "a".repeat(1024)
+        try {
+            // Write 6MB
+            for (i in 0 until 6 * 1024) {
+                writer.write(chunk)
+            }
+            writer.flush()
+        } catch (e: Exception) {
+            // Write failed, maybe server closed connection. This is good.
+        }
+
+        // Check response
+        try {
+            val line = reader.readLine()
+            if (line == null) {
+                 org.junit.Assert.fail("Server closed connection without response")
+            }
+            if (!line.contains("400")) {
+                 org.junit.Assert.fail("Expected 400 Bad Request but got: $line")
+            }
+        } catch (e: Exception) {
+            org.junit.Assert.fail("Exception checking response: ${e.message}")
+        } finally {
+            socket.close()
+        }
+    }
+}


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix DoS vulnerability in WebServer

**Vulnerability:**
The `WebServer` (NanoHTTPD) was vulnerable to Denial of Service (DoS) attacks because it did not strictly enforce the presence of the `Content-Length` header for POST/PUT requests. If a client omitted the header, the server could attempt to read an unbounded amount of data from the socket, leading to disk or memory exhaustion.

**Fix:**
Enforce `Content-Length` check in `WebServer.serve()`. If the header is missing for POST/PUT requests, the server now immediately returns `400 Bad Request` with the message "Content-Length required", preventing the `parseBody` method from reading the stream.

**Verification:**
- Added `WebServerMissingContentLengthTest.kt`: Verifies that a POST request without `Content-Length` receives a 400 error.
- Updated `ActionTest.kt`: Fixed existing test to properly send `Content-Length` (via `doOutput=true`) so it passes the new check.
- Ran all tests in `:service` module to ensure no regressions.

---
*PR created automatically by Jules for task [10726116075382284619](https://jules.google.com/task/10726116075382284619) started by @tryigit*