### PR TITLE
🛡️ Sentinel: [HIGH] Fix Configuration Injection in app_config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** The `web_port` file containing the authentication token was being created in the configuration directory before the directory's permissions were restricted to `0700`. This created a window where the directory and the token file could be world-readable.
 **Learning:** Even if you change file permissions immediately after creation, there is a race condition window. Securing the parent directory *before* creating sensitive files inside it is a more robust way to prevent access.
 **Prevention:** Always ensure the parent directory has restrictive permissions (e.g., `0700`) before writing sensitive files into it. Use `Os.chmod` immediately after directory creation.
+
+## 2024-05-29 - [Configuration Injection in Space-Delimited Files]
+**Vulnerability:** The application stored configuration (`app_config`) as a space-delimited text file but accepted unvalidated user input for fields. This allowed "Configuration Injection" where attackers could insert newlines or spaces to create fake entries or corrupt the file structure.
+**Learning:** Simple text-based file formats are prone to injection if delimiters (spaces, newlines) are not strictly forbidden in the input data.
+**Prevention:** Always validate that user input does not contain the delimiters used by the storage format. For space-delimited files, reject any input matching `\s`.

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -218,6 +218,11 @@ class WebServer(
                          val pkg = obj.getString("package")
                          val tmpl = obj.optString("template", "null").ifEmpty { "null" }
                          val kb = obj.optString("keybox", "null").ifEmpty { "null" }
+
+                         if (pkg.contains(Regex("\\s")) || tmpl.contains(Regex("\\s")) || kb.contains(Regex("\\s"))) {
+                             return newFixedLengthResponse(Response.Status.BAD_REQUEST, "text/plain", "Invalid input: whitespace not allowed")
+                         }
+
                          sb.append("$pkg $tmpl $kb\n")
                      }
                      if (saveFile("app_config", sb.toString())) {
@@ -411,7 +416,7 @@ class WebServer(
             <h3 style="margin:5px 0; color:var(--accent); letter-spacing:2px;">COMMUNITY POWERED</h3>
             <div id="communityCount" style="font-size:2.5em; font-weight:300;">Loading...</div>
             <div style="font-size:0.8em; color:#888; margin-bottom:5px;">TELEGRAM MEMBERS</div>
-            <a href="https://t.me/cleverestech" target="_blank" style="color:#fff; text-decoration:none; font-size:0.8em; border-bottom:1px dotted #fff;">JOIN US</a>
+            <a href="https://t.me/cleverestech" target="_blank" rel="noopener noreferrer" style="color:#fff; text-decoration:none; font-size:0.8em; border-bottom:1px dotted #fff;">JOIN US</a>
         </div>
     </div>
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/AppConfigInjectionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/AppConfigInjectionTest.kt
@@ -1,0 +1,106 @@
+package cleveres.tricky.cleverestech
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.Rule
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import java.nio.charset.StandardCharsets
+
+class AppConfigInjectionTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var server: WebServer
+    private lateinit var configDir: File
+
+    @Before
+    fun setUp() {
+        configDir = tempFolder.newFolder("config")
+        server = WebServer(0, configDir)
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.stop()
+    }
+
+    @Test
+    fun testAppConfigInjectionRejected() {
+        val port = server.listeningPort
+        val token = server.token
+        val url = URL("http://localhost:$port/api/app_config_structured?token=$token")
+
+        val conn = url.openConnection() as HttpURLConnection
+        conn.requestMethod = "POST"
+        conn.doOutput = true
+        conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
+
+        // Malicious payload: Injecting a newline
+        val maliciousPkg = "com.valid.app\ncom.injected.app"
+
+        val jsonArray = JSONArray()
+        val obj = JSONObject()
+        obj.put("package", maliciousPkg)
+        obj.put("template", "valid_template")
+        obj.put("keybox", "valid_keybox")
+        jsonArray.put(obj)
+
+        val postData = "data=" + java.net.URLEncoder.encode(jsonArray.toString(), "UTF-8")
+        val postDataBytes = postData.toByteArray(StandardCharsets.UTF_8)
+
+        conn.outputStream.use { it.write(postDataBytes) }
+
+        val responseCode = conn.responseCode
+        // Expect BAD_REQUEST (400) or similar due to validation failure
+        assertTrue("Should reject injection", responseCode >= 400)
+
+        val appConfigFile = File(configDir, "app_config")
+        // File should NOT exist if it was the first request and failed
+        assertFalse(appConfigFile.exists())
+    }
+
+    @Test
+    fun testAppConfigValidInput() {
+        val port = server.listeningPort
+        val token = server.token
+        val url = URL("http://localhost:$port/api/app_config_structured?token=$token")
+
+        val conn = url.openConnection() as HttpURLConnection
+        conn.requestMethod = "POST"
+        conn.doOutput = true
+        conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
+
+        val pkg = "com.valid.app"
+        val jsonArray = JSONArray()
+        val obj = JSONObject()
+        obj.put("package", pkg)
+        obj.put("template", "valid_template")
+        obj.put("keybox", "valid_keybox")
+        jsonArray.put(obj)
+
+        val postData = "data=" + java.net.URLEncoder.encode(jsonArray.toString(), "UTF-8")
+        val postDataBytes = postData.toByteArray(StandardCharsets.UTF_8)
+
+        conn.outputStream.use { it.write(postDataBytes) }
+
+        val responseCode = conn.responseCode
+        assertEquals(200, responseCode)
+
+        val appConfigFile = File(configDir, "app_config")
+        assertTrue(appConfigFile.exists())
+
+        val content = appConfigFile.readText()
+        assertTrue(content.contains("com.valid.app valid_template valid_keybox"))
+    }
+}


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Configuration Injection in app_config

**Vulnerability:** The `app_config` file uses a space-delimited, line-based format. The `/api/app_config_structured` endpoint accepted JSON input for `package`, `template`, and `keybox` fields without validation. This allowed an attacker (with valid token) to inject spaces or newlines into these fields, corrupting the configuration file or injecting arbitrary rules (Configuration Injection / CRLF Injection).

**Impact:** An attacker could bypass the intended structure of the configuration file, potentially injecting malicious rules or corrupting existing ones, leading to unpredictable behavior or denial of service for the configuration mechanism.

**Fix:**
1.  Added strict validation in `WebServer.kt` to reject any input containing whitespace (`Regex("\\s")`) for `package`, `template`, and `keybox` fields.
2.  Added `rel="noopener noreferrer"` to the external Telegram link in the WebUI to prevent potential Referer header token leakage.

**Verification:**
*   Added `AppConfigInjectionTest.kt` which reproduces the vulnerability (by asserting rejection) and verifies valid inputs still work.
*   Verified the frontend link attribute using a Playwright script on extracted HTML.


---
*PR created automatically by Jules for task [10762976452144497122](https://jules.google.com/task/10762976452144497122) started by @tryigit*