### PR TITLE
Fix missing inject binary in module zip

### DIFF
--- a/module/build.gradle.kts
+++ b/module/build.gradle.kts
@@ -126,6 +126,18 @@ afterEvaluate {
                 into("lib")
             }
 
+            from(layout.buildDirectory.dir("intermediates/cxx/$variantCapped")) {
+                include("**/obj/**/inject")
+                eachFile {
+                    val segments = relativePath.segments
+                    if (segments.size >= 3 && segments[segments.size - 3] == "obj") {
+                        val abi = segments[segments.size - 2]
+                        relativePath = RelativePath(true, "lib", abi, "inject")
+                    }
+                }
+                includeEmptyDirs = false
+            }
+
             doLast {
                 val apk = file("${moduleDir.get().asFile}/service.apk")
                 if (!apk.exists() || apk.length() == 0L) {


### PR DESCRIPTION
Fixes an issue where the `inject` binary was not being included in the module zip file, causing installation failures with "lib/arm64-v8a/inject not exists". This was due to AGP filtering out executables. The fix manually copies the binary from the CMake build output.

---
*PR created automatically by Jules for task [11515367283901999990](https://jules.google.com/task/11515367283901999990) started by @tryigit*