### PR TITLE
Serialize blank permissions into app rule

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,10 +357,10 @@
             <div class="section-header" style="margin-top:10px;">Blank Permissions (Privacy)</div>
             <div style="display:flex; gap:15px; flex-wrap:wrap; margin-bottom:15px;">
                 <div class="row" style="flex:1; min-width:120px; justify-content:flex-start; gap:10px;">
-                    <input type="checkbox" id="permContacts" class="toggle" style="transform:scale(0.8)" disabled title="Coming Soon"> <label for="permContacts">Contacts</label>
+                    <input type="checkbox" id="permContacts" class="toggle" style="transform:scale(0.8)"> <label for="permContacts">Contacts</label>
                 </div>
                 <div class="row" style="flex:1; min-width:120px; justify-content:flex-start; gap:10px;">
-                    <input type="checkbox" id="permMedia" class="toggle" style="transform:scale(0.8)" disabled title="Coming Soon"> <label for="permMedia">Media</label>
+                    <input type="checkbox" id="permMedia" class="toggle" style="transform:scale(0.8)"> <label for="permMedia">Media</label>
                 </div>
             </div>
 
@@ -373,7 +373,7 @@
                 <input type="search" id="appFilter" placeholder="Filter..." oninput="renderAppTable()" aria-label="Filter rules" style="width:150px; padding:5px 10px; font-size:0.85em; background:var(--input-bg); border:1px solid var(--border); color:#fff; border-radius:4px;">
             </div>
             <table id="appTable">
-                <thead><tr><th>Package</th><th>Profile</th><th>Flags</th><th></th></tr></thead>
+                <thead><tr><th>Package</th><th>Profile</th><th>Keybox</th><th>Permissions</th><th></th></tr></thead>
                 <tbody></tbody>
             </table>
             <div style="margin-top:15px; text-align:right;">
@@ -770,7 +770,7 @@
 
             if (appRules.length === 0) {
                 const tr = document.createElement('tr');
-                tr.innerHTML = '<td colspan="4" style="text-align:center; padding:20px; color:#666;">No active rules. Add a package above to customize spoofing.</td>';
+                tr.innerHTML = '<td colspan="5" style="text-align:center; padding:20px; color:#666;">No active rules. Add a package above to customize spoofing.</td>';
                 tbody.appendChild(tr);
                 return;
             }
@@ -785,6 +785,7 @@
                     <td>${rule.package}</td>
                     <td>${rule.template === 'null' ? 'Default' : rule.template}</td>
                     <td>${rule.keybox && rule.keybox !== 'null' ? rule.keybox : ''}</td>
+                    <td>${rule.permissions ? rule.permissions.map(p => `<span class="tag">${p}</span>`).join(' ') : ''}</td>
                     <td style="text-align:right;">
                         <button class="danger" onclick="removeAppRule(${idx})" aria-label="Remove rule for ${rule.package}">×</button>
                     </td>
@@ -794,7 +795,7 @@
 
             if (visibleCount === 0) {
                 const tr = document.createElement('tr');
-                tr.innerHTML = '<td colspan="4" style="text-align:center; padding:20px; color:#666;">No matching rules found.</td>';
+                tr.innerHTML = '<td colspan="5" style="text-align:center; padding:20px; color:#666;">No matching rules found.</td>';
                 tbody.appendChild(tr);
             }
         }
@@ -813,14 +814,16 @@
                 return;
             }
 
-            // TODO: Serialize blank permissions into the rule
-            // Current backend supports: package template keybox
-            // We might need to encode flags in template name or add a new column in future
+            const permissions = [];
+            if (pContacts) permissions.push('CONTACTS');
+            if (pMedia) permissions.push('MEDIA');
 
-            appRules.push({ package: pkg, template: tmpl === 'null' ? '' : tmpl, keybox: kb });
+            appRules.push({ package: pkg, template: tmpl === 'null' ? '' : tmpl, keybox: kb, permissions: permissions });
             renderAppTable();
             pkgInput.value = '';
             document.getElementById('appKeybox').value = '';
