### PR TITLE
⚡ Performance: Use non-blocking delay in LatencySimulator

### DIFF
--- a/LatencySimulator.kt
+++ b/LatencySimulator.kt
@@ -3,6 +3,7 @@ package com.android.keystore
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Process
+import kotlinx.coroutines.delay
 
 class LatencySimulator(private val context: Context) {
     // LATENCY EMULATION LAYER
@@ -16,33 +17,33 @@ class LatencySimulator(private val context: Context) {
         const val CANNOT_ATTEST_IDS = -66
     }
 
-    fun emulateTeeOperation(action: () -> Unit) {
+    suspend fun emulateTeeOperation(action: () -> Unit) {
         val start = System.nanoTime()
         action()
         val elapsedMs = (System.nanoTime() - start) / 1_000_000
 
         if (elapsedMs < MIN_TEE_WAIT_MS) {
-            Thread.sleep(MIN_TEE_WAIT_MS - elapsedMs)
+            delay(MIN_TEE_WAIT_MS - elapsedMs)
         }
     }
 
-    fun emulateStrongBoxGenerateKey(action: () -> Unit) {
+    suspend fun emulateStrongBoxGenerateKey(action: () -> Unit) {
         val start = System.nanoTime()
         action()
         val elapsedMs = (System.nanoTime() - start) / 1_000_000
 
         if (elapsedMs < STRONGBOX_GENERATE_WAIT_MS) {
-            Thread.sleep(STRONGBOX_GENERATE_WAIT_MS - elapsedMs)
+            delay(STRONGBOX_GENERATE_WAIT_MS - elapsedMs)
         }
     }
 
-    fun emulateStrongBoxCreateOperation(action: () -> Unit) {
+    suspend fun emulateStrongBoxCreateOperation(action: () -> Unit) {
         val start = System.nanoTime()
         action()
         val elapsedMs = (System.nanoTime() - start) / 1_000_000
 
         if (elapsedMs < STRONGBOX_CREATE_WAIT_MS) {
-            Thread.sleep(STRONGBOX_CREATE_WAIT_MS - elapsedMs)
+            delay(STRONGBOX_CREATE_WAIT_MS - elapsedMs)
         }
     }
 


### PR DESCRIPTION
💡 **What:** Replaced blocking `Thread.sleep()` with non-blocking `kotlinx.coroutines.delay()` in `LatencySimulator.kt`. Converted emulator functions to `suspend`.
🎯 **Why:** `Thread.sleep()` in a coroutine environment blocks the underlying thread. This is a severe anti-pattern for performance and scalability, preventing thread reuse and potentially starving critical system operations.
📊 **Measured Improvement:** As `LatencySimulator` is currently unreferenced within existing performance benchmarking suites, direct benchmarks of this change are impractical. However, this optimization enables the caller thread to handle other tasks while awaiting TEE latency emulation, freeing up CPU resources.

---
*PR created automatically by Jules for task [4669496103278820922](https://jules.google.com/task/4669496103278820922) started by @tryigit*