### PR TITLE
🔧 Bugfix: Fix Zip bomb DoS when skipping unsafe entries during extraction

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -2368,15 +2368,16 @@ class WebServer(
                 var entry = zis.nextEntry
                 while (entry != null) {
                     val name = entry.name
-                    if (!name.contains("..") && !name.startsWith("/") && !name.contains("\\")) {
-                        val file = File(configDir, name)
-                        if (file.canonicalPath.equals(configDir.canonicalPath) || file.canonicalPath.startsWith(configDir.canonicalPath + File.separator)) {
-                            if (name.startsWith("keyboxes/")) {
-                                File(configDir, "keyboxes").mkdirs()
-                            }
-                            if (!entry.isDirectory) {
-                                SecureFile.writeStream(file, zis, 50 * 1024 * 1024)
-                            }
+                    if (name.contains("..") || name.startsWith("/") || name.contains("\\")) {
+                        throw SecurityException("Zip entry contains path traversal: $name")
+                    }
+                    val file = File(configDir, name)
+                    if (file.canonicalPath.equals(configDir.canonicalPath) || file.canonicalPath.startsWith(configDir.canonicalPath + File.separator)) {
+                        if (name.startsWith("keyboxes/")) {
+                            File(configDir, "keyboxes").mkdirs()
+                        }
+                        if (!entry.isDirectory) {
+                            SecureFile.writeStream(file, zis, 50 * 1024 * 1024)
                         }
                     }
                     zis.closeEntry()


### PR DESCRIPTION
Fixes a major vulnerability where attempting to skip an unsafe file entry from a `ZipInputStream` triggered the execution of `zis.closeEntry()`. In Java/Kotlin, `closeEntry()` forcibly parses the stream to find the next entry's offset, triggering decompression of the discarded payload and rendering the application vulnerable to CPU Exhaustion DoS by zip bombs. 

This PR aborts processing entirely when an unsafe entry is encountered by throwing a `SecurityException`, cleanly bypassing decompression.

---
*PR created automatically by Jules for task [5452415706494742393](https://jules.google.com/task/5452415706494742393) started by @tryigit*