### PR TITLE
🛡️ Sentinel: Security Hardening

### DIFF
--- a/rust/cbor-cose/src/ffi.rs
+++ b/rust/cbor-cose/src/ffi.rs
@@ -708,14 +708,11 @@ pub unsafe extern "C" fn rust_prop_get(name_ptr: *const u8, name_len: usize) -> 
         };
 
         if let Some(val) = crate::properties::get_property(name_str) {
-            let mut vec = val.into_bytes();
+            let vec = val.into_bytes();
             // Ensure null termination is NOT added unless needed, the C++ side expects exact string length usually.
             // Wait, readString16_manual expects length or null terminated?
             // "Returns a RustBuffer containing the spoofed value"
-            let len = vec.len();
-            let data = vec.as_mut_ptr();
-            std::mem::forget(vec);
-            RustBuffer { data, len }
+            RustBuffer::from_vec(vec)
         } else {
             RustBuffer::empty()
         }

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -2325,16 +2325,16 @@ class WebServer(
                     val name = entry.name
                     if (!name.contains("..") && !name.startsWith("/") && !name.contains("\\")) {
                         val file = File(configDir, name)
-                        if (!file.canonicalPath.equals(configDir.canonicalPath) && !file.canonicalPath.startsWith(configDir.canonicalPath + File.separator)) {
-                            continue
-                        }
-                        if (name.startsWith("keyboxes/")) {
-                            File(configDir, "keyboxes").mkdirs()
-                        }
-                        if (!entry.isDirectory) {
-                            SecureFile.writeStream(file, zis, 50 * 1024 * 1024)
+                        if (file.canonicalPath.equals(configDir.canonicalPath) || file.canonicalPath.startsWith(configDir.canonicalPath + File.separator)) {
+                            if (name.startsWith("keyboxes/")) {
+                                File(configDir, "keyboxes").mkdirs()
+                            }
+                            if (!entry.isDirectory) {
+                                SecureFile.writeStream(file, zis, 50 * 1024 * 1024)
+                            }
                         }
                     }
+                    zis.closeEntry()
                     entry = zis.nextEntry
                 }
             }


### PR DESCRIPTION
🛡️ Sentinel: Security Hardening

**Security Hardening Details:**

1. **Rust UB Memory Leak in `rust_prop_get`:**
   When allocating a dynamically sized string buffer inside `rust_prop_get` for JNI/C++, the old code used `std::mem::forget(vec)` directly on a `Vec`. This is inherently unsafe when passed across FFI boundaries as `Vec` drops its allocated capacity metadata, and when the C++ code attempts to `Box::from_raw` it, it causes Undefined Behavior. Refactored to utilize the robust `RustBuffer::from_vec` that converts it properly to a boxed slice before releasing it to C++.

2. **Kotlin Infinite Loop DoS in `restoreBackupZip`:**
   In `service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt`, the zip extraction method used a `continue` statement upon encountering an invalid canonical path to prevent path traversal. However, the `continue` statement completely bypassed `zis.closeEntry()` and `zis.nextEntry`, causing the loop to indefinitely process the same malicious entry and lock up the execution thread. Moved the entry advancing logic outside of the `if` branches to ensure it runs unconditionally.

---
*PR created automatically by Jules for task [5848498879284581662](https://jules.google.com/task/5848498879284581662) started by @tryigit*