### PR TITLE
feat: Integrate bootloader spoofing props via common_func.sh

### DIFF
--- a/module/template/customize.sh
+++ b/module/template/customize.sh
@@ -62,7 +62,12 @@ fi
 extract "$ZIPFILE" 'customize.sh'  "$TMPDIR/.vunzip"
 extract "$ZIPFILE" 'verify.sh'     "$TMPDIR/.vunzip"
 
+if ! command -v busybox >/dev/null 2>&1; then
+  abort "! busybox is required for installation"
+fi
+
 ui_print "- Extracting module files"
+extract "$ZIPFILE" 'common_func.sh'  "$MODPATH"
 extract "$ZIPFILE" 'module.prop'     "$MODPATH"
 extract "$ZIPFILE" 'post-fs-data.sh' "$MODPATH"
 extract "$ZIPFILE" 'provision_attestation.sh' "$MODPATH"

--- a/module/template/post-fs-data.sh
+++ b/module/template/post-fs-data.sh
@@ -18,12 +18,15 @@ find "$MODDIR" -maxdepth 1 -name '*.so' -exec chcon u:object_r:cleverestricky_pu
 [ -f "$MODDIR/provision_attestation.sh" ] && chcon u:object_r:cleverestricky_exec:s0 "$MODDIR/provision_attestation.sh" 2>/dev/null
 
 # ===== Property Hiding =====
-# All property hiding (bootloader state, verified boot, debug flags, etc.)
-# is handled by BootLogic.kt inside the daemon at startup.
-# Shell-based resetprop commands were intentionally removed:
-#   - Shell scripts are trivially scannable by detection frameworks
-#   - Compiled daemon code is far harder to fingerprint
-#   - The daemon applies properties immediately on launch via service.sh
+. $MODDIR/common_func.sh
+resetprop_if_diff ro.boot.verifiedbootstate green
+resetprop_if_diff ro.boot.flash.locked 1
+resetprop_if_diff ro.boot.veritymode enforcing
+resetprop_if_diff ro.boot.vbmeta.device_state locked
+resetprop_if_diff ro.boot.warranty_bit 0
+resetprop_if_diff ro.secure 1
+resetprop_if_diff ro.debuggable 0
+resetprop_if_diff ro.oem_unlock_supported 0
 
 # Dynamic TEE Attestation Provisioning (Fixes CSR code 20 without Keybox)
 if [ -f "$MODDIR/provision_attestation.sh" ]; then

--- a/module/template/service.sh
+++ b/module/template/service.sh
@@ -5,6 +5,16 @@ CONFIG_DIR="/data/adb/cleverestricky"
 
 cd $MODDIR
 
+. $MODDIR/common_func.sh
+resetprop_if_diff ro.boot.verifiedbootstate green
+resetprop_if_diff ro.boot.flash.locked 1
+resetprop_if_diff ro.boot.veritymode enforcing
+resetprop_if_diff ro.boot.vbmeta.device_state locked
+resetprop_if_diff ro.boot.warranty_bit 0
+resetprop_if_diff ro.secure 1
+resetprop_if_diff ro.debuggable 0
+resetprop_if_diff ro.oem_unlock_supported 0
+
 (
 FAIL_COUNT=0
 MAX_FAILS=5


### PR DESCRIPTION
Integrates bootloader hiding properties into `post-fs-data.sh` and `service.sh` using a `common_func.sh` file, extracts that script during installation, and adds a check for `busybox` in `customize.sh` to make the module more standalone as requested by the user.

---
*PR created automatically by Jules for task [2994153961635324334](https://jules.google.com/task/2994153961635324334) started by @tryigit*