### PR TITLE
🎨 Palette: Add empty state to Apps table

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -1002,6 +1002,12 @@ class WebServer(
         function renderAppTable() {
             const tbody = document.querySelector('#appTable tbody');
             tbody.innerHTML = '';
+            if (appRules.length === 0) {
+                const tr = document.createElement('tr');
+                tr.innerHTML = '<td colspan="4" style="text-align:center; padding:20px; color:#666;">No active rules. Add a package above to customize spoofing.</td>';
+                tbody.appendChild(tr);
+                return;
+            }
             appRules.forEach((rule, idx) => {
                 const tr = document.createElement('tr');
                 tr.innerHTML = `

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
@@ -85,6 +85,7 @@ class WebServerHtmlTest {
         assertTrue("Missing Blank Permissions Logic", html.contains("Blank Permissions (Privacy)"))
         assertTrue("Missing Contacts Permission Toggle", html.contains("id=\"permContacts\""))
         assertTrue("Missing Remove Button Accessibility", html.contains("aria-label=\"Remove rule for \${rule.package}\""))
+        assertTrue("Missing Empty State", html.contains("No active rules"))
 
         // Verify Editor
         assertTrue("Missing File Selector", html.contains("id=\"fileSelector\""))


### PR DESCRIPTION
💡 What: Added a helpful empty state message when no app rules are defined in the embedded WebUI.
🎯 Why: Prevents confusion by guiding the user when the list is empty, addressing a "blank page" issue.
♿ Accessibility: Provides context for the empty table state.
📸 Verified with Playwright and WebServerHtmlTest.

---
*PR created automatically by Jules for task [8928151038496713348](https://jules.google.com/task/8928151038496713348) started by @tryigit*