### PR TITLE
🛡️ Sentinel: [Security Improvement] Add Security Headers

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerHeadersTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerHeadersTest.kt
@@ -1,0 +1,70 @@
+package cleveres.tricky.cleverestech
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+
+class WebServerHeadersTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var server: WebServer
+    private lateinit var configDir: File
+
+    @Before
+    fun setUp() {
+        // Mock Logger
+        Logger.setImpl(object : Logger.LogImpl {
+            override fun d(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String, t: Throwable?) { t?.printStackTrace() }
+            override fun i(tag: String, msg: String) {}
+        })
+        configDir = tempFolder.newFolder("config")
+        server = WebServer(0, configDir)
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.stop()
+    }
+
+    @Test
+    fun testSecurityHeadersPresent() {
+        val port = server.listeningPort
+        val token = server.token
+        val url = URL("http://localhost:$port/?token=$token")
+
+        val conn = url.openConnection() as HttpURLConnection
+        conn.requestMethod = "GET"
+        conn.connect()
+
+        assertEquals(200, conn.responseCode)
+
+        // Verify Headers
+        val csp = conn.getHeaderField("Content-Security-Policy")
+        val contentTypeOptions = conn.getHeaderField("X-Content-Type-Options")
+        val frameOptions = conn.getHeaderField("X-Frame-Options")
+        val referrerPolicy = conn.getHeaderField("Referrer-Policy")
+
+        assertNotNull("CSP header missing", csp)
+        assertTrue("CSP incorrect: $csp", csp.contains("default-src 'self'"))
+
+        assertEquals("nosniff", contentTypeOptions)
+        assertEquals("DENY", frameOptions)
+        assertEquals("no-referrer", referrerPolicy)
+    }
+
+    private fun assertTrue(message: String, condition: Boolean) {
+        if (!condition) throw AssertionError(message)
+    }
+}


### PR DESCRIPTION
🛡️ Sentinel: [Security Improvement] Add Security Headers

**Severity:** MEDIUM (Enhancement)

**Vulnerability:**
The `WebServer` responses were missing standard security headers, potentially exposing the WebUI to Cross-Site Scripting (XSS), MIME sniffing, and Clickjacking attacks. Although the server runs on localhost, adding these headers is a best practice defense-in-depth measure.

**Impact:**
-   **XSS:** Without CSP, if an attacker could inject scripts (unlikely in current code but possible in future), they could execute arbitrary code.
-   **MIME Sniffing:** Browsers might incorrectly interpret non-script files as scripts.
-   **Clickjacking:** The WebUI could be embedded in an iframe on a malicious site (if bound to a reachable interface or via DNS rebinding, though currently bound to 127.0.0.1).

**Fix:**
Implemented a `secureResponse` helper function in `WebServer.kt` that wraps the standard `newFixedLengthResponse` and injects the following headers:
-   `Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'`
-   `X-Content-Type-Options: nosniff`
-   `X-Frame-Options: DENY`
-   `Referrer-Policy: no-referrer`

Replaced all direct usages of `newFixedLengthResponse` with `secureResponse`.

**Verification:**
Added `WebServerHeadersTest.kt` which starts a mock server and asserts that the headers are present in the HTTP response.
Ran `./gradlew :service:test` and verified all tests passed.

---
*PR created automatically by Jules for task [6982068558466624460](https://jules.google.com/task/6982068558466624460) started by @tryigit*