### PR TITLE
⚡ Bolt: Optimize package cache with ConcurrentHashMap

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -8,8 +8,7 @@ import cleveres.tricky.cleverestech.keystore.CertHack
 import cleveres.tricky.cleverestech.util.RandomUtils
 import cleveres.tricky.cleverestech.util.SecureFile
 import java.io.File
-import java.util.Collections
-import java.util.LinkedHashMap
+import java.util.concurrent.ConcurrentHashMap
 
 class PackageTrie {
     private class Node {
@@ -648,24 +647,21 @@ object Config {
 
     // Cache to reduce IPC calls to PackageManager for getPackagesForUid
     // Key: callingUid, Value: Array of package names
-    private val packageCache = Collections.synchronizedMap(
-        object : LinkedHashMap<Int, Array<String>>(200, 0.75f, true) {
-            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Int, Array<String>>?): Boolean {
-                return size > 200
-            }
-        }
-    )
+    // OPTIMIZATION: Use ConcurrentHashMap to allow lock-free reads and better concurrency.
+    // The map is unbounded but limited by the number of installed apps (~hundreds, max ~50k UIDs),
+    // which fits well within memory limits compared to synchronized access overhead.
+    private val packageCache = ConcurrentHashMap<Int, Array<String>?>()
 
     /**
      * Retrieves the list of packages for a given UID, using a cache to avoid frequent IPC calls.
      * Returns an empty array if the UID has no associated packages or if PackageManager is unavailable.
      */
     fun getPackages(uid: Int): Array<String> {
-        packageCache[uid]?.let { return it }
-        val pm = getPm() ?: return emptyArray()
-        val ps = pm.getPackagesForUid(uid) ?: emptyArray()
-        packageCache[uid] = ps
-        return ps
+        val packages = packageCache.computeIfAbsent(uid) {
+            val pm = getPm() ?: return@computeIfAbsent null
+            pm.getPackagesForUid(uid) ?: emptyArray()
+        }
+        return packages ?: emptyArray()
     }
 
     private fun checkPackages(packages: PackageTrie, callingUid: Int) = kotlin.runCatching {

--- a/service/src/test/java/cleveres/tricky/cleverestech/ConfigPackageCacheTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ConfigPackageCacheTest.kt
@@ -1,0 +1,117 @@
+package cleveres.tricky.cleverestech
+
+import android.content.pm.IPackageManager
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.lang.reflect.Proxy
+
+class ConfigPackageCacheTest {
+
+    private lateinit var mockPm: IPackageManager
+    private var originalPm: IPackageManager? = null
+
+    // State for the mock
+    private val callCounts = mutableMapOf<Int, Int>()
+    private val packages = mutableMapOf<Int, Array<String>>()
+
+    @Before
+    fun setup() {
+        callCounts.clear()
+        packages.clear()
+
+        // Create dynamic proxy for IPackageManager
+        mockPm = Proxy.newProxyInstance(
+            IPackageManager::class.java.classLoader,
+            arrayOf(IPackageManager::class.java)
+        ) { _, method, args ->
+            if (method.name == "getPackagesForUid") {
+                val uid = args[0] as Int
+                callCounts[uid] = (callCounts[uid] ?: 0) + 1
+                return@newProxyInstance packages[uid] ?: emptyArray<String>()
+            }
+            // Return null for other methods (getPackageInfo, etc)
+            null
+        } as IPackageManager
+
+        // Reflection to set Config.iPm
+        val field = Config::class.java.getDeclaredField("iPm")
+        field.isAccessible = true
+        originalPm = field.get(Config) as IPackageManager?
+        field.set(Config, mockPm)
+
+        // Clear cache
+        clearPackageCache()
+    }
+
+    @After
+    fun tearDown() {
+        // Restore original PM
+        val field = Config::class.java.getDeclaredField("iPm")
+        field.isAccessible = true
+        field.set(Config, originalPm)
+
+        clearPackageCache()
+    }
+
+    private fun clearPackageCache() {
+        val field = Config::class.java.getDeclaredField("packageCache")
+        field.isAccessible = true
+        val cache = field.get(Config) as MutableMap<*, *>
+        cache.clear()
+    }
+
+    @Test
+    fun testCacheBehavior() {
+        val uid = 1001
+        packages[uid] = arrayOf("com.example.app1")
+
+        // First call - should hit PM
+        val result1 = Config.getPackages(uid)
+        assertEquals(1, result1.size)
+        assertEquals("com.example.app1", result1[0])
+        assertEquals(1, callCounts[uid] ?: 0)
+
+        // Second call - should hit cache
+        val result2 = Config.getPackages(uid)
+        assertEquals(1, result2.size)
+        assertEquals("com.example.app1", result2[0])
+        assertEquals(1, callCounts[uid] ?: 0) // Count should still be 1
+    }
+
+    @Test
+    fun testCacheMiss() {
+        val uid = 9999
+        // No package for this UID
+
+        val result1 = Config.getPackages(uid)
+        assertEquals(0, result1.size)
+        assertEquals(1, callCounts[uid] ?: 0)
+
+        val result2 = Config.getPackages(uid)
+        assertEquals(0, result2.size)
+        assertEquals(1, callCounts[uid] ?: 0)
+    }
+
+    @Test
+    fun testMultipleUids() {
+        val uid1 = 2001
+        val uid2 = 2002
+        packages[uid1] = arrayOf("app1")
+        packages[uid2] = arrayOf("app2")
+
+        Config.getPackages(uid1)
+        assertEquals(1, callCounts[uid1])
+        assertEquals(0, callCounts[uid2] ?: 0)
+
+        Config.getPackages(uid2)
+        assertEquals(1, callCounts[uid1])
+        assertEquals(1, callCounts[uid2])
+
+        Config.getPackages(uid1)
+        Config.getPackages(uid2)
+        assertEquals(1, callCounts[uid1])
+        assertEquals(1, callCounts[uid2])
+    }
+}


### PR DESCRIPTION
⚡ Bolt: Optimize package cache with ConcurrentHashMap

💡 What: Replaced synchronized LinkedHashMap with ConcurrentHashMap for `packageCache`.
🎯 Why: `getPackages(uid)` is a hot path called by multiple apps concurrently. The previous synchronized map caused lock contention, serializing these calls.
📊 Impact: Eliminates lock contention for read operations. `getPackages` is now lock-free for hits.
🔬 Measurement: Verified with `ConfigPackageCacheTest` which confirms correct caching behavior and ensures PM is only called once per UID. Concurrency improvement is inherent to the data structure change.


---
*PR created automatically by Jules for task [5217707030002170700](https://jules.google.com/task/5217707030002170700) started by @tryigit*