### PR TITLE
🛡️ Sentinel: [HIGH] Fix weak CSRF validation in WebServer

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -241,9 +241,9 @@ class WebServer(
         // Allow null origin/referer for non-browser clients (e.g. curl) if token is present
         // But for browser-based (indicated by Origin), enforce matching Host
         if (origin != null && host != null) {
-             // Simple check: Origin should contain Host
-             // Origin: http://localhost:8080
-             if (!origin.contains(host)) {
+             val allowedOrigin = "http://$host"
+             val allowedSecureOrigin = "https://$host"
+             if (origin != allowedOrigin && origin != allowedSecureOrigin) {
                  return secureResponse(Response.Status.FORBIDDEN, "text/plain", "CSRF Forbidden")
              }
         }

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerCsrfTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerCsrfTest.kt
@@ -1,0 +1,69 @@
+package cleveres.tricky.cleverestech
+
+import fi.iki.elonen.NanoHTTPD
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+import java.util.UUID
+
+class WebServerCsrfTest {
+
+    private fun createSession(server: WebServer, host: String, origin: String): NanoHTTPD.IHTTPSession {
+        return object : NanoHTTPD.IHTTPSession {
+            override fun execute() {}
+            override fun getCookies() = null
+            override fun getHeaders() = mapOf(
+                "host" to host,
+                "origin" to origin,
+                "content-length" to "0"
+            )
+            override fun getInputStream() = null
+            override fun getMethod() = NanoHTTPD.Method.POST
+            override fun getParms() = mapOf("token" to server.token)
+            override fun getQueryParameterString() = ""
+            override fun getUri() = "/api/config"
+            override fun parseBody(files: Map<String, String>?) {}
+            override fun getRemoteIpAddress() = "127.0.0.1"
+            override fun getRemoteHostName() = "localhost"
+            override fun getParameters(): Map<String, List<String>> = HashMap()
+        }
+    }
+
+    @Test
+    fun testCsrfWeakness() {
+        val tempDir = File(System.getProperty("java.io.tmpdir"), "csrf_test_${UUID.randomUUID()}")
+        tempDir.mkdirs()
+        val server = WebServer(0, tempDir)
+
+        // Case: Host: localhost, Origin: http://localhost.attacker.com
+        // This simulates an attacker using a domain that contains "localhost" substring.
+        // Current logic: origin.contains(host) -> TRUE.
+        // This allows the request to proceed (Response OK because token is valid).
+        // We WANT it to be FORBIDDEN.
+
+        val session = createSession(server, "localhost", "http://localhost.attacker.com")
+        val response = server.serve(session)
+
+        // Asserting FORBIDDEN will fail on current code
+        assertEquals("Should block partial match", NanoHTTPD.Response.Status.FORBIDDEN, response.status)
+
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun testCsrfValid() {
+        val tempDir = File(System.getProperty("java.io.tmpdir"), "csrf_test_valid_${UUID.randomUUID()}")
+        tempDir.mkdirs()
+        val server = WebServer(0, tempDir)
+
+        // Case: Host: localhost:8080, Origin: http://localhost:8080
+        val session = createSession(server, "localhost:8080", "http://localhost:8080")
+        val response = server.serve(session)
+
+        // Should NOT be FORBIDDEN.
+        // Passed CSRF, valid token, but POST /api/config is not handled -> NOT_FOUND
+        assertEquals("Should allow exact match", NanoHTTPD.Response.Status.NOT_FOUND, response.status)
+
+        tempDir.deleteRecursively()
+    }
+}


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix weak CSRF validation in WebServer

🚨 Severity: HIGH
💡 Vulnerability: The CSRF protection mechanism relied on a partial string match (`origin.contains(host)`), which could theoretically be bypassed by an attacker using a domain that contains the target host string (e.g., `localhost.attacker.com`).
🎯 Impact: An attacker could perform unauthorized actions on behalf of a victim if they visit a malicious site.
🔧 Fix: Replaced the partial match with strict equality checks against the expected origin (http/https + host).
✅ Verification: Added `WebServerCsrfTest.kt` which confirms that partial matches are now blocked (FORBIDDEN) while exact matches are allowed.


---
*PR created automatically by Jules for task [11641759729975791429](https://jules.google.com/task/11641759729975791429) started by @tryigit*