### PR TITLE
⚡ Optimize FilePoller with FileObserver

### DIFF
--- a/service/src/androidTest/java/cleveres/tricky/cleverestech/FilePollerInstrumentationTest.kt
+++ b/service/src/androidTest/java/cleveres/tricky/cleverestech/FilePollerInstrumentationTest.kt
@@ -1,0 +1,55 @@
+package cleveres.tricky.cleverestech
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+class FilePollerInstrumentationTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun benchmarkDetectionLatency() {
+        val testFile = tempFolder.newFile("benchmark_poller.txt")
+        testFile.writeText("initial")
+
+        val latch = CountDownLatch(1)
+        val startTime = System.currentTimeMillis()
+
+        // Use default interval (5000ms) to show that efficient polling (FileObserver) works
+        // If it falls back to polling, this test will likely fail (timeout > 200ms)
+        val poller = FilePoller(testFile) {
+            latch.countDown()
+        }
+        poller.start()
+
+        // Wait a bit to ensure poller is ready
+        Thread.sleep(100)
+
+        // Modify file
+        testFile.writeText("modified")
+        testFile.setLastModified(System.currentTimeMillis())
+
+        // Expect detection within 200ms (should fail with 5s polling, pass with FileObserver)
+        val detected = latch.await(200, TimeUnit.MILLISECONDS)
+        val duration = System.currentTimeMillis() - startTime
+
+        poller.stop()
+
+        if (!detected) {
+            println("Benchmark: Detection timed out (latency > 200ms). Expected if falling back to polling.")
+        } else {
+            println("Benchmark: Detection took ${duration}ms")
+        }
+
+        assertTrue("Detection took too long: ${duration}ms. Expected near-instant detection with FileObserver.", detected)
+    }
+}

--- a/service/src/main/java/cleveres/tricky/cleverestech/FilePoller.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/FilePoller.kt
@@ -1,5 +1,6 @@
 package cleveres.tricky.cleverestech
 
+import android.os.FileObserver
 import java.io.File
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledFuture
@@ -15,6 +16,7 @@ class FilePoller(
     @Volatile
     private var lastModified: Long = 0
     private var scheduledFuture: ScheduledFuture<*>? = null
+    private var observer: FileObserver? = null
 
     companion object {
         private val scheduler = Executors.newSingleThreadScheduledExecutor { r ->
@@ -34,6 +36,28 @@ class FilePoller(
     fun start() {
         if (isRunning) return
         isRunning = true
+
+        try {
+            val parent = file.parentFile
+            if (parent != null && parent.exists()) {
+                val observer = object : FileObserver(parent.absolutePath, CLOSE_WRITE or MOVED_TO) {
+                    override fun onEvent(event: Int, path: String?) {
+                        if (path == file.name && file.exists()) {
+                            val currentModified = file.lastModified()
+                            if (currentModified > lastModified) {
+                                lastModified = currentModified
+                                onModified(file)
+                            }
+                        }
+                    }
+                }
+                observer.startWatching()
+                this.observer = observer
+                return
+            }
+        } catch (t: Throwable) {
+            // Fallback to polling if FileObserver fails (e.g. on unit tests or unsupported environment)
+        }
 
         scheduledFuture = scheduler.scheduleWithFixedDelay({
             if (!isRunning) return@scheduleWithFixedDelay // Double check
@@ -55,6 +79,8 @@ class FilePoller(
     @Synchronized
     fun stop() {
         isRunning = false
+        observer?.stopWatching()
+        observer = null
         scheduledFuture?.cancel(false)
         scheduledFuture = null
     }


### PR DESCRIPTION
This change optimizes `FilePoller.kt` by utilizing `android.os.FileObserver` when available. This replaces the previous 5-second polling interval with immediate event-driven detection, improving responsiveness and reducing unnecessary wakeups. A fallback mechanism ensures that the class remains functional in environments where `FileObserver` is not supported (e.g., local JVM unit tests). An instrumentation test was added to verify the performance improvement.

---
*PR created automatically by Jules for task [2060985965936563268](https://jules.google.com/task/2060985965936563268) started by @tryigit*