### PR TITLE
🎨 Palette: Make WebUI tabs keyboard accessible

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -562,16 +562,16 @@ class WebServer(
 
     <h1>${getAppName()} <span style="font-size:0.5em; vertical-align:middle; color:var(--accent); opacity:0.7; border: 1px solid var(--accent); border-radius: 4px; padding: 2px 6px; margin-left: 10px;">BETA</span></h1>
 
-    <div class="tabs" role="tablist">
-        <div class="tab active" id="tab_dashboard" onclick="switchTab('dashboard')">Dashboard</div>
-        <div class="tab" id="tab_spoof" onclick="switchTab('spoof')">Spoofing</div>
-        <div class="tab" id="tab_apps" onclick="switchTab('apps')">Apps</div>
-        <div class="tab" id="tab_keys" onclick="switchTab('keys')">Keyboxes</div>
-        <div class="tab" id="tab_editor" onclick="switchTab('editor')">Editor</div>
+    <div class="tabs" role="tablist" aria-label="Navigation">
+        <div class="tab active" id="tab_dashboard" onclick="switchTab('dashboard')" role="tab" tabindex="0" aria-selected="true" aria-controls="dashboard" onkeydown="handleTabKey(event, 'dashboard')">Dashboard</div>
+        <div class="tab" id="tab_spoof" onclick="switchTab('spoof')" role="tab" tabindex="0" aria-selected="false" aria-controls="spoof" onkeydown="handleTabKey(event, 'spoof')">Spoofing</div>
+        <div class="tab" id="tab_apps" onclick="switchTab('apps')" role="tab" tabindex="0" aria-selected="false" aria-controls="apps" onkeydown="handleTabKey(event, 'apps')">Apps</div>
+        <div class="tab" id="tab_keys" onclick="switchTab('keys')" role="tab" tabindex="0" aria-selected="false" aria-controls="keys" onkeydown="handleTabKey(event, 'keys')">Keyboxes</div>
+        <div class="tab" id="tab_editor" onclick="switchTab('editor')" role="tab" tabindex="0" aria-selected="false" aria-controls="editor" onkeydown="handleTabKey(event, 'editor')">Editor</div>
     </div>
 
     <!-- DASHBOARD -->
-    <div id="dashboard" class="content active">
+    <div id="dashboard" class="content active" role="tabpanel" aria-labelledby="tab_dashboard">
         <div class="panel">
             <h3>System Control</h3>
             <div class="row"><label for="global_mode">Global Mode</label><input type="checkbox" class="toggle" id="global_mode" onchange="toggle('global_mode')"></div>
@@ -619,7 +619,7 @@ class WebServer(
     </div>
 
     <!-- SPOOFING (Replacing Lab) -->
-    <div id="spoof" class="content">
+    <div id="spoof" class="content" role="tabpanel" aria-labelledby="tab_spoof">
         <div class="panel">
             <h3>Identity Manager</h3>
             <p style="color:#888; font-size:0.9em; margin-bottom:15px;">Select a verified device identity to spoof globally.</p>
@@ -703,7 +703,7 @@ class WebServer(
     </div>
 
     <!-- APPS -->
-    <div id="apps" class="content">
+    <div id="apps" class="content" role="tabpanel" aria-labelledby="tab_apps">
         <div class="panel">
             <h3>New Rule</h3>
             <div style="margin-bottom:10px;">
@@ -750,7 +750,7 @@ class WebServer(
     </div>
 
     <!-- KEYS -->
-    <div id="keys" class="content">
+    <div id="keys" class="content" role="tabpanel" aria-labelledby="tab_keys">
         <div class="panel">
             <h3>Upload Keybox</h3>
             <input type="file" id="kbFilePicker" style="display:none" onchange="loadFileContent(this)" onclick="this.value = null">
@@ -770,7 +770,7 @@ class WebServer(
     </div>
 
     <!-- EDITOR -->
-    <div id="editor" class="content">
+    <div id="editor" class="content" role="tabpanel" aria-labelledby="tab_editor">
         <div class="panel">
             <div class="row">
                 <select id="fileSelector" onchange="loadFile()" style="width:70%;">
@@ -837,11 +837,25 @@ class WebServer(
         }
 
         function switchTab(id) {
-            document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+            document.querySelectorAll('.tab').forEach(t => {
+                t.classList.remove('active');
+                t.setAttribute('aria-selected', 'false');
+            });
             document.querySelectorAll('.content').forEach(c => c.classList.remove('active'));
-            document.getElementById('tab_' + id).classList.add('active');
+
+            const tab = document.getElementById('tab_' + id);
+            tab.classList.add('active');
+            tab.setAttribute('aria-selected', 'true');
+
             document.getElementById(id).classList.add('active');
             if (id === 'apps') loadAppConfig();
+        }
+
+        function handleTabKey(e, id) {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                switchTab(id);
+            }
         }
 
         async function init() {

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
@@ -93,4 +93,28 @@ class WebServerHtmlTest {
         assertTrue("Missing Keybox File Picker", html.contains("id=\"kbFilePicker\""))
         assertTrue("Missing Verify Button", html.contains("verifyKeyboxes"))
     }
+
+    @Test
+    fun testAccessibilityAttributes() {
+        val port = server.listeningPort
+        val token = server.token
+        val url = URL("http://localhost:$port/?token=$token")
+        val conn = url.openConnection() as HttpURLConnection
+        val html = conn.inputStream.bufferedReader().readText()
+
+        // Verify Tabs Accessibility
+        assertTrue("Missing Tab Role", html.contains("role=\"tab\""))
+        assertTrue("Missing Tabindex", html.contains("tabindex=\"0\""))
+        assertTrue("Missing Aria Selected", html.contains("aria-selected=\"true\""))
+        assertTrue("Missing Key Handler", html.contains("onkeydown=\"handleTabKey"))
+        assertTrue("Missing Tab Controls", html.contains("aria-controls=\"dashboard\""))
+
+        // Verify Panels Accessibility
+        assertTrue("Missing Tabpanel Role", html.contains("role=\"tabpanel\""))
+        assertTrue("Missing Aria Labelledby", html.contains("aria-labelledby=\"tab_dashboard\""))
+
+        // Verify JS helpers
+        assertTrue("Missing handleTabKey JS", html.contains("function handleTabKey(e, id)"))
+        assertTrue("Missing aria-selected update in switchTab", html.contains("setAttribute('aria-selected'"))
+    }
 }


### PR DESCRIPTION
This PR addresses an accessibility issue where the main navigation tabs were inaccessible to keyboard users and screen readers because they were implemented as `div` elements with `onclick` handlers.

Changes:
- Added `role="tablist"`, `role="tab"`, and `role="tabpanel"` attributes to define the semantic structure.
- Added `tabindex="0"` to make tabs focusable.
- Added `aria-selected` and `aria-controls` / `aria-labelledby` to link tabs to their panels and communicate state.
- Implemented `handleTabKey` in the embedded JavaScript to support activating tabs with `Enter` or `Space` keys.
- Updated the `WebServerHtmlTest` to verify the presence of these new accessibility attributes.

This ensures the WebUI is more inclusive and complies with basic accessibility standards without altering the visual design.

---
*PR created automatically by Jules for task [17969501159952051522](https://jules.google.com/task/17969501159952051522) started by @tryigit*