### PR TITLE
⚡ Bolt: Optimize KeyboxVerifier hash checking

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -209,11 +209,15 @@ object KeyboxVerifier {
         return false
     }
 
+    @OptIn(ExperimentalStdlibApi::class)
+    private val hexFormat = HexFormat { upperCase = false }
+
+    @OptIn(ExperimentalStdlibApi::class)
     private fun checkHash(data: ByteArray, algorithm: String, set: Set<String>): Boolean {
         try {
             val digest = MessageDigest.getInstance(algorithm).digest(data)
             // Convert to Hex String (Zero Padded)
-            val hex = digest.joinToString("") { "%02x".format(it) }
+            val hex = digest.toHexString(hexFormat)
             return set.contains(hex)
         } catch (e: Exception) {
             return false

--- a/service/src/test/java/cleveres/tricky/cleverestech/KeyboxVerifierHashTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/KeyboxVerifierHashTest.kt
@@ -1,0 +1,51 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.util.KeyboxVerifier
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import java.security.MessageDigest
+
+class KeyboxVerifierHashTest {
+
+    @OptIn(ExperimentalStdlibApi::class)
+    @Test
+    fun testCheckHashOptimization() {
+        // We use reflection to access the private checkHash method
+        val method = KeyboxVerifier::class.java.getDeclaredMethod("checkHash", ByteArray::class.java, String::class.java, Set::class.java)
+        method.isAccessible = true
+
+        val input = "test content".toByteArray()
+        val algorithm = "SHA-256"
+
+        // Calculate expected hash using the old inefficient method (to ensure compatibility)
+        // This verifies that the new implementation (using HexFormat) produces the exact same output
+        // as the old implementation (using String.format) which the rest of the system expects.
+        val digest = MessageDigest.getInstance(algorithm).digest(input)
+        val expectedHex = digest.joinToString("") { "%02x".format(it) }
+
+        val set = setOf(expectedHex)
+
+        // Invoke the optimized method
+        val result = method.invoke(KeyboxVerifier, input, algorithm, set) as Boolean
+
+        assertTrue("Optimized checkHash should find the hash in the set", result)
+
+        // Test with negative bytes (0xFF) to ensure formatting is correct
+        val negativeInput = byteArrayOf(-1, 0, 1) // 0xFF, 0x00, 0x01
+        // SHA-256 of this
+        val negDigest = MessageDigest.getInstance(algorithm).digest(negativeInput)
+        val negHex = negDigest.joinToString("") { "%02x".format(it) }
+
+        val negSet = setOf(negHex)
+        val negResult = method.invoke(KeyboxVerifier, negativeInput, algorithm, negSet) as Boolean
+
+        assertTrue("Optimized checkHash should handle negative bytes correctly", negResult)
+
+        // Test failure case
+        val wrongSet = setOf("0000000000000000000000000000000000000000000000000000000000000000")
+        val failResult = method.invoke(KeyboxVerifier, input, algorithm, wrongSet) as Boolean
+
+        assertFalse("Optimized checkHash should fail if hash not in set", failResult)
+    }
+}


### PR DESCRIPTION
**Performance Improvement:**
- Replaced manual hex conversion loop using `joinToString` and `String.format("%02x")` with Kotlin 1.9 `HexFormat` and `toHexString`.
- This eliminates `StringBuilder` allocation, `Byte` boxing, and format string parsing overhead for every hash check.
- `KeyboxVerifier` checks SHA1, SHA256, and MD5 hashes for every certificate in every keybox against the CRL, so this is a hot path during verification.

**Verification:**
- Added `KeyboxVerifierHashTest` unit test which uses reflection to access the private `checkHash` method.
- Verified that `toHexString(hexFormat)` produces identical output ("ff" for 0xFF) to the legacy implementation, ensuring compatibility with CRL data.
- Ran `./gradlew :service:testDebugUnitTest` and all tests passed.

---
*PR created automatically by Jules for task [11800150802047271922](https://jules.google.com/task/11800150802047271922) started by @tryigit*