### PR TITLE
Remove unused onLastWeakRef from RefBase

### DIFF
--- a/module/src/main/cpp/binder/include/utils/RefBase.h
+++ b/module/src/main/cpp/binder/include/utils/RefBase.h
@@ -119,10 +119,6 @@ inline bool operator _op_ (const U* o) const {                   \
         // Only called in OBJECT_LIFETIME_WEAK case.  Returns true if OK to promote to
         // strong reference. May have side effects if it returns true.
         virtual bool            onIncStrongAttempted(const void* id);
-        // Invoked in the OBJECT_LIFETIME_WEAK case when the last reference of either
-        // kind goes away.  Unused.
-        // TODO: Remove.
-        virtual void            onLastWeakRef(const void* id);
 
     private:
         friend class weakref_type;

--- a/module/src/main/cpp/binder/stub_utils.cpp
+++ b/module/src/main/cpp/binder/stub_utils.cpp
@@ -33,7 +33,6 @@ namespace android {
     void RefBase::onFirstRef() {}
     void RefBase::onLastStrongRef(const void* id) {}
     bool RefBase::onIncStrongAttempted(const void* id) { return false; }
-    void RefBase::onLastWeakRef(const void* id) {}
 
     RefBase* RefBase::weakref_type::refBase() const { return nullptr; }
 


### PR DESCRIPTION
Removed unused `onLastWeakRef` from `RefBase` header and stub implementation to clean up the code as per TODO.

---
*PR created automatically by Jules for task [8053414530846120310](https://jules.google.com/task/8053414530846120310) started by @tryigit*