### PR TITLE
Fix logic in test_repro.kt

### DIFF
--- a/test_repro.kt
+++ b/test_repro.kt
@@ -1,4 +1,3 @@
-
 import org.json.JSONObject
 import java.math.BigInteger
 import java.util.HashSet
@@ -35,9 +34,12 @@ fun main() {
             println("Not a decimal: ${e.message}")
         }
 
-        if (added && (decStr.length == 32 || decStr.length == 40 || decStr.length == 64)) {
-            println("Ambiguity detected. Adding literal: $decStr")
-            set.add(decStr.lowercase())
+        // Ambiguity handling (mirrors KeyboxVerifier logic)
+        if (decStr.length == 32 || decStr.length == 40 || decStr.length == 64) {
+            if (decStr.matches(Regex("^[0-9a-fA-F]+$"))) {
+                println("Ambiguity detected. Adding literal: $decStr")
+                set.add(decStr.lowercase())
+            }
         }
     }
 


### PR DESCRIPTION
The `test_repro.kt` script contained flawed logic for handling ambiguous keys. It only added the literal interpretation if the key was also a valid decimal, failing to account for non-decimal hex keys (e.g. starting with '0' or containing letters) which should also be treated as literals if their length matches known Key ID formats (32/40/64). This mismatch with the actual `KeyboxVerifier` implementation caused confusion. This change updates `test_repro.kt` to mirror the robust ambiguity handling logic found in `KeyboxVerifier.kt`.

---
*PR created automatically by Jules for task [1970798956461681508](https://jules.google.com/task/1970798956461681508) started by @tryigit*