+            document.getElementById('permContacts').checked = false;
+            document.getElementById('permMedia').checked = false;
             toggleAddButton();
             pkgInput.focus();
             notify('Rule Added');

--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -23,7 +23,7 @@ object Config {
         "ro.oem_unlock_supported" to "0"
     )
 
-    data class AppSpoofConfig(val template: String?, val keyboxFilename: String?)
+    data class AppSpoofConfig(val template: String?, val keyboxFilename: String?, val permissions: Set<String> = emptySet())
 
     // Optimization: Cache results of needHack/needGenerate to avoid repeated Trie lookups.
     // The cache is bundled with the Trie in a state object to ensure consistency during updates.
@@ -100,12 +100,18 @@ object Config {
                         val pkg = parts[0]
                         var template: String? = null
                         var keybox: String? = null
+                        val permissions = HashSet<String>()
 
                         if (parts.size > 1 && parts[1] != "null") template = parts[1].lowercase()
                         if (parts.size > 2 && parts[2] != "null") keybox = parts[2]
+                        if (parts.size > 3 && parts[3] != "null") {
+                            parts[3].split(",").forEach {
+                                if (it.isNotBlank()) permissions.add(it.trim())
+                            }
+                        }
 
-                        if (template != null || keybox != null) {
-                            newConfigs.add(pkg, AppSpoofConfig(template, keybox))
+                        if (template != null || keybox != null || permissions.isNotEmpty()) {
+                            newConfigs.add(pkg, AppSpoofConfig(template, keybox, permissions))
                         }
                     }
                 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
@@ -160,8 +160,10 @@ class WebServerHtmlTest {
         // Verify Label Cursor CSS
         assertTrue("Missing label cursor CSS", html.contains("label { font-size: 0.9em; color: #BBB; cursor: pointer; }"))
 
-        // Verify Disabled Attributes
-        assertTrue("Contacts Checkbox not disabled", html.contains("<input type=\"checkbox\" id=\"permContacts\" class=\"toggle\" style=\"transform:scale(0.8)\" disabled title=\"Coming Soon\">"))
-        assertTrue("Media Checkbox not disabled", html.contains("<input type=\"checkbox\" id=\"permMedia\" class=\"toggle\" style=\"transform:scale(0.8)\" disabled title=\"Coming Soon\">"))
+        // Verify Disabled Attributes Removed (Enabled now)
+        assertTrue("Contacts Checkbox is missing", html.contains("id=\"permContacts\""))
+        assertTrue("Contacts Checkbox is disabled", !html.contains("id=\"permContacts\" class=\"toggle\" style=\"transform:scale(0.8)\" disabled"))
+        assertTrue("Media Checkbox is missing", html.contains("id=\"permMedia\""))
+        assertTrue("Media Checkbox is disabled", !html.contains("id=\"permMedia\" class=\"toggle\" style=\"transform:scale(0.8)\" disabled"))
     }
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerPermissionsTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerPermissionsTest.kt
@@ -1,0 +1,146 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.util.SecureFile
+import cleveres.tricky.cleverestech.util.SecureFileOperations
+import fi.iki.elonen.NanoHTTPD
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class WebServerPermissionsTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var server: WebServer
+    private lateinit var configDir: File
+
+    @Before
+    fun setUp() {
+        Logger.setImpl(object : Logger.LogImpl {
+            override fun d(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String, t: Throwable?) {}
+            override fun i(tag: String, msg: String) {}
+        })
+
+        // Mock SecureFile implementation for tests
+        SecureFile.impl = object : SecureFileOperations {
+            override fun writeText(file: File, content: String) {
+                file.writeText(content)
+            }
+            override fun mkdirs(file: File, mode: Int) {
+                file.mkdirs()
+            }
+            override fun touch(file: File, mode: Int) {
+                if (!file.exists()) file.createNewFile()
+            }
+        }
+
+        configDir = tempFolder.newFolder("config")
+        server = WebServer(0, configDir)
+    }
+
+    @Test
+    fun testSaveAndLoadAppConfigWithPermissions() {
+        // Prepare data
+        val rules = JSONArray()
+        val rule1 = JSONObject()
+        rule1.put("package", "com.example.app")
+        rule1.put("template", "pixel5")
+        rule1.put("keybox", "kb1.xml")
+        val perms1 = JSONArray()
+        perms1.put("CONTACTS")
+        perms1.put("MEDIA")
+        rule1.put("permissions", perms1)
+        rules.put(rule1)
+
+        val rule2 = JSONObject()
+        rule2.put("package", "com.example.other")
+        rule2.put("template", "null")
+        rule2.put("keybox", "null")
+        val perms2 = JSONArray() // Empty
+        rule2.put("permissions", perms2)
+        rules.put(rule2)
+
+        // Simulate POST request to SAVE
+        val sessionPost = MockSession(
+            NanoHTTPD.Method.POST,
+            "/api/app_config_structured",
+            mapOf("data" to rules.toString()),
+            server.token,
+            mapOf("content-length" to "100") // Dummy length
+        )
+        val responsePost = server.serve(sessionPost)
+        assertEquals(NanoHTTPD.Response.Status.OK, responsePost.status)
+
+        // Verify file content
+        val configFile = File(configDir, "app_config")
+        assertTrue(configFile.exists())
+        val content = configFile.readText()
+
+        assertTrue("Content should contain permissions (CONTACTS,MEDIA). Content: $content", content.contains("CONTACTS,MEDIA"))
+
+        // Simulate GET request to LOAD
+        val sessionGet = MockSession(
+            NanoHTTPD.Method.GET,
+            "/api/app_config_structured",
+            emptyMap(),
+            server.token
+        )
+        val responseGet = server.serve(sessionGet)
+        assertEquals(NanoHTTPD.Response.Status.OK, responseGet.status)
+
+        val jsonStr = responseGet.data.bufferedReader().readText()
+        val jsonArr = JSONArray(jsonStr)
+
+        var foundRule1 = false
+        for (i in 0 until jsonArr.length()) {
+            val obj = jsonArr.getJSONObject(i)
+            if (obj.getString("package") == "com.example.app") {
+                foundRule1 = true
+                assertTrue("Should have permissions field", obj.has("permissions"))
+                val p = obj.getJSONArray("permissions")
+                assertEquals(2, p.length())
+                val pList = listOf(p.getString(0), p.getString(1))
+                assertTrue(pList.contains("CONTACTS"))
+                assertTrue(pList.contains("MEDIA"))
+            }
+        }
+        assertTrue("Should find rule1", foundRule1)
+    }
+
+    // Mock Session class
+    inner class MockSession(
+        private val method: NanoHTTPD.Method,
+        private val uri: String,
+        private val params: Map<String, String>,
+        private val token: String,
+        private val headers: Map<String, String> = emptyMap()
+    ) : NanoHTTPD.IHTTPSession {
+        override fun execute() {}
+        override fun getCookies() = server.CookieHandler(HashMap())
+        override fun getHeaders(): Map<String, String> {
+            val h = HashMap<String, String>()
+            h["host"] = "localhost"
+            h["x-auth-token"] = token
+            h.putAll(headers)
+            return h
+        }
+        override fun getInputStream() = null
+        override fun getMethod() = method
+        override fun getParms() = params
+        override fun getQueryParameterString() = ""
+        override fun getUri() = uri
+        override fun parseBody(files: Map<String, String>?) {}
+        override fun getRemoteIpAddress() = "127.0.0.1"
+        override fun getRemoteHostName() = "localhost"
+        override fun getParameters() = emptyMap<String, List<String>>()
+    }
+}


### PR DESCRIPTION
Implemented serialization of blank permissions (Contacts, Media) into the app configuration rule. Updated backend logic to support 4th column in app_config file and API. Updated frontend to enable permission checkboxes and display permissions in the table. Added regression test WebServerPermissionsTest.

---
*PR created automatically by Jules for task [5702108257078517307](https://jules.google.com/task/5702108257078517307) started by @tryigit*