### PR TITLE
Fix KeyboxVerifier CRL parsing for large serial numbers

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -88,8 +88,9 @@ object KeyboxVerifier {
 
             // Try treating as Decimal first (Spec compliant)
             // Heuristic: If string is longer than 20 chars, it cannot be a Decimal u64 (max 20 digits).
-            // It is likely a 128-bit Hex string. We skip Decimal parsing to avoid ambiguity with all-digit Hex strings.
-            if (decStr.length <= 20) {
+            // However, X.509 serials can be larger. We skip Decimal parsing ONLY if it matches known Hex KeyID lengths (32, 40, 64)
+            // to avoid ambiguity with all-digit Hex strings.
+            if (decStr.length <= 20 || (decStr.length != 32 && decStr.length != 40 && decStr.length != 64)) {
                 try {
                     val hexStr = java.math.BigInteger(decStr).toString(16).lowercase()
                     set.add(hexStr)

--- a/service/src/test/java/cleveres/tricky/cleverestech/KeyboxVerifierLargeSerialTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/KeyboxVerifierLargeSerialTest.kt
@@ -1,0 +1,44 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.util.KeyboxVerifier
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import java.math.BigInteger
+
+class KeyboxVerifierLargeSerialTest {
+
+    @Test
+    fun testParseCrlLargeSerialNumber() {
+        // A 25-digit decimal number.
+        // Google CRL uses decimal strings for serial numbers.
+        // X.509 Serial Numbers can be up to 20 octets (usually handled as large integers).
+        val decimalSerial = "1234567890123456789012345"
+
+        // Correct Hex representation
+        val expectedHex = BigInteger(decimalSerial).toString(16).lowercase()
+        // 105d4ac1d3f232b78129
+
+        // If bug exists, it parses as Hex literal
+        val wrongHex = BigInteger(decimalSerial, 16).toString(16).lowercase()
+        // 1234567890123456789012345
+
+        val json = """
+        {
+          "entries": {
+            "$decimalSerial": "REVOKED"
+          }
+        }
+        """.trimIndent()
+
+        val revoked = KeyboxVerifier.parseCrl(json)
+
+        println("Decimal Input: $decimalSerial")
+        println("Expected Hex: $expectedHex")
+        println("Wrong Hex:   $wrongHex")
+        println("Revoked Set: $revoked")
+
+        assertTrue("Should contain correct hex '$expectedHex' (parsed as Decimal)", revoked.contains(expectedHex))
+        assertFalse("Should NOT contain wrong hex '$wrongHex' (parsed as Hex literal)", revoked.contains(wrongHex))
+    }
+}


### PR DESCRIPTION
Fixes a bug where large decimal Certificate Serial Numbers in CRLs were incorrectly parsed as Hex strings, bypassing revocation checks.

---
*PR created automatically by Jules for task [1833092947114302055](https://jules.google.com/task/1833092947114302055) started by @tryigit*