### PR TITLE
Fix Magisk block incorrectly triggering on KernelSU/APatch

### DIFF
--- a/module/template/customize.sh
+++ b/module/template/customize.sh
@@ -12,17 +12,13 @@ if [ "$BOOTMODE" ] && [ "$KSU" ]; then
 elif [ "$BOOTMODE" ] && [ "$APATCH" ]; then
   ui_print "- Installing from APatch app"
   ui_print "- APatch version: $APATCH_VER_CODE"
-fi
-
-if [ "$MAGISK_VER_CODE" ] || [ "$(which magisk)" ]; then
+elif [ "$MAGISK_VER_CODE" ] || [ "$(which magisk)" ]; then
   ui_print "*********************************************************"
   ui_print "! Magisk is NOT supported!"
   ui_print "! Magisk has been detected. Installation is blocked because Magisk causes issues."
   ui_print "! Please use KernelSU or APatch instead."
   abort    "*********************************************************"
-fi
-
-if [ -z "$KSU" ] && [ -z "$APATCH" ]; then
+else
   ui_print "*********************************************************"
   ui_print "! Install from recovery or unsupported root is not supported"
   ui_print "! Please install from KernelSU or APatch app"


### PR DESCRIPTION
KernelSU and APatch provide a Magisk compatibility layer, which sets `$MAGISK_VER_CODE`. In the `customize.sh` script, the Magisk block was evaluated unconditionally, causing KernelSU and APatch installations to fail.

This commit refactors the root check into an `if-elif-else` chain, ensuring that if `$KSU` or `$APATCH` is detected, the check immediately proceeds without evaluating the Magisk-specific block, while maintaining the block for actual Magisk environments and unsupported roots.

---
*PR created automatically by Jules for task [12595627662398879610](https://jules.google.com/task/12595627662398879610) started by @tryigit*