### PR TITLE
🎨 Palette: Add 2-step delete confirmation for App Config

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -3,3 +3,7 @@
 ## 2026-02-05 - File Picker for Text Content
 **Learning:** Users uploading configuration files (XML/JSON) often have them as files, not clipboard content. Pasting into a textarea is error-prone.
 **Action:** Always provide a "Load from File" button that populates the textarea using FileReader, allowing both file selection and manual editing.
+
+## 2026-02-05 - 2-Step Delete Interaction
+**Learning:** Native `confirm()` dialogs are safe but disruptive. A 2-step button (State 1: Action, State 2: Confirmation) provides a smoother "delightful" UX for destructive actions in embedded WebUIs.
+**Action:** Use the `dataset.state` pattern with a `setTimeout` reset for future destructive actions in vanilla JS interfaces.

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -690,7 +690,25 @@ class WebServer(
                 const tdAction = document.createElement('td');
                 const btn = document.createElement('button');
                 btn.textContent = 'DEL';
-                btn.onclick = () => removeAppRule(idx);
+                btn.dataset.state = 'initial';
+                btn.onclick = function() {
+                    if (this.dataset.state === 'initial') {
+                        this.dataset.state = 'confirm';
+                        this.textContent = 'SURE?';
+                        this.style.borderColor = '#f00';
+                        this.style.color = '#f00';
+                        const self = this;
+                        this.timer = setTimeout(function() {
+                             self.dataset.state = 'initial';
+                             self.textContent = 'DEL';
+                             self.style.borderColor = '';
+                             self.style.color = '';
+                        }, 3000);
+                    } else {
+                        clearTimeout(this.timer);
+                        removeAppRule(idx);
+                    }
+                };
                 btn.ariaLabel = `Delete rule for ${'$'}{rule.package}`;
                 btn.style.padding = '2px 8px';
                 btn.style.fontSize = '0.8em';

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
@@ -80,6 +80,10 @@ class WebServerHtmlTest {
         assertTrue("Missing copyFingerprint function", html.contains("function copyFingerprint(btn)"))
         assertTrue("Missing feedback logic in copyFingerprint", html.contains("btn.innerText = 'COPIED!';"))
 
+        // Verify 2-step delete logic
+        assertTrue("Missing 2-step delete logic (SURE?)", html.contains("SURE?"))
+        assertTrue("Missing 2-step delete logic (dataset.state)", html.contains("dataset.state"))
+
         // Verify Empty State Logic
         assertTrue("Missing empty state logic in verifyKeyboxes", html.contains("No keyboxes found."))
 


### PR DESCRIPTION
💡 **What:** Replaced the immediate "DEL" button in the App Config table with a 2-step confirmation button.
🎯 **Why:** To prevent accidental deletion of application configuration rules, which is a destructive action.
📸 **Verification:**
- Validated with Playwright (screenshot confirmed "SURE?" state).
- Verified with `WebServerHtmlTest` unit test.
♿ **Accessibility:** The button uses clear text changes and color indicators (Red for danger) to signal the confirmation state.

---
*PR created automatically by Jules for task [6360258797133891267](https://jules.google.com/task/6360258797133891267) started by @tryigit*