### PR TITLE
Fix false positive Keybox revocation for ambiguous decimal keys

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -98,15 +98,6 @@ object KeyboxVerifier {
                 // Not a valid decimal, fall back to Hex
             }
 
-            // Ambiguity handling:
-            // If it was parsed as Decimal, but it *also* has the length of a standard Hex Key ID (32, 40, 64),
-            // it is possible that it is actually a Hex Key ID that happens to consist only of digits.
-            // In this case, we add BOTH interpretations to be safe.
-            if (added && (decStr.length == 32 || decStr.length == 40 || decStr.length == 64)) {
-                // It is already confirmed to be all digits (since BigInteger parsed it), so it matches Hex regex.
-                set.add(decStr.lowercase())
-            }
-
             if (!added) {
                 // Try treating as Hex (literal) as fallback
                 if (decStr.matches(Regex("^[0-9a-fA-F]+$"))) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/ReproFalsePositiveRevocationTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ReproFalsePositiveRevocationTest.kt
@@ -1,0 +1,36 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.util.KeyboxVerifier
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class ReproFalsePositiveRevocationTest {
+
+    @Test
+    fun testAmbiguousKeyDoesNotProduceFalsePositive() {
+        // A 32-character string that consists only of digits.
+        // It is a valid Decimal number (Google CRL format).
+        // It is ALSO a valid Hex string (if interpreted as Hex Key ID).
+        //
+        // Google CRL uses Decimal Serial Numbers.
+        // We should interpret it as Decimal.
+        // We should NOT interpret it as Hex, because that would revoke a completely different certificate
+        // (one whose serial number in Hex matches this string).
+
+        val decimalSerial = "10000000000000000000000000000001" // 32 chars
+
+        val json = """
+        {
+          "entries": {
+            "$decimalSerial": "REVOKED"
+          }
+        }
+        """.trimIndent()
+
+        val revoked = KeyboxVerifier.parseCrl(json)
+        println("Revoked: $revoked")
+
+        // The bug is that it adds "10000000000000000000000000000001" to the set
+        assertFalse("Should NOT contain literal string '$decimalSerial' just because it looks like Hex", revoked.contains(decimalSerial.lowercase()))
+    }
+}


### PR DESCRIPTION
Fixes a high-severity bug in KeyboxVerifier where valid certificates were falsely flagged as revoked due to ambiguous parsing of CRL entries.

Previously, if a decimal serial number in the CRL was 32, 40, or 64 digits long, the verifier would also add its literal string representation (interpreted as Hex) to the revocation set. This meant that a certificate with a hex serial number identical to that decimal string would be falsely revoked.

This change removes that ambiguity handling block, enforcing that decimal strings are only treated as decimal values (which are then converted to their correct hex representation for comparison), as per the Google CRL specification.

---
*PR created automatically by Jules for task [4828438780055997000](https://jules.google.com/task/4828438780055997000) started by @tryigit*