### PR TITLE
[Weekly Ship] Keybox Picker for App Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ Create/edit `/data/adb/cleverestricky/app_config` (or use the WebUI "App Config"
 packageName [TEMPLATE] [keybox_filename]
 ```
 
+**Using the WebUI:**
+1. Navigate to the **Apps** tab.
+2. Enter the package name (e.g., `com.google.android.gms`).
+3. Select a device template from the dropdown (or keep default).
+4. Select a **Keybox** from the dropdown list.
+   - *Note:* Custom keybox XML files must be placed in `/data/adb/cleverestricky/keyboxes/` to appear in this list.
+5. Click **Add Rule** and then **Save Configuration**.
+
 **Examples:**
 ```
 # Force GMS to use Pixel 8 Pro template and a specific keybox

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerTest.kt
@@ -1,0 +1,108 @@
+package cleveres.tricky.cleverestech
+
+import fi.iki.elonen.NanoHTTPD
+import fi.iki.elonen.NanoHTTPD.IHTTPSession
+import fi.iki.elonen.NanoHTTPD.Method
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+import java.util.UUID
+
+class WebServerTest {
+
+    @Test
+    fun testListKeyboxes() {
+        // Setup temp directory
+        val tempDir = File(System.getProperty("java.io.tmpdir"), "webserver_test_${UUID.randomUUID()}")
+        tempDir.mkdirs()
+        val keyboxDir = File(tempDir, "keyboxes")
+        keyboxDir.mkdirs()
+
+        // Create dummy keyboxes
+        File(keyboxDir, "test1.xml").createNewFile()
+        File(keyboxDir, "test2.xml").createNewFile()
+        File(keyboxDir, "ignore.txt").createNewFile()
+
+        // Init WebServer with no-op permission setter
+        val server = WebServer(0, tempDir) { _, _ -> }
+
+        // Create dummy session
+        val session = object : IHTTPSession {
+            override fun execute() {}
+            override fun getCookies() = server.CookieHandler(HashMap())
+            override fun getHeaders() = HashMap<String, String>()
+            override fun getInputStream(): InputStream? = null
+            override fun getMethod() = Method.GET
+            override fun getParms(): Map<String, String> {
+                val map = HashMap<String, String>()
+                map["token"] = server.token // Auth token
+                return map
+            }
+            override fun getQueryParameterString() = ""
+            override fun getUri() = "/api/keyboxes"
+            override fun parseBody(files: Map<String, String>?) {}
+            override fun getRemoteIpAddress() = "127.0.0.1"
+            override fun getRemoteHostName() = "localhost"
+            override fun getParameters(): Map<String, List<String>> = HashMap()
+        }
+
+        val response = server.serve(session)
+        val jsonStr = inputStreamToString(response.data)
+
+        // Assertions
+        assertEquals(NanoHTTPD.Response.Status.OK, response.status)
+        assertTrue("JSON should contain test1.xml", jsonStr.contains("test1.xml"))
+        assertTrue("JSON should contain test2.xml", jsonStr.contains("test2.xml"))
+        assertTrue("JSON should NOT contain ignore.txt", !jsonStr.contains("ignore.txt"))
+
+        // Cleanup
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun testFrontendContainsKeyboxPicker() {
+        // Setup temp directory
+        val tempDir = File(System.getProperty("java.io.tmpdir"), "webserver_test_${UUID.randomUUID()}")
+        tempDir.mkdirs()
+
+        // Init WebServer
+        val server = WebServer(0, tempDir) { _, _ -> }
+
+        // Create dummy session
+        val session = object : IHTTPSession {
+            override fun execute() {}
+            override fun getCookies() = server.CookieHandler(HashMap())
+            override fun getHeaders() = HashMap<String, String>()
+            override fun getInputStream(): InputStream? = null
+            override fun getMethod() = Method.GET
+            override fun getParms(): Map<String, String> {
+                 val map = HashMap<String, String>()
+                 map["token"] = server.token
+                 return map
+            }
+            override fun getQueryParameterString() = ""
+            override fun getUri() = "/"
+            override fun parseBody(files: Map<String, String>?) {}
+            override fun getRemoteIpAddress() = "127.0.0.1"
+            override fun getRemoteHostName() = "localhost"
+            override fun getParameters(): Map<String, List<String>> = HashMap()
+        }
+
+        val response = server.serve(session)
+        val html = inputStreamToString(response.data)
+
+        // Assertions
+        assertEquals(NanoHTTPD.Response.Status.OK, response.status)
+        assertTrue("HTML should contain <select id=\"appKeybox\">", html.contains("<select id=\"appKeybox\">"))
+        assertTrue("HTML should NOT contain <input type=\"text\" id=\"appKeybox\"", !html.contains("<input type=\"text\" id=\"appKeybox\""))
+
+        // Cleanup
+        tempDir.deleteRecursively()
+    }
+
+    private fun inputStreamToString(inputStream: InputStream?): String {
+        return inputStream?.bufferedReader()?.use { it.readText() } ?: ""
+    }
+}


### PR DESCRIPTION
This week's ship adds a **Keybox Picker** to the WebUI's App Config section. Users no longer need to manually type filenames; they can now select from available XML files in the `keyboxes/` directory. This improves usability and reduces configuration errors.

**Changes:**
- **Backend:** Added `listKeyboxes()` and `/api/keyboxes` endpoint in `WebServer.kt`.
- **Frontend:** Replaced text input with `<select>` in embedded HTML/JS.
- **Tests:** Added `WebServerTest.kt` to verify API response and HTML structure.
- **Docs:** Updated `README.md` to reflect the new workflow.

---
*PR created automatically by Jules for task [4451093876613505473](https://jules.google.com/task/4451093876613505473) started by @tryigit*