### PR TITLE
🎨 Palette: Add accessibility attributes to WebUI

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,7 @@
 ## 2026-02-05 - 2-Step Delete Interaction
 **Learning:** Native `confirm()` dialogs are safe but disruptive. A 2-step button (State 1: Action, State 2: Confirmation) provides a smoother "delightful" UX for destructive actions in embedded WebUIs.
 **Action:** Use the `dataset.state` pattern with a `setTimeout` reset for future destructive actions in vanilla JS interfaces.
+
+## 2026-02-05 - Accessible Custom Notifications
+**Learning:** Visual toast notifications ("Dynamic Islands") are invisible to screen readers without `aria-live`. Adding `role="status"` and `aria-live="polite"` makes them accessible without disrupting the user flow.
+**Action:** Ensure all custom notification containers have `aria-live` attributes to announce status changes dynamically.

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -531,7 +531,7 @@ class WebServer(
 </head>
 <body>
     <div class="island-container">
-        <div id="island" class="island">
+        <div id="island" class="island" role="status" aria-live="polite">
             <span id="islandText">Notification</span>
         </div>
     </div>
@@ -959,7 +959,7 @@ class WebServer(
                     <td>${'$'}{rule.template === 'null' ? 'Default' : rule.template}</td>
                     <td>${'$'}{rule.keybox && rule.keybox !== 'null' ? '<span class="tag">KEYBOX</span>' : ''}</td>
                     <td style="text-align:right;">
-                        <button class="danger" onclick="removeAppRule(${'$'}{idx})">×</button>
+                        <button class="danger" onclick="removeAppRule(${'$'}{idx})" aria-label="Remove rule for ${'$'}{rule.package}">×</button>
                     </td>
                 `;
                 tbody.appendChild(tr);

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
@@ -59,7 +59,10 @@ class WebServerHtmlTest {
         // Verify Dynamic Island
         assertTrue("Missing Island Container", html.contains("class=\"island-container\""))
         assertTrue("Missing Island", html.contains("id=\"island\""))
+        assertTrue("Missing Island Role", html.contains("role=\"status\""))
+        assertTrue("Missing Island Live", html.contains("aria-live=\"polite\""))
         assertTrue("Missing notify function", html.contains("function notify(msg, type = 'normal')"))
+        assertTrue("Missing Remove Button Accessibility", html.contains("aria-label=\"Remove rule for ${'$'}{rule.package}\""))
 
         // Verify Random Logic
         assertTrue("Missing Randomized Extras Header", html.contains("<h3>System-Wide Spoofing (Global Hardware)</h3>"))


### PR DESCRIPTION
This PR improves the accessibility of the embedded WebUI in `WebServer.kt` by adding ARIA attributes to the notification system ("Dynamic Island") and the "Remove App Rule" button.

**Changes:**
- **`WebServer.kt`**:
    - Added `role="status"` and `aria-live="polite"` to the `#island` container. This ensures that toast notifications are announced by screen readers when they appear.
    - Added `aria-label="Remove rule for ${package}"` to the delete button in the App Rules table. This provides context for screen reader users who would otherwise just hear "button" or "times" (for the × symbol).
- **`WebServerHtmlTest.kt`**:
    - Added assertions to verify the presence of these new attributes in the generated HTML.
- **`.Jules/palette.md`**:
    - Added a journal entry documenting the importance of `aria-live` for custom notifications.

**Verification:**
- Verified frontend changes using a Playwright script (`verify_ux.py`) which mocked the API and checked for the existence of the attributes on the rendered DOM elements.
- Validated that the visual UI remains unchanged (via screenshot).
- Ran unit tests `WebServerHtmlTest` to ensure no regressions.

---
*PR created automatically by Jules for task [1992211794188344166](https://jules.google.com/task/1992211794188344166) started by @tryigit*