### PR TITLE
🛡️ Sentinel: Fix insecure permissions and harden upload validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** The application stored configuration (`app_config`) as a space-delimited text file but accepted unvalidated user input for fields. This allowed "Configuration Injection" where attackers could insert newlines or spaces to create fake entries or corrupt the file structure.
 **Learning:** Simple text-based file formats are prone to injection if delimiters (spaces, newlines) are not strictly forbidden in the input data.
 **Prevention:** Always validate that user input does not contain the delimiters used by the storage format. For space-delimited files, reject any input matching `\s`.
+
+## 2025-05-30 - [Inconsistent Permission Initialization]
+**Vulnerability:** The service initialization logic (`Main.kt`) explicitly set the configuration directory permissions to `0755` (readable by all), overriding the secure `0700` permissions set during installation. This created a vulnerability window on every boot where sensitive files could potentially be read by other applications if their individual file permissions were weak.
+**Learning:** Security configurations distributed across multiple initialization points (installer scripts vs. runtime code) can drift and contradict each other. Runtime initialization code should treat the secure state as the source of truth, not defaults.
+**Prevention:** Centralize security configuration constants and verify that all initialization paths (install, boot, runtime) enforce the same strict permissions (`0700` for config dirs).

--- a/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
@@ -26,7 +26,7 @@ fun main(args: Array<String>) {
         if (!configDir.exists()) configDir.mkdirs()
         // Secure directory before writing sensitive file
         try {
-            Os.chmod(configDir.absolutePath, 493) // 0755
+            Os.chmod(configDir.absolutePath, 448) // 0700
         } catch (t: Throwable) {
             Logger.e("failed to set permissions for config dir", t)
         }

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -307,7 +307,8 @@ class WebServer(
              val filename = session.parms["filename"]
              val content = session.parms["content"]
 
-             if (filename != null && content != null && filename.endsWith(".xml") && !filename.contains("/")) {
+             // Security: Strict filename validation to prevent path traversal and weird files
+             if (filename != null && content != null && filename.endsWith(".xml") && filename.matches(Regex("^[a-zA-Z0-9._-]+$"))) {
                  val keyboxDir = File(configDir, "keyboxes")
                  if (!keyboxDir.exists()) {
                      keyboxDir.mkdirs()

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerUploadTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerUploadTest.kt
@@ -1,0 +1,90 @@
+package cleveres.tricky.cleverestech
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import java.nio.charset.StandardCharsets
+
+class WebServerUploadTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var server: WebServer
+    private lateinit var configDir: File
+
+    @Before
+    fun setUp() {
+        Logger.setImpl(object : Logger.LogImpl {
+            override fun d(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String, t: Throwable?) { t?.printStackTrace() }
+            override fun i(tag: String, msg: String) {}
+        })
+        configDir = tempFolder.newFolder("config")
+
+        server = WebServer(0, configDir)
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.stop()
+    }
+
+    private fun uploadKeybox(filename: String, content: String): Int {
+        val port = server.listeningPort
+        val token = server.token
+        val url = URL("http://localhost:$port/api/upload_keybox?token=$token")
+
+        val postData = "filename=$filename&content=$content"
+        val postDataBytes = postData.toByteArray(StandardCharsets.UTF_8)
+
+        val conn = url.openConnection() as HttpURLConnection
+        conn.requestMethod = "POST"
+        conn.doOutput = true
+        conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
+        conn.outputStream.write(postDataBytes)
+        conn.outputStream.close()
+
+        return conn.responseCode
+    }
+
+    @Test
+    fun testUploadKeyboxValidFilename() {
+        val responseCode = uploadKeybox("valid_keybox.xml", "<xml>ok</xml>")
+        assertEquals(200, responseCode)
+
+        val f = File(configDir, "keyboxes/valid_keybox.xml")
+        assert(f.exists())
+    }
+
+    @Test
+    fun testUploadKeyboxInvalidFilenameSpace() {
+        val responseCode = uploadKeybox("keybox space.xml", "<xml>bad</xml>")
+        assertEquals(400, responseCode)
+    }
+
+    @Test
+    fun testUploadKeyboxInvalidFilenameSpecialChar() {
+        val responseCode = uploadKeybox("keybox!.xml", "<xml>bad</xml>")
+        assertEquals(400, responseCode)
+    }
+
+    @Test
+    fun testUploadKeyboxInvalidFilenameTraversal() {
+        // Even if we URL encode it, the server sees the decoded param.
+        // But here we send raw string in post body (x-www-form-urlencoded).
+        // ".." is dots. "/" is slash.
+        // If we send "filename=../foo.xml", regex matches "." but not "/".
+
+        val responseCode = uploadKeybox("../foo.xml", "<xml>bad</xml>")
+        assertEquals(400, responseCode)
+    }
+}


### PR DESCRIPTION
Fixes a critical permission vulnerability in Main.kt where the config directory was set to world-readable on boot. Also hardens the WebServer upload endpoint.

---
*PR created automatically by Jules for task [12348365352155914417](https://jules.google.com/task/12348365352155914417) started by @tryigit*