### PR TITLE
🎨 Palette: Add search filter to apps list

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -745,7 +745,10 @@ class WebServer(
         </div>
 
         <div class="panel">
-            <h3>Active Rules</h3>
+            <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:10px;">
+                <h3 style="border:none; margin:0; padding:0;">Active Rules</h3>
+                <input type="text" id="appFilter" placeholder="Filter..." oninput="renderAppTable()" aria-label="Filter rules" style="width:150px; padding:5px 10px; font-size:0.85em; background:var(--input-bg); border:1px solid var(--border); color:#fff; border-radius:4px;">
+            </div>
             <table id="appTable">
                 <thead><tr><th>Package</th><th>Profile</th><th>Flags</th><th></th></tr></thead>
                 <tbody></tbody>
@@ -1026,15 +1029,22 @@ class WebServer(
         }
 
         function renderAppTable() {
+            const filter = document.getElementById('appFilter') ? document.getElementById('appFilter').value.toLowerCase() : '';
             const tbody = document.querySelector('#appTable tbody');
             tbody.innerHTML = '';
+
             if (appRules.length === 0) {
                 const tr = document.createElement('tr');
                 tr.innerHTML = '<td colspan="4" style="text-align:center; padding:20px; color:#666;">No active rules. Add a package above to customize spoofing.</td>';
                 tbody.appendChild(tr);
                 return;
             }
+
+            let visibleCount = 0;
             appRules.forEach((rule, idx) => {
+                if (filter && !rule.package.toLowerCase().includes(filter)) return;
+
+                visibleCount++;
                 const tr = document.createElement('tr');
                 tr.innerHTML = `
                     <td>${'$'}{rule.package}</td>
@@ -1046,6 +1056,12 @@ class WebServer(
                 `;
                 tbody.appendChild(tr);
             });
+
+            if (visibleCount === 0) {
+                const tr = document.createElement('tr');
+                tr.innerHTML = '<td colspan="4" style="text-align:center; padding:20px; color:#666;">No matching rules found.</td>';
+                tbody.appendChild(tr);
+            }
         }
 
         function addAppRule() {

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
@@ -87,6 +87,11 @@ class WebServerHtmlTest {
         assertTrue("Missing Remove Button Accessibility", html.contains("aria-label=\"Remove rule for \${rule.package}\""))
         assertTrue("Missing Empty State", html.contains("No active rules"))
 
+        // Verify Apps Search Filter
+        assertTrue("Missing App Filter Input", html.contains("id=\"appFilter\""))
+        assertTrue("Missing App Filter ARIA Label", html.contains("aria-label=\"Filter rules\""))
+        assertTrue("Missing App Filter JS Logic", html.contains("rule.package.toLowerCase().includes(filter)"))
+
         // Verify Editor
         assertTrue("Missing File Selector", html.contains("id=\"fileSelector\""))
 


### PR DESCRIPTION
Added a search/filter input to the "Active Rules" list in the WebUI to help users quickly find specific app rules. Includes accessibility improvements like `aria-label` and distinct empty states.

---
*PR created automatically by Jules for task [6091965142106758586](https://jules.google.com/task/6091965142106758586) started by @tryigit*