### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS via Zip Bomb in Backup Restore

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -1994,14 +1994,14 @@ class WebServer(
                                  val kbDir = File(configDir, "keyboxes")
                                  if (!kbDir.exists()) SecureFile.mkdirs(kbDir, 448)
                                  val f = File(kbDir, kbName)
-                                 val content = zis.readBytes().toString(Charsets.UTF_8)
-                                 SecureFile.writeText(f, content)
+                                 // Use streaming with 50MB limit to prevent OOM/ZipBomb
+                                 SecureFile.writeStream(f, zis, 50 * 1024 * 1024)
                              }
                         } else if (BACKUP_FILES.contains(name)) {
                              // Restore config file
                              val f = File(configDir, name)
-                             val content = zis.readBytes().toString(Charsets.UTF_8)
-                             SecureFile.writeText(f, content)
+                             // Use streaming with 50MB limit to prevent OOM/ZipBomb
+                             SecureFile.writeStream(f, zis, 50 * 1024 * 1024)
                         }
                     }
                     zis.closeEntry()

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerZipBombTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerZipBombTest.kt
@@ -1,0 +1,131 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.util.SecureFile
+import cleveres.tricky.cleverestech.util.SecureFileOperations
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.InputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class WebServerZipBombTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var configDir: File
+    private lateinit var originalImpl: SecureFileOperations
+    private var writeStreamCalled = false
+    private var limitPassed: Long = -1
+
+    @Before
+    fun setUp() {
+        configDir = tempFolder.newFolder("config")
+        originalImpl = SecureFile.impl
+
+        // Mock Logger to prevent spam
+        Logger.setImpl(object : Logger.LogImpl {
+            override fun d(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String, t: Throwable?) {}
+            override fun i(tag: String, msg: String) {}
+        })
+    }
+
+    @After
+    fun tearDown() {
+        SecureFile.impl = originalImpl
+    }
+
+    @Test
+    fun testRestoreUsesStreamingWithLimit() {
+        // Setup mock
+        SecureFile.impl = object : SecureFileOperations {
+            override fun writeText(file: File, content: String) {
+                Assert.fail("Should use writeStream instead of writeText")
+            }
+
+            override fun writeStream(file: File, inputStream: InputStream, limit: Long) {
+                writeStreamCalled = true
+                limitPassed = limit
+                // Simulate reading to ensure stream is valid
+                inputStream.readBytes()
+            }
+
+            override fun mkdirs(file: File, mode: Int) {}
+            override fun touch(file: File, mode: Int) {}
+        }
+
+        // Create a valid zip with one file
+        val baos = ByteArrayOutputStream()
+        ZipOutputStream(baos).use { zos ->
+            zos.putNextEntry(ZipEntry("target.txt"))
+            zos.write("some content".toByteArray())
+            zos.closeEntry()
+        }
+        val zipBytes = baos.toByteArray()
+
+        // Call restoreBackupZip
+        // We need to access WebServer.restoreBackupZip, but it is in companion object or static?
+        // Ah, it's in companion object of WebServer class.
+        // Let's check WebServer.kt again. It is in companion object.
+
+        WebServer.restoreBackupZip(configDir, ByteArrayInputStream(zipBytes))
+
+        Assert.assertTrue("writeStream should be called", writeStreamCalled)
+        Assert.assertEquals("Limit should be 50MB", 50 * 1024 * 1024L, limitPassed)
+    }
+
+    @Test
+    fun testSecureFileLimitEnforcement() {
+        // Test the logic inside DefaultSecureFileOperations (streaming and limit)
+        // Since we can't easily use Os.write in unit tests (Android dependency),
+        // we can't fully test DefaultSecureFileOperations here without Robolectric or mocking Os.
+        // However, we can verify the logic if we extract it or if we trust the implementation.
+        // Given the constraints, verifying that WebServer CALLS the method with the limit is the key step.
+        // The implementation of writeStream in SecureFile.kt handles the limit check.
+
+        // We will assume the implementation of SecureFile.kt is correct as per the code review.
+        // But let's verify that WebServer handles the exception if writeStream throws it.
+
+        SecureFile.impl = object : SecureFileOperations {
+            override fun writeText(file: File, content: String) {}
+            override fun writeStream(file: File, inputStream: InputStream, limit: Long) {
+                 throw java.io.IOException("File size exceeds limit of $limit bytes")
+            }
+            override fun mkdirs(file: File, mode: Int) {}
+            override fun touch(file: File, mode: Int) {}
+        }
+
+        val baos = ByteArrayOutputStream()
+        ZipOutputStream(baos).use { zos ->
+            zos.putNextEntry(ZipEntry("target.txt"))
+            zos.write("large content".toByteArray())
+            zos.closeEntry()
+        }
+        val zipBytes = baos.toByteArray()
+
+        try {
+            WebServer.restoreBackupZip(configDir, ByteArrayInputStream(zipBytes))
+            // It should propagate the exception or handle it?
+            // WebServer.restoreBackupZip calls SecureFile.writeStream.
+            // If exception is thrown, it bubbles up.
+            // The caller of restoreBackupZip (in serve method) catches Exception.
+        } catch (e: Exception) {
+            Assert.assertEquals("File size exceeds limit of 52428800 bytes", e.message)
+            return
+        }
+        // If no exception, check if it was swallowed inside restoreBackupZip?
+        // Looking at restoreBackupZip code:
+        // It iterates entries. Inside loop calls writeStream.
+        // It does NOT have try-catch inside the loop.
+        // So exception should propagate.
+    }
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential Denial of Service (DoS) and Out-of-Memory (OOM) via Zip Bomb during backup restoration. The previous implementation read the entire uncompressed content of each zip entry into memory before writing to disk, allowing a malicious zip file (small compressed size, huge uncompressed size) to crash the application.
🎯 Impact: An attacker could crash the service by uploading a specially crafted backup file, leading to denial of service.
🔧 Fix: Implemented streaming file write (`SecureFile.writeStream`) with a strict 50MB size limit per file. The content is now piped directly from the `ZipInputStream` to the file system without being fully loaded into RAM.
✅ Verification: Added `WebServerZipBombTest` which verifies that `restoreBackupZip` uses the streaming method with the correct limit. Verified that existing tests pass.

---
*PR created automatically by Jules for task [7066551992378699672](https://jules.google.com/task/7066551992378699672) started by @tryigit*