### PR TITLE
Fix build failures in KeyboxVerifier and XSS tests

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -105,7 +105,9 @@ object KeyboxVerifier {
             // We MUST add it as a literal Hex string to ensure we catch it if it's a Key ID.
             if (decStr.length == 32 || decStr.length == 40 || decStr.length == 64) {
                 if (decStr.matches(Regex("^[0-9a-fA-F]+$"))) {
-                    set.add(decStr.lowercase())
+                    if (!added) {
+                        set.add(decStr.lowercase())
+                    }
                 }
             }
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/ReproKeyIDConfusionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ReproKeyIDConfusionTest.kt
@@ -1,6 +1,7 @@
 package cleveres.tricky.cleverestech
 
 import cleveres.tricky.cleverestech.util.KeyboxVerifier
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -27,10 +28,11 @@ class ReproKeyIDConfusionTest {
         println("Ambiguous Key: $ambiguousKey")
         println("Revoked Set: $revoked")
 
-        // We expect the set to contain the key ITSELF (treated as Hex).
-        assertTrue("Should contain '$ambiguousKey' (Hex literal)", revoked.contains(ambiguousKey))
+        // We do NOT expect the set to contain the key ITSELF (treated as Hex) if it is a valid decimal.
+        // Treating it as Hex causes false positive revocations (see ReproFalsePositiveRevocationTest).
+        assertFalse("Should NOT contain '$ambiguousKey' (Hex literal) to avoid false positives", revoked.contains(ambiguousKey))
 
-        // OPTIONAL: We might also expect the Decimal interpretation, just in case it WAS a serial number.
+        // We expect the Decimal interpretation.
         val decimalInterpretation = java.math.BigInteger(ambiguousKey).toString(16).lowercase()
         assertTrue("Should contain '$decimalInterpretation' (Decimal interpretation)", revoked.contains(decimalInterpretation))
     }


### PR DESCRIPTION
Resolved build failures in `:service:testDebugUnitTest`. 

1. **False Positive Revocation**: `KeyboxVerifier` was aggressively interpreting 32/40/64 digit strings as both Decimal and Hex. This caused false positives if a valid Decimal serial number happened to match a different certificate's Hex serial. The fix ensures that if a string is a valid Decimal (no leading zero, all digits), it is NOT treated as a raw Hex literal.
2. **Conflicting Test**: `ReproKeyIDConfusionTest` asserted the old behavior. It was updated to assert the new, safer behavior (valid decimals are not treated as hex).
3. **XSS Repro Test**: `ReproXssTest` failed because it expected to successfully save a malicious file via `/api/save`. The server correctly rejects this with `BAD_REQUEST`. The test was updated to assert this rejection, verifying the security fix.

---
*PR created automatically by Jules for task [14250928544050025682](https://jules.google.com/task/14250928544050025682) started by @tryigit*