### PR TITLE
🎨 Palette: Add missing labels for better accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-05 - Embedded Web Server Testing
 **Learning:** For Android apps with embedded `NanoHTTPD` web servers, you can unit test the HTML generation by instantiating the server class (mocking Android dependencies if needed) and extracting the response body from `serve(session)`. This allows for frontend verification using Playwright on the dumped HTML file without needing an emulator.
 **Action:** Use `WebServerHtmlTest` pattern to dump HTML to `/tmp/index.html` for Playwright verification in future tasks.
+
+## 2026-02-06 - Validating Embedded UI with Playwright
+**Learning:** When verifying embedded UIs where the HTML is constructed as a raw string in Kotlin/Java, you can extract the HTML string directly (via regex or simple string parsing) to a standalone file. This file can then be served via a simple HTTP server (e.g., `python3 -m http.server`) to allow Playwright verification of structure and accessibility attributes, bypassing the need for a full Android build environment.
+**Action:** Use this extraction method for rapid UI verification of embedded servers.

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -838,9 +838,10 @@ class WebServer(
     <div id="keys" class="content" role="tabpanel" aria-labelledby="tab_keys">
         <div class="panel">
             <h3>Upload Keybox</h3>
-            <input type="file" id="kbFilePicker" style="display:none" onchange="loadFileContent(this)" onclick="this.value = null">
+            <input type="file" id="kbFilePicker" style="display:none" onchange="loadFileContent(this)" onclick="this.value = null" aria-label="Upload Keybox File">
             <button onclick="document.getElementById('kbFilePicker').click()" style="width:100%; margin-bottom:10px; border-style:dashed;">Select XML File</button>
 
+            <label for="kbFilename" style="display:block; font-size:0.8em; margin-bottom:5px; color:#888;">Target Filename</label>
             <input type="text" id="kbFilename" placeholder="filename.xml" style="margin-bottom:10px;">
             <textarea id="kbContent" placeholder="XML Content" style="height:100px; font-family:monospace; font-size:0.8em;" aria-label="Keybox XML Content"></textarea>
             <button onclick="runWithState(this, 'Uploading...', uploadKeybox)" class="primary" style="margin-top:10px; width:100%;">Upload</button>
@@ -858,7 +859,7 @@ class WebServer(
     <div id="editor" class="content" role="tabpanel" aria-labelledby="tab_editor">
         <div class="panel">
             <div class="row">
-                <select id="fileSelector" onchange="loadFile()" style="width:70%;">
+                <select id="fileSelector" onchange="loadFile()" style="width:70%;" aria-label="Select file to edit">
                     <option value="target.txt">target.txt</option>
                     <option value="security_patch.txt">security_patch.txt</option>
                     <option value="spoof_build_vars">spoof_build_vars</option>

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
@@ -136,5 +136,10 @@ class WebServerHtmlTest {
         // Verify Accessibility Labels for Textareas
         assertTrue("File Editor missing aria-label", html.contains("id=\"fileEditor\" style=\"height:500px; font-family:monospace; margin-top:10px; line-height:1.4;\" aria-label=\"File Content\""))
         assertTrue("Keybox Content missing aria-label", html.contains("id=\"kbContent\" placeholder=\"XML Content\" style=\"height:100px; font-family:monospace; font-size:0.8em;\" aria-label=\"Keybox XML Content\""))
+
+        // Verify Keybox Filename Label and File Picker Accessibility
+        assertTrue("Keybox Filename missing label", html.contains("<label for=\"kbFilename\""))
+        assertTrue("Keybox File Picker missing aria-label", html.contains("id=\"kbFilePicker\" style=\"display:none\" onchange=\"loadFileContent(this)\" onclick=\"this.value = null\" aria-label=\"Upload Keybox File\""))
+        assertTrue("File Selector missing aria-label", html.contains("id=\"fileSelector\" onchange=\"loadFile()\" style=\"width:70%;\" aria-label=\"Select file to edit\""))
     }
 }


### PR DESCRIPTION
Improved accessibility and usability by adding missing labels to form inputs in the embedded WebServer UI.

Changes:
- Added a visible "Target Filename" label above the filename input in the Keys tab.
- Added `aria-label="Select file to edit"` to the file selector in the Editor tab.
- Added `aria-label="Upload Keybox File"` to the hidden file picker input.
- Added test assertions to `WebServerHtmlTest` to ensure these accessibility features are present.

Verification:
- Ran `WebServerHtmlTest` successfully.
- Verified frontend changes with Playwright (screenshot attached).

---
*PR created automatically by Jules for task [15300870042958334976](https://jules.google.com/task/15300870042958334976) started by @tryigit*