### PR TITLE
🛡️ Sentinel: [MEDIUM] Add input validation to /api/save and fix KeyboxVerifier ambiguity

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerSaveValidationTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerSaveValidationTest.kt
@@ -1,0 +1,116 @@
+package cleveres.tricky.cleverestech
+
+import fi.iki.elonen.NanoHTTPD
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.io.InputStream
+import java.util.UUID
+import cleveres.tricky.cleverestech.util.SecureFile
+import cleveres.tricky.cleverestech.util.SecureFileOperations
+
+class WebServerSaveValidationTest {
+
+    @Rule
+    @JvmField
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var webServer: WebServer
+    private lateinit var configDir: File
+
+    @Before
+    fun setUp() {
+        configDir = tempFolder.newFolder("config")
+        webServer = WebServer(8080, configDir)
+
+        // Mock SecureFile to avoid Android OS dependency
+        SecureFile.impl = object : SecureFileOperations {
+             override fun writeText(file: File, content: String) {
+                 file.parentFile?.mkdirs()
+                 file.writeText(content)
+             }
+        }
+    }
+
+    private fun mockSession(filename: String, content: String): NanoHTTPD.IHTTPSession {
+        return object : NanoHTTPD.IHTTPSession {
+            override fun execute() {}
+            override fun getCookies() = null
+            override fun getHeaders() = mapOf("content-length" to "100")
+            override fun getInputStream(): InputStream? = null
+            override fun getMethod() = NanoHTTPD.Method.POST
+            override fun getParms() = mapOf(
+                "token" to webServer.token,
+                "filename" to filename,
+                "content" to content
+            )
+            override fun getParameters() = emptyMap<String, List<String>>()
+            override fun getQueryParameterString() = ""
+            override fun getUri() = "/api/save"
+            override fun parseBody(files: MutableMap<String, String>?) {}
+            override fun getRemoteIpAddress() = "127.0.0.1"
+            override fun getRemoteHostName() = "localhost"
+        }
+    }
+
+    @Test
+    fun testAppConfigValid() {
+        val content = "com.example.app pixel8pro keybox.xml\n# Comment\ncom.foo.bar\n"
+        val response = webServer.serve(mockSession("app_config", content))
+        assertEquals(NanoHTTPD.Response.Status.OK, response.status)
+        assertTrue(File(configDir, "app_config").exists())
+    }
+
+    @Test
+    fun testAppConfigInvalid() {
+        val content = "com.example.app pixel8pro keybox.xml\nINJECTED LINE!!!!\n"
+        val response = webServer.serve(mockSession("app_config", content))
+        assertEquals(NanoHTTPD.Response.Status.BAD_REQUEST, response.status)
+    }
+
+    @Test
+    fun testTargetTxtValid() {
+        val content = "com.example.app\ncom.foo.bar!\n# Comment"
+        val response = webServer.serve(mockSession("target.txt", content))
+        assertEquals(NanoHTTPD.Response.Status.OK, response.status)
+    }
+
+    @Test
+    fun testTargetTxtInvalid() {
+        val content = "com.example.app\nINVALID PACK AGE\n"
+        val response = webServer.serve(mockSession("target.txt", content))
+        assertEquals(NanoHTTPD.Response.Status.BAD_REQUEST, response.status)
+    }
+
+    @Test
+    fun testSpoofBuildVarsValid() {
+        val content = "MANUFACTURER=Google\nMODEL=Pixel 8\nro.product.model=Pixel 8"
+        val response = webServer.serve(mockSession("spoof_build_vars", content))
+        assertEquals(NanoHTTPD.Response.Status.OK, response.status)
+    }
+
+    @Test
+    fun testSpoofBuildVarsInvalid() {
+        val content = "MANUFACTURER=Google\nINVALID_LINE_NO_EQUALS\n"
+        val response = webServer.serve(mockSession("spoof_build_vars", content))
+        assertEquals(NanoHTTPD.Response.Status.BAD_REQUEST, response.status)
+    }
+
+    @Test
+    fun testSecurityPatchValid() {
+        val content = "2024-01-01\nsystem=20240101"
+        val response = webServer.serve(mockSession("security_patch.txt", content))
+        assertEquals(NanoHTTPD.Response.Status.OK, response.status)
+    }
+
+    @Test
+    fun testSecurityPatchInvalid() {
+        val content = "2024-01-01\nINJECTED <script>"
+        val response = webServer.serve(mockSession("security_patch.txt", content))
+        assertEquals(NanoHTTPD.Response.Status.BAD_REQUEST, response.status)
+    }
+}

--- a/test_repro.kt
+++ b/test_repro.kt
@@ -1,0 +1,49 @@
+
+import org.json.JSONObject
+import java.math.BigInteger
+import java.util.HashSet
+
+fun main() {
+    val ambiguousKey = "11112222333344445555666677778888"
+    val jsonStr = """
+    {
+      "entries": {
+        "$ambiguousKey": "REVOKED"
+      }
+    }
+    """.trimIndent()
+
+    val json = JSONObject(jsonStr)
+    val entries = json.getJSONObject("entries")
+    val set = HashSet<String>()
+    val keys = entries.keys()
+
+    while (keys.hasNext()) {
+        val decStr = keys.next()
+        println("Processing key: '$decStr' length: ${decStr.length}")
+
+        var added = false
+        try {
+            if (decStr.length > 1 && decStr.startsWith("0")) {
+                throw NumberFormatException("Leading zero implies Hex")
+            }
+            val hexStr = BigInteger(decStr).toString(16).lowercase()
+            println("Parsed as decimal -> hex: $hexStr")
+            set.add(hexStr)
+            added = true
+        } catch (e: Exception) {
+            println("Not a decimal: ${e.message}")
+        }
+
+        if (added && (decStr.length == 32 || decStr.length == 40 || decStr.length == 64)) {
+            println("Ambiguity detected. Adding literal: $decStr")
+            set.add(decStr.lowercase())
+        }
+    }
+
+    if (set.contains(ambiguousKey)) {
+        println("SUCCESS: Set contains literal key")
+    } else {
+        println("FAILURE: Set does NOT contain literal key")
+    }
+}


### PR DESCRIPTION
- Implemented `validateContent` in `WebServer.kt` to enforce regex-based validation for `app_config`, `target.txt`, `spoof_build_vars`, and `security_patch.txt`.
- Added `WebServerSaveValidationTest.kt` to verify the new validation logic.
- Updated `KeyboxVerifier.kt` to handle ambiguous numeric Key IDs in CRLs by treating them as both decimal and hex if length matches standard Key ID lengths.
- Verified fix for `ReproKeyIDConfusionTest` build failure reported by user.

---
*PR created automatically by Jules for task [4829459865029575596](https://jules.google.com/task/4829459865029575596) started by @tryigit*