### PR TITLE
Fix KeyboxVerifier CRL parsing ambiguity for hex strings with leading zeros

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -87,8 +87,10 @@ object KeyboxVerifier {
             var added = false
 
             // Try treating as Decimal first (Spec compliant)
-            // Try treating as Decimal first (Spec compliant)
             try {
+                if (decStr.length > 1 && decStr.startsWith("0")) {
+                    throw NumberFormatException("Leading zero implies Hex")
+                }
                 val hexStr = java.math.BigInteger(decStr).toString(16).lowercase()
                 set.add(hexStr)
                 added = true

--- a/service/src/test/java/cleveres/tricky/cleverestech/KeyboxVerifierLeadingZeroTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/KeyboxVerifierLeadingZeroTest.kt
@@ -1,0 +1,41 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.util.KeyboxVerifier
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KeyboxVerifierLeadingZeroTest {
+
+    @Test
+    fun testParseCrlWithLeadingZeroDigits() {
+        // "0123" consists only of digits.
+        // BigInteger("0123") parses as 123 (decimal) -> "7b" (hex).
+        // However, standard decimal formatting usually prohibits leading zeros.
+        // "0123" is much more likely to be a Hex string "0123".
+
+        val json = """
+        {
+          "entries": {
+            "0123": "REVOKED"
+          }
+        }
+        """.trimIndent()
+
+        val revoked = KeyboxVerifier.parseCrl(json)
+
+        println("Revoked Set: $revoked")
+
+        // We expect "0123" (canonicalized to "123" maybe? or just "0123"?)
+        // BigInteger("0123", 16) -> 291 -> "123" (hex)
+
+        // If the Key ID is "0123", the BigInteger representation is 291.
+        // toString(16) gives "123".
+
+        // Wait, if the serial is hex "123", toString(16) is "123".
+
+        assertTrue("Should contain '123' (hex value of 0123)", revoked.contains("123"))
+
+        // Currently, it likely contains "7b" (hex value of decimal 123).
+        // Let's verify failure.
+    }
+}


### PR DESCRIPTION
Strings in the CRL JSON that consist entirely of digits but have leading zeros (and length > 1) were incorrectly parsed as decimal numbers. This caused incorrect hex hashes to be generated for revoked Key IDs (e.g., '0123' -> 123 (dec) -> 7b (hex), instead of 0123 (hex)).

The fix forces `KeyboxVerifier` to treat strings with leading zeros as Hex (unless the string is just '0').

Added `KeyboxVerifierLeadingZeroTest` to verify the fix and prevent regressions.

---
*PR created automatically by Jules for task [2544387033306871439](https://jules.google.com/task/2544387033306871439) started by @tryigit*