### PR TITLE
Implement android::Vector class wrapper

### DIFF
--- a/module/src/main/cpp/binder/include/utils/Vector.h
+++ b/module/src/main/cpp/binder/include/utils/Vector.h
@@ -1,7 +1,27 @@
 #pragma once
 
-// TODO
+#include <vector>
+#include <sys/types.h>
+
 namespace android {
-    template<class TYPE>
-    class Vector;
-}
+
+template<class TYPE>
+class Vector : public std::vector<TYPE> {
+public:
+    using std::vector<TYPE>::vector;
+
+    inline ssize_t add(const TYPE& item) {
+        this->push_back(item);
+        return static_cast<ssize_t>(this->size() - 1);
+    }
+
+    inline bool isEmpty() const {
+        return this->empty();
+    }
+
+    inline void removeAt(size_t index) {
+        this->erase(this->begin() + index);
+    }
+};
+
+} // namespace android


### PR DESCRIPTION
Implemented `android::Vector` by inheriting from `std::vector` and adding AOSP-specific methods (`add`, `isEmpty`, `removeAt`) to enable correct compilation and usage within the binder module.

---
*PR created automatically by Jules for task [7656912859277065710](https://jules.google.com/task/7656912859277065710) started by @tryigit*