### PR TITLE
🎨 Palette: WebUI/UX Enhancement

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -1169,12 +1169,17 @@ class WebServer(
 
         <div class="panel">
             <h3>Upload Keybox / CBOX</h3>
-            <div id="dropZone" role="button" tabindex="0" style="border: 2px dashed var(--border); border-radius: 6px; padding: 20px; text-align: center; margin-bottom: 10px; cursor: pointer;" onclick="document.getElementById('kbFilePicker').click()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault(); document.getElementById('kbFilePicker').click();}">
-                <label for="kbFilename" style="display:none">Keybox File</label>
-                <input type="file" id="kbFilePicker" style="display:none" onchange="loadFileContent(this)" onclick="event.stopPropagation(); this.value = null" aria-label="Upload Keybox File">
-                <label for="kbContent" style="display:block; font-size:0.85em; color:#888; margin-bottom:4px;">Keybox Content (XML)</label>
-                <textarea id="kbContent" placeholder="XML Content" style="height:100px; font-family:monospace; font-size:0.8em;" aria-label="Keybox XML Content"></textarea>
-                <div id="dropZoneContent"><div style="font-size: 2em; margin-bottom: 10px;">📂</div><div style="font-size: 0.9em; color: #888;">Select .xml, .cbox, or .zip</div></div>
+            <div class="grid-2">
+                <div id="dropZone" role="button" tabindex="0" style="border: 2px dashed var(--border); border-radius: 6px; padding: 20px; text-align: center; margin-bottom: 10px; cursor: pointer;" onclick="document.getElementById('kbFilePicker').click()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault(); document.getElementById('kbFilePicker').click();}">
+                    <label for="kbFilename" style="display:none">Keybox File</label>
+                    <input type="file" id="kbFilePicker" style="display:none" onchange="loadFileContent(this)" onclick="event.stopPropagation(); this.value = null" aria-label="Upload Keybox File">
+                    <div id="dropZoneContent"><div style="font-size: 2em; margin-bottom: 10px;">📂</div><div style="font-size: 0.9em; color: #888;">Select .xml, .cbox, or .zip</div></div>
+                </div>
+                <div>
+                    <label for="kbContent" style="display:block; font-size:0.85em; color:#888; margin-bottom:4px;">Manual Paste (XML)</label>
+                    <textarea id="kbContent" placeholder="Paste Keybox XML Content Here" style="height:100px; font-family:monospace; font-size:0.8em;" aria-label="Keybox XML Content"></textarea>
+                    <button id="saveKeyboxBtn" class="primary" style="width:100%; margin-top:10px;" onclick="savePastedKeybox()">Save Pasted XML</button>
+                </div>
             </div>
         </div>
         <div class="panel">
@@ -1509,9 +1514,13 @@ class WebServer(
                 const file = input.files[0];
 
                 // 1. Preview content
-                const reader = new FileReader();
-                reader.onload = (e) => document.getElementById('kbContent').value = e.target.result;
-                reader.readAsText(file);
+                if (!file.name.endsWith('.cbox') && !file.name.endsWith('.zip')) {
+                    const reader = new FileReader();
+                    reader.onload = (e) => document.getElementById('kbContent').value = e.target.result;
+                    reader.readAsText(file);
+                } else {
+                    document.getElementById('kbContent').value = 'Binary file (' + file.name + ') selected. Preview unavailable.';
+                }
 
                 // 2. Upload
                 const dz = document.getElementById('dropZoneContent');
@@ -1544,6 +1553,35 @@ class WebServer(
             const dz = document.getElementById('dropZoneContent');
             dz.innerHTML = '<div style="font-size: 2em; margin-bottom: 10px;">📂</div><div style="font-size: 0.9em; color: #888;">Select .xml, .cbox, or .zip</div>';
             document.getElementById('dropZone').style.borderColor = 'var(--border)';
+        }
+
+        async function savePastedKeybox() {
+            const content = document.getElementById('kbContent').value.trim();
+            if (!content) {
+                notify('Please paste XML content first', 'error');
+                return;
+            }
+            let filename = prompt("Enter a filename for this Keybox (e.g. keybox1.xml):", "keybox.xml");
+            if (!filename) return;
+            if (!filename.endsWith('.xml')) filename += '.xml';
+
+            notify('Saving...', 'working');
+            try {
+                const res = await fetchAuth('/api/upload_keybox', {
+                    method: 'POST',
+                    body: new URLSearchParams({ filename: filename, content: content })
+                });
+                if (!res.ok) {
+                    const msg = await res.text();
+                    notify('Error: ' + msg, 'error');
+                } else {
+                    notify('Saved Successfully');
+                    document.getElementById('kbContent').value = '';
+                    loadKeyInfo();
+                }
+            } catch(e) {
+                notify('Error', 'error');
+            }
         }
 
         // Rest of existing JS (simplified/merged)

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerHtmlTest.kt
@@ -136,7 +136,7 @@ class WebServerHtmlTest {
 
         // Verify Accessibility Labels for Textareas
         assertTrue("File Editor missing aria-label", html.contains("id=\"fileEditor\" style=\"height:500px; font-family:monospace; margin-top:10px; line-height:1.4;\" aria-label=\"File Content\""))
-        assertTrue("Keybox Content missing aria-label", html.contains("id=\"kbContent\" placeholder=\"XML Content\" style=\"height:100px; font-family:monospace; font-size:0.8em;\" aria-label=\"Keybox XML Content\""))
+        assertTrue("Keybox Content missing aria-label", html.contains("id=\"kbContent\" placeholder=\"Paste Keybox XML Content Here\" style=\"height:100px; font-family:monospace; font-size:0.8em;\" aria-label=\"Keybox XML Content\""))
 
         // Verify Keybox Filename Label and File Picker Accessibility
         assertTrue("Keybox Filename missing label", html.contains("<label for=\"kbFilename\""))

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerLabelTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerLabelTest.kt
@@ -48,7 +48,7 @@ class WebServerLabelTest {
         val html = conn.inputStream.bufferedReader().readText()
 
         assertTrue("Keybox Content textarea should have a visible label",
-            html.contains("<label for=\"kbContent\"") && html.contains(">Keybox Content (XML)</label>")
+            html.contains("<label for=\"kbContent\"") && html.contains(">Manual Paste (XML)</label>")
         )
     }
 


### PR DESCRIPTION
This PR improves the UX for the "Keyboxes" tab in the CleveresTricky WebUI by separating the drag-and-drop file upload zone from the manual XML pasting area, preventing accidental file picker activations when trying to paste text. It also adds a dedicated "Save Pasted XML" button and prevents binary files from rendering gibberish inside the preview box. Associated Kotlin unit tests have been updated.

---
*PR created automatically by Jules for task [1727145624022817883](https://jules.google.com/task/1727145624022817883) started by @tryigit*