### PR TITLE
Fix missing templates.json in backup

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -1938,7 +1938,7 @@ class WebServer(
             "target.txt", "security_patch.txt", "spoof_build_vars", "app_config",
             "drm_fix", "random_on_boot", "global_mode", "tee_broken_mode",
             "rkp_bypass", "auto_beta_fetch", "auto_keybox_check", "random_drm_on_boot",
-            "remote_keys.xml", "custom_templates", "keybox.xml"
+            "remote_keys.xml", "custom_templates", "keybox.xml", "templates.json"
         )
 
         fun createBackupZip(configDir: File): ByteArray {

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerTemplateBackupTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerTemplateBackupTest.kt
@@ -1,0 +1,83 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.util.SecureFile
+import cleveres.tricky.cleverestech.util.SecureFileOperations
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.nio.file.Files
+
+class WebServerTemplateBackupTest {
+
+    private lateinit var testDir: File
+    private lateinit var configDir: File
+    private lateinit var originalSecureFileImpl: SecureFileOperations
+
+    @Before
+    fun setUp() {
+        testDir = Files.createTempDirectory("cleverestricky_test").toFile()
+        configDir = File(testDir, "config")
+        configDir.mkdirs()
+
+        // Save original implementation
+        originalSecureFileImpl = SecureFile.impl
+
+        // Mock SecureFile to use standard IO
+        SecureFile.impl = object : SecureFileOperations {
+            override fun writeText(file: File, content: String) {
+                file.parentFile?.mkdirs()
+                file.writeText(content)
+            }
+
+            override fun mkdirs(file: File, mode: Int) {
+                file.mkdirs()
+            }
+
+            override fun touch(file: File, mode: Int) {
+                file.parentFile?.mkdirs()
+                file.createNewFile()
+            }
+        }
+    }
+
+    @After
+    fun tearDown() {
+        // Restore original implementation
+        SecureFile.impl = originalSecureFileImpl
+        testDir.deleteRecursively()
+    }
+
+    @Test
+    fun testTemplatesJsonBackup() {
+        // Setup: Create templates.json
+        val templatesJson = """[{"id":"custom","model":"Custom Model"}]"""
+        File(configDir, "templates.json").writeText(templatesJson)
+
+        // Also create a custom_templates file to check if it's backed up (legacy/unused?)
+        File(configDir, "custom_templates").writeText("some legacy content")
+
+        // Create Backup
+        val zipBytes = WebServer.createBackupZip(configDir)
+        assertTrue("Zip should not be empty", zipBytes.isNotEmpty())
+
+        // Clear config dir
+        configDir.deleteRecursively()
+        configDir.mkdirs()
+
+        // Restore
+        WebServer.restoreBackupZip(configDir, ByteArrayInputStream(zipBytes))
+
+        // Verify: templates.json should exist
+        val restoredTemplates = File(configDir, "templates.json")
+        assertTrue("templates.json should be restored", restoredTemplates.exists())
+        assertEquals(templatesJson, restoredTemplates.readText())
+
+        // Verify: custom_templates should exist (it's in the list)
+        val restoredCustomTemplates = File(configDir, "custom_templates")
+        assertTrue("custom_templates should be restored", restoredCustomTemplates.exists())
+    }
+}


### PR DESCRIPTION
Fix missing templates.json in backup

The `templates.json` file, which stores custom device templates, was missing from the backup zip file list. This caused custom templates to be lost when restoring a backup.

This commit adds `templates.json` to the `BACKUP_FILES` set in `WebServer.kt`.
A regression test `WebServerTemplateBackupTest` has been added to verify that `templates.json` is correctly included in the backup and restored.

---
*PR created automatically by Jules for task [14490929019231823732](https://jules.google.com/task/14490929019231823732) started by @tryigit*