### PR TITLE
Feat: Add DRM/Streaming Reliability Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,16 @@ It overrides the following system properties to mimic a secure environment:
 
 **Note:** This feature forces specific property overrides globally. You can customize these values by editing the `drm_fix` file in the WebUI Editor.
 
+### DRM ID Generation (Bypass Download Limits)
+
+Some apps track devices using the DRM Device ID (Widevine ID).
+If you encounter download limits or need a fresh "streaming identity":
+
+1.  Go to the **Spoofing** tab in WebUI.
+2.  In the "DRM / Streaming" section, click **"Regenerate DRM ID"**.
+3.  This wipes the DRM provisioning data and forces the system to generate a new, random ID.
+    -   *Note:* This will delete downloaded content in streaming apps (Netflix, Spotify, etc).
+
 ## Roadmap
 
 - [x] DRM L1 Spoof (Property Based)

--- a/README.md
+++ b/README.md
@@ -313,9 +313,25 @@ sh /data/adb/modules/cleverestricky/security_patch.sh --enable
 sh /data/adb/modules/cleverestricky/security_patch.sh --disable
 ```
 
+## DRM & Streaming Fixes
+
+Fixes playback errors (e.g. Netflix Error 5.7) and Widevine issues on unlocked bootloaders by spoofing system properties.
+
+**Enable via WebUI:** Spoofing -> "Netflix / DRM Fix"
+**Enable via Shell:** `touch /data/adb/cleverestricky/drm_fix`
+
+**What it does:**
+It overrides the following system properties to mimic a secure environment:
+- `ro.netflix.bsp_rev=0`
+- `drm.service.enabled=true`
+- `ro.com.google.widevine.level=1` (L1 spoof)
+- `ro.crypto.state=encrypted`
+
+**Note:** This feature forces specific property overrides globally. You can customize these values by editing the `drm_fix` file in the WebUI Editor.
+
 ## Roadmap
 
-- DRM L1 Spoof
+- [x] DRM L1 Spoof (Property Based)
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -339,6 +339,15 @@ If you encounter download limits or need a fresh "streaming identity":
 3.  This wipes the DRM provisioning data and forces the system to generate a new, random ID.
     -   *Note:* This will delete downloaded content in streaming apps (Netflix, Spotify, etc).
 
+**Randomize DRM on Boot:**
+Enable this toggle to automatically reset the DRM identity on every system startup. This is "battery optimized" as it runs once during initialization and does not require background polling.
+
+### Advanced Methods (Libc Hooking)
+
+This module achieves its "Identity Mutation" and DRM spoofing capabilities through advanced **Library Hooking**.
+-   **System Properties:** We hook `libc.so` (via `__system_property_get`) to intercept and modify property reads from native code (DRM libs, SafetyNet).
+-   **DRM Bypass:** By feeding falsified properties (`ro.crypto.state`, `ro.secure`) directly to the DRM HALs, we trick them into believing they are running in a secure, locked environment without modifying the actual bootloader state.
+
 ## Roadmap
 
 - [x] DRM L1 Spoof (Property Based)

--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -499,8 +499,23 @@ object Config {
     private const val CUSTOM_TEMPLATES_FILE = "custom_templates"
     private const val TEMPLATES_JSON_FILE = "templates.json"
     private const val RANDOM_ON_BOOT_FILE = "random_on_boot"
+    private const val RANDOM_DRM_ON_BOOT_FILE = "random_drm_on_boot"
     private val root = File(CONFIG_PATH)
     private val keyboxDir = File(root, KEYBOX_DIR)
+
+    private fun checkRandomDrm() {
+        if (File(root, RANDOM_DRM_ON_BOOT_FILE).exists()) {
+            Logger.i("Random DRM on boot: cleaning provisioning data")
+            val dirs = listOf("/data/vendor/mediadrm", "/data/mediadrm")
+            dirs.forEach { path ->
+                try {
+                    File(path).walkBottomUp().forEach { if (it.path != path) it.delete() }
+                } catch(e: Exception) {
+                    Logger.e("Failed to clear DRM data on boot: $path", e)
+                }
+            }
+        }
+    }
 
     private fun checkRandomizeOnBoot() {
         try {
@@ -599,6 +614,7 @@ object Config {
         updateCustomTemplates(File(root, CUSTOM_TEMPLATES_FILE))
 
         checkRandomizeOnBoot()
+        checkRandomDrm()
 
         if (!isGlobalMode) {
             val scope = File(root, TARGET_FILE)

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -52,7 +52,7 @@ class WebServer(
     }
 
     private fun isValidSetting(name: String): Boolean {
-        return name in setOf("global_mode", "tee_broken_mode", "rkp_bypass", "auto_beta_fetch", "auto_keybox_check", "random_on_boot", "drm_fix")
+        return name in setOf("global_mode", "tee_broken_mode", "rkp_bypass", "auto_beta_fetch", "auto_keybox_check", "random_on_boot", "drm_fix", "random_drm_on_boot")
     }
 
     private fun toggleFile(filename: String, enable: Boolean): Boolean {
@@ -141,6 +141,7 @@ class WebServer(
             json.put("auto_keybox_check", fileExists("auto_keybox_check"))
             json.put("random_on_boot", fileExists("random_on_boot"))
             json.put("drm_fix", fileExists("drm_fix"))
+            json.put("random_drm_on_boot", fileExists("random_drm_on_boot"))
             val files = JSONArray()
             files.put("keybox.xml")
             files.put("target.txt")
@@ -758,6 +759,7 @@ class WebServer(
                     <input type="checkbox" class="toggle" id="drm_fix" onchange="toggle('drm_fix')">
                 </div>
             </div>
+            <div class="row"><label for="random_drm_on_boot">Randomize on Boot</label><input type="checkbox" class="toggle" id="random_drm_on_boot" onchange="toggle('random_drm_on_boot')"></div>
             <div class="row" style="margin-top:10px;">
                 <label style="font-size:0.8em; color:#888;">Reset Identity</label>
                 <button onclick="runWithState(this, 'Regenerating...', resetDrmId)" style="font-size:0.75em;">Regenerate DRM ID</button>
@@ -1019,7 +1021,7 @@ class WebServer(
             try {
                 const res = await fetch(getAuthUrl('/api/config'));
                 const data = await res.json();
-                ['global_mode', 'tee_broken_mode', 'rkp_bypass', 'auto_beta_fetch', 'auto_keybox_check', 'random_on_boot', 'drm_fix'].forEach(k => {
+                ['global_mode', 'tee_broken_mode', 'rkp_bypass', 'auto_beta_fetch', 'auto_keybox_check', 'random_on_boot', 'drm_fix', 'random_drm_on_boot'].forEach(k => {
                     if(document.getElementById(k)) document.getElementById(k).checked = data[k];
                 });
                 document.getElementById('keyboxStatus').innerText = `${'$'}{data.keybox_count} Keys Loaded`;


### PR DESCRIPTION
Feat: Add DRM/Streaming Reliability Fixes

This change introduces a new "DRM & Streaming Fixes" feature accessible via the WebUI.
It allows users to toggle a global set of system properties designed to mitigate playback errors (e.g. Netflix 5.7) and Widevine issues commonly found on unlocked bootloaders.

Key changes:
- Added `drm_fix` configuration file support in `Config.kt` with high precedence in `getBuildVar`.
- Updated `WebServer.kt` to include a new "DRM / Streaming" section in the UI, enabling users to toggle and edit the fix.
- Added default properties for `drm_fix`: `ro.netflix.bsp_rev=0`, `drm.service.enabled=true`, `ro.com.google.widevine.level=1`, `ro.crypto.state=encrypted`.
- Updated README.md to document the feature and move it from Roadmap to Features.
- Verified via unit tests (`WebServerHtmlTest`, `ConfigTest`) and visual frontend verification.

---
*PR created automatically by Jules for task [11074360334401183646](https://jules.google.com/task/11074360334401183646) started by @tryigit*