### PR TITLE
🛡️ Sentinel: Security Hardening

### DIFF
--- a/fix_rust_prop.py
+++ b/fix_rust_prop.py
@@ -1,6 +1,0 @@
-import sys
-
-with open('rust/cbor-cose/src/ffi.rs', 'r') as f:
-    content = f.read()
-
-content = content.replace("RustBuffer::empty()", "RustBuffer::empty()") # Check if empty() exists. Wait, earlier grep showed it exists.

--- a/rust/cbor-cose/src/ffi.rs
+++ b/rust/cbor-cose/src/ffi.rs
@@ -698,7 +698,10 @@ pub unsafe extern "C" fn rust_prop_get(name_ptr: *const u8, name_len: usize) -> 
             return RustBuffer::empty();
         }
 
-        let name_slice = std::slice::from_raw_parts(name_ptr, name_len);
+        let name_slice = match unsafe { validate_slice_args(name_ptr, name_len) } {
+            Some(s) => s,
+            None => return RustBuffer::empty(),
+        };
         let name_str = match std::str::from_utf8(name_slice) {
             Ok(s) => s,
             Err(_) => return RustBuffer::empty(),
@@ -738,10 +741,13 @@ pub unsafe extern "C" fn rust_prop_set(
         let value_slice = if value_ptr.is_null() || value_len == 0 {
             &[]
         } else {
-            std::slice::from_raw_parts(value_ptr, value_len)
+            unsafe { validate_slice_args(value_ptr, value_len) }.unwrap_or(&[])
         };
 
-        let name_slice = std::slice::from_raw_parts(name_ptr, name_len);
+        let name_slice = match unsafe { validate_slice_args(name_ptr, name_len) } {
+            Some(s) => s,
+            None => return,
+        };
 
         if let (Ok(name_str), Ok(value_str)) = (
             std::str::from_utf8(name_slice),


### PR DESCRIPTION
Replaced unsafe direct usage of `std::slice::from_raw_parts` in `rust_prop_get` and `rust_prop_set` functions with the safety-enforcing `validate_slice_args`. This enforces correct bounds checking, potential null checks, alignment validation, and protects against size overflows, hardening the C/C++ FFI boundary from potential Zygote panics or undefined behavior. Cargo checks, tests, and formatting were verified successfully.

---
*PR created automatically by Jules for task [14238440582320334325](https://jules.google.com/task/14238440582320334325) started by @tryigit*