### PR TITLE
🎨 Palette: Improve form accessibility in WebUI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2026-02-03 - Mobile Text Selection
 **Learning:** Selecting long technical strings (like fingerprints) inside `div` elements is often frustrating on mobile touch interfaces due to imprecise cursors.
 **Action:** Always provide a dedicated "Copy" button for long, non-editable text fields to improve usability.
+
+## 2026-05-21 - Automated Accessibility Verification
+**Learning:** This project utilizes unit tests (`WebServerHtmlTest`) to parse and verify the existence of accessibility attributes (`aria-label`, `label for`) in the server-generated HTML.
+**Action:** When working on backend-generated UIs, leverage or create similar string-parsing unit tests to enforce accessibility standards in the CI pipeline, rather than relying solely on frontend inspection.

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -417,7 +417,7 @@ class WebServer(
         <div class="panel">
             <h3>IDENTITY SELECTOR</h3>
             <p style="color:#888; font-size:0.9em;">Select a verified device identity to spoof globally or save for specific apps.</p>
-            <select id="templateSelect" onchange="previewTemplate()"></select>
+            <select id="templateSelect" onchange="previewTemplate()" aria-label="Device Identity Selector"></select>
 
             <div id="templatePreview" style="margin-top:15px; border:1px solid var(--border); padding:15px; display:none;">
                 <div class="row"><span>Model:</span> <b id="pModel"></b></div>
@@ -445,18 +445,18 @@ class WebServer(
         <div class="panel">
             <h3>ADD NEW RULE</h3>
             <div style="margin-bottom:10px;">
-                <label style="font-size:0.8em; color:#888;">TARGET PACKAGE</label>
+                <label for="appPkg" style="font-size:0.8em; color:#888;">TARGET PACKAGE</label>
                 <input type="text" id="appPkg" list="pkgList" placeholder="com.example.app" aria-label="Target Package">
                 <datalist id="pkgList"></datalist>
             </div>
             <div style="margin-bottom:10px;">
-                <label style="font-size:0.8em; color:#888;">DEVICE IDENTITY</label>
+                <label for="appTemplate" style="font-size:0.8em; color:#888;">DEVICE IDENTITY</label>
                 <select id="appTemplate">
                     <option value="null">Default (No Spoof)</option>
                 </select>
             </div>
             <div style="margin-bottom:15px;">
-                <label style="font-size:0.8em; color:#888;">KEYBOX OVERRIDE</label>
+                <label for="appKeybox" style="font-size:0.8em; color:#888;">KEYBOX OVERRIDE</label>
                 <input type="text" id="appKeybox" placeholder="keybox.xml (optional)">
             </div>
             <button class="primary" onclick="addAppRule()">ADD RULE</button>

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
@@ -52,9 +52,15 @@ class WebServerHtmlTest {
         assertTrue("Missing label for tee_broken_mode", html.contains("<label for=\"tee_broken_mode\""))
         assertTrue("Missing label for rkp_bypass", html.contains("<label for=\"rkp_bypass\""))
 
+        // Verify new labels for App Config
+        assertTrue("Missing label for appPkg", html.contains("<label for=\"appPkg\""))
+        assertTrue("Missing label for appTemplate", html.contains("<label for=\"appTemplate\""))
+        assertTrue("Missing label for appKeybox", html.contains("<label for=\"appKeybox\""))
+
         // Verify aria-labels
         assertTrue("Missing aria-label for fileSelector", html.contains("aria-label=\"Select configuration file\""))
         assertTrue("Missing aria-label for editor", html.contains("aria-label=\"Configuration editor\""))
+        assertTrue("Missing aria-label for templateSelect", html.contains("aria-label=\"Device Identity Selector\""))
 
         // Verify aria-live
         assertTrue("Missing aria-live for keyboxStatus", html.contains("id=\"keyboxStatus\" aria-live=\"polite\""))


### PR DESCRIPTION
Improved the accessibility of the embedded WebServer UI by programmatically associating labels with input fields in the "App Config" section and adding an `aria-label` to the "Identity Selector" dropdown. Updated unit tests to verify these attributes are present in the generated HTML. Verified changes with Playwright.

---
*PR created automatically by Jules for task [17699015781477102965](https://jules.google.com/task/17699015781477102965) started by @tryigit*