### PR TITLE
Fix KeyboxVerifier incorrectly parsing 32-digit decimal serials as hex

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -87,17 +87,13 @@ object KeyboxVerifier {
             var added = false
 
             // Try treating as Decimal first (Spec compliant)
-            // Heuristic: If string is longer than 20 chars, it cannot be a Decimal u64 (max 20 digits).
-            // However, X.509 serials can be larger. We skip Decimal parsing ONLY if it matches known Hex KeyID lengths (32, 40, 64)
-            // to avoid ambiguity with all-digit Hex strings.
-            if (decStr.length <= 20 || (decStr.length != 32 && decStr.length != 40 && decStr.length != 64)) {
-                try {
-                    val hexStr = java.math.BigInteger(decStr).toString(16).lowercase()
-                    set.add(hexStr)
-                    added = true
-                } catch (e: Exception) {
-                    // Not a valid decimal, fall back to Hex
-                }
+            // Try treating as Decimal first (Spec compliant)
+            try {
+                val hexStr = java.math.BigInteger(decStr).toString(16).lowercase()
+                set.add(hexStr)
+                added = true
+            } catch (e: Exception) {
+                // Not a valid decimal, fall back to Hex
             }
 
             if (!added) {


### PR DESCRIPTION
Fixed a bug in `KeyboxVerifier` where 32-digit decimal serial numbers were incorrectly parsed as hex strings. Removed the arbitrary length-based heuristic and prioritized decimal parsing for all numeric inputs, ensuring correct handling of large serial numbers while maintaining support for standard hex key IDs. Updated tests to reflect this logic.

---
*PR created automatically by Jules for task [2252140158459884947](https://jules.google.com/task/2252140158459884947) started by @tryigit*