### PR TITLE
🔧 Bugfix: Support multiple Keybox elements in CertHack XML parser

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -209,15 +209,20 @@ public final class CertHack {
                 return Collections.emptyList();
             }
             int numberOfKeyboxes = Integer.parseInt(Objects.requireNonNull(numPath.get("text")));
+            int actualKeyboxElements = xmlParser.getChildCount("AndroidAttestation", "Keybox");
 
             for (int i = 0; i < numberOfKeyboxes; i++) {
-                String keyboxAlgorithm = xmlParser.obtainPath(
-                        "AndroidAttestation.Keybox.Key[" + i + "]").get("algorithm");
-                String privateKey = xmlParser.obtainPath(
-                        "AndroidAttestation.Keybox.Key[" + i + "].PrivateKey").get("text");
+                String keyBasePath;
+                if (actualKeyboxElements > 1 && i < actualKeyboxElements) {
+                    keyBasePath = "AndroidAttestation.Keybox[" + i + "].Key";
+                } else {
+                    keyBasePath = "AndroidAttestation.Keybox.Key[" + i + "]";
+                }
 
-                var numCertsPath = xmlParser.obtainPath(
-                        "AndroidAttestation.Keybox.Key[" + i + "].CertificateChain.NumberOfCertificates");
+                String keyboxAlgorithm = xmlParser.obtainPath(keyBasePath).get("algorithm");
+                String privateKey = xmlParser.obtainPath(keyBasePath + ".PrivateKey").get("text");
+
+                var numCertsPath = xmlParser.obtainPath(keyBasePath + ".CertificateChain.NumberOfCertificates");
                 if (numCertsPath == null || numCertsPath.get("text") == null) continue;
 
                 int numberOfCertificates = Integer.parseInt(Objects.requireNonNull(numCertsPath.get("text")));
@@ -225,7 +230,7 @@ public final class CertHack {
                 LinkedList<Certificate> certificateChain = new LinkedList<>();
                 for (int j = 0; j < numberOfCertificates; j++) {
                     String certPem = xmlParser.obtainPath(
-                            "AndroidAttestation.Keybox.Key[" + i + "].CertificateChain.Certificate[" + j + "]").get("text");
+                            keyBasePath + ".CertificateChain.Certificate[" + j + "]").get("text");
                     certificateChain.add(parseCert(certPem));
                 }
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/MultiKeyboxTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/MultiKeyboxTest.java
@@ -1,0 +1,76 @@
+package cleveres.tricky.cleverestech.keystore;
+
+import org.junit.Test;
+import java.io.StringReader;
+import static org.junit.Assert.assertEquals;
+import cleveres.tricky.cleverestech.Logger;
+
+public class MultiKeyboxTest {
+
+    private static final String EC_KEY = "-----BEGIN EC PRIVATE KEY-----\n" +
+            "MHcCAQEEIAcPs+YkQGT6EDkaEH6Z9StSR7mQuKnh49K0DVqB/ZxYoAoGCCqGSM49\n" +
+            "AwEHoUQDQgAEzi23gXvUATkDmPcNPgsqe24eWmSIfuteSk8S5wJxs4ABt+O6QGAO\n" +
+            "XHqvCjNpJSbUxgz3SZefi8TWWQ1t32G/1w==\n" +
+            "-----END EC PRIVATE KEY-----";
+
+    private static final String TEST_CERT = "-----BEGIN CERTIFICATE-----\n" +
+            "MIIBfTCCASOgAwIBAgIUBZ47iWGUbx00hmWBPTYkakbXnigwCgYIKoZIzj0EAwIw\n" +
+            "FDESMBAGA1UEAwwJVGVzdCBDZXJ0MB4XDTI2MDEyOTIxNTI0M1oXDTI3MDEyNDIx\n" +
+            "NTI0M1owFDESMBAGA1UEAwwJVGVzdCBDZXJ0MFkwEwYHKoZIzj0CAQYIKoZIzj0D\n" +
+            "AQcDQgAEzi23gXvUATkDmPcNPgsqe24eWmSIfuteSk8S5wJxs4ABt+O6QGAOXHqv\n" +
+            "CjNpJSbUxgz3SZefi8TWWQ1t32G/16NTMFEwHQYDVR0OBBYEFCwifKyDaNaHtKvx\n" +
+            "m+0eLn/LZoTaMB8GA1UdIwQYMBaAFCwifKyDaNaHtKvxm+0eLn/LZoTaMA8GA1Ud\n" +
+            "EwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIgT+CWCLXuIN5XY0c3mFN1p1FM\n" +
+            "1KAiK9pMwjbHYxNxDmYCIQDXriCpaafMnkJIqGb8UsI5XlkQD0soXYP7hd9ymW/t\n" +
+            "qg==\n" +
+            "-----END CERTIFICATE-----";
+
+    @Test
+    public void testMultipleKeyboxElements() {
+        Logger.setImpl(new Logger.LogImpl() {
+            @Override public void d(String tag, String msg) { System.out.println("D/" + tag + ": " + msg); }
+            @Override public void e(String tag, String msg) { System.out.println("E/" + tag + ": " + msg); }
+            @Override public void e(String tag, String msg, Throwable t) { System.out.println("E/" + tag + ": " + msg); t.printStackTrace(); }
+            @Override public void i(String tag, String msg) { System.out.println("I/" + tag + ": " + msg); }
+        });
+
+        // XML with 2 Keybox elements, each containing 1 Key
+        String xml = "<?xml version=\"1.0\"?>\n" +
+                "<AndroidAttestation>\n" +
+                "<NumberOfKeyboxes>2</NumberOfKeyboxes>\n" +
+                "<Keybox>\n" +
+                "<Key algorithm=\"ecdsa\">\n" +
+                "<PrivateKey>\n" + EC_KEY + "\n</PrivateKey>\n" +
+                "<CertificateChain>\n" +
+                "<NumberOfCertificates>1</NumberOfCertificates>\n" +
+                "<Certificate>\n" + TEST_CERT + "\n</Certificate>\n" +
+                "</CertificateChain>\n" +
+                "</Key>\n" +
+                "</Keybox>\n" +
+                "<Keybox>\n" +
+                "<Key algorithm=\"ecdsa\">\n" +
+                "<PrivateKey>\n" + EC_KEY + "\n</PrivateKey>\n" +
+                "<CertificateChain>\n" +
+                "<NumberOfCertificates>1</NumberOfCertificates>\n" +
+                "<Certificate>\n" + TEST_CERT + "\n</Certificate>\n" +
+                "</CertificateChain>\n" +
+                "</Key>\n" +
+                "</Keybox>\n" +
+                "</AndroidAttestation>";
+
+        // Expectation: Both keyboxes are loaded.
+        // Current implementation: Reads "NumberOfKeyboxes" = 2.
+        // Loops i=0, 1.
+        // i=0: Access "AndroidAttestation.Keybox.Key[0]".
+        //      "AndroidAttestation.Keybox" returns the FIRST Keybox element.
+        //      "Key[0]" returns the key inside it. OK.
+        // i=1: Access "AndroidAttestation.Keybox.Key[1]".
+        //      "AndroidAttestation.Keybox" returns the FIRST Keybox element.
+        //      "Key[1]" tries to find second key inside FIRST Keybox.
+        //      It DOES NOT EXIST. Fails.
+
+        CertHack.readFromXml(new StringReader(xml));
+
+        assertEquals("Should load 2 keys", 2, CertHack.getKeyboxCount());
+    }
+}


### PR DESCRIPTION
Fixed a bug in CertHack.java where the XML parser assumed all keys were contained within a single <Keybox> element. This caused keys in subsequent <Keybox> elements (common in multi-device XMLs) to be ignored.

The fix introduces dynamic path construction:
- Checks the actual number of <Keybox> child elements.
- Uses 'AndroidAttestation.Keybox[i].Key' path for multiple Keybox elements.
- Falls back to 'AndroidAttestation.Keybox.Key[i]' for the legacy single-Keybox structure.

Verified with a new reproduction test (MultiKeyboxTest) and existing CertHackTest.

---
*PR created automatically by Jules for task [5413833551040273929](https://jules.google.com/task/5413833551040273929) started by @tryigit*