### PR TITLE
Fix BCC generation: Use untagged COSE_Sign1

### DIFF
--- a/rust/cbor-cose/src/bcc.rs
+++ b/rust/cbor-cose/src/bcc.rs
@@ -41,8 +41,8 @@ pub fn generate_spoofed_bcc() -> Vec<u8> {
 
     // 5. Construct BCC Array
     let bcc_array = CborValue::Array(vec![
-        CborValue::Raw(Cow::Owned(bcc_0.to_tagged_vec().unwrap())),
-        CborValue::Raw(Cow::Owned(bcc_1.to_tagged_vec().unwrap())),
+        CborValue::Raw(Cow::Owned(bcc_0.to_vec().unwrap())),
+        CborValue::Raw(Cow::Owned(bcc_1.to_vec().unwrap())),
     ]);
 
     cbor::encode(&bcc_array)

--- a/rust/cbor-cose/src/bcc.rs
+++ b/rust/cbor-cose/src/bcc.rs
@@ -8,9 +8,7 @@ use std::borrow::Cow;
 
 use crate::cbor;
 use crate::cbor::CborValue;
-use coset::{
-    iana, CborSerializable, CoseKey, CoseSign1, CoseSign1Builder, HeaderBuilder,
-};
+use coset::{iana, CborSerializable, CoseKey, CoseSign1, CoseSign1Builder, HeaderBuilder};
 use p256::ecdsa::{signature::Signer, SigningKey, VerifyingKey};
 use p256::pkcs8::EncodePublicKey;
 use rand_core::OsRng;
@@ -131,6 +129,9 @@ mod tests {
         }
 
         // Should be array of 4 (0x84)
-        assert_eq!(first_elem_byte, 0x84, "Expected untagged COSE_Sign1 (Array(4))");
+        assert_eq!(
+            first_elem_byte, 0x84,
+            "Expected untagged COSE_Sign1 (Array(4))"
+        );
     }
 }


### PR DESCRIPTION
Replaced `to_tagged_vec()` with `to_vec()` in `rust/cbor-cose/src/bcc.rs` to fix a compilation error and comply with Android BCC requirements (untagged COSE_Sign1). Verified that `cargo build` and `cargo test` pass.

---
*PR created automatically by Jules for task [10338875606480039931](https://jules.google.com/task/10338875606480039931) started by @tryigit*