### PR TITLE
Fix Config.getPatchLevel to respect clockSource

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -9,6 +9,8 @@ import cleveres.tricky.cleverestech.util.PackageTrie
 import cleveres.tricky.cleverestech.util.RandomUtils
 import cleveres.tricky.cleverestech.util.SecureFile
 import java.io.File
+import java.time.Instant
+import java.time.ZoneId
 import java.util.concurrent.ConcurrentHashMap
 
 object Config {
@@ -439,9 +441,9 @@ object Config {
 
         val patchStr = patchVal as String
         val effectiveDate = if (patchStr.equals("today", ignoreCase = true)) {
-            java.time.LocalDate.now().toString()
+            Instant.ofEpochMilli(clockSource()).atZone(ZoneId.systemDefault()).toLocalDate().toString()
         } else if (patchStr.contains("YYYY") || patchStr.contains("MM") || patchStr.contains("DD")) {
-             val now = java.time.LocalDate.now()
+             val now = Instant.ofEpochMilli(clockSource()).atZone(ZoneId.systemDefault()).toLocalDate()
              patchStr.replace("YYYY", String.format("%04d", now.year))
                      .replace("MM", String.format("%02d", now.monthValue))
                      .replace("DD", String.format("%02d", now.dayOfMonth))

--- a/service/src/test/java/cleveres/tricky/cleverestech/ReproPatchLevelTimeTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ReproPatchLevelTimeTest.kt
@@ -1,0 +1,43 @@
+package cleveres.tricky.cleverestech
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+import java.time.Instant
+import java.time.ZoneId
+import java.util.TimeZone
+
+class ReproPatchLevelTimeTest {
+
+    @Test
+    fun testGetPatchLevelRespectsClockSource() {
+        // 1. Set a fixed time: 2023-05-20
+        val fixedTime = Instant.parse("2023-05-20T12:00:00Z").toEpochMilli()
+        val originalClock = Config.clockSource
+        Config.clockSource = { fixedTime }
+
+        // 2. Set default security patch to "today"
+        // We use reflection to set private state or use updateSecurityPatch with a file
+        val file = File.createTempFile("security_patch", "txt")
+        file.writeText("today") // Sets default patch to today
+
+        // Use reflection to invoke updateSecurityPatch
+        val method = Config::class.java.declaredMethods.find { it.name.startsWith("updateSecurityPatch") }
+        method!!.isAccessible = true
+        method.invoke(Config, file)
+
+        try {
+            // 3. Get patch level
+            // If it respects clockSource, it should be 20230520.
+            // If it uses LocalDate.now(), it will be the ACTUAL today (e.g. 2024...)
+            val level = Config.getPatchLevel(12345)
+
+            // Expected: 202305 (convertPatchLevel(false) returns YYYYMM)
+            assertEquals("Patch level should use clockSource time", 202305, level)
+
+        } finally {
+            Config.clockSource = originalClock
+            file.delete()
+        }
+    }
+}


### PR DESCRIPTION
Updated `Config.getPatchLevel` to use the injected `clockSource` for date generation instead of `LocalDate.now()`. Added a regression test to verify that the method respects the mocked time.

---
*PR created automatically by Jules for task [10719271107608817939](https://jules.google.com/task/10719271107608817939) started by @tryigit*