### PR TITLE
⚡ Bolt: Optimize Attestation Hot Paths

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -156,16 +156,6 @@ public final class CertHack {
         return derOctectString.getOctets();
     }
 
-    private static byte[] hexToByteArray(String s) {
-        int len = s.length();
-        byte[] data = new byte[len / 2];
-        for (int i = 0; i < len; i += 2) {
-            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
-                    + Character.digit(s.charAt(i + 1), 16));
-        }
-        return data;
-    }
-
     /**
      * Optimization: Use a custom key object to avoid expensive Base64 encoding
      * and large String allocations for cache lookups.
@@ -390,17 +380,6 @@ public final class CertHack {
             if (hasIdAttestation) {
                 for (Map.Entry<Integer, byte[]> entry : idAttestationTags.entrySet()) {
                     allTags.add(new DERTaggedObject(true, entry.getKey(), new DEROctetString(entry.getValue())));
-                }
-            }
-
-            if (moduleHash == null) {
-                String moduleHashStr = Config.INSTANCE.getBuildVar("MODULE_HASH");
-                if (moduleHashStr != null && !moduleHashStr.isEmpty()) {
-                    try {
-                        moduleHash = hexToByteArray(moduleHashStr);
-                    } catch (Exception e) {
-                        Logger.e("Failed to parse MODULE_HASH build var", e);
-                    }
                 }
             }
 
@@ -731,16 +710,6 @@ public final class CertHack {
             }
 
             byte[] moduleHash = Config.INSTANCE.getModuleHash();
-            if (moduleHash == null) {
-                String moduleHashStr = Config.INSTANCE.getBuildVar("MODULE_HASH");
-                if (moduleHashStr != null && !moduleHashStr.isEmpty()) {
-                    try {
-                        moduleHash = hexToByteArray(moduleHashStr);
-                    } catch (Exception e) {
-                        Logger.e("Failed to parse MODULE_HASH build var", e);
-                    }
-                }
-            }
             if (moduleHash != null) {
                 teeEnforcedList.add(new DERTaggedObject(true, 724, new DEROctetString(moduleHash)));
             }

--- a/service/src/test/java/cleveres/tricky/cleverestech/ConfigPatchLevelSharedUidTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ConfigPatchLevelSharedUidTest.kt
@@ -10,15 +10,19 @@ class ConfigPatchLevelSharedUidTest {
     fun testPatchLevelSharedUid() {
         Config.reset()
 
-        val securityPatchField = Config::class.java.getDeclaredField("securityPatch")
-        securityPatchField.isAccessible = true
-        // Set securityPatch map directly
-        val testPatchMap = mapOf("com.example.pkgB" to "2023-01-01")
-        securityPatchField.set(Config, testPatchMap)
+        val securityPatchStateField = Config::class.java.getDeclaredField("securityPatchState")
+        securityPatchStateField.isAccessible = true
 
-        val defaultPatchField = Config::class.java.getDeclaredField("defaultSecurityPatch")
-        defaultPatchField.isAccessible = true
-        defaultPatchField.set(Config, "2024-01-01") // Set default
+        val testPatchMap = mapOf("com.example.pkgB" to "2023-01-01")
+        val defaultPatch = "2024-01-01"
+
+        val stateClass = Config::class.java.declaredClasses.find { it.simpleName == "SecurityPatchState" }
+            ?: throw ClassNotFoundException("SecurityPatchState not found")
+        val stateConstructor = stateClass.getDeclaredConstructor(Map::class.java, Any::class.java)
+        stateConstructor.isAccessible = true
+        val state = stateConstructor.newInstance(testPatchMap, defaultPatch)
+
+        securityPatchStateField.set(Config, state)
 
         // Mock packages for UID 1001: [com.example.pkgA, com.example.pkgB]
         val packages = arrayOf("com.example.pkgA", "com.example.pkgB")

--- a/service/src/test/java/cleveres/tricky/cleverestech/ConfigPatchLevelTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ConfigPatchLevelTest.kt
@@ -23,12 +23,19 @@ class ConfigPatchLevelTest {
         iPmField.isAccessible = true
         iPmField.set(Config, mockPm)
 
-        // 3. Inject Security Patch Map
-        val securityPatchField = Config::class.java.getDeclaredField("securityPatch")
-        securityPatchField.isAccessible = true
+        // 3. Inject Security Patch Map via SecurityPatchState
+        val securityPatchStateField = Config::class.java.getDeclaredField("securityPatchState")
+        securityPatchStateField.isAccessible = true
 
         val testPatchMap = mapOf("com.example.patched" to "2023-12-05")
-        securityPatchField.set(Config, testPatchMap)
+
+        val stateClass = Config::class.java.declaredClasses.find { it.simpleName == "SecurityPatchState" }
+            ?: throw ClassNotFoundException("SecurityPatchState not found")
+        val constructor = stateClass.getDeclaredConstructor(Map::class.java, Any::class.java)
+        constructor.isAccessible = true
+        val state = constructor.newInstance(testPatchMap, null)
+
+        securityPatchStateField.set(Config, state)
 
         try {
             // 5. Verify Patch Level


### PR DESCRIPTION
Optimized CleveresTricky performance by introducing caching for security patch levels and module hash parsing.

Changes:
- `Config.kt`: Introduced `SecurityPatchState` to cache `getPatchLevel(uid)` results. Added `moduleHashFromVars` to cache parsed module hash.
- `CertHack.java`: Removed manual hex parsing logic for `MODULE_HASH`, relying on `Config`'s cached value.
- `ConfigPatchLevelTest.kt` & `ConfigPatchLevelSharedUidTest.kt`: Updated reflection logic to support the new `SecurityPatchState` structure.

This reduces object allocations and IPC calls in the hot path of attestation.

---
*PR created automatically by Jules for task [5950261220761402998](https://jules.google.com/task/5950261220761402998) started by @tryigit*