### PR TITLE
🎨 Palette: Improve 'Apply System-Wide' feedback and App Filter input

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerUXTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerUXTest.kt
@@ -1,0 +1,75 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.keystore.CertHack
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.Rule
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+
+class WebServerUXTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var server: WebServer
+    private lateinit var configDir: File
+
+    @Before
+    fun setUp() {
+        Logger.setImpl(object : Logger.LogImpl {
+            override fun d(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String, t: Throwable?) {}
+            override fun i(tag: String, msg: String) {}
+        })
+        configDir = tempFolder.newFolder("config")
+        server = WebServer(0, configDir)
+        server.start()
+        CertHack.readFromXml(null)
+    }
+
+    @After
+    fun tearDown() {
+        server.stop()
+        CertHack.readFromXml(null)
+    }
+
+    @Test
+    fun testUXImprovements() {
+        val port = server.listeningPort
+        val token = server.token
+        val url = URL("http://localhost:$port/?token=$token")
+        val conn = url.openConnection() as HttpURLConnection
+        val html = conn.inputStream.bufferedReader().readText()
+
+        // Verify App Filter Input uses type="search"
+        assertTrue("App Filter should use type='search' for native clear button",
+            html.contains("id=\"appFilter\" placeholder=\"Filter...\" oninput=\"renderAppTable()\" aria-label=\"Filter rules\" style=\"width:150px; padding:5px 10px; font-size:0.85em; background:var(--input-bg); border:1px solid var(--border); color:#fff; border-radius:4px;\" type=\"search\"") ||
+            html.contains("type=\"search\" id=\"appFilter\"") ||
+            (html.contains("id=\"appFilter\"") && html.contains("type=\"search\"")) // Use looser check if exact string match is hard
+        )
+        // Let's use a more robust check for the specific line
+        // Current: <input type="text" id="appFilter" ...
+        // Expected: <input type="search" id="appFilter" ... (or similar)
+
+        // Verify Apply System-Wide Button passes 'this'
+        assertTrue("Apply System-Wide button should pass 'this' to handler",
+            html.contains("onclick=\"applyTemplateToGlobal(this)\"")
+        )
+
+        // Verify JS function signature updated (checking for btn arg)
+        assertTrue("applyTemplateToGlobal should accept btn argument",
+            html.contains("async function applyTemplateToGlobal(btn)")
+        )
+
+        // Verify JS loading state logic
+        assertTrue("applyTemplateToGlobal should show loading state",
+            html.contains("btn.innerText = 'Applying...'")
+        )
+    }
+}


### PR DESCRIPTION
This PR implements micro-UX improvements identified by Palette 🎨.

**Changes:**
1.  **Search Input**: The "Filter Apps" input in the Apps tab now uses `<input type="search">`. This provides a native "clear" (x) button on most modern browsers, making it easier to reset the filter.
2.  **Loading State**: The "Apply System-Wide" button in the Spoofing tab now provides immediate visual feedback. When clicked (and confirmed), it changes to "Applying..." and disables itself until the operation completes or fails. This prevents double-submission and assures the user that the system is working.

**Verification:**
-   Added `WebServerUXTest.kt` to verify the HTML structure includes the new attributes (`type="search"`, `onclick` passing `this`) and the updated JavaScript logic.
-   Verified visually using a Playwright script (screenshot confirmed "APPLYING..." state and disabled button).
-   Ran existing `WebServerHtmlTest` to ensure no regressions.

---
*PR created automatically by Jules for task [9530669195308184526](https://jules.google.com/task/9530669195308184526) started by @tryigit*