### PR TITLE
⚡ Bolt: Use AHash for faster fingerprint lookups

### DIFF
--- a/rust/cbor-cose/Cargo.lock
+++ b/rust/cbor-cose/Cargo.lock
@@ -3,6 +3,19 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +89,7 @@ dependencies = [
 name = "cleverestricky-cbor-cose"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "coset",
  "hex",
  "hmac",
@@ -325,6 +339,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +540,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,7 +572,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -570,7 +602,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys",
@@ -780,6 +812,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +904,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "zerocopy"

--- a/rust/cbor-cose/Cargo.toml
+++ b/rust/cbor-cose/Cargo.toml
@@ -20,6 +20,7 @@ minreq = { version = "2.12", features = ["https-rustls"], optional = true }
 coset = "0.3"
 p256 = { version = "0.13", features = ["arithmetic", "ecdsa", "std"] }
 rand_core = { version = "0.6", features = ["std"] }
+ahash = "0.8.12"
 
 [dev-dependencies]
 hex = "0.4"

--- a/rust/cbor-cose/src/fingerprint.rs
+++ b/rust/cbor-cose/src/fingerprint.rs
@@ -7,7 +7,7 @@
 //! This module is gated behind the `fingerprint` feature (enabled by default)
 //! which pulls in `minreq` for lightweight HTTPS fetching.
 
-use std::collections::HashMap;
+use ahash::AHashMap;
 use std::sync::RwLock;
 
 /// Thread-safe in-memory fingerprint cache.
@@ -22,7 +22,7 @@ const DEFAULT_FP_URL: &str =
 #[allow(dead_code)]
 struct FingerprintCache {
     /// Map of device codename → fingerprint string.
-    entries: HashMap<String, String>,
+    entries: AHashMap<String, String>,
     /// URL the fingerprints were fetched from (diagnostic metadata).
     source_url: String,
     /// Timestamp (seconds since epoch) of last successful fetch (diagnostic metadata).
@@ -38,8 +38,8 @@ struct FingerprintCache {
 ///
 /// The device codename is extracted from the third `/`-separated segment
 /// (before the `:`), e.g. `husky` from `google/husky/husky:15/...`.
-pub fn parse_fingerprints(data: &str) -> HashMap<String, String> {
-    let mut map = HashMap::new();
+pub fn parse_fingerprints(data: &str) -> AHashMap<String, String> {
+    let mut map = AHashMap::new();
     for line in data.lines() {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {


### PR DESCRIPTION
This PR optimizes the `fingerprint.rs` module in `rust/cbor-cose` by replacing the default SipHash-based `HashMap` with `AHashMap` from the `ahash` crate.

**Changes:**
- Added `ahash = "0.8"` to `rust/cbor-cose/Cargo.toml`.
- Replaced `use std::collections::HashMap;` with `use ahash::AHashMap;` in `rust/cbor-cose/src/fingerprint.rs`.
- Updated all `HashMap` usages to `AHashMap`.

**Performance:**
- `AHash` is significantly faster than SipHash for hash map lookups, which benefits the frequent fingerprint checks in the Zygisk hooks.

**Verification:**
- Ran `cargo check` and `cargo test` in `rust/cbor-cose`. All 54 tests passed.


---
*PR created automatically by Jules for task [4398937477010101411](https://jules.google.com/task/4398937477010101411) started by @tryigit*