### PR TITLE
🛡️ Sentinel: Security Hardening

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -710,6 +710,9 @@ class WebServer(
              val tmpFilePath = map["file"]
              if (tmpFilePath != null) {
                  val originalName = params["filename"] ?: "upload.bin"
+                 if (originalName.contains("..") || originalName.contains("/")) {
+                     return secureResponse(Response.Status.BAD_REQUEST, "text/plain", "Invalid filename")
+                 }
                  val tmpFile = File(tmpFilePath)
                  val bytes = tmpFile.readBytes()
 
@@ -718,6 +721,9 @@ class WebServer(
                      val keyboxDir = File(configDir, "keyboxes")
                      SecureFile.mkdirs(keyboxDir, 448)
                      val dest = File(keyboxDir, originalName)
+                     if (!dest.canonicalPath.startsWith(keyboxDir.canonicalPath)) {
+                         return secureResponse(Response.Status.BAD_REQUEST, "text/plain", "Path traversal attempt detected")
+                     }
                      SecureFile.writeBytes(dest, bytes)
                      // Trigger refresh
                      CboxManager.refresh()


### PR DESCRIPTION
🛡️ **Sentinel: Security Hardening**

This PR contains the following critical security improvements:

1. **Path Traversal Fix (Kotlin):** Prevented an arbitrary file write in `WebServer.kt`'s binary upload API (`/api/upload_keybox`). By checking `originalName` for directory traversal payloads (`..` and `/`) and enforcing a canonical path constraint (`canonicalPath.startsWith(...)`), we lock the upload strictly to the intended `keyboxes` directory. This mitigates unauthorized data access and overwriting of configuration/system files.

2. **Memory Safety Audit (Rust/C++ FFI):** Conducted a deep autonomous audit across the codebase for JNI leaks and unhandled panics resulting in aborts. The Native Rust C FFI boundary in `rust/cbor-cose/src/ffi.rs` uses `validate_slice_args` securely to prevent reading out of bounds. Also confirmed that all FFI functions use standard `panic::catch_unwind` rather than crashing the Android Zygote.

3. **General Hardening:** Verified that no other legacy JNI `unsafe` code was vulnerable to typical dereference issues (only safe wrappers and checked offsets are used).

---
*PR created automatically by Jules for task [3682069393469783075](https://jules.google.com/task/3682069393469783075) started by @tryigit*