### PR TITLE
Fix KeyboxVerifier ignoring ambiguous numeric Key IDs

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -105,9 +105,7 @@ object KeyboxVerifier {
             // We MUST add it as a literal Hex string to ensure we catch it if it's a Key ID.
             if (decStr.length == 32 || decStr.length == 40 || decStr.length == 64) {
                 if (decStr.matches(Regex("^[0-9a-fA-F]+$"))) {
-                    if (!added) {
-                        set.add(decStr.lowercase())
-                    }
+                    set.add(decStr.lowercase())
                 }
             }
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/ReproFalsePositiveRevocationTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ReproFalsePositiveRevocationTest.kt
@@ -1,21 +1,19 @@
 package cleveres.tricky.cleverestech
 
 import cleveres.tricky.cleverestech.util.KeyboxVerifier
-import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ReproFalsePositiveRevocationTest {
 
     @Test
-    fun testAmbiguousKeyDoesNotProduceFalsePositive() {
+    fun testAmbiguousKeyIsIncludedToAvoidSecurityBypass() {
         // A 32-character string that consists only of digits.
         // It is a valid Decimal number (Google CRL format).
         // It is ALSO a valid Hex string (if interpreted as Hex Key ID).
         //
-        // Google CRL uses Decimal Serial Numbers.
-        // We should interpret it as Decimal.
-        // We should NOT interpret it as Hex, because that would revoke a completely different certificate
-        // (one whose serial number in Hex matches this string).
+        // We accept the risk of False Positive (revoking a cert with serial 'decimalSerial' treated as hex)
+        // in exchange for ensuring we don't miss a banned Key ID.
 
         val decimalSerial = "10000000000000000000000000000001" // 32 chars
 
@@ -30,7 +28,7 @@ class ReproFalsePositiveRevocationTest {
         val revoked = KeyboxVerifier.parseCrl(json)
         println("Revoked: $revoked")
 
-        // The bug is that it adds "10000000000000000000000000000001" to the set
-        assertFalse("Should NOT contain literal string '$decimalSerial' just because it looks like Hex", revoked.contains(decimalSerial.lowercase()))
+        // We expect it to be included as literal hex as well.
+        assertTrue("Should contain literal string '$decimalSerial' to ensure Key ID coverage", revoked.contains(decimalSerial.lowercase()))
     }
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/ReproKeyIDConfusionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ReproKeyIDConfusionTest.kt
@@ -28,11 +28,11 @@ class ReproKeyIDConfusionTest {
         println("Ambiguous Key: $ambiguousKey")
         println("Revoked Set: $revoked")
 
-        // We do NOT expect the set to contain the key ITSELF (treated as Hex) if it is a valid decimal.
-        // Treating it as Hex causes false positive revocations (see ReproFalsePositiveRevocationTest).
-        assertFalse("Should NOT contain '$ambiguousKey' (Hex literal) to avoid false positives", revoked.contains(ambiguousKey))
+        // We DO expect the set to contain the key ITSELF (treated as Hex) even if it is a valid decimal.
+        // We prioritize catching revoked Key IDs (security) over avoiding false positives.
+        assertTrue("Should contain '$ambiguousKey' (Hex literal) to catch Key ID revocation", revoked.contains(ambiguousKey))
 
-        // We expect the Decimal interpretation.
+        // We ALSO expect the Decimal interpretation (ambiguity handling).
         val decimalInterpretation = java.math.BigInteger(ambiguousKey).toString(16).lowercase()
         assertTrue("Should contain '$decimalInterpretation' (Decimal interpretation)", revoked.contains(decimalInterpretation))
     }


### PR DESCRIPTION
Modified `KeyboxVerifier` to add both decimal (Serial Number) and literal hex (Key ID) interpretations to the revocation set when a CRL entry is ambiguous (all digits, typical Key ID length).
This prevents a security bypass where a banned Key ID (that happens to be all digits) would be ignored because it was successfully parsed as a Serial Number.
Updated `ReproKeyIDConfusionTest` and `ReproFalsePositiveRevocationTest` to reflect this security-first policy, accepting the low risk of false positives (revoking an innocent Serial Number that matches a banned Key ID) to ensure no revoked Key IDs are missed.

---
*PR created automatically by Jules for task [14943725433964304252](https://jules.google.com/task/14943725433964304252) started by @tryigit*