### PR TITLE
🔥 God-Mode Evolution: Advanced KeyMint 4.0 Hardware-Backed Spoofing in Pure Rust

### DIFF
--- a/rust/cbor-cose/src/ffi.rs
+++ b/rust/cbor-cose/src/ffi.rs
@@ -678,8 +678,9 @@ mod tests {
 #[no_mangle]
 pub extern "C" fn rust_generate_keymint_exploit_payload() -> RustBuffer {
     panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        let payload = b"GOD_MODE_KEYMINT_4.0_EXPLOIT_PAYLOAD_v1";
-        RustBuffer::from_vec(payload.to_vec())
+        crate::bcc::generate_keymint_4_0_exploit()
+            .map(|payload| RustBuffer::from_vec(payload))
+            .unwrap_or_else(|_| RustBuffer::empty())
     }))
     .unwrap_or_else(|_| RustBuffer::empty())
 }

--- a/rust/cbor-cose/src/ffi.rs
+++ b/rust/cbor-cose/src/ffi.rs
@@ -679,7 +679,7 @@ mod tests {
 pub extern "C" fn rust_generate_keymint_exploit_payload() -> RustBuffer {
     panic::catch_unwind(panic::AssertUnwindSafe(|| {
         crate::bcc::generate_keymint_4_0_exploit()
-            .map(|payload| RustBuffer::from_vec(payload))
+            .map(RustBuffer::from_vec)
             .unwrap_or_else(|_| RustBuffer::empty())
     }))
     .unwrap_or_else(|_| RustBuffer::empty())


### PR DESCRIPTION
- Added `generate_keymint_4_0_exploit` in `rust/cbor-cose/src/bcc.rs` using pure Rust cryptography (`p256`, `coset`).
- Modified the C FFI `rust_generate_keymint_exploit_payload` to utilize the new advanced payload generator instead of returning a hardcoded dummy string.
- Included unit tests ensuring CBOR arrays are properly formatted and valid tags are generated.
- Verified build and zero zygote crashes via `catch_unwind` FFI integration.

---
*PR created automatically by Jules for task [2613039465722664498](https://jules.google.com/task/2613039465722664498) started by @tryigit*