### PR TITLE
🔧 Bugfix: Add dummy.py to fix CodeQL Python dataset finalization

### DIFF
--- a/dummy.py
+++ b/dummy.py
@@ -1,0 +1,1 @@
+print('CodeQL python dummy')


### PR DESCRIPTION
CodeQL fails to finalize the python database dataset if the repository is configured to scan Python (e.g. via GitHub's Advanced Security default setup) but no Python code actually exists in the repository. This causes a fatal error (exit code 32). Adding a `dummy.py` file to the root directory is the standard workaround to satisfy the CodeQL scanner when there's no actual Python code present.

---
*PR created automatically by Jules for task [14546044549916366036](https://jules.google.com/task/14546044549916366036) started by @tryigit*