### PR TITLE
🎨 Palette: Add explicit labels to identity inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -11,3 +11,7 @@
 ## 2026-02-05 - Accessible Notifications
 **Learning:** Custom "Dynamic Island" or toast notifications are often invisible to screen readers if they only animate opacity.
 **Action:** Always use `role="status"` and `aria-live="polite"` on notification containers so updates are announced without shifting focus.
+
+## 2026-05-21 - CSS Grids vs Inputs
+**Learning:** When using `display: grid` (e.g., `grid-2`), direct children become grid items. Adding a sibling `<label>` before an `<input>` breaks the layout if they aren't wrapped in a container `div`.
+**Action:** Always wrap `label + input` pairs in a `div` when retrofitting accessibility into existing grid-based layouts.

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -637,24 +637,48 @@ class WebServer(
 
             <div class="section-header">Modem / Telephony</div>
             <div class="grid-2">
-                <input type="text" id="inputImei" placeholder="IMEI (Slot 1)" style="font-family:monospace;">
-                <input type="text" id="inputImsi" placeholder="IMSI (Subscriber ID)" style="font-family:monospace;">
+                <div>
+                    <label for="inputImei" style="display:block; font-size:0.8em; margin-bottom:5px; color:#888;">IMEI (Slot 1)</label>
+                    <input type="text" id="inputImei" placeholder="35..." style="font-family:monospace;">
+                </div>
+                <div>
+                    <label for="inputImsi" style="display:block; font-size:0.8em; margin-bottom:5px; color:#888;">IMSI (Subscriber ID)</label>
+                    <input type="text" id="inputImsi" placeholder="310..." style="font-family:monospace;">
+                </div>
             </div>
             <div class="grid-2" style="margin-top:10px;">
-                <input type="text" id="inputIccid" placeholder="ICCID (Sim Serial)" style="font-family:monospace;">
-                <input type="text" id="inputSerial" placeholder="Device Serial No" style="font-family:monospace;">
+                <div>
+                    <label for="inputIccid" style="display:block; font-size:0.8em; margin-bottom:5px; color:#888;">ICCID (Sim Serial)</label>
+                    <input type="text" id="inputIccid" placeholder="89..." style="font-family:monospace;">
+                </div>
+                <div>
+                    <label for="inputSerial" style="display:block; font-size:0.8em; margin-bottom:5px; color:#888;">Device Serial No</label>
+                    <input type="text" id="inputSerial" placeholder="Alphanumeric..." style="font-family:monospace;">
+                </div>
             </div>
 
             <div class="section-header">Network Interface</div>
             <div class="grid-2">
-                <input type="text" id="inputWifiMac" placeholder="WiFi MAC" style="font-family:monospace;">
-                <input type="text" id="inputBtMac" placeholder="BT MAC" style="font-family:monospace;">
+                <div>
+                    <label for="inputWifiMac" style="display:block; font-size:0.8em; margin-bottom:5px; color:#888;">WiFi MAC</label>
+                    <input type="text" id="inputWifiMac" placeholder="00:11:22:33:44:55" style="font-family:monospace;">
+                </div>
+                <div>
+                    <label for="inputBtMac" style="display:block; font-size:0.8em; margin-bottom:5px; color:#888;">BT MAC</label>
+                    <input type="text" id="inputBtMac" placeholder="00:11:22:33:44:55" style="font-family:monospace;">
+                </div>
             </div>
 
             <div class="section-header">Operator Config (MBN Emulation)</div>
             <div class="grid-2">
-                 <input type="text" id="inputSimIso" placeholder="SIM Country ISO (us)">
-                 <input type="text" id="inputSimOp" placeholder="Operator Name">
+                 <div>
+                    <label for="inputSimIso" style="display:block; font-size:0.8em; margin-bottom:5px; color:#888;">SIM Country ISO</label>
+                    <input type="text" id="inputSimIso" placeholder="us">
+                 </div>
+                 <div>
+                    <label for="inputSimOp" style="display:block; font-size:0.8em; margin-bottom:5px; color:#888;">Operator Name</label>
+                    <input type="text" id="inputSimOp" placeholder="T-Mobile">
+                 </div>
             </div>
 
             <div style="margin-top:15px; text-align:right;">

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
@@ -66,7 +66,15 @@ class WebServerHtmlTest {
         // Verify Random Logic
         assertTrue("Missing Randomized Extras Header", html.contains("<h3>System-Wide Spoofing (Global Hardware)</h3>"))
         assertTrue("Missing IMEI Input", html.contains("id=\"inputImei\""))
+        assertTrue("Missing IMEI Label", html.contains("<label for=\"inputImei\""))
+        assertTrue("Missing IMSI Label", html.contains("<label for=\"inputImsi\""))
+        assertTrue("Missing ICCID Label", html.contains("<label for=\"inputIccid\""))
+        assertTrue("Missing Serial Label", html.contains("<label for=\"inputSerial\""))
+        assertTrue("Missing WiFi MAC Label", html.contains("<label for=\"inputWifiMac\""))
+        assertTrue("Missing BT MAC Label", html.contains("<label for=\"inputBtMac\""))
         assertTrue("Missing SIM ISO Input", html.contains("id=\"inputSimIso\""))
+        assertTrue("Missing SIM ISO Label", html.contains("<label for=\"inputSimIso\""))
+        assertTrue("Missing Operator Label", html.contains("<label for=\"inputSimOp\""))
         assertTrue("Missing Generate Random Button", html.contains("generateRandomIdentity"))
 
         // Verify Apps Logic


### PR DESCRIPTION
This PR improves the accessibility of the 'System-Wide Spoofing' section in the embedded WebUI. 

Previously, these fields relied solely on placeholders (e.g., `placeholder="IMEI (Slot 1)"`) which is an accessibility anti-pattern. I have added explicit `<label>` tags for all inputs in this section.

To preserve the existing 2-column grid layout (`.grid-2`), I wrapped each label+input pair in a container `div`. I also simplified the placeholders to show example data (e.g., `35...`) rather than duplicating the label text.

Verified with:
- `WebServerHtmlTest` (Unit test)
- Playwright visual verification (screenshot confirmed layout integrity)

---
*PR created automatically by Jules for task [5625188859150460730](https://jules.google.com/task/5625188859150460730) started by @tryigit*