### PR TITLE
⚡ Bolt: Optimize CBOR encoding with Cow<str>

### DIFF
--- a/rust/cbor-cose/src/bcc.rs
+++ b/rust/cbor-cose/src/bcc.rs
@@ -13,6 +13,7 @@ use coset::{
 use p256::ecdsa::{signature::Signer, SigningKey, VerifyingKey};
 use p256::pkcs8::EncodePublicKey;
 use rand_core::OsRng;
+use std::borrow::Cow;
 
 /// Generate a spoofed Boot Certificate Chain (BCC).
 ///
@@ -40,8 +41,8 @@ pub fn generate_spoofed_bcc() -> Vec<u8> {
 
     // 5. Construct BCC Array
     let bcc_array = CborValue::Array(vec![
-        CborValue::Raw(bcc_0.to_tagged_vec().unwrap()),
-        CborValue::Raw(bcc_1.to_tagged_vec().unwrap()),
+        CborValue::Raw(Cow::Owned(bcc_0.to_tagged_vec().unwrap())),
+        CborValue::Raw(Cow::Owned(bcc_1.to_tagged_vec().unwrap())),
     ]);
 
     cbor::encode(&bcc_array)
@@ -67,10 +68,10 @@ fn public_key_to_cose_key(key: &VerifyingKey) -> CoseKey {
 /// * `signer_key` - The private key to sign this entry with.
 /// * `payload_key` - The public key to be contained in the payload.
 /// * `extra_payload` - Optional map to add to the payload (e.g. device info).
-fn create_bcc_entry(
+fn create_bcc_entry<'a>(
     signer_key: &SigningKey,
     payload_key: &CoseKey,
-    _extra_payload: Option<CborValue>, // Unused for basic spoofing but kept for future
+    _extra_payload: Option<CborValue<'a>>, // Unused for basic spoofing but kept for future
 ) -> CoseSign1 {
     // Payload is the COSE_Key of the next key
     let payload_bytes = payload_key.clone().to_vec().unwrap();

--- a/rust/cbor-cose/src/cbor.rs
+++ b/rust/cbor-cose/src/cbor.rs
@@ -6,6 +6,7 @@
 //! - Arrays and maps (with deterministic key ordering)
 //! - Simple values (null, true, false)
 
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::io::{self, Write};
 
@@ -21,31 +22,31 @@ const MT_SIMPLE: u8 = 7;
 
 /// A CBOR value that can be encoded.
 #[derive(Debug, Clone, PartialEq)]
-pub enum CborValue {
+pub enum CborValue<'a> {
     /// Unsigned integer (major type 0).
     UnsignedInt(u64),
     /// Negative integer (major type 1). Stored as the positive magnitude - 1.
     NegativeInt(i64),
     /// Byte string (major type 2).
-    ByteString(Vec<u8>),
+    ByteString(Cow<'a, [u8]>),
     /// Text string (major type 3).
-    TextString(String),
+    TextString(Cow<'a, str>),
     /// Array of CBOR values (major type 4).
-    Array(Vec<CborValue>),
+    Array(Vec<CborValue<'a>>),
     /// Map of CBOR key-value pairs (major type 5).
     /// Keys are sorted in canonical order during encoding.
-    Map(Vec<(CborValue, CborValue)>),
+    Map(Vec<(CborValue<'a>, CborValue<'a>)>),
     /// CBOR tag (major type 6).
-    Tag(u64, Box<CborValue>),
+    Tag(u64, Box<CborValue<'a>>),
     /// Boolean value.
     Bool(bool),
     /// Null value.
     Null,
     /// Raw encoded CBOR bytes (embedded directly).
-    Raw(Vec<u8>),
+    Raw(Cow<'a, [u8]>),
 }
 
-impl CborValue {
+impl<'a> CborValue<'a> {
     /// Create from a signed integer, choosing unsigned or negative encoding.
     pub fn from_int(value: i64) -> Self {
         if value >= 0 {
@@ -320,7 +321,7 @@ mod tests {
     fn test_encode_byte_string() {
         let bytes = vec![0x01, 0x02, 0x03];
         assert_eq!(
-            encode(&CborValue::ByteString(bytes)),
+            encode(&CborValue::ByteString(Cow::Owned(bytes))),
             vec![0x43, 0x01, 0x02, 0x03]
         );
     }
@@ -408,7 +409,7 @@ mod tests {
     #[test]
     fn test_encode_large_byte_string() {
         let bytes = vec![0xAB; 300];
-        let encoded = encode(&CborValue::ByteString(bytes.clone()));
+        let encoded = encode(&CborValue::ByteString(Cow::Owned(bytes.clone())));
         // 300 = 0x012C => MT_BYTE_STRING | 25, then 0x01, 0x2C
         assert_eq!(encoded[0], 0x59); // 0x40 | 25
         assert_eq!(encoded[1], 0x01);

--- a/rust/cbor-cose/src/cose.rs
+++ b/rust/cbor-cose/src/cose.rs
@@ -7,6 +7,7 @@
 
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
+use std::borrow::Cow;
 
 use crate::cbor::{self, CborValue};
 
@@ -41,10 +42,10 @@ const COSE_CRV_P256: i64 = 1;
 /// ]
 fn build_mac_structure(protected_headers: &[u8], payload: &[u8]) -> Vec<u8> {
     let structure = CborValue::Array(vec![
-        CborValue::TextString("MAC0".into()),
-        CborValue::ByteString(protected_headers.to_vec()),
-        CborValue::ByteString(vec![]), // external_aad
-        CborValue::ByteString(payload.to_vec()),
+        CborValue::TextString(Cow::Borrowed("MAC0")),
+        CborValue::ByteString(Cow::Borrowed(protected_headers)),
+        CborValue::ByteString(Cow::Borrowed(&[])), // external_aad
+        CborValue::ByteString(Cow::Borrowed(payload)),
     ]);
     cbor::encode(&structure)
 }
@@ -105,11 +106,11 @@ pub fn encode_cose_key(x: &[u8], y: &[u8]) -> Result<Vec<u8>, CoseError> {
         ),
         (
             CborValue::from_int(COSE_KEY_EC2_X),
-            CborValue::ByteString(x.to_vec()),
+            CborValue::ByteString(Cow::Borrowed(x)),
         ),
         (
             CborValue::from_int(COSE_KEY_EC2_Y),
-            CborValue::ByteString(y.to_vec()),
+            CborValue::ByteString(Cow::Borrowed(y)),
         ),
     ]);
     Ok(cbor::encode(&key))
@@ -140,10 +141,10 @@ pub fn generate_maced_public_key(
     let tag = compute_hmac(hmac_key, &mac_structure)?;
 
     let cose_mac0 = CborValue::Array(vec![
-        CborValue::ByteString(protected),
+        CborValue::ByteString(Cow::Owned(protected)),
         CborValue::Map(vec![]), // unprotected headers (empty)
-        CborValue::ByteString(payload),
-        CborValue::ByteString(tag),
+        CborValue::ByteString(Cow::Owned(payload)),
+        CborValue::ByteString(Cow::Owned(tag)),
     ]);
 
     Ok(cbor::encode(&cose_mac0))
@@ -175,47 +176,47 @@ pub fn create_device_info_cbor(
 
     let map = CborValue::Map(vec![
         (
-            CborValue::TextString("brand".into()),
-            CborValue::TextString(brand.into()),
+            CborValue::TextString(Cow::Borrowed("brand")),
+            CborValue::TextString(Cow::Borrowed(brand)),
         ),
         (
-            CborValue::TextString("manufacturer".into()),
-            CborValue::TextString(manufacturer.into()),
+            CborValue::TextString(Cow::Borrowed("manufacturer")),
+            CborValue::TextString(Cow::Borrowed(manufacturer)),
         ),
         (
-            CborValue::TextString("product".into()),
-            CborValue::TextString(product.into()),
+            CborValue::TextString(Cow::Borrowed("product")),
+            CborValue::TextString(Cow::Borrowed(product)),
         ),
         (
-            CborValue::TextString("model".into()),
-            CborValue::TextString(model.into()),
+            CborValue::TextString(Cow::Borrowed("model")),
+            CborValue::TextString(Cow::Borrowed(model)),
         ),
         (
-            CborValue::TextString("device".into()),
-            CborValue::TextString(device.into()),
+            CborValue::TextString(Cow::Borrowed("device")),
+            CborValue::TextString(Cow::Borrowed(device)),
         ),
         (
-            CborValue::TextString("vb_state".into()),
-            CborValue::TextString("green".into()),
+            CborValue::TextString(Cow::Borrowed("vb_state")),
+            CborValue::TextString(Cow::Borrowed("green")),
         ),
         (
-            CborValue::TextString("bootloader_state".into()),
-            CborValue::TextString("locked".into()),
+            CborValue::TextString(Cow::Borrowed("bootloader_state")),
+            CborValue::TextString(Cow::Borrowed("locked")),
         ),
         (
-            CborValue::TextString("vbmeta_digest".into()),
-            CborValue::ByteString(vec![0; 32]),
+            CborValue::TextString(Cow::Borrowed("vbmeta_digest")),
+            CborValue::ByteString(Cow::Borrowed(&[0; 32])),
         ),
         (
-            CborValue::TextString("os_version".into()),
-            CborValue::TextString("15.0.0".into()),
+            CborValue::TextString(Cow::Borrowed("os_version")),
+            CborValue::TextString(Cow::Borrowed("15.0.0")),
         ),
         (
-            CborValue::TextString("system_patch_level".into()),
+            CborValue::TextString(Cow::Borrowed("system_patch_level")),
             CborValue::UnsignedInt(20250205),
         ),
         (
-            CborValue::TextString("vendor_patch_level".into()),
+            CborValue::TextString(Cow::Borrowed("vendor_patch_level")),
             CborValue::UnsignedInt(20250205),
         ),
     ]);
@@ -238,14 +239,14 @@ pub fn create_certificate_request_response(
 ) -> Vec<u8> {
     let keys_array: Vec<CborValue> = maced_keys
         .iter()
-        .map(|k| CborValue::ByteString(k.clone()))
+        .map(|k| CborValue::ByteString(Cow::Borrowed(k)))
         .collect();
 
     let response = CborValue::Array(vec![
         CborValue::UnsignedInt(3), // version
         CborValue::Array(keys_array),
-        CborValue::ByteString(challenge.to_vec()),
-        CborValue::ByteString(device_info.to_vec()),
+        CborValue::ByteString(Cow::Borrowed(challenge)),
+        CborValue::ByteString(Cow::Borrowed(device_info)),
     ]);
 
     cbor::encode(&response)

--- a/rust/cbor-cose/src/ffi.rs
+++ b/rust/cbor-cose/src/ffi.rs
@@ -10,6 +10,7 @@
 //! All functions in this module use `unsafe` only at the FFI boundary to convert
 //! between C pointers and Rust slices. The inner logic is entirely safe Rust.
 
+use std::borrow::Cow;
 use std::panic;
 use std::ptr;
 
@@ -117,9 +118,8 @@ pub extern "C" fn rust_cbor_encode_int(value: i64) -> RustBuffer {
 pub unsafe extern "C" fn rust_cbor_encode_bytes(data: *const u8, len: usize) -> RustBuffer {
     panic::catch_unwind(panic::AssertUnwindSafe(|| {
         let bytes = unsafe { validate_slice_args(data, len) }
-            .unwrap_or(&[])
-            .to_vec();
-        RustBuffer::from_vec(cbor::encode(&CborValue::ByteString(bytes)))
+            .unwrap_or(&[]);
+        RustBuffer::from_vec(cbor::encode(&CborValue::ByteString(Cow::Borrowed(bytes))))
     }))
     .unwrap_or_else(|_| RustBuffer::empty())
 }
@@ -132,8 +132,8 @@ pub unsafe extern "C" fn rust_cbor_encode_bytes(data: *const u8, len: usize) -> 
 pub unsafe extern "C" fn rust_cbor_encode_text(data: *const u8, len: usize) -> RustBuffer {
     panic::catch_unwind(panic::AssertUnwindSafe(|| {
         let s = match unsafe { validate_slice_args(data, len) } {
-            Some(bytes) => String::from_utf8_lossy(bytes).into_owned(),
-            None => String::new(),
+            Some(bytes) => String::from_utf8_lossy(bytes),
+            None => Cow::Borrowed(""),
         };
         RustBuffer::from_vec(cbor::encode(&CborValue::TextString(s)))
     }))
@@ -200,12 +200,12 @@ pub unsafe extern "C" fn rust_create_device_info(
     device_len: usize,
 ) -> RustBuffer {
     panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        let to_str = |ptr: *const u8, len: usize| -> Option<String> {
+        let to_str = |ptr: *const u8, len: usize| -> Option<Cow<str>> {
             let bytes = unsafe { validate_slice_args(ptr, len) }?;
             if bytes.is_empty() {
                 return None;
             }
-            Some(String::from_utf8_lossy(bytes).into_owned())
+            Some(String::from_utf8_lossy(bytes))
         };
 
         let brand = to_str(brand_ptr, brand_len);


### PR DESCRIPTION
This PR optimizes the CBOR encoding logic in the `rust/cbor-cose` crate by replacing `String` and `Vec<u8>` with `Cow<'a, str>` and `Cow<'a, [u8]>` in the `CborValue` enum. This enables zero-copy operations for static strings (like map keys in DeviceInfo) and byte slices passed via FFI, reducing unnecessary heap allocations in hot paths such as RKP attestation.

Key changes:
- `CborValue` now carries a lifetime `'a`.
- `encode` function signature updated.
- `ffi.rs` helper `to_str` now returns `Option<Cow<str>>`.
- `cose.rs` uses `Cow::Borrowed` for all static map keys.


---
*PR created automatically by Jules for task [5498708511172660033](https://jules.google.com/task/5498708511172660033) started by @tryigit*