### PR TITLE
fix: Make Create Keybox screen scrollable

### DIFF
--- a/encryptor-app/src/main/java/cleveres/tricky/encryptor/MainActivity.kt
+++ b/encryptor-app/src/main/java/cleveres/tricky/encryptor/MainActivity.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -230,6 +232,7 @@ fun CreateKeyboxScreen(onNavigateBack: () -> Unit) {
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
@@ -329,7 +332,7 @@ fun CreateKeyboxScreen(onNavigateBack: () -> Unit) {
                 )
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = Modifier.height(16.dp))
 
             Button(
                 onClick = {


### PR DESCRIPTION
The "Create Keybox" screen was cutting off the "Encrypt & Save" button and other bottom elements when the on-screen keyboard was open or on smaller screens. This was due to the lack of a scrollable container.

This change:
1. Adds `verticalScroll(rememberScrollState())` to the main `Column` modifier in `CreateKeyboxScreen`.
2. Replaces `Spacer(modifier = Modifier.weight(1f))` (which is incompatible with infinite-height scrollable columns) with a fixed `Spacer(modifier = Modifier.height(16.dp))`.

Verified by compiling the app (`:encryptor-app:assembleDebug`) and running unit tests (`:encryptor-app:testDebugUnitTest`).

---
*PR created automatically by Jules for task [17956749654234340871](https://jules.google.com/task/17956749654234340871) started by @tryigit*