### PR TITLE
Fix KeyboxVerifier hex parsing ambiguity

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -87,12 +87,16 @@ object KeyboxVerifier {
             var added = false
 
             // Try treating as Decimal first (Spec compliant)
-            try {
-                val hexStr = java.math.BigInteger(decStr).toString(16).lowercase()
-                set.add(hexStr)
-                added = true
-            } catch (e: Exception) {
-                // Not a valid decimal, fall back to Hex
+            // Heuristic: If string is longer than 20 chars, it cannot be a Decimal u64 (max 20 digits).
+            // It is likely a 128-bit Hex string. We skip Decimal parsing to avoid ambiguity with all-digit Hex strings.
+            if (decStr.length <= 20) {
+                try {
+                    val hexStr = java.math.BigInteger(decStr).toString(16).lowercase()
+                    set.add(hexStr)
+                    added = true
+                } catch (e: Exception) {
+                    // Not a valid decimal, fall back to Hex
+                }
             }
 
             if (!added) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/KeyboxVerifierBugTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/KeyboxVerifierBugTest.kt
@@ -1,0 +1,32 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.util.KeyboxVerifier
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KeyboxVerifierBugTest {
+
+    @Test
+    fun testParseCrlWithLongAllDigitHex() {
+        // A 32-character string that happens to be all digits.
+        // In the context of CRL (mixed Decimal u64 / Hex u128), this should be treated as Hex.
+        // If treated as Decimal, the value is wildly different.
+
+        val targetHex = "10000000000000000000000000000001"
+        val json = """
+        {
+          "entries": {
+            "$targetHex": "REVOKED"
+          }
+        }
+        """.trimIndent()
+
+        val revoked = KeyboxVerifier.parseCrl(json)
+
+        println("Revoked Set: $revoked")
+
+        // We expect the set to contain the hex string itself (normalized)
+        // Since input is already lowercase hex (and valid), result should be identical.
+        assertTrue("Should contain '$targetHex' but has $revoked", revoked.contains(targetHex))
+    }
+}


### PR DESCRIPTION
Fixes a critical logic error in `KeyboxVerifier.parseCrl` where long 128-bit Hex strings were incorrectly parsed as Decimal if they contained only digits. This ensures robust revocation checking for all key formats.

---
*PR created automatically by Jules for task [4996748206671858148](https://jules.google.com/task/4996748206671858148) started by @tryigit*