### PR TITLE
🎨 Palette: Add Clear Filter button to empty state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2026-07-20 - Kotlin String Interpolation in Embedded JS
 **Learning:** When embedding JavaScript within Kotlin `"""` strings, using template literals (`${var}`) conflicts with Kotlin's string interpolation. You must escape the dollar sign as `${'$'}` in Kotlin to ensure it is emitted literally for the JS runtime.
 **Action:** Always use `${'$'}` when writing JS template literals inside Kotlin multiline strings.
+
+## 2026-08-15 - Actionable Empty States
+**Learning:** When a search filter yields no results, a static "No results" message is a dead end. Providing a "Clear Filter" button directly within the empty state message allows users to recover immediately without searching for the filter input's clear control.
+**Action:** Enhance empty states with context-aware recovery actions (e.g., Clear Filter, Reset Search).

--- a/index.html
+++ b/index.html
@@ -795,7 +795,7 @@
 
             if (visibleCount === 0) {
                 const tr = document.createElement('tr');
-                tr.innerHTML = '<td colspan="5" style="text-align:center; padding:20px; color:#666;">No matching rules found.</td>';
+                tr.innerHTML = '<td colspan="5" style="text-align:center; padding:20px; color:#666;">No matching rules found. <button class="primary" onclick="document.getElementById(\'appFilter\').value=\'\'; renderAppTable()" style="padding: 2px 8px; font-size: 0.8em; margin-left: 10px;">Clear Filter</button></td>';
                 tbody.appendChild(tr);
             }
         }

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -1589,7 +1589,7 @@ class WebServer(
 
             if (visibleCount === 0) {
                 const tr = document.createElement('tr');
-                tr.innerHTML = '<td colspan="5" style="text-align:center; padding:20px; color:#666;">No matching rules found.</td>';
+                tr.innerHTML = '<td colspan="5" style="text-align:center; padding:20px; color:#666;">No matching rules found. <button class="primary" onclick="document.getElementById(\'appFilter\').value=\'\'; renderAppTable()" style="padding: 2px 8px; font-size: 0.8em; margin-left: 10px;">Clear Filter</button></td>';
                 tbody.appendChild(tr);
             }
         }


### PR DESCRIPTION
💡 What: Added a "Clear Filter" button to the "No matching rules found" message in the Apps tab.
🎯 Why: Users filtering the app list can reach a dead end with no results. The button provides a direct action to reset the filter and recover the list view.
📸 Before: "No matching rules found."
📸 After: "No matching rules found. [Clear Filter]"
♿ Accessibility: The button is keyboard accessible and uses existing primary button styles.

---
*PR created automatically by Jules for task [9205409334542456027](https://jules.google.com/task/9205409334542456027) started by @tryigit*