### PR TITLE
🎨 Palette: Add Drag & Drop to Keybox Upload

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,8 @@
         .island.error .error-icon { display: block; }
         @keyframes spin { to { transform: rotate(360deg); } }
 
+        .drag-over { border-color: var(--accent) !important; background: rgba(255,255,255,0.1) !important; }
+
         h1 { text-align: center; font-weight: 200; letter-spacing: 2px; margin: 25px 0; color: var(--accent); font-size: 1.5em; text-transform: uppercase; }
 
         .tabs { display: flex; justify-content: center; border-bottom: 1px solid var(--border); background: var(--panel); overflow-x: auto; }
@@ -387,7 +389,7 @@
         <div class="panel">
             <h3>Upload Keybox</h3>
             <input type="file" id="kbFilePicker" style="display:none" onchange="loadFileContent(this)" onclick="this.value = null" aria-label="Upload Keybox File">
-            <button onclick="document.getElementById('kbFilePicker').click()" style="width:100%; margin-bottom:10px; border-style:dashed;">Select XML File</button>
+            <button id="dropZone" onclick="document.getElementById('kbFilePicker').click()" style="width:100%; margin-bottom:10px; border-style:dashed;">Select XML File or Drag & Drop</button>
 
             <label for="kbFilename" style="display:block; font-size:0.8em; margin-bottom:5px; color:#888;">Target Filename</label>
             <input type="text" id="kbFilename" placeholder="filename.xml" style="margin-bottom:10px;">
@@ -900,13 +902,47 @@
              notify('Keybox Uploaded');
         }
 
