### PR TITLE
Fix Auto Beta Fetch toggle not showing correct state in WebUI

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -132,7 +132,7 @@ class WebServer(
             json.put("global_mode", fileExists("global_mode"))
             json.put("tee_broken_mode", fileExists("tee_broken_mode"))
             json.put("rkp_bypass", fileExists("rkp_bypass"))
-            json.put("auto_beta", fileExists("auto_beta_fetch"))
+            json.put("auto_beta_fetch", fileExists("auto_beta_fetch"))
             json.put("auto_keybox_check", fileExists("auto_keybox_check"))
             json.put("random_on_boot", fileExists("random_on_boot"))
             val files = JSONArray()

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerConfigKeysTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerConfigKeysTest.kt
@@ -1,0 +1,63 @@
+package cleveres.tricky.cleverestech
+
+import fi.iki.elonen.NanoHTTPD
+import org.json.JSONObject
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.io.InputStream
+import java.util.UUID
+
+class WebServerConfigKeysTest {
+
+    @Rule
+    @JvmField
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var webServer: WebServer
+    private lateinit var configDir: File
+
+    @Before
+    fun setUp() {
+        configDir = tempFolder.newFolder("config")
+        // Create the file so the value should be true
+        File(configDir, "auto_beta_fetch").createNewFile()
+    }
+
+    @Test
+    fun testApiConfigKeysMatchFrontendExpectations() {
+        webServer = WebServer(8080, configDir)
+
+        val session = object : NanoHTTPD.IHTTPSession {
+            override fun execute() {}
+            override fun getCookies() = null
+            override fun getHeaders() = emptyMap<String, String>()
+            override fun getInputStream(): InputStream? = null
+            override fun getMethod() = NanoHTTPD.Method.GET
+            override fun getParms() = mapOf("token" to webServer.token)
+            override fun getParameters() = emptyMap<String, List<String>>()
+            override fun getQueryParameterString() = ""
+            override fun getUri() = "/api/config"
+            override fun parseBody(files: MutableMap<String, String>?) {}
+            override fun getRemoteIpAddress() = "127.0.0.1"
+            override fun getRemoteHostName() = "localhost"
+        }
+
+        val response = webServer.serve(session)
+        val jsonStr = response.data.bufferedReader().use { it.readText() }
+        val json = JSONObject(jsonStr)
+
+        // The frontend expects "auto_beta_fetch"
+        // But the backend sends "auto_beta"
+
+        if (!json.has("auto_beta_fetch")) {
+            fail("API response is missing 'auto_beta_fetch'. It has: ${json.keys().asSequence().toList()}")
+        }
+
+        assertTrue("auto_beta_fetch should be true", json.getBoolean("auto_beta_fetch"))
+    }
+}


### PR DESCRIPTION
Fixed a bug where the "Auto Beta Fetch" toggle in the WebUI would not reflect the actual state of the setting. The API endpoint `/api/config` was returning the wrong JSON key (`auto_beta` instead of `auto_beta_fetch`), causing the frontend logic to fail to find the value. This change aligns the backend response with the frontend expectation and adds a regression test.

---
*PR created automatically by Jules for task [15165742736143677692](https://jules.google.com/task/15165742736143677692) started by @tryigit*