### PR TITLE
Improve Identity Manager accessibility with proper label

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2026-08-15 - Actionable Empty States
 **Learning:** When a search filter yields no results, a static "No results" message is a dead end. Providing a "Clear Filter" button directly within the empty state message allows users to recover immediately without searching for the filter input's clear control.
 **Action:** Enhance empty states with context-aware recovery actions (e.g., Clear Filter, Reset Search).
+
+## 2026-08-16 - Implicit Labels via Paragraphs
+**Learning:** Descriptions for form controls (e.g., `<select>`) are often implemented as `<p>` tags instead of `<label>`, breaking screen reader accessibility by decoupling the description from the control.
+**Action:** When auditing embedded HTML, verify all form controls have an associated `<label>` (via `for` attribute or nesting) rather than relying on proximity or visual layout.

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -1160,7 +1160,7 @@ class WebServer(
 
         <div class="panel">
             <h3>Identity Manager</h3>
-            <p style="color:#888; font-size:0.9em; margin-bottom:15px;">Select a verified device identity to spoof globally.</p>
+            <label for="templateSelect" style="color:#888; font-size:0.9em; margin-bottom:15px; display:block;">Select a verified device identity to spoof globally.</label>
 
             <select id="templateSelect" onchange="previewTemplate()" style="margin-bottom:15px;"></select>
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerAccessibilityTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerAccessibilityTest.kt
@@ -1,0 +1,68 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.keystore.CertHack
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.Rule
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+
+class WebServerAccessibilityTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var server: WebServer
+    private lateinit var configDir: File
+
+    @Before
+    fun setUp() {
+        // Mock logger to avoid spam
+        Logger.setImpl(object : Logger.LogImpl {
+            override fun d(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String, t: Throwable?) {}
+            override fun i(tag: String, msg: String) {}
+        })
+        configDir = tempFolder.newFolder("config")
+        server = WebServer(0, configDir)
+        server.start()
+        CertHack.readFromXml(null)
+    }
+
+    @After
+    fun tearDown() {
+        server.stop()
+        CertHack.readFromXml(null)
+    }
+
+    @Test
+    fun testIdentityManagerAccessibility() {
+        val port = server.listeningPort
+        val token = server.token
+        val url = URL("http://localhost:$port/?token=$token")
+        val conn = url.openConnection() as HttpURLConnection
+        val html = conn.inputStream.bufferedReader().readText()
+
+        // Verify that the Identity Manager description is now a label associated with the select element
+        val expectedLabelStart = "<label for=\"templateSelect\""
+        val expectedLabelStyle = "display:block;" // We added this style
+        val expectedText = "Select a verified device identity to spoof globally.</label>"
+
+        assertTrue("Identity Manager should use a label for templateSelect",
+            html.contains(expectedLabelStart)
+        )
+
+        assertTrue("Label should have display:block style",
+            html.contains(expectedLabelStyle)
+        )
+
+        assertTrue("Label should contain correct text",
+            html.contains(expectedText)
+        )
+    }
+}


### PR DESCRIPTION
Replaced `<p>` description with `<label for="...">` in Identity Manager section of WebServer.kt to improve accessibility. Added regression test.

---
*PR created automatically by Jules for task [125953864230552557](https://jules.google.com/task/125953864230552557) started by @tryigit*