### PR TITLE
Remove permissive Magisk rules and scope file access

### DIFF
--- a/module/template/post-fs-data.sh
+++ b/module/template/post-fs-data.sh
@@ -5,3 +5,12 @@ CONFIG_DIR="/data/adb/cleverestricky"
 if [ -d "$CONFIG_DIR" ]; then
   chcon -R u:object_r:cleverestricky_data_file:s0 "$CONFIG_DIR"
 fi
+
+# Fix SELinux context for module files to ensure they are accessible
+# service.apk and libraries need to be readable by apps (LSPosed)
+chcon u:object_r:cleverestricky_public_file:s0 "$MODDIR"/*.apk
+chcon u:object_r:cleverestricky_public_file:s0 "$MODDIR"/*.so
+
+# Executables need to be executable by daemon
+chcon u:object_r:cleverestricky_exec:s0 "$MODDIR/inject"
+chcon u:object_r:cleverestricky_exec:s0 "$MODDIR/daemon"

--- a/module/template/sepolicy.rule
+++ b/module/template/sepolicy.rule
@@ -40,16 +40,11 @@ allow cleverestricky_daemon port:udp_socket name_bind;
 allow cleverestricky_daemon fwmarkd_socket:sock_file write;
 allow cleverestricky_daemon netd:unix_stream_socket connectto;
 
-# make lsposed happy
-# TODO: remove those rules
-type magisk_file file_type
-typeattribute magisk_file mlstrustedobject
-allow * magisk_file file *
-allow * magisk_file dir *
-allow * magisk_file fifo_file *
-allow * magisk_file chr_file *
-allow * magisk_file lnk_file *
-allow * magisk_file sock_file *
+# Define a type for module files that need to be publicly readable (APKs, libs)
+type cleverestricky_public_file, file_type, data_file_type, mlstrustedobject;
+
+# Allow all domains to read public module files (e.g. for Xposed/LSPosed loading)
+allow * cleverestricky_public_file:file { read open getattr map };
 
 # allow hooking system server
 allow system_server system_server process execmem

--- a/service/src/test/java/cleveres/tricky/cleverestech/SepolicyTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/SepolicyTest.kt
@@ -1,5 +1,6 @@
 package cleveres.tricky.cleverestech
 
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
@@ -27,5 +28,20 @@ class SepolicyTest {
         assertTrue("sepolicy.rule missing tcp_socket permissions", content.contains("allow cleverestricky_daemon self:tcp_socket"))
         assertTrue("sepolicy.rule missing udp_socket permissions", content.contains("allow cleverestricky_daemon self:udp_socket"))
         assertTrue("sepolicy.rule missing netd permissions", content.contains("allow cleverestricky_daemon netd:unix_stream_socket connectto;"))
+    }
+
+    @Test
+    fun testNoBroadMagiskFilePermissions() {
+        val sepolicyFile = File("../module/template/sepolicy.rule")
+        val content = sepolicyFile.readText()
+        assertFalse("sepolicy.rule should not contain broad magisk_file file permissions", content.contains("allow * magisk_file file *"))
+    }
+
+    @Test
+    fun testPublicFilePermissions() {
+        val sepolicyFile = File("../module/template/sepolicy.rule")
+        val content = sepolicyFile.readText()
+        assertTrue("sepolicy.rule missing public file definition", content.contains("type cleverestricky_public_file, file_type, data_file_type, mlstrustedobject;"))
+        assertTrue("sepolicy.rule missing public file read permissions", content.contains("allow * cleverestricky_public_file:file { read open getattr map };"))
     }
 }


### PR DESCRIPTION
This change addresses the TODO in `module/template/sepolicy.rule` to remove permissive rules added to "make lsposed happy". 

Instead of allowing all domains to read/write all `magisk_file` types (which is insecure), I implemented a scoped approach:
1.  Defined `cleverestricky_public_file` which is readable by all domains (`*`).
2.  Updated `post-fs-data.sh` to label the Xposed module APK and native libraries with this new type.
3.  Ensured executables (`daemon`, `inject`) are labeled `cleverestricky_exec`.
4.  Removed the insecure `magisk_file` block.

This ensures that apps (and LSPosed) can load the module's code without exposing other Magisk files or granting write access.

---
*PR created automatically by Jules for task [9397695610544715043](https://jules.google.com/task/9397695610544715043) started by @tryigit*