### PR TITLE
🛡️ Sentinel: Fix Information Disclosure in PropertyHiderService

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/PropertyHiderService.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/PropertyHiderService.kt
@@ -19,6 +19,15 @@ class PropertyHiderService : Binder() {
             reply?.writeNoException() // Important: write no exception before writing result
 
             if (propertyName != null) {
+                // Security: Prevent exposure of internal configuration variables
+                if (propertyName.startsWith("ATTESTATION_ID_")) {
+                    if (BuildConfig.DEBUG) {
+                        Logger.d("PropertyHiderService: Blocked access to sensitive config '$propertyName' from ${Binder.getCallingUid()}")
+                    }
+                    reply?.writeString(null)
+                    return true
+                }
+
                 // Use getBuildVar as it holds the loaded properties from spoof_build_vars
                 val callingUid = Binder.getCallingUid()
                 val spoofedValue = Config.getBuildVar(propertyName, callingUid)

--- a/service/src/test/java/android/os/Binder.java
+++ b/service/src/test/java/android/os/Binder.java
@@ -1,6 +1,9 @@
 package android.os;
 
 public class Binder implements IBinder {
+    public static int callingUid = 0;
+    public static int getCallingUid() { return callingUid; }
+
     public boolean onTransact(int code, Parcel data, Parcel reply, int flags) {
         return false;
     }

--- a/service/src/test/java/android/os/Parcel.java
+++ b/service/src/test/java/android/os/Parcel.java
@@ -47,6 +47,11 @@ public class Parcel {
         Object o = queue.poll();
         return (o instanceof Long) ? (Long) o : 0L;
     }
+    public String readString() {
+        Object o = queue.poll();
+        return (o instanceof String) ? (String) o : null;
+    }
+    public void writeString(String val) { queue.add(val); }
 
     // Other stubs
     public void writeNoException() {}

--- a/service/src/test/java/cleveres/tricky/cleverestech/PropertyHiderServiceTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/PropertyHiderServiceTest.kt
@@ -1,0 +1,79 @@
+package cleveres.tricky.cleverestech
+
+import android.os.Binder
+import android.os.Parcel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class PropertyHiderServiceTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Before
+    fun setUp() {
+        // Reset Binder calling UID
+        Binder.callingUid = 0
+        // Suppress logging
+        Logger.setImpl(object : Logger.LogImpl {
+            override fun d(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String, t: Throwable?) {}
+            override fun i(tag: String, msg: String) {}
+        })
+    }
+
+    @Test
+    fun testSensitiveExposure() {
+        // 1. Setup Config with sensitive property
+        val buildVarsFile = tempFolder.newFile("spoof_build_vars")
+        buildVarsFile.writeText("ATTESTATION_ID_IMEI=123456789012345\nro.product.model=Pixel 8")
+        Config.updateBuildVars(buildVarsFile)
+
+        // 2. Instantiate Service
+        val service = PropertyHiderService()
+
+        // 3. Prepare Mock Data
+        val data = Parcel.obtain()
+        // My mock enforceInterface does nothing, so we don't need to write the token.
+        data.writeString("ATTESTATION_ID_IMEI")
+
+        val reply = Parcel.obtain()
+
+        // 4. Simulate Call from Unprivileged App
+        Binder.callingUid = 10000 // App UID
+
+        val code = PropertyHiderService.GET_SPOOFED_PROPERTY_TRANSACTION_CODE
+
+        service.transact(code, data, reply, 0)
+
+        // 5. Verify Result
+        val result = reply.readString()
+
+        // Expect blocked access (security fix)
+        assertNull("Sensitive ID should be blocked", result)
+    }
+
+    @Test
+    fun testNormalPropertyAccess() {
+        val buildVarsFile = tempFolder.newFile("spoof_build_vars")
+        buildVarsFile.writeText("ro.product.model=Pixel 8")
+        Config.updateBuildVars(buildVarsFile)
+
+        val service = PropertyHiderService()
+        val data = Parcel.obtain()
+        data.writeString("ro.product.model")
+        val reply = Parcel.obtain()
+
+        Binder.callingUid = 10000
+        service.transact(PropertyHiderService.GET_SPOOFED_PROPERTY_TRANSACTION_CODE, data, reply, 0)
+
+        val result = reply.readString()
+        assertEquals("Pixel 8", result)
+    }
+}


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix Information Disclosure in PropertyHiderService

**Severity:** HIGH

**Vulnerability:**
The `PropertyHiderService` exposed all loaded configuration properties (including sensitive `ATTESTATION_ID_*` values like IMEI and Serial Number) to any application that could access the Binder interface. This allowed unauthorized apps to bypass Android permissions (`READ_PHONE_STATE`) and retrieve the spoofed hardware identifiers.

**Impact:**
Malicious apps could fingerprint the device using the spoofed identifiers or harvest valid IMEIs if the user configured them, undermining the privacy goals of the module.

**Fix:**
Modified `PropertyHiderService.kt` to explicitly block queries for properties starting with `ATTESTATION_ID_`. The service now returns `null` for these requests, while continuing to serve other spoofed properties (like `ro.boot.*`) necessary for root hiding.

**Verification:**
Added `PropertyHiderServiceTest.kt` which simulates an unprivileged app request for `ATTESTATION_ID_IMEI`. The test confirms that the service returns `null` (blocked) instead of the configured value. Existing tests passed.

---
*PR created automatically by Jules for task [13536122747739376322](https://jules.google.com/task/13536122747739376322) started by @tryigit*