### PR TITLE
Verify existence of inject binary during Magisk module build

### DIFF
--- a/module/build.gradle.kts
+++ b/module/build.gradle.kts
@@ -144,6 +144,13 @@ afterEvaluate {
                     throw GradleException("service.apk is missing or empty!")
                 }
 
+                abiList.forEach { abi ->
+                    val injectPath = file("${moduleDir.get().asFile}/lib/$abi/inject")
+                    if (!injectPath.exists()) {
+                        throw GradleException("inject binary for $abi is missing at $injectPath")
+                    }
+                }
+
                 fileTree(moduleDir).visit {
                     if (isDirectory) return@visit
                     val md = MessageDigest.getInstance("SHA-256")


### PR DESCRIPTION
The user reported an installation failure for "Beta V2.1.3-777" where the installer complained about "lib/arm64-v8a/inject not exists".

I investigated the `module/template/customize.sh` script and confirmed that it expects `lib/arm64-v8a/inject` to exist in the zip. The file is supposed to be included by `module/build.gradle.kts` from the CMake build output.

To prevent this issue from recurring and to strictly enforce the presence of this binary, I added a `doLast` block in the `prepareModuleFilesTask` in `module/build.gradle.kts`. This block iterates over the configured `abiList` and explicitly verifies that `lib/$abi/inject` exists in the staging directory. If it is missing, the build process throws a `GradleException`, preventing the creation of a broken installer.

I verified the fix by running `./gradlew :module:prepareModuleFilesDebug`, which passed, confirming that in the current environment the binaries are correctly built and the check logic is valid.

---
*PR created automatically by Jules for task [16788136358024574789](https://jules.google.com/task/16788136358024574789) started by @tryigit*