### PR TITLE
Fix printf format specifier warnings in binder_interceptor.cpp

### DIFF
--- a/module/src/main/cpp/binder_interceptor.cpp
+++ b/module/src/main/cpp/binder_interceptor.cpp
@@ -262,8 +262,8 @@ int new_ioctl(int fd, int request, ...) {
         }
 
         auto &bwr = *(struct binder_write_read*) arg;
-        LOGD("read buffer %p size %zu consumed %zu", bwr.read_buffer, bwr.read_size,
-             bwr.read_consumed);
+        LOGD("read buffer %p size %llu consumed %llu", (void*)bwr.read_buffer, (unsigned long long)bwr.read_size,
+             (unsigned long long)bwr.read_consumed);
         if (bwr.read_buffer != 0 && bwr.read_size != 0 && bwr.read_consumed > sizeof(int32_t)) {
             auto ptr = bwr.read_buffer;
             auto consumed = bwr.read_consumed;


### PR DESCRIPTION
Fixed build warnings where 'binder_uintptr_t' and 'binder_size_t' (aka 'unsigned long long') were being passed to '%p' and '%zu' respectively. Added explicit casts to match the format specifiers or updated specifiers to '%llu' where appropriate.

---
*PR created automatically by Jules for task [2159469608527384212](https://jules.google.com/task/2159469608527384212) started by @tryigit*