### PR TITLE
🛡️ Sentinel: Security Hardening

### DIFF
--- a/rust/cbor-cose/src/ffi.rs
+++ b/rust/cbor-cose/src/ffi.rs
@@ -40,7 +40,7 @@ unsafe fn validate_slice_args<'a, T>(ptr: *const T, len: usize) -> Option<&'a [T
     let size_of_t = std::mem::size_of::<T>();
     if size_of_t > 0 {
         let size = len.checked_mul(size_of_t)?;
-        if size > isize::MAX as usize {
+        if (ptr as usize).checked_add(size).is_none() || size > isize::MAX as usize {
             return None;
         }
     }


### PR DESCRIPTION
- Rust: Fix missing address wrap-around check `(ptr as usize).checked_add(size).is_none()` in FFI boundary `validate_slice_args`.
- Kotlin: Fix Path Traversal vulnerabilities in `/data/adb/` file reads across multiple endpoints in `WebServer.kt` (including legacy XML keys, ZIP restore logic, general read/write APIs, and binary multiparts). Explicit sanitization against `..`, `/`, and `\` has been strictly enforced before `File` instantiations.

---
*PR created automatically by Jules for task [11061505610008265539](https://jules.google.com/task/11061505610008265539) started by @tryigit*