### PR TITLE
Get verified boot keys

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/VbMetaParser.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/VbMetaParser.kt
@@ -1,0 +1,70 @@
+package cleveres.tricky.cleverestech
+
+import java.io.RandomAccessFile
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+object VbMetaParser {
+    // AVB0 Magic (4 bytes)
+    private val AVB_MAGIC = "AVB0".toByteArray()
+    private const val HEADER_SIZE = 256
+    private const val AUTH_DATA_BLOCK_SIZE_LOC = 12
+    private const val PUBLIC_KEY_OFFSET_LOC = 64
+    private const val PUBLIC_KEY_SIZE_LOC = 72
+
+    /**
+     * Extracts the public key from the vbmeta image at the given path.
+     * Returns null if the file cannot be read or parsing fails.
+     */
+    fun extractPublicKey(path: String): ByteArray? {
+        return try {
+            RandomAccessFile(path, "r").use { file ->
+                // Read header
+                val header = ByteArray(HEADER_SIZE)
+                if (file.read(header) != HEADER_SIZE) {
+                    Logger.e("VbMetaParser: Failed to read header from $path")
+                    return null
+                }
+
+                // Verify Magic
+                for (i in AVB_MAGIC.indices) {
+                    if (header[i] != AVB_MAGIC[i]) {
+                        Logger.e("VbMetaParser: Invalid magic in $path")
+                        return null
+                    }
+                }
+
+                val buffer = ByteBuffer.wrap(header).order(ByteOrder.BIG_ENDIAN)
+                val authDataBlockSize = buffer.getLong(AUTH_DATA_BLOCK_SIZE_LOC)
+                val publicKeyOffset = buffer.getLong(PUBLIC_KEY_OFFSET_LOC)
+                val publicKeySize = buffer.getLong(PUBLIC_KEY_SIZE_LOC)
+
+                if (publicKeyOffset < 0 || publicKeySize <= 0 || authDataBlockSize < 0) {
+                    Logger.e("VbMetaParser: Invalid offset ($publicKeyOffset), size ($publicKeySize), or auth data size ($authDataBlockSize)")
+                    return null
+                }
+
+                // Seek to public key location
+                // The public key is in the Auxiliary Data block, which follows the Authentication Data block.
+                // The Authentication Data block starts at HEADER_SIZE (256).
+                // So the Auxiliary Data block starts at HEADER_SIZE + authDataBlockSize.
+                // publicKeyOffset is relative to the start of the Auxiliary Data block.
+
+                val absoluteOffset = HEADER_SIZE + authDataBlockSize + publicKeyOffset
+                file.seek(absoluteOffset)
+
+                val keyBytes = ByteArray(publicKeySize.toInt())
+                if (file.read(keyBytes) != keyBytes.size) {
+                    Logger.e("VbMetaParser: Failed to read public key bytes")
+                    return null
+                }
+
+                Logger.d("VbMetaParser: Successfully extracted public key from $path")
+                keyBytes
+            }
+        } catch (e: Exception) {
+            Logger.e("VbMetaParser: Error reading $path", e)
+            null
+        }
+    }
+}

--- a/service/src/main/java/cleveres/tricky/cleverestech/util.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util.kt
@@ -18,10 +18,25 @@ val bootHash by lazy {
     getBootHashFromProp() ?: "d75926e016f5acee00523712b830379c53203ac08cb8a485583005f529ee7587".hexToByteArray()
 }
 
-// TODO: get verified boot keys
 @OptIn(ExperimentalStdlibApi::class)
 val bootKey by lazy {
-    getBootKeyFromProp() ?: "c34b68e0571933605261e790156658696e4788a88cb5b71d6173cf214c7e87ca".hexToByteArray()
+    getVerifiedBootKey() ?: getBootKeyFromProp() ?: "c34b68e0571933605261e790156658696e4788a88cb5b71d6173cf214c7e87ca".hexToByteArray()
+}
+
+@OptIn(ExperimentalStdlibApi::class)
+private fun getVerifiedBootKey(): ByteArray? {
+    val slot = systemPropertiesGet("ro.boot.slot_suffix", "") ?: ""
+    val paths = mutableListOf<String>()
+    if (slot.isNotEmpty()) {
+        paths.add("/dev/block/by-name/vbmeta$slot")
+    }
+    paths.add("/dev/block/by-name/vbmeta")
+
+    for (path in paths) {
+        val key = VbMetaParser.extractPublicKey(path)
+        if (key != null) return key
+    }
+    return null
 }
 
 @OptIn(ExperimentalStdlibApi::class)

