### PR TITLE
🔧 Bugfix: Fix FFI panic boundary on properties cache

### DIFF
--- a/rust/cbor-cose/src/ffi.rs
+++ b/rust/cbor-cose/src/ffi.rs
@@ -693,7 +693,7 @@ pub extern "C" fn rust_generate_keymint_exploit_payload() -> RustBuffer {
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn rust_prop_get(name_ptr: *const u8, name_len: usize) -> RustBuffer {
-    std::panic::catch_unwind(|| {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         if name_ptr.is_null() || name_len == 0 {
             return RustBuffer::empty();
         }
@@ -716,7 +716,7 @@ pub unsafe extern "C" fn rust_prop_get(name_ptr: *const u8, name_len: usize) -> 
         } else {
             RustBuffer::empty()
         }
-    })
+    }))
     .unwrap_or(RustBuffer::empty())
 }
 
@@ -729,7 +729,7 @@ pub unsafe extern "C" fn rust_prop_set(
     value_ptr: *const u8,
     value_len: usize,
 ) {
-    let _ = std::panic::catch_unwind(|| {
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         if name_ptr.is_null() || name_len == 0 {
             return;
         }
@@ -749,5 +749,5 @@ pub unsafe extern "C" fn rust_prop_set(
         ) {
             crate::properties::set_property(name_str, value_str);
         }
-    });
+    }));
 }


### PR DESCRIPTION
Fix Rust FFI panic unwind safety in properties cache

The `rust_prop_get` and `rust_prop_set` functions were using `std::panic::catch_unwind(|| ...)` but capturing raw pointers inside the closures.
Since raw pointers do not implement the `UnwindSafe` trait, this caused compilation errors or unsafe behaviors across the FFI boundary.

Wrapped the closures in `std::panic::AssertUnwindSafe` to correctly acknowledge and handle the unwind safety for these captures, restoring the required panic safety boundary.

---
*PR created automatically by Jules for task [9942845663047712435](https://jules.google.com/task/9942845663047712435) started by @tryigit*