### PR TITLE
⚡ Bolt: Remove redundant OnceLock in properties.rs

### DIFF
--- a/rust/cbor-cose/src/properties.rs
+++ b/rust/cbor-cose/src/properties.rs
@@ -1,29 +1,28 @@
 use ahash::AHashMap;
-use std::sync::{OnceLock, RwLock};
+use std::sync::RwLock;
 
-static PROPERTIES: OnceLock<RwLock<AHashMap<String, String>>> = OnceLock::new();
-
-fn get_cache() -> &'static RwLock<AHashMap<String, String>> {
-    PROPERTIES.get_or_init(|| RwLock::new(AHashMap::new()))
-}
+static PROPERTIES: RwLock<Option<AHashMap<String, String>>> = RwLock::new(None);
 
 pub fn get_property(name: &str) -> Option<String> {
     // Avoid panics inside Zygote
-    if let Ok(cache) = get_cache().read() {
-        cache.get(name).cloned()
+    if let Ok(cache) = PROPERTIES.read() {
+        cache.as_ref().and_then(|c| c.get(name).cloned())
     } else {
         None
     }
 }
 
 pub fn set_property(name: &str, value: &str) {
-    if let Ok(mut cache) = get_cache().write() {
-        cache.insert(name.to_string(), value.to_string());
+    if let Ok(mut cache) = PROPERTIES.write() {
+        let map = cache.get_or_insert_with(AHashMap::new);
+        map.insert(name.to_string(), value.to_string());
     }
 }
 
 pub fn clear_properties() {
-    if let Ok(mut cache) = get_cache().write() {
-        cache.clear();
+    if let Ok(mut cache) = PROPERTIES.write() {
+        if let Some(map) = cache.as_mut() {
+            map.clear();
+        }
     }
 }


### PR DESCRIPTION
Replaced the `OnceLock<RwLock<AHashMap<String, String>>>` wrapper with a simple static `RwLock<Option<AHashMap<String, String>>>` initialized with `RwLock::new(None)`. This avoids unnecessary instantiation on startup (since `RwLock::new` is a `const fn` and no longer requires `OnceLock` overhead), reduces binary size, and improves runtime performance by deferring `AHashMap` allocation and hash state generation until the first `set_property` call.

---
*PR created automatically by Jules for task [17553387169243342912](https://jules.google.com/task/17553387169243342912) started by @tryigit*