### PR TITLE
Fix silent failure in KeyboxVerifier CRL parsing

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -4,6 +4,7 @@ import cleveres.tricky.cleverestech.Logger
 import cleveres.tricky.cleverestech.keystore.CertHack
 import org.json.JSONObject
 import java.io.File
+import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
 import java.security.MessageDigest
@@ -85,11 +86,13 @@ object KeyboxVerifier {
     fun parseCrl(reader: java.io.Reader): Set<String> {
         val set = HashSet<String>()
         val jsonReader = android.util.JsonReader(reader)
+        var entriesFound = false
         try {
             jsonReader.beginObject()
             while (jsonReader.hasNext()) {
                 val name = jsonReader.nextName()
                 if (name == "entries") {
+                    entriesFound = true
                     jsonReader.beginObject()
                     while (jsonReader.hasNext()) {
                         val decStr = jsonReader.nextName()
@@ -102,10 +105,12 @@ object KeyboxVerifier {
                 }
             }
             jsonReader.endObject()
-        } catch (e: Exception) {
-            Logger.e("Failed to parse CRL JSON", e)
         } finally {
             try { jsonReader.close() } catch (e: Exception) {}
+        }
+
+        if (!entriesFound) {
+            throw IOException("CRL missing 'entries' field")
         }
         return set
     }


### PR DESCRIPTION
Fixes a critical bug where `KeyboxVerifier` would silently ignore invalid or empty CRL JSONs, treating them as having no revocations. This ensures fail-closed behavior for security.

---
*PR created automatically by Jules for task [3046795599892933485](https://jules.google.com/task/3046795599892933485) started by @tryigit*