### PR TITLE
🛡️ Sentinel: Security Hardening (Panic Safety & Error Propagation)

### DIFF
--- a/rust/cbor-cose/Cargo.toml
+++ b/rust/cbor-cose/Cargo.toml
@@ -29,7 +29,6 @@ rand = "0.8"
 serial_test = "2.0"
 
 [profile.release]
-panic = "abort"
 lto = "fat"
 codegen-units = 1
 strip = true

--- a/rust/cbor-cose/src/bcc.rs
+++ b/rust/cbor-cose/src/bcc.rs
@@ -40,8 +40,12 @@ pub fn generate_spoofed_bcc() -> Result<Vec<u8>, CoseError> {
 
     // 5. Construct BCC Array
     let bcc_array = CborValue::Array(vec![
-        CborValue::Raw(Cow::Owned(bcc_0.to_vec().map_err(|_| CoseError::EncodingError)?)),
-        CborValue::Raw(Cow::Owned(bcc_1.to_vec().map_err(|_| CoseError::EncodingError)?)),
+        CborValue::Raw(Cow::Owned(
+            bcc_0.to_vec().map_err(|_| CoseError::EncodingError)?,
+        )),
+        CborValue::Raw(Cow::Owned(
+            bcc_1.to_vec().map_err(|_| CoseError::EncodingError)?,
+        )),
     ]);
 
     Ok(cbor::encode(&bcc_array))
@@ -49,7 +53,9 @@ pub fn generate_spoofed_bcc() -> Result<Vec<u8>, CoseError> {
 
 /// Helper to convert p256 Public Key to COSE_Key structure.
 fn public_key_to_cose_key(key: &VerifyingKey) -> Result<CoseKey, CoseError> {
-    let _encoded = key.to_public_key_der().map_err(|_| CoseError::InvalidPublicKey)?;
+    let _encoded = key
+        .to_public_key_der()
+        .map_err(|_| CoseError::InvalidPublicKey)?;
     // P-256 point is last 64 bytes of SubjectPublicKeyInfo for uncompressed
     // (technically we should parse DER properly, but for P-256 it's fixed offset usually.
     // However, p256 crate provides encoded point directly via `to_encoded_point`)
@@ -57,8 +63,10 @@ fn public_key_to_cose_key(key: &VerifyingKey) -> Result<CoseKey, CoseError> {
     let x = point.x().ok_or(CoseError::InvalidPublicKey)?.as_slice();
     let y = point.y().ok_or(CoseError::InvalidPublicKey)?.as_slice();
 
-    Ok(coset::CoseKeyBuilder::new_ec2_pub_key(iana::EllipticCurve::P_256, x.to_vec(), y.to_vec())
-        .build())
+    Ok(
+        coset::CoseKeyBuilder::new_ec2_pub_key(iana::EllipticCurve::P_256, x.to_vec(), y.to_vec())
+            .build(),
+    )
 }
 
 /// Create a COSE_Sign1 entry for the BCC.

--- a/rust/cbor-cose/src/ffi.rs
+++ b/rust/cbor-cose/src/ffi.rs
@@ -282,12 +282,12 @@ pub unsafe extern "C" fn rust_create_certificate_request(
 /// The caller must free the buffer with `rust_free_buffer`.
 #[no_mangle]
 pub extern "C" fn rust_generate_spoofed_bcc() -> RustBuffer {
-    panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        match crate::bcc::generate_spoofed_bcc() {
+    panic::catch_unwind(panic::AssertUnwindSafe(
+        || match crate::bcc::generate_spoofed_bcc() {
             Ok(bcc) => RustBuffer::from_vec(bcc),
             Err(_) => RustBuffer::empty(),
-        }
-    }))
+        },
+    ))
     .unwrap_or_else(|_| RustBuffer::empty())
 }
 

--- a/rust/cbor-cose/src/ffi.rs
+++ b/rust/cbor-cose/src/ffi.rs
@@ -283,8 +283,10 @@ pub unsafe extern "C" fn rust_create_certificate_request(
 #[no_mangle]
 pub extern "C" fn rust_generate_spoofed_bcc() -> RustBuffer {
     panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        let bcc = crate::bcc::generate_spoofed_bcc();
-        RustBuffer::from_vec(bcc)
+        match crate::bcc::generate_spoofed_bcc() {
+            Ok(bcc) => RustBuffer::from_vec(bcc),
+            Err(_) => RustBuffer::empty(),
+        }
     }))
     .unwrap_or_else(|_| RustBuffer::empty())
 }


### PR DESCRIPTION
This PR significantly hardens the Rust core (`rust/cbor-cose`) against Denial of Service (DoS) and potential memory safety issues at the FFI boundary.

### Key Changes
1.  **Panic Safety (CRITICAL):**
    -   Removed `panic = "abort"` from `Cargo.toml`.
    -   *Why:* The FFI layer relies on `std::panic::catch_unwind` to prevent Rust panics from crashing the entire Android Zygote/app process. With `panic = "abort"`, `catch_unwind` is ignored, and any panic (even a checked index out of bounds) would kill the process. This change restores the intended safety mechanism.

2.  **Error Propagation:**
    -   Refactored `cose.rs` and `bcc.rs` to replace `unwrap()` and `expect()` with proper `Result<T, CoseError>` return types.
    -   Introduced `CoseError::EncodingError` to handle serialization failures gracefully.
    -   Updated cryptographic helpers (`compute_hmac_cbor`, `generate_maced_public_key`, `public_key_to_cose_key`) to propagate errors up the stack.

3.  **FFI Boundary Hardening:**
    -   Updated `rust_generate_spoofed_bcc` in `ffi.rs` to handle the new `Result` type.
    -   If an error occurs internally, the function now safely catches it (and any residual panics) and returns an empty `RustBuffer` to C++, signalling failure without crashing.

## Verification
-   **Build:** `cargo check` passes.
-   **Tests:** `cargo test` passes (59 tests), covering the new error handling paths.
-   **Lints:** `cargo clippy` passes with no warnings.
-   **Panic Test:** Verified that `catch_unwind` works correctly via `ffi::panic_tests::test_ffi_catch_unwind_works`.

## Risk Assessment
-   **Low Risk:** The changes purely improve error handling and safety. Logic for successful execution paths remains unchanged.

---
*PR created automatically by Jules for task [727809459031607946](https://jules.google.com/task/727809459031607946) started by @tryigit*