--- a/service/src/test/java/cleveres/tricky/cleverestech/VbMetaParserTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/VbMetaParserTest.kt
@@ -1,0 +1,93 @@
+package cleveres.tricky.cleverestech
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+class VbMetaParserTest {
+
+    @Before
+    fun setup() {
+        Logger.setImpl(object : Logger.LogImpl {
+            override fun d(tag: String, msg: String) { println("DEBUG: $tag: $msg") }
+            override fun e(tag: String, msg: String) { println("ERROR: $tag: $msg") }
+            override fun e(tag: String, msg: String, t: Throwable?) {
+                println("ERROR: $tag: $msg")
+                t?.printStackTrace()
+            }
+            override fun i(tag: String, msg: String) { println("INFO: $tag: $msg") }
+        })
+    }
+
+    @Test
+    fun testExtractPublicKey() {
+        val tempFile = File.createTempFile("vbmeta", ".img")
+        try {
+            val key = "dummy_public_key".toByteArray()
+            val authDataSize: Long = 64
+            val keyOffset: Long = 10 // Relative to Aux Block start
+            val header = ByteBuffer.allocate(256).order(ByteOrder.BIG_ENDIAN)
+            header.put("AVB0".toByteArray())
+
+            // Set Auth Data Block Size at 12
+            header.position(12)
+            header.putLong(authDataSize)
+
+            // Set Public Key Offset at 64
+            header.position(64)
+            header.putLong(keyOffset)
+
+            // Set Public Key Size at 72
+            header.position(72)
+            header.putLong(key.size.toLong())
+
+            RandomAccessFile(tempFile, "rw").use { raf ->
+                raf.write(header.array())
+
+                // Write dummy Auth Data (64 bytes)
+                val authData = ByteArray(authDataSize.toInt())
+                // Fill with something to ensure we skip it
+                for(i in authData.indices) authData[i] = 0xAA.toByte()
+                raf.write(authData)
+
+                // Now at offset 256 + 64.
+                // We need to write key at keyOffset (10) from here.
+                // So seek to 256 + 64 + 10 = 330
+                raf.seek(256 + authDataSize + keyOffset)
+                raf.write(key)
+            }
+
+            val extracted = VbMetaParser.extractPublicKey(tempFile.absolutePath)
+            assertArrayEquals(key, extracted)
+
+        } finally {
+            tempFile.delete()
+        }
+    }
+
+    @Test
+    fun testExtractPublicKey_InvalidMagic() {
+        val tempFile = File.createTempFile("vbmeta_invalid", ".img")
+        try {
+            RandomAccessFile(tempFile, "rw").use { raf ->
+                raf.write(ByteArray(256)) // Zero header
+            }
+
+            val extracted = VbMetaParser.extractPublicKey(tempFile.absolutePath)
+            assertNull(extracted)
+        } finally {
+            tempFile.delete()
+        }
+    }
+
+    @Test
+    fun testExtractPublicKey_FileNotFound() {
+        val extracted = VbMetaParser.extractPublicKey("/path/to/non/existent/file")
+        assertNull(extracted)
+    }
+}


### PR DESCRIPTION
Implemented dynamic retrieval of the Verified Boot Key by parsing the 'vbmeta' partition image. Added 'VbMetaParser' to handle AVB header parsing and extraction of the public key from the Auxiliary Data Block. Updated 'util.kt' to use this parser with fallback to existing hardcoded keys.

---
*PR created automatically by Jules for task [15663386240257351508](https://jules.google.com/task/15663386240257351508) started by @tryigit*