### PR TITLE
⚡ Cache KeyStore instance to avoid repeated I/O

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/util/DeviceKeyManagerTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/DeviceKeyManagerTest.kt
@@ -1,0 +1,67 @@
+package cleveres.tricky.cleverestech.util
+
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.MockedStatic
+import org.mockito.Mockito
+import org.mockito.Mockito.*
+import java.security.KeyStore
+import javax.crypto.SecretKey
+import javax.crypto.spec.SecretKeySpec
+
+class DeviceKeyManagerTest {
+
+    private lateinit var keyStoreMock: KeyStore
+    private lateinit var keyStoreStaticMock: MockedStatic<KeyStore>
+
+    @Before
+    fun setUp() {
+        // Reset DeviceKeyManager state via reflection
+        val instance = DeviceKeyManager
+        val fallbackField = instance.javaClass.getDeclaredField("fallbackKey")
+        fallbackField.isAccessible = true
+        fallbackField.set(instance, null)
+
+        val useFallbackField = instance.javaClass.getDeclaredField("useFallback")
+        useFallbackField.isAccessible = true
+        useFallbackField.set(instance, false)
+
+        val cachedKeyField = instance.javaClass.getDeclaredField("cachedKey")
+        cachedKeyField.isAccessible = true
+        cachedKeyField.set(instance, null)
+
+        // Setup Mocks
+        keyStoreMock = mock(KeyStore::class.java)
+        keyStoreStaticMock = mockStatic(KeyStore::class.java)
+        keyStoreStaticMock.`when`<KeyStore> { KeyStore.getInstance("AndroidKeyStore") }.thenReturn(keyStoreMock)
+
+        val secretKey = SecretKeySpec(ByteArray(32), "AES")
+        val entry = mock(KeyStore.SecretKeyEntry::class.java)
+        `when`(entry.secretKey).thenReturn(secretKey)
+        `when`(keyStoreMock.getEntry(eq("cleveres_device_cache_key"), any())).thenReturn(entry)
+    }
+
+    @After
+    fun tearDown() {
+        keyStoreStaticMock.close()
+    }
+
+    @Test
+    fun testKeyStoreLoadedOnce() {
+        val data = "test data".toByteArray()
+
+        // First call
+        val result1 = DeviceKeyManager.encrypt(data)
+        assertNotNull(result1)
+
+        // Second call
+        val result2 = DeviceKeyManager.encrypt(data)
+        assertNotNull(result2)
+
+        // Verify KeyStore.getInstance was called only once (optimization)
+        keyStoreStaticMock.verify({ KeyStore.getInstance("AndroidKeyStore") }, times(1))
+        verify(keyStoreMock, times(1)).load(null)
+    }
+}


### PR DESCRIPTION
This PR optimizes the `DeviceKeyManager` by caching the `SecretKey` obtained from the Android KeyStore. This eliminates the need to reload the KeyStore and perform a key lookup for every encryption or decryption operation, which involves expensive I/O. The optimization uses a thread-safe double-checked locking pattern. A regression test `DeviceKeyManagerTest` has been added to verify that the KeyStore is loaded only once.

---
*PR created automatically by Jules for task [15840080278474515388](https://jules.google.com/task/15840080278474515388) started by @tryigit*