### PR TITLE
Fix WebServer permission validation regex

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -413,8 +413,8 @@ class WebServer(
                                             // Security: Validate template and keybox to prevent XSS
                                             val isTmplValid = tmpl.isEmpty() || tmpl.matches(TEMPLATE_NAME_REGEX)
                                             val isKbValid = kb.isEmpty() || kb.matches(KEYBOX_FILENAME_REGEX)
-                                            // Validate permissions: Comma-separated uppercase alphanumeric
-                                            val isPermsValid = perms.isEmpty() || perms.matches(Regex("^[A-Z0-9,]+$"))
+                                            // Validate permissions: Comma-separated alphanumeric, dots, underscores (standard permission format)
+                                            val isPermsValid = perms.isEmpty() || perms.matches(Regex("^[a-zA-Z0-9_.,]+$"))
 
                                             if (isTmplValid && isKbValid && isPermsValid) {
                                                 val obj = JSONObject()
@@ -482,7 +482,7 @@ class WebServer(
                          }
 
                          // Validate permissions
-                         if (permsStr != "null" && !permsStr.matches(Regex("^[A-Z0-9,]+$"))) {
+                         if (permsStr != "null" && !permsStr.matches(Regex("^[a-zA-Z0-9_.,]+$"))) {
                              return secureResponse(Response.Status.BAD_REQUEST, "text/plain", "Invalid input: invalid permission format")
                          }
 
@@ -769,7 +769,7 @@ class WebServer(
                     if (parts.size > 2 && parts[2] != "null" && !parts[2].matches(KEYBOX_FILENAME_REGEX)) return false
 
                     // Permissions (optional)
-                    if (parts.size > 3 && parts[3] != "null" && !parts[3].matches(Regex("^[A-Z0-9,]+$"))) return false
+                    if (parts.size > 3 && parts[3] != "null" && !parts[3].matches(Regex("^[A-zA-Z0-9_.,]+$"))) return false
                 }
             }
             "target.txt" -> {

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerExtendedPermissionsTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerExtendedPermissionsTest.kt
@@ -1,0 +1,103 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.util.SecureFile
+import cleveres.tricky.cleverestech.util.SecureFileOperations
+import fi.iki.elonen.NanoHTTPD
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class WebServerExtendedPermissionsTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var server: WebServer
+    private lateinit var configDir: File
+
+    @Before
+    fun setUp() {
+        Logger.setImpl(object : Logger.LogImpl {
+            override fun d(tag: String, msg: String) { println("DEBUG: $tag: $msg") }
+            override fun e(tag: String, msg: String) { println("ERROR: $tag: $msg") }
+            override fun e(tag: String, msg: String, t: Throwable?) { println("ERROR: $tag: $msg"); t?.printStackTrace() }
+            override fun i(tag: String, msg: String) { println("INFO: $tag: $msg") }
+        })
+
+        SecureFile.impl = object : SecureFileOperations {
+            override fun writeText(file: File, content: String) {
+                file.parentFile?.mkdirs()
+                file.writeText(content)
+            }
+            override fun mkdirs(file: File, mode: Int) {
+                file.mkdirs()
+            }
+            override fun touch(file: File, mode: Int) {
+                file.parentFile?.mkdirs()
+                if (!file.exists()) file.createNewFile()
+            }
+        }
+
+        configDir = tempFolder.newFolder("config")
+        server = WebServer(0, configDir)
+    }
+
+    @Test
+    fun testSaveAppConfigWithStandardAndroidPermission() {
+        // Prepare data with a standard Android permission (lowercase, dots)
+        val rules = JSONArray()
+        val rule = JSONObject()
+        rule.put("package", "com.example.app")
+        rule.put("template", "null")
+        rule.put("keybox", "null")
+        val perms = JSONArray()
+        perms.put("android.permission.INTERNET")
+        rule.put("permissions", perms)
+        rules.put(rule)
+
+        // Simulate POST request
+        val sessionPost = MockSession(
+            NanoHTTPD.Method.POST,
+            "/api/app_config_structured",
+            mapOf("data" to rules.toString()),
+            server.token,
+            mapOf("content-length" to "100") // Dummy length required by WebServer
+        )
+        val responsePost = server.serve(sessionPost)
+
+        // This is expected to fail with BAD_REQUEST currently
+        assertEquals("Standard Android permission should be accepted", NanoHTTPD.Response.Status.OK, responsePost.status)
+    }
+
+    inner class MockSession(
+        private val method: NanoHTTPD.Method,
+        private val uri: String,
+        private val params: Map<String, String>,
+        private val token: String,
+        private val headers: Map<String, String> = emptyMap()
+    ) : NanoHTTPD.IHTTPSession {
+        override fun execute() {}
+        override fun getCookies() = server.CookieHandler(HashMap())
+        override fun getHeaders(): Map<String, String> {
+            val h = HashMap<String, String>()
+            h["host"] = "localhost"
+            h["x-auth-token"] = token
+            h.putAll(headers)
+            return h
+        }
+        override fun getInputStream() = null
+        override fun getMethod() = method
+        override fun getParms() = params
+        override fun getQueryParameterString() = ""
+        override fun getUri() = uri
+        override fun parseBody(files: Map<String, String>?) {}
+        override fun getRemoteIpAddress() = "127.0.0.1"
+        override fun getRemoteHostName() = "localhost"
+        override fun getParameters() = emptyMap<String, List<String>>()
+    }
+}


### PR DESCRIPTION
Fixed a bug where the WebServer would reject valid Android permissions (like `android.permission.INTERNET`) in the app configuration because the validation regex was too strict (only allowing uppercase). Updated the regex to allow lowercase letters, dots, and underscores. Added a regression test to verify the fix.

---
*PR created automatically by Jules for task [13298566237869425173](https://jules.google.com/task/13298566237869425173) started by @tryigit*