### PR TITLE
🔧 Bugfix: Ambiguous Key IDs parsing

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -98,6 +98,15 @@ object KeyboxVerifier {
                 // Not a valid decimal, fall back to Hex
             }
 
+            // Ambiguity handling:
+            // If it was parsed as Decimal, but it *also* has the length of a standard Hex Key ID (32, 40, 64),
+            // it is possible that it is actually a Hex Key ID that happens to consist only of digits.
+            // In this case, we add BOTH interpretations to be safe.
+            if (added && (decStr.length == 32 || decStr.length == 40 || decStr.length == 64)) {
+                // It is already confirmed to be all digits (since BigInteger parsed it), so it matches Hex regex.
+                set.add(decStr.lowercase())
+            }
+
             if (!added) {
                 // Try treating as Hex (literal) as fallback
                 if (decStr.matches(Regex("^[0-9a-fA-F]+$"))) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/ReproKeyIDConfusionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ReproKeyIDConfusionTest.kt
@@ -1,0 +1,37 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.util.KeyboxVerifier
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReproKeyIDConfusionTest {
+
+    @Test
+    fun testAmbiguousKeyID() {
+        // A 32-character string that happens to be all digits.
+        // It is statistically possible for a Hex Key ID (MD5/128-bit) or truncated SHA to be all digits.
+        // Google CRL uses Hex for Key IDs.
+        // If "11112222333344445555666677778888" is in the CRL, it implies the Key with that ID is revoked.
+
+        val ambiguousKey = "11112222333344445555666677778888"
+        val json = """
+        {
+          "entries": {
+            "$ambiguousKey": "REVOKED"
+          }
+        }
+        """.trimIndent()
+
+        val revoked = KeyboxVerifier.parseCrl(json)
+
+        println("Ambiguous Key: $ambiguousKey")
+        println("Revoked Set: $revoked")
+
+        // We expect the set to contain the key ITSELF (treated as Hex).
+        assertTrue("Should contain '$ambiguousKey' (Hex literal)", revoked.contains(ambiguousKey))
+
+        // OPTIONAL: We might also expect the Decimal interpretation, just in case it WAS a serial number.
+        val decimalInterpretation = java.math.BigInteger(ambiguousKey).toString(16).lowercase()
+        assertTrue("Should contain '$decimalInterpretation' (Decimal interpretation)", revoked.contains(decimalInterpretation))
+    }
+}


### PR DESCRIPTION
Fixed a security bug where Key IDs consisting entirely of digits (length 32/40/64) were parsed solely as Decimal serial numbers, missing the Hex literal interpretation. Now adds both interpretations to the revocation set to ensure safety.

---
*PR created automatically by Jules for task [15981560430624903694](https://jules.google.com/task/15981560430624903694) started by @tryigit*