### PR TITLE
🔧 Bugfix: Fix Config state leakage in unit tests

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -899,6 +899,11 @@ object Config {
 
     @androidx.annotation.VisibleForTesting
     fun reset() {
+        ConfigObserver.stopWatching()
+        KeyboxDirObserver.stopWatching()
+        keyboxPoller?.stop()
+        scope.coroutineContext.cancelChildren()
+
         root = File(CONFIG_PATH)
         packageCache.clear()
         dynamicPatchCache.clear()


### PR DESCRIPTION
This PR fixes a bug where `Config.reset()` failed to clean up background threads and observers, leading to state leakage and flaky unit tests.

Changes:
- Modified `service/src/main/java/cleveres/tricky/cleverestech/Config.kt`:
    - Updated `reset()` to call `ConfigObserver.stopWatching()`, `KeyboxDirObserver.stopWatching()`, and `keyboxPoller?.stop()`.
    - Added `scope.coroutineContext.cancelChildren()` to ensure background coroutines are terminated.

Verification:
- Ran `./gradlew :service:testDebugUnitTest` and confirmed all tests pass.
- Verified that `ConfigPatchLevelTest` no longer fails due to race conditions.
- Confirmed version number remains V2.1.4 as requested.


---
*PR created automatically by Jules for task [8602200594752273107](https://jules.google.com/task/8602200594752273107) started by @tryigit*