### PR TITLE
🎨 Palette: Add Ctrl+S shortcut for file editor

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-08 - Mirrored Static Artifacts Drift
 **Learning:** When a project maintains a static file (e.g., `index.html`) as a mirror of an embedded string in code (e.g., `WebServer.kt`), they can easily drift out of sync (e.g., missing CSS rules).
 **Action:** Always diff the static artifact against the source of truth before editing to detect and resolve drift, ensuring consistent behavior across dev and prod.
+
+## 2025-05-15 - Mocking Backend for Embedded UI Verification
+**Learning:** When verifying frontend interactions (like loading states) in an embedded WebView where the backend is unavailable (e.g., Android-specific APIs), use Playwright's `page.route` to mock API responses and introduce delays. This allows testing of transient UI states (spinners, disabled buttons) without a real server.
+**Action:** Use `page.route` with `time.sleep` in Python handlers to verify async UI states.

--- a/index.html
+++ b/index.html
@@ -401,9 +401,9 @@
                     <option value="app_config">app_config</option>
                     <option value="drm_fix">drm_fix</option>
                 </select>
-                <button id="saveBtn" onclick="runWithState(this, 'Saving...', saveFile)">Save</button>
+                <button id="saveBtn" onclick="runWithState(this, 'Saving...', saveFile)" title="Ctrl+S">Save</button>
             </div>
-            <textarea id="fileEditor" style="height:500px; font-family:monospace; margin-top:10px; line-height:1.4;" aria-label="File Content"></textarea>
+            <textarea id="fileEditor" style="height:500px; font-family:monospace; margin-top:10px; line-height:1.4;" aria-label="File Content" onkeydown="if((event.ctrlKey||event.metaKey)&&event.key.toLowerCase()==='s'){event.preventDefault();document.getElementById('saveBtn').click();}"></textarea>
         </div>
     </div>
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -977,9 +977,9 @@ class WebServer(
                     <option value="app_config">app_config</option>
                     <option value="drm_fix">drm_fix</option>
                 </select>
-                <button id="saveBtn" onclick="runWithState(this, 'Saving...', saveFile)">Save</button>
+                <button id="saveBtn" onclick="runWithState(this, 'Saving...', saveFile)" title="Ctrl+S">Save</button>
             </div>
-            <textarea id="fileEditor" style="height:500px; font-family:monospace; margin-top:10px; line-height:1.4;" aria-label="File Content"></textarea>
+            <textarea id="fileEditor" style="height:500px; font-family:monospace; margin-top:10px; line-height:1.4;" aria-label="File Content" onkeydown="if((event.ctrlKey||event.metaKey)&&event.key.toLowerCase()==='s'){event.preventDefault();document.getElementById('saveBtn').click();}"></textarea>
         </div>
     </div>
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerUXTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerUXTest.kt
@@ -72,4 +72,23 @@ class WebServerUXTest {
             html.contains("btn.innerText = 'Applying...'")
         )
     }
+
+    @Test
+    fun testEditorShortcuts() {
+        val port = server.listeningPort
+        val token = server.token
+        val url = URL("http://localhost:$port/?token=$token")
+        val conn = url.openConnection() as HttpURLConnection
+        val html = conn.inputStream.bufferedReader().readText()
+
+        // Verify Save Button has title
+        assertTrue("Save button should have title hint for Ctrl+S",
+            html.contains("title=\"Ctrl+S\"") && html.contains("id=\"saveBtn\"")
+        )
+
+        // Verify Textarea has onkeydown handler
+        assertTrue("File editor textarea should have onkeydown handler for Ctrl+S",
+            html.contains("onkeydown=\"if((event.ctrlKey||event.metaKey)&&event.key.toLowerCase()==='s'){event.preventDefault();document.getElementById('saveBtn').click();}\"")
+        )
+    }
 }


### PR DESCRIPTION
*   💡 What: Added `Ctrl+S` (and `Cmd+S`) support to the file editor textarea in the WebUI.
*   🎯 Why: To allow users to save configuration files quickly without clicking the "Save" button.
*   📸 Before/After: Save button now has a `Ctrl+S` tooltip. Textarea responds to keydown.
*   ♿ Accessibility: Added `title` attribute to the Save button for discoverability.

---
*PR created automatically by Jules for task [6449841435568594627](https://jules.google.com/task/6449841435568594627) started by @tryigit*