### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure file permissions (TOCTOU)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** The service initialization logic (`Main.kt`) explicitly set the configuration directory permissions to `0755` (readable by all), overriding the secure `0700` permissions set during installation. This created a vulnerability window on every boot where sensitive files could potentially be read by other applications if their individual file permissions were weak.
 **Learning:** Security configurations distributed across multiple initialization points (installer scripts vs. runtime code) can drift and contradict each other. Runtime initialization code should treat the secure state as the source of truth, not defaults.
 **Prevention:** Centralize security configuration constants and verify that all initialization paths (install, boot, runtime) enforce the same strict permissions (`0700` for config dirs).
+
+## 2026-05-30 - [Inconsistent SecureFile Usage (TOCTOU)]
+**Vulnerability:** Found Config.kt and Main.kt using standard File.writeText followed by setReadable or relying on directory permissions, creating TOCTOU race conditions and potential for default permissions.
+**Learning:** Security utilities like SecureFile are only effective if used consistently. Manually setting permissions after creation is always vulnerable to race conditions.
+**Prevention:** Enforce usage of SecureFile.writeText for all sensitive file writes via lint rules or code review checklists. Never use standard File write methods for config files.

--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -6,6 +6,7 @@ import android.os.ServiceManager
 import android.system.Os
 import cleveres.tricky.cleverestech.keystore.CertHack
 import cleveres.tricky.cleverestech.util.RandomUtils
+import cleveres.tricky.cleverestech.util.SecureFile
 import java.io.File
 import java.util.Collections
 import java.util.LinkedHashMap
@@ -536,7 +537,7 @@ object Config {
                     sb.append("SIM_OPERATOR_NAME=${RandomUtils.generateRandomCarrier()}\n")
 
                     val f = File(root, SPOOF_BUILD_VARS_FILE)
-                    f.writeText(sb.toString())
+                    SecureFile.writeText(f, sb.toString())
                     Logger.i("Randomized identity on boot: ${t.id}")
                 }
             }

--- a/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
@@ -3,6 +3,7 @@ package cleveres.tricky.cleverestech
 import android.system.Os
 import cleveres.tricky.cleverestech.rkp.LocalRkpProxy
 import cleveres.tricky.cleverestech.util.KeyboxAutoCleaner
+import cleveres.tricky.cleverestech.util.SecureFile
 import java.io.File
 import java.security.MessageDigest
 import kotlin.system.exitProcess
@@ -39,9 +40,7 @@ fun main(args: Array<String>) {
             Logger.e("failed to init RKP permissions", t)
         }
 
-        portFile.writeText("$port|$token")
-        portFile.setReadable(false, false) // Clear all
-        portFile.setReadable(true, true) // Owner only (0600)
+        SecureFile.writeText(portFile, "$port|$token")
     } catch (e: Exception) {
         Logger.e("Failed to start web server", e)
     }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Found `Config.kt` and `Main.kt` using standard `File.writeText` followed by `setReadable` or relying on directory permissions, creating TOCTOU race conditions and potential for default permissions on sensitive files (spoofing config, auth token).
🎯 Impact: Local attackers could potentially read sensitive configuration or the web server auth token during the race window or if directory permissions are compromised.
🔧 Fix: Refactored `Config.checkRandomizeOnBoot` and `Main.kt` to use `SecureFile.writeText`, which uses `O_CREAT | O_TRUNC | O_WRONLY` with `0600` mode atomically.
✅ Verification: Verified code changes and ran `./gradlew test` to ensure no regressions.

---
*PR created automatically by Jules for task [13271948601538267465](https://jules.google.com/task/13271948601538267465) started by @tryigit*