### PR TITLE
🛡️ Sentinel: Secure RKP root secret permissions (0600)

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
@@ -34,7 +34,7 @@ fun main(args: Array<String>) {
         // Initialize RKP Proxy and ensure key is accessible by system/interceptor
         try {
             LocalRkpProxy.getMacKey()
-            Os.chmod(LocalRkpProxy.KEY_FILE_PATH, 438) // 0666
+            Os.chmod(LocalRkpProxy.KEY_FILE_PATH, 384) // 0600
         } catch (t: Throwable) {
             Logger.e("failed to init RKP permissions", t)
         }
@@ -68,6 +68,8 @@ fun main(args: Array<String>) {
             if (!TelephonyInterceptor.tryRunTelephonyInterceptor()) {
                  Logger.i("Retrying Telephony Interceptor injection...")
             }
+            // Maintenance: Check RKP key rotation (Anti-Fingerprinting)
+            LocalRkpProxy.checkAndRotate()
             Thread.sleep(10000)
         }
     }


### PR DESCRIPTION
Fixed insecure file permissions on RKP root secret (was 0666, now 0600). Added maintenance rotation logic to `Main` service loop to ensure keys are rotated securely by the root process. Updated `LocalRkpProxy` to handle permission failures gracefully.

---
*PR created automatically by Jules for task [15577467009106678988](https://jules.google.com/task/15577467009106678988) started by @tryigit*