+        function processKeyboxFile(file) {
+            document.getElementById('kbFilename').value = file.name;
+            const reader = new FileReader();
+            reader.onload = (e) => document.getElementById('kbContent').value = e.target.result;
+            reader.readAsText(file);
+        }
+
         function loadFileContent(input) {
             if (input.files && input.files[0]) {
-                const file = input.files[0];
-                document.getElementById('kbFilename').value = file.name;
-                const reader = new FileReader();
-                reader.onload = (e) => document.getElementById('kbContent').value = e.target.result;
-                reader.readAsText(file);
+                processKeyboxFile(input.files[0]);
+            }
+        }
+
+        // Drag & Drop Logic
+        const dropZone = document.getElementById('dropZone');
+        if (dropZone) {
+            ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
+                dropZone.addEventListener(eventName, preventDefaults, false);
+            });
+
+            function preventDefaults(e) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
+
+            ['dragenter', 'dragover'].forEach(eventName => {
+                dropZone.addEventListener(eventName, () => dropZone.classList.add('drag-over'), false);
+            });
+
+            ['dragleave', 'drop'].forEach(eventName => {
+                dropZone.addEventListener(eventName, () => dropZone.classList.remove('drag-over'), false);
+            });
+
+            dropZone.addEventListener('drop', handleDrop, false);
+
+            function handleDrop(e) {
+                const dt = e.dataTransfer;
+                const files = dt.files;
+                if (files && files[0]) {
+                    processKeyboxFile(files[0]);
+                }
             }
         }
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -848,6 +848,8 @@ class WebServer(
         .island.error .error-icon { display: block; }
         @keyframes spin { to { transform: rotate(360deg); } }
 
+        .drag-over { border-color: var(--accent) !important; background: rgba(255,255,255,0.1) !important; }
+
         h1 { text-align: center; font-weight: 200; letter-spacing: 2px; margin: 25px 0; color: var(--accent); font-size: 1.5em; text-transform: uppercase; }
 
         .tabs { display: flex; justify-content: center; border-bottom: 1px solid var(--border); background: var(--panel); overflow-x: auto; }
@@ -1181,7 +1183,7 @@ class WebServer(
         <div class="panel">
             <h3>Upload Keybox</h3>
             <input type="file" id="kbFilePicker" style="display:none" onchange="loadFileContent(this)" onclick="this.value = null" aria-label="Upload Keybox File">
-            <button onclick="document.getElementById('kbFilePicker').click()" style="width:100%; margin-bottom:10px; border-style:dashed;">Select XML File</button>
+            <button id="dropZone" onclick="document.getElementById('kbFilePicker').click()" style="width:100%; margin-bottom:10px; border-style:dashed;">Select XML File or Drag & Drop</button>
 
             <label for="kbFilename" style="display:block; font-size:0.8em; margin-bottom:5px; color:#888;">Target Filename</label>
             <input type="text" id="kbFilename" placeholder="filename.xml" style="margin-bottom:10px;">
@@ -1694,13 +1696,47 @@ class WebServer(
              notify('Keybox Uploaded');
         }
 
+        function processKeyboxFile(file) {
+            document.getElementById('kbFilename').value = file.name;
+            const reader = new FileReader();
+            reader.onload = (e) => document.getElementById('kbContent').value = e.target.result;
+            reader.readAsText(file);
+        }
+
         function loadFileContent(input) {
             if (input.files && input.files[0]) {
-                const file = input.files[0];
-                document.getElementById('kbFilename').value = file.name;
-                const reader = new FileReader();
-                reader.onload = (e) => document.getElementById('kbContent').value = e.target.result;
-                reader.readAsText(file);
+                processKeyboxFile(input.files[0]);
+            }
+        }
+
+        // Drag & Drop Logic
+        const dropZone = document.getElementById('dropZone');
+        if (dropZone) {
+            ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
+                dropZone.addEventListener(eventName, preventDefaults, false);
+            });
+
+            function preventDefaults(e) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
+
+            ['dragenter', 'dragover'].forEach(eventName => {
+                dropZone.addEventListener(eventName, () => dropZone.classList.add('drag-over'), false);
+            });
+
+            ['dragleave', 'drop'].forEach(eventName => {
+                dropZone.addEventListener(eventName, () => dropZone.classList.remove('drag-over'), false);
+            });
+
+            dropZone.addEventListener('drop', handleDrop, false);
+
+            function handleDrop(e) {
+                const dt = e.dataTransfer;
+                const files = dt.files;
+                if (files && files[0]) {
+                    processKeyboxFile(files[0]);
+                }
             }
         }
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerDragDropTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerDragDropTest.kt
@@ -1,0 +1,66 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.keystore.CertHack
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.Rule
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+
+class WebServerDragDropTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var server: WebServer
+    private lateinit var configDir: File
+
+    @Before
+    fun setUp() {
+        Logger.setImpl(object : Logger.LogImpl {
+            override fun d(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String, t: Throwable?) {}
+            override fun i(tag: String, msg: String) {}
+        })
+        configDir = tempFolder.newFolder("config")
+        server = WebServer(0, configDir)
+        server.start()
+        CertHack.readFromXml(null)
+    }
+
+    @After
+    fun tearDown() {
+        server.stop()
+        CertHack.readFromXml(null)
+    }
+
+    @Test
+    fun testDragDropImplementation() {
+        val port = server.listeningPort
+        val token = server.token
+        val url = URL("http://localhost:$port/?token=$token")
+        val conn = url.openConnection() as HttpURLConnection
+        val html = conn.inputStream.bufferedReader().readText()
+
+        assertTrue("Should contain drag-over CSS class",
+            html.contains(".drag-over { border-color: var(--accent) !important;")
+        )
+
+        assertTrue("Button should have ID dropZone",
+            html.contains("id=\"dropZone\"")
+        )
+
+        assertTrue("Button text should include Drag & Drop",
+            html.contains("Select XML File or Drag & Drop")
+        )
+
+        assertTrue("Should contain processKeyboxFile function",
+            html.contains("function processKeyboxFile(file)")
+        )
+    }
+}


### PR DESCRIPTION
Implemented drag and drop functionality for the Keybox upload section in the WebUI. Users can now drag an XML file onto the "Select XML File" button to load it, providing a more modern and convenient interaction. The button text has been updated to reflect this capability. A new unit test ensures the feature's implementation details are present in the served HTML.

---
*PR created automatically by Jules for task [7057041877160887554](https://jules.google.com/task/7057041877160887554) started by @tryigit*