### PR TITLE
🔧 Bugfix: Fix Stored XSS in WebServer app_config parser

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -221,11 +221,14 @@ class WebServer(
                         if (line.isNotBlank() && !line.startsWith("#")) {
                             val parts = line.trim().split(Regex("\\s+"))
                             if (parts.isNotEmpty()) {
-                                val obj = JSONObject()
-                                obj.put("package", parts[0])
-                                obj.put("template", if (parts.size > 1 && parts[1] != "null") parts[1] else "")
-                                obj.put("keybox", if (parts.size > 2 && parts[2] != "null") parts[2] else "")
-                                array.put(obj)
+                                val pkg = parts[0]
+                                if (pkg.matches(Regex("^[a-zA-Z0-9_.*]+$"))) {
+                                    val obj = JSONObject()
+                                    obj.put("package", pkg)
+                                    obj.put("template", if (parts.size > 1 && parts[1] != "null") parts[1] else "")
+                                    obj.put("keybox", if (parts.size > 2 && parts[2] != "null") parts[2] else "")
+                                    array.put(obj)
+                                }
                             }
                         }
                     }

--- a/service/src/test/java/cleveres/tricky/cleverestech/ReproXssTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ReproXssTest.kt
@@ -1,0 +1,94 @@
+package cleveres.tricky.cleverestech
+
+import fi.iki.elonen.NanoHTTPD
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.Rule
+import java.io.File
+import java.io.InputStream
+import java.util.UUID
+
+class ReproXssTest {
+
+    @Rule
+    @JvmField
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var webServer: WebServer
+    private lateinit var configDir: File
+
+    @Before
+    fun setUp() {
+        configDir = tempFolder.newFolder("config")
+        // Initialize other files to avoid errors
+        File(configDir, "target.txt").createNewFile()
+    }
+
+    @Test
+    fun testStoredXssViaApiSave() {
+        webServer = WebServer(8080, configDir)
+
+        // 1. Attack: Use /api/save to write a malicious app_config
+        // This bypasses the validation in /api/app_config_structured POST handler
+        val maliciousPackage = "<svg/onload=alert(1)>"
+        val maliciousContent = "$maliciousPackage null null"
+
+        val saveSession = object : NanoHTTPD.IHTTPSession {
+            override fun execute() {}
+            override fun getCookies() = null
+            override fun getHeaders() = mapOf("content-length" to "100") // Dummy
+            override fun getInputStream(): InputStream? = null
+            override fun getMethod() = NanoHTTPD.Method.POST
+            override fun getParms() = mapOf("token" to webServer.token, "filename" to "app_config", "content" to maliciousContent)
+            override fun getParameters() = emptyMap<String, List<String>>()
+            override fun getQueryParameterString() = ""
+            override fun getUri() = "/api/save"
+            override fun parseBody(files: MutableMap<String, String>?) {}
+            override fun getRemoteIpAddress() = "127.0.0.1"
+            override fun getRemoteHostName() = "localhost"
+        }
+
+        val saveResponse = webServer.serve(saveSession)
+        if (saveResponse.status != NanoHTTPD.Response.Status.OK) {
+            fail("Failed to save malicious file: ${saveResponse.status}")
+        }
+
+        // 2. Victim: Retrieve the config via /api/app_config_structured
+        val getSession = object : NanoHTTPD.IHTTPSession {
+            override fun execute() {}
+            override fun getCookies() = null
+            override fun getHeaders() = emptyMap<String, String>()
+            override fun getInputStream(): InputStream? = null
+            override fun getMethod() = NanoHTTPD.Method.GET
+            override fun getParms() = mapOf("token" to webServer.token)
+            override fun getParameters() = emptyMap<String, List<String>>()
+            override fun getQueryParameterString() = ""
+            override fun getUri() = "/api/app_config_structured"
+            override fun parseBody(files: MutableMap<String, String>?) {}
+            override fun getRemoteIpAddress() = "127.0.0.1"
+            override fun getRemoteHostName() = "localhost"
+        }
+
+        val getResponse = webServer.serve(getSession)
+        val jsonStr = getResponse.data.bufferedReader().use { it.readText() }
+
+        println("JSON Response: $jsonStr")
+
+        val jsonArray = JSONArray(jsonStr)
+
+        // Assert that the malicious package is filtered out
+        if (jsonArray.length() != 0) {
+            val item = jsonArray.getJSONObject(0)
+            val pkg = item.getString("package")
+            if (pkg == maliciousPackage) {
+                fail("Vulnerability still exists: XSS payload was retrieved via API")
+            }
+        }
+
+        // If length is 0, it means it was filtered, which is good.
+    }
+}


### PR DESCRIPTION
This PR fixes a Stored Cross-Site Scripting (XSS) vulnerability in the `WebServer` component.
The `/api/save` endpoint allows modifying the `app_config` file without validation.
Previously, the `/api/app_config_structured` (GET) endpoint naively parsed the file content and returned it as JSON.
The WebUI then rendered the package name using `innerHTML`, allowing execution of malicious scripts if the `app_config` file contained XSS payloads (e.g., `<svg/onload=alert(1)>`).

The fix implements strict validation in the `GET` handler, discarding any entries where the package name contains invalid characters.
This ensures that even if the file contains malicious data (e.g., via manual edit or the `/api/save` vulnerability), it is sanitized before reaching the browser.
A reproduction test `ReproXssTest` is included.

---
*PR created automatically by Jules for task [5067359722764090147](https://jules.google.com/task/5067359722764090147) started by @tryigit*