### PR TITLE
⚡ Bolt: O(1) Binder Intercept Tracking

### DIFF
--- a/module/src/main/cpp/binder_interceptor.cpp
+++ b/module/src/main/cpp/binder_interceptor.cpp
@@ -277,7 +277,7 @@ class BinderStub : public BBinder {
 static sp<BinderStub> gBinderStub = nullptr;
 
 static std::shared_mutex g_binder_fd_lock;
-static std::map<int, bool> g_binder_fds;
+static std::unordered_map<int, bool> g_binder_fds;
 
 static bool is_binder_fd(int fd) {
     {
@@ -458,9 +458,10 @@ BinderInterceptor::onTransact(uint32_t code, const android::Parcel &data, androi
         {
             WriteGuard wg{lock};
             wp<IBinder> t = target;
-            auto it = items.lower_bound(t);
-            if (it == items.end() || it->first != t) {
-                it = items.emplace_hint(it, t, InterceptItem{});
+            auto it = items.find(t);
+            if (it == items.end()) {
+                auto result = items.insert({t, InterceptItem{}});
+                it = result.first;
                 it->second.target = t;
             } else if (it->second.interceptor != nullptr && it->second.interceptor != interceptor) {
                 Parcel data, reply;

--- a/module/src/main/cpp/binder_interceptor.h
+++ b/module/src/main/cpp/binder_interceptor.h
@@ -7,10 +7,23 @@
 #include <binder/Binder.h>
 #include <utils/StrongPointer.h>
 #include <map>
+#include <unordered_map>
 #include <shared_mutex>
 
 // Using android namespace for convenience if many types from it are used
 using namespace android;
+
+struct WpIBinderHash {
+    std::size_t operator()(const wp<IBinder>& ptr) const {
+        return std::hash<IBinder*>()(ptr.unsafe_get());
+    }
+};
+
+struct WpIBinderEqual {
+    bool operator()(const wp<IBinder>& lhs, const wp<IBinder>& rhs) const {
+        return lhs == rhs;
+    }
+};
 
 class BinderInterceptor : public BBinder {
 public:
@@ -48,7 +61,7 @@ private:
     using WriteGuard = std::unique_lock<RwLock>;
     using ReadGuard = std::shared_lock<RwLock>;
     RwLock lock;
-    std::map<wp<IBinder>, InterceptItem> items{};
+    std::unordered_map<wp<IBinder>, InterceptItem, WpIBinderHash, WpIBinderEqual> items{};
 };
 
 #endif // BINDER_INTERCEPTOR_H


### PR DESCRIPTION
Identified an O(log N) bottleneck in `module/src/main/cpp/binder_interceptor.cpp` where `std::map` was used to track Binder file descriptors and active interceptors. I successfully replaced these maps with `std::unordered_map` and implemented custom `std::hash` and equality structs using `unsafe_get()` for Android's `wp<IBinder>` to provide O(1) time complexity in Binder hot-paths. I've successfully compiled and run tests to verify that these changes do not introduce regressions.

---
*PR created automatically by Jules for task [7861373795756921522](https://jules.google.com/task/7861373795756921522) started by @tryigit*