### PR TITLE
🔧 Bugfix: update log tag from SysService to cleverestricky

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -6,13 +6,13 @@ The module does not use a proprietary log file. Instead, it integrates directly 
 ## Best Logcat Filter
 To view logs specifically for this module, use the following filter in your terminal:
 ```bash
-adb logcat -s SysService
+adb logcat -s cleverestricky
 ```
 
 ## What to Pay Attention To First
 When analyzing logs, pay attention to the following:
 1. **Initialization:** Look for the startup message `Welcome to Service!` to ensure the module is loading.
-2. **Errors:** Look for any `E/SysService` tags which indicate errors (e.g., failure to load config, server start failures).
+2. **Errors:** Look for any `E/cleverestricky` tags which indicate errors (e.g., failure to load config, server start failures).
 3. **WebUI:** Check if `Web server started on port` appears.
 4. **Interceptors:** Verify that `PropertyHiderService registered successfully` and similar Binder interceptor logs appear.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ CleveresTricky provides comprehensive keystore spoofing with the following capab
 **Integrity Support:**
 - MEETS_USE_BRAIN
 
+
+## Troubleshooting
+
+For instructions on how to read the logs and the best logcat filters to use, please refer to the [Log Documentation](LOG.md).
+
 ## Quick Start
 
 1. Flash the module and reboot

--- a/service/src/main/java/cleveres/tricky/cleverestech/Logger.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Logger.kt
@@ -4,7 +4,7 @@ import android.util.Log
 import cleveres.tricky.cleverestech.BuildConfig
 
 object Logger {
-    const val TAG = "SysService"
+    const val TAG = "cleverestricky"
 
     interface LogImpl {
         fun d(tag: String, msg: String)


### PR DESCRIPTION
This PR updates the internal logging tag `SysService` to `cleverestricky` across the codebase, ensuring consistency and clear identification in logcat.

Changes included:
- Replaced `SysService` with `cleverestricky` in `Logger.kt` inside the `service` module.
- Updated `LOG.md` instructions and examples to reflect the new `cleverestricky` logcat filter.
- Added a reference to `LOG.md` within the `Troubleshooting` section of `README.md` for better discoverability.

Tests were successfully run via `./gradlew :service:testDebugUnitTest`.

---
*PR created automatically by Jules for task [4713936807405336082](https://jules.google.com/task/4713936807405336082) started by @tryigit*