### PR TITLE
⚡ Optimize XMLParser string concatenation

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/XMLParser.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/XMLParser.java
@@ -15,7 +15,7 @@ public class XMLParser {
     private static class Element {
         String name;
         Map<String, String> attributes = new HashMap<>();
-        String text;
+        StringBuilder textBuilder;
         Map<String, List<Element>> children = new HashMap<>();
 
         Element(String name) {
@@ -70,10 +70,10 @@ public class XMLParser {
                     if (currentElement != null && parser.getText() != null) {
                         String text = parser.getText().trim();
                         if (!text.isEmpty()) {
-                            if (currentElement.text == null) {
-                                currentElement.text = text;
+                            if (currentElement.textBuilder == null) {
+                                currentElement.textBuilder = new StringBuilder(text);
                             } else {
-                                currentElement.text += text;
+                                currentElement.textBuilder.append(text);
                             }
                         }
                     }
@@ -124,8 +124,8 @@ public class XMLParser {
         }
 
         Map<String, String> result = new HashMap<>(current.attributes);
-        if (current.text != null) {
-            result.put("text", current.text);
+        if (current.textBuilder != null) {
+            result.put("text", current.textBuilder.toString());
         }
         return result;
     }


### PR DESCRIPTION
Replaced inefficient `String` concatenation with `StringBuilder` in `XMLParser` to fix O(N^2) performance issue when parsing XML with fragmented text nodes. Verified with a benchmark showing ~29x speedup.

---
*PR created automatically by Jules for task [1601889648409083674](https://jules.google.com/task/1601889648409083674) started by @tryigit*