### PR TITLE
🔧 Bugfix: fix encryptor-app compileSdk version

### DIFF
--- a/encryptor-app/build.gradle.kts
+++ b/encryptor-app/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace = "cleveres.tricky.encryptor"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "cleveres.tricky.encryptor"
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
 


### PR DESCRIPTION
Update compileSdk and targetSdk for encryptor-app module to match library requirements.

---
*PR created automatically by Jules for task [10777376391896056752](https://jules.google.com/task/10777376391896056752) started by @tryigit*