### PR TITLE
🎨 Palette: Add accessibility attributes to notification island and remove buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,7 @@
 ## 2026-02-05 - 2-Step Delete Interaction
 **Learning:** Native `confirm()` dialogs are safe but disruptive. A 2-step button (State 1: Action, State 2: Confirmation) provides a smoother "delightful" UX for destructive actions in embedded WebUIs.
 **Action:** Use the `dataset.state` pattern with a `setTimeout` reset for future destructive actions in vanilla JS interfaces.
+
+## 2026-02-05 - Accessible Notifications
+**Learning:** Custom "Dynamic Island" or toast notifications are often invisible to screen readers if they only animate opacity.
+**Action:** Always use `role="status"` and `aria-live="polite"` on notification containers so updates are announced without shifting focus.

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -531,7 +531,7 @@ class WebServer(
 </head>
 <body>
     <div class="island-container">
-        <div id="island" class="island">
+        <div id="island" class="island" role="status" aria-live="polite">
             <span id="islandText">Notification</span>
         </div>
     </div>
@@ -959,7 +959,7 @@ class WebServer(
                     <td>${'$'}{rule.template === 'null' ? 'Default' : rule.template}</td>
                     <td>${'$'}{rule.keybox && rule.keybox !== 'null' ? '<span class="tag">KEYBOX</span>' : ''}</td>
                     <td style="text-align:right;">
-                        <button class="danger" onclick="removeAppRule(${'$'}{idx})">×</button>
+                        <button class="danger" onclick="removeAppRule(${'$'}{idx})" aria-label="Remove rule for ${'$'}{rule.package}">×</button>
                     </td>
                 `;
                 tbody.appendChild(tr);

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
@@ -59,6 +59,7 @@ class WebServerHtmlTest {
         // Verify Dynamic Island
         assertTrue("Missing Island Container", html.contains("class=\"island-container\""))
         assertTrue("Missing Island", html.contains("id=\"island\""))
+        assertTrue("Missing Island Accessibility", html.contains("role=\"status\" aria-live=\"polite\""))
         assertTrue("Missing notify function", html.contains("function notify(msg, type = 'normal')"))
 
         // Verify Random Logic
@@ -71,6 +72,7 @@ class WebServerHtmlTest {
         assertTrue("Missing App Package Input", html.contains("id=\"appPkg\""))
         assertTrue("Missing Blank Permissions Logic", html.contains("Blank Permissions (Privacy)"))
         assertTrue("Missing Contacts Permission Toggle", html.contains("id=\"permContacts\""))
+        assertTrue("Missing Remove Button Accessibility", html.contains("aria-label=\"Remove rule for \${rule.package}\""))
 
         // Verify Editor
         assertTrue("Missing File Selector", html.contains("id=\"fileSelector\""))


### PR DESCRIPTION
This PR improves the accessibility of the embedded WebUI.
It ensures that screen readers announce "Dynamic Island" notifications and providing context for the icon-only "Remove" buttons in the app rules list.
Verified with unit tests and manual Playwright DOM inspection.

---
*PR created automatically by Jules for task [5360032291951690770](https://jules.google.com/task/5360032291951690770) started by @tryigit*