### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix input validation for keybox field

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -261,6 +261,11 @@ class WebServer(
                              return secureResponse(Response.Status.BAD_REQUEST, "text/plain", "Invalid input: invalid characters")
                          }
 
+                         // Validate keybox (alphanumeric, dots, underscores, hyphens)
+                         if (kb != "null" && !kb.matches(Regex("^[a-zA-Z0-9_.-]+$"))) {
+                             return secureResponse(Response.Status.BAD_REQUEST, "text/plain", "Invalid input: invalid characters")
+                         }
+
                          if (pkg.contains(Regex("\\s")) || tmpl.contains(Regex("\\s")) || kb.contains(Regex("\\s"))) {
                              return secureResponse(Response.Status.BAD_REQUEST, "text/plain", "Invalid input: whitespace not allowed")
                          }

--- a/service/src/test/java/cleveres/tricky/cleverestech/AppConfigKeyboxValidationTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/AppConfigKeyboxValidationTest.kt
@@ -1,0 +1,102 @@
+package cleveres.tricky.cleverestech
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.Rule
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import java.nio.charset.StandardCharsets
+
+class AppConfigKeyboxValidationTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var server: WebServer
+    private lateinit var configDir: File
+
+    @Before
+    fun setUp() {
+        configDir = tempFolder.newFolder("config")
+        server = WebServer(0, configDir)
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.stop()
+    }
+
+    @Test
+    fun testKeyboxWithSpecialCharactersShouldBeRejected() {
+        val port = server.listeningPort
+        val token = server.token
+        val url = URL("http://localhost:$port/api/app_config_structured?token=$token")
+
+        val conn = url.openConnection() as HttpURLConnection
+        conn.requestMethod = "POST"
+        conn.doOutput = true
+        conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
+
+        // Malicious payload: Keybox with special characters that should be rejected
+        // per the memory description: "^[a-zA-Z0-9_.-]+$"
+        val maliciousKeybox = "foo<script>bar.xml"
+
+        val jsonArray = JSONArray()
+        val obj = JSONObject()
+        obj.put("package", "com.valid.app")
+        obj.put("template", "valid_template")
+        obj.put("keybox", maliciousKeybox)
+        jsonArray.put(obj)
+
+        val postData = "data=" + java.net.URLEncoder.encode(jsonArray.toString(), "UTF-8")
+        val postDataBytes = postData.toByteArray(StandardCharsets.UTF_8)
+
+        conn.outputStream.use { it.write(postDataBytes) }
+
+        val responseCode = conn.responseCode
+
+        // Currently this fails because the code accepts it (returns 200)
+        // We want it to be >= 400
+        val msg = if (responseCode == 200) "Accepted invalid keybox: $maliciousKeybox" else "Rejected"
+        println("Response: $responseCode - $msg")
+
+        assertTrue("Should reject keybox with special characters", responseCode >= 400)
+    }
+
+    @Test
+    fun testKeyboxWithPathTraversalShouldBeRejected() {
+        val port = server.listeningPort
+        val token = server.token
+        val url = URL("http://localhost:$port/api/app_config_structured?token=$token")
+
+        val conn = url.openConnection() as HttpURLConnection
+        conn.requestMethod = "POST"
+        conn.doOutput = true
+        conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
+
+        val maliciousKeybox = "../../etc/passwd"
+
+        val jsonArray = JSONArray()
+        val obj = JSONObject()
+        obj.put("package", "com.valid.app")
+        obj.put("template", "valid_template")
+        obj.put("keybox", maliciousKeybox)
+        jsonArray.put(obj)
+
+        val postData = "data=" + java.net.URLEncoder.encode(jsonArray.toString(), "UTF-8")
+        val postDataBytes = postData.toByteArray(StandardCharsets.UTF_8)
+
+        conn.outputStream.use { it.write(postDataBytes) }
+
+        val responseCode = conn.responseCode
+        assertTrue("Should reject keybox with path traversal", responseCode >= 400)
+    }
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `/api/app_config_structured` endpoint failed to enforce strict regex validation on the `keybox` field, allowing invalid characters (except whitespace) to be persisted to the `app_config` file. This could potentially facilitate Path Traversal or Configuration Injection if the file consumer is vulnerable.
🎯 Impact: Attackers with access to the WebUI token could inject malicious configuration entries or attempt path traversal.
🔧 Fix: Added strict regex validation `^[a-zA-Z0-9_.-]+$` for the keybox field, matching the intended design and documentation.
✅ Verification: Added unit test `AppConfigKeyboxValidationTest` which confirms that payloads containing special characters (e.g., `<`, `>`) or path traversal sequences (`../`) are rejected with HTTP 400.

---
*PR created automatically by Jules for task [1767689457152186763](https://jules.google.com/task/1767689457152186763) started by @tryigit*