### PR TITLE
🛡️ Sentinel: [HIGH] Prevent XXE by strictly blocking DTDs in XMLParser

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/XMLParser.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/XMLParser.java
@@ -54,6 +54,12 @@ public class XMLParser {
         int eventType = parser.getEventType();
         while (eventType != XmlPullParser.END_DOCUMENT) {
             switch (eventType) {
+                case XmlPullParser.DOCDECL:
+                    // Security: Explicitly reject DTDs to prevent XXE (XML External Entity) attacks.
+                    // Even if FEATURE_PROCESS_DOCDECL was disabled, checking the event type adds
+                    // a second layer of defense.
+                    throw new SecurityException("DTD is not allowed in this parser to prevent XXE attacks");
+
                 case XmlPullParser.START_TAG:
                     Element element = new Element(parser.getName());
                     for (int i = 0; i < parser.getAttributeCount(); i++) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/XMLParserXxeTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/XMLParserXxeTest.kt
@@ -1,0 +1,39 @@
+package cleveres.tricky.cleverestech.keystore
+
+import org.junit.Assert.fail
+import org.junit.Test
+import java.io.StringReader
+
+class XMLParserXxeTest {
+
+    @Test
+    fun testDtdIsStrictlyRejected() {
+        // Simple DTD without entities.
+        // If parser ignores DTD (feature=false), it might skip this or report DOCDECL.
+        // We want it to REPORT DOCDECL so we can reject it.
+        val xml = """
+            <!DOCTYPE foo [
+              <!ELEMENT foo ANY >
+            ]>
+            <root>hello</root>
+        """.trimIndent()
+
+        try {
+            XMLParser(StringReader(xml))
+            fail("Parsing should have failed due to DTD presence!")
+        } catch (e: SecurityException) {
+            // Success! The parser explicitly rejected the DTD.
+            if (e.message?.contains("DTD is not allowed") != true) {
+                fail("Threw SecurityException but with unexpected message: ${e.message}")
+            }
+        } catch (e: Exception) {
+             val msg = e.message ?: ""
+             // If parser throws exception on DTD, that's also fine (blocked)
+             if (msg.contains("docdecl not permitted")) {
+                 return
+             }
+             // If it failed for another reason (e.g. malformed), rethrow to fail test
+             throw e
+        }
+    }
+}


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Prevent XXE by strictly blocking DTDs in XMLParser

**Vulnerability:**
XML External Entity (XXE) attacks are possible if the XML parser processes DTDs (Document Type Definitions). An attacker can define external entities that resolve to local files or internal network resources, leading to data exfiltration or Denial of Service (DoS).

**Fix:**
Modified `service/src/main/java/cleveres/tricky/cleverestech/keystore/XMLParser.java` to explicitly handle the `XmlPullParser.DOCDECL` event. Instead of relying solely on `parser.setFeature(XmlPullParser.FEATURE_PROCESS_DOCDECL, false)` (which might be ignored or fail silently on some implementations), the parser now throws a `SecurityException` immediately upon encountering a DTD.

**Verification:**
Added `service/src/test/java/cleveres/tricky/cleverestech/keystore/XMLParserXxeTest.kt`.
Ran `./gradlew :service:testDebugUnitTest`. The new test passes (confirming DTDs are rejected), and existing tests pass (confirming no regressions).

---
*PR created automatically by Jules for task [8640259216562273354](https://jules.google.com/task/8640259216562273354) started by @tryigit*