### PR TITLE
Fix KeyboxVerifier ignoring negative decimal serial numbers

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -138,6 +138,9 @@ object KeyboxVerifier {
             isDecimal = false
         } else {
             for (i in 0 until decStr.length) {
+                if (i == 0 && decStr[i] == '-' && decStr.length > 1) {
+                    continue
+                }
                 if (!Character.isDigit(decStr[i])) {
                     isDecimal = false
                     break

--- a/service/src/test/java/cleveres/tricky/cleverestech/KeyboxVerifierNegativeTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/KeyboxVerifierNegativeTest.kt
@@ -1,0 +1,32 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.util.KeyboxVerifier
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.math.BigInteger
+
+class KeyboxVerifierNegativeTest {
+
+    @Test
+    fun testParseCrlWithNegativeDecimal() {
+        // Serial Number -10.
+        // BigInteger(-10).toString(16) = "-a".
+
+        val negativeSerial = "-10"
+
+        val json = """
+        {
+          "entries": {
+            "$negativeSerial": "REVOKED"
+          }
+        }
+        """.trimIndent()
+
+        val revoked = KeyboxVerifier.parseCrl(json)
+
+        println("Revoked Set: $revoked")
+
+        // If bug exists, "-a" is missing because "-10" fails isDecimal check (has '-') and HEX_REGEX (has '-').
+        assertTrue("Should contain '-a' for negative decimal -10", revoked.contains("-a"))
+    }
+}


### PR DESCRIPTION
Fixes a bug where negative decimal serial numbers in the CRL were ignored by `KeyboxVerifier`.
The `isDecimal` logic was updated to allow a leading hyphen.
Added a regression test `KeyboxVerifierNegativeTest`.

---
*PR created automatically by Jules for task [17545538353381567737](https://jules.google.com/task/17545538353381567737) started by @tryigit*