### PR TITLE
Fix broken backup/restore unit tests

### DIFF
--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -80,7 +80,12 @@ android {
     testOptions {
         unitTests.all {
             it.testLogging {
-                events = setOf(org.gradle.api.tasks.testing.logging.TestLogEvent.STANDARD_OUT, org.gradle.api.tasks.testing.logging.TestLogEvent.STANDARD_ERROR)
+                events = setOf(
+                    org.gradle.api.tasks.testing.logging.TestLogEvent.STANDARD_OUT,
+                    org.gradle.api.tasks.testing.logging.TestLogEvent.STANDARD_ERROR,
+                    org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
+                )
+                exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
             }
         }
     }

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerBackupTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerBackupTest.kt
@@ -29,6 +29,22 @@ class WebServerBackupTest {
                 file.writeText(content)
             }
 
+            override fun writeStream(file: File, inputStream: java.io.InputStream, limit: Long) {
+                file.parentFile?.mkdirs()
+                file.outputStream().use { output ->
+                    var totalBytes = 0L
+                    val buffer = ByteArray(8192)
+                    var bytesRead: Int
+                    while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+                        if (limit > 0 && totalBytes + bytesRead > limit) {
+                            throw java.io.IOException("File size exceeds limit of $limit bytes")
+                        }
+                        output.write(buffer, 0, bytesRead)
+                        totalBytes += bytesRead
+                    }
+                }
+            }
+
             override fun mkdirs(file: File, mode: Int) {
                 file.mkdirs()
             }

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerTemplateBackupTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerTemplateBackupTest.kt
@@ -33,6 +33,22 @@ class WebServerTemplateBackupTest {
                 file.writeText(content)
             }
 
+            override fun writeStream(file: File, inputStream: java.io.InputStream, limit: Long) {
+                file.parentFile?.mkdirs()
+                file.outputStream().use { output ->
+                    var totalBytes = 0L
+                    val buffer = ByteArray(8192)
+                    var bytesRead: Int
+                    while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+                        if (limit > 0 && totalBytes + bytesRead > limit) {
+                            throw java.io.IOException("File size exceeds limit of $limit bytes")
+                        }
+                        output.write(buffer, 0, bytesRead)
+                        totalBytes += bytesRead
+                    }
+                }
+            }
+
             override fun mkdirs(file: File, mode: Int) {
                 file.mkdirs()
             }


### PR DESCRIPTION
The module build was failing due to unit test failures in `WebServerBackupTest` and `WebServerTemplateBackupTest`.
Investigation revealed that the tests were using a mock implementation of `SecureFileOperations` that did not override the `writeStream` method.
The default interface implementation of `writeStream` is a no-op, causing the backup restoration logic (which relies on `writeStream`) to fail silently during tests (creating empty or no files).

This change:
1.  Implements `writeStream` in the test mocks to correctly copy the stream to the file system, enabling the backup restore logic to work as expected in tests.
2.  Adds size limit enforcement to the mock implementation to match the contract of `SecureFileOperations`.
3.  Updates `service/build.gradle.kts` to log failed tests to standard output, making it easier to diagnose issues in the future.

Verified by running `./gradlew :service:testDebugUnitTest`, which now passes all tests.

---
*PR created automatically by Jules for task [8579307687059517770](https://jules.google.com/task/8579307687059517770) started by @tryigit*