### PR TITLE
⚡ Bolt: Optimize `Config.getPackages` allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,7 @@
 ## 2026-05-28 - [HashMap Overhead in Tries]
 **Learning:** `PackageTrie` was using `HashMap<Char, Node>` for child storage. For package names (low branching factor, mostly linear segments), this introduced significant memory and CPU overhead (boxing `Char`, hashing, `Entry` objects). Replacing it with parallel arrays (`CharArray` + `Array<Node>`) and linear scanning yielded a ~2.3x speedup.
 **Action:** For small collections or specialized trees with low branching factors (like tries for strings), prefer simple arrays over `HashMap` to avoid object overhead and indirect access.
+
+## 2026-02-10 - [Lambda Allocation in Hot Cache Paths]
+**Learning:** `ConcurrentHashMap.computeIfAbsent` allocates a `Function` lambda instance on every call if the lambda captures variables (like `this`), even if the key is already present. In hot paths (like permission checks), this creates significant GC pressure.
+**Action:** In hot paths using `computeIfAbsent`, check for the existence of the key (e.g., `map[key]`) before calling `computeIfAbsent` to avoid allocation in the hit case.

--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -613,6 +613,9 @@ object Config {
      * Returns an empty array if the UID has no associated packages or if PackageManager is unavailable.
      */
     fun getPackages(uid: Int): Array<String> {
+        // Optimization: fast path for cache hit to avoid lambda allocation
+        packageCache[uid]?.let { return it }
+
         val packages = packageCache.computeIfAbsent(uid) {
             val pm = getPm() ?: return@computeIfAbsent null
             pm.getPackagesForUid(uid) ?: emptyArray()


### PR DESCRIPTION
⚡ Bolt: Optimized `Config.getPackages` to avoid lambda allocation on cache hits.

💡 What: Modified `Config.getPackages(uid)` to check `packageCache[uid]` before calling `computeIfAbsent`.
🎯 Why: `computeIfAbsent` allocates a new `Function` object (lambda wrapper) on every call if the lambda captures variables (like `this`), even if the key is already in the cache. This creates unnecessary GC pressure in a hot path used by permission checks.
📊 Impact: Eliminates object allocation for the vast majority of calls (cache hits). Reduces GC overhead in `needHack`/`needGenerate` logic.
🔬 Measurement: Verified that `ConfigPackageCacheTest` still passes, ensuring cache behavior is preserved.


---
*PR created automatically by Jules for task [4210814524545702589](https://jules.google.com/task/4210814524545702589) started by @tryigit*