### PR TITLE
Optimize CBOR encoding with Cow<'a, str> and Cow<'a, [u8]>

### DIFF
--- a/rust/cbor-cose/src/bcc.rs
+++ b/rust/cbor-cose/src/bcc.rs
@@ -4,6 +4,8 @@
 //! This allows the device to present a "valid" chain of trust rooted in a
 //! randomly generated key, effectively creating a fresh identity.
 
+use std::borrow::Cow;
+
 use crate::cbor;
 use crate::cbor::CborValue;
 use coset::{
@@ -40,8 +42,8 @@ pub fn generate_spoofed_bcc() -> Vec<u8> {
 
     // 5. Construct BCC Array
     let bcc_array = CborValue::Array(vec![
-        CborValue::Raw(bcc_0.to_tagged_vec().unwrap()),
-        CborValue::Raw(bcc_1.to_tagged_vec().unwrap()),
+        CborValue::Raw(Cow::Owned(bcc_0.to_tagged_vec().unwrap())),
+        CborValue::Raw(Cow::Owned(bcc_1.to_tagged_vec().unwrap())),
     ]);
 
     cbor::encode(&bcc_array)
@@ -67,10 +69,10 @@ fn public_key_to_cose_key(key: &VerifyingKey) -> CoseKey {
 /// * `signer_key` - The private key to sign this entry with.
 /// * `payload_key` - The public key to be contained in the payload.
 /// * `extra_payload` - Optional map to add to the payload (e.g. device info).
-fn create_bcc_entry(
+fn create_bcc_entry<'a>(
     signer_key: &SigningKey,
     payload_key: &CoseKey,
-    _extra_payload: Option<CborValue>, // Unused for basic spoofing but kept for future
+    _extra_payload: Option<CborValue<'a>>, // Unused for basic spoofing but kept for future
 ) -> CoseSign1 {
     // Payload is the COSE_Key of the next key
     let payload_bytes = payload_key.clone().to_vec().unwrap();

--- a/rust/cbor-cose/src/cose.rs
+++ b/rust/cbor-cose/src/cose.rs
@@ -5,9 +5,9 @@
 //!
 //! Based on RFC 9052 (COSE) and Android RKP specification.
 
-use std::borrow::Cow;
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
+use std::borrow::Cow;
 
 use crate::cbor::{self, CborValue};
 

--- a/rust/cbor-cose/src/ffi.rs
+++ b/rust/cbor-cose/src/ffi.rs
@@ -213,13 +213,7 @@ pub unsafe extern "C" fn rust_create_device_info(
         let model = to_str(model_ptr, model_len);
         let device = to_str(device_ptr, device_len);
 
-        let result = cose::create_device_info_cbor(
-            brand,
-            manufacturer,
-            product,
-            model,
-            device,
-        );
+        let result = cose::create_device_info_cbor(brand, manufacturer, product, model, device);
 
         RustBuffer::from_vec(result)
     }))


### PR DESCRIPTION
This PR optimizes the `rust/cbor-cose` crate by refactoring the `CborValue` enum to use `Cow<'a, str>` and `Cow<'a, [u8]>` instead of `String` and `Vec<u8>`.

Key changes:
- `CborValue` now carries a lifetime `'a`.
- `encode` and `encode_item` signatures updated to accept `&CborValue<'a>`.
- `ffi.rs`: `to_str` helper now returns `Option<Cow<'a, str>>` using `String::from_utf8_lossy`. `rust_cbor_encode_bytes` and `rust_create_device_info` now use `Cow::Borrowed` to avoid copying valid data passed from C++.
- `cose.rs`: Static map keys (e.g., "brand", "model") now use `Cow::Borrowed`, eliminating redundant allocations.
- `bcc.rs`: Updated to use `Cow::Owned` for generated keys.
- All tests updated to reflect these changes.

These changes reduce unnecessary heap allocations, particularly in the FFI boundary and RKP attestation flows.

---
*PR created automatically by Jules for task [1434974849211503355](https://jules.google.com/task/1434974849211503355) started by @tryigit*