### PR TITLE
⚡ Optimize /api/packages by using IPackageManager IPC

### DIFF
--- a/stub/src/main/java/android/content/pm/IPackageManager.java
+++ b/stub/src/main/java/android/content/pm/IPackageManager.java
@@ -9,6 +9,10 @@ public interface IPackageManager {
 
     PackageInfo getPackageInfo(String packageName, int flags, int userId);
 
+    ParceledListSlice<PackageInfo> getInstalledPackages(long flags, int userId);
+
+    ParceledListSlice<PackageInfo> getInstalledPackages(int flags, int userId);
+
     class Stub {
         public static IPackageManager asInterface(IBinder binder) {
             throw new RuntimeException("");

--- a/stub/src/main/java/android/content/pm/ParceledListSlice.java
+++ b/stub/src/main/java/android/content/pm/ParceledListSlice.java
@@ -1,0 +1,33 @@
+package android.content.pm;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import java.util.List;
+
+public class ParceledListSlice<T extends Parcelable> implements Parcelable {
+    public List<T> getList() {
+        throw new RuntimeException("Stub!");
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        throw new RuntimeException("Stub!");
+    }
+
+    public static final Creator<ParceledListSlice> CREATOR = new Creator<ParceledListSlice>() {
+        @Override
+        public ParceledListSlice createFromParcel(Parcel source) {
+            throw new RuntimeException("Stub!");
+        }
+
+        @Override
+        public ParceledListSlice[] newArray(int size) {
+            throw new RuntimeException("Stub!");
+        }
+    };
+}


### PR DESCRIPTION
Replaced `pm list packages` shell execution with `IPackageManager.getInstalledPackages` IPC call in `WebServer.kt`. Added necessary stubs for `ParceledListSlice` and `IPackageManager`. verified compilation and ran unit tests.

---
*PR created automatically by Jules for task [17442505227180450850](https://jules.google.com/task/17442505227180450850) started by @tryigit*