### PR TITLE
Fix TelephonyInterceptor registration logic preventing IMEI spoofing

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/TelephonyInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/TelephonyInterceptor.kt
@@ -108,8 +108,6 @@ object TelephonyInterceptor : BinderInterceptor() {
     }
 
     fun tryRunTelephonyInterceptor(): Boolean {
-        if (injected) return true // Assume success if injected once? Or we need to re-check binder?
-
         Logger.i("trying to register telephony interceptor ($triedCount) ...")
 
         // "iphonesubinfo" is the standard service name for IPhoneSubInfo


### PR DESCRIPTION
The `TelephonyInterceptor.tryRunTelephonyInterceptor` method had a logic flaw where it would return `true` immediately if `injected` was true, skipping the actual binder hook registration. This meant that if the first attempt injected the library but failed to get the binder backdoor (which is common due to timing), subsequent attempts would never register the interceptor, leaving Telephony services unhooked.

This fix removes the early return, allowing the method to always check for the binder backdoor and attempt registration if available.

---
*PR created automatically by Jules for task [9726875746132715209](https://jules.google.com/task/9726875746132715209) started by @tryigit*