### PR TITLE
⚡ implement CRL caching with ETag support

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -24,8 +24,19 @@ object KeyboxVerifier {
         VALID, REVOKED, INVALID, ERROR
     }
 
-    private const val CRL_URL = "https://android.googleapis.com/attestation/status"
+    private var CRL_URL = "https://android.googleapis.com/attestation/status"
     private val HASH_LENGTHS = listOf(32, 40, 64)
+
+    @androidx.annotation.VisibleForTesting
+    fun setCrlUrlForTesting(url: String) {
+        CRL_URL = url
+    }
+
+    private var cachedCrl: Set<String>? = null
+    private var cachedEtag: String? = null
+    private var lastFetchTime: Long = 0
+    private const val CACHE_TTL = 24 * 60 * 60 * 1000L // 24 hours
+    private val cacheLock = java.util.concurrent.locks.ReentrantLock()
 
     private fun isHex(str: String): Boolean {
         if (str.isEmpty()) return false
@@ -72,26 +83,78 @@ object KeyboxVerifier {
 
     @JvmStatic
     fun fetchCrl(): Set<String>? {
+        val now = System.currentTimeMillis()
+        cacheLock.lock()
+        try {
+            if (cachedCrl != null && (now - lastFetchTime) < CACHE_TTL) {
+                return cachedCrl
+            }
+        } finally {
+            cacheLock.unlock()
+        }
+
         return try {
             val url = URL(CRL_URL)
             val conn = url.openConnection() as HttpURLConnection
             conn.connectTimeout = 10000
             conn.readTimeout = 10000
             conn.requestMethod = "GET"
-            conn.setRequestProperty("Cache-Control", "no-cache")
 
-            if (conn.responseCode != 200) {
-                Logger.e("CRL Fetch Failed: ${conn.responseCode}")
-                return null
+            cacheLock.lock()
+            try {
+                cachedEtag?.let {
+                    conn.setRequestProperty("If-None-Match", it)
+                }
+            } finally {
+                cacheLock.unlock()
             }
+
+            val responseCode = conn.responseCode
+            if (responseCode == 304) {
+                cacheLock.lock()
+                try {
+                    lastFetchTime = now
+                    return cachedCrl
+                } finally {
+                    cacheLock.unlock()
+                }
+            }
+
+            if (responseCode != 200) {
+                Logger.e("CRL Fetch Failed: $responseCode")
+                // Return cached if available even if expired, as fallback
+                cacheLock.lock()
+                try {
+                    return cachedCrl
+                } finally {
+                    cacheLock.unlock()
+                }
+            }
+
+            val etag = conn.getHeaderField("ETag")
 
             // Use streaming parser to prevent OOM on large CRL files
-            conn.inputStream.bufferedReader().use { reader ->
+            val newCrl = conn.inputStream.bufferedReader().use { reader ->
                 parseCrl(reader)
             }
+
+            cacheLock.lock()
+            try {
+                cachedCrl = newCrl
+                cachedEtag = etag
+                lastFetchTime = now
+            } finally {
+                cacheLock.unlock()
+            }
+            newCrl
         } catch (e: Exception) {
             Logger.e("Failed to fetch CRL", e)
-            null
+            cacheLock.lock()
+            try {
+                cachedCrl // Fallback to cache on error
+            } finally {
+                cacheLock.unlock()
+            }
         }
     }
 
@@ -102,26 +165,7 @@ object KeyboxVerifier {
 
     @JvmStatic
     fun countRevokedKeys(): Int {
-        return try {
-            val url = URL(CRL_URL)
-            val conn = url.openConnection() as HttpURLConnection
-            conn.connectTimeout = 10000
-            conn.readTimeout = 10000
-            conn.requestMethod = "GET"
-            conn.setRequestProperty("Cache-Control", "no-cache")
-
-            if (conn.responseCode != 200) {
-                Logger.e("CRL Fetch Failed (Count): ${conn.responseCode}")
-                return -1
-            }
-
-            conn.inputStream.bufferedReader().use { reader ->
-                countCrlEntries(reader)
-            }
-        } catch (e: Exception) {
-            Logger.e("Failed to count CRL entries", e)
-            -1
-        }
+        return fetchCrl()?.size ?: -1
     }
 
     @JvmStatic

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierCacheTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierCacheTest.kt
@@ -1,0 +1,95 @@
+package cleveres.tricky.cleverestech.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.net.ServerSocket
+import java.util.concurrent.atomic.AtomicInteger
+
+class KeyboxVerifierCacheTest {
+
+    @Test
+    fun `fetchCrl caches results and uses ETag`() {
+        val crlJson = """
+            {
+              "entries": {
+                "12345": "REVOKED"
+              }
+            }
+        """.trimIndent()
+
+        val requestCount = AtomicInteger(0)
+        val lastEtag = java.util.concurrent.atomic.AtomicReference<String?>(null)
+        val server = ServerSocket(0)
+        val port = server.localPort
+
+        val thread = Thread {
+            try {
+                while (!Thread.interrupted()) {
+                    val client = server.accept()
+                    requestCount.incrementAndGet()
+                    val reader = client.inputStream.bufferedReader()
+                    // Read request headers
+                    var line = reader.readLine()
+                    var ifNoneMatch: String? = null
+                    while (line != null && line.isNotEmpty()) {
+                        if (line.startsWith("If-None-Match:", ignoreCase = true)) {
+                            ifNoneMatch = line.substringAfter(":").trim()
+                        }
+                        line = reader.readLine()
+                    }
+
+                    val writer = client.outputStream.bufferedWriter()
+                    if (ifNoneMatch != null && ifNoneMatch == "W/\"test-etag\"") {
+                        writer.write("HTTP/1.1 304 Not Modified\r\n")
+                        writer.write("\r\n")
+                    } else {
+                        writer.write("HTTP/1.1 200 OK\r\n")
+                        writer.write("Content-Type: application/json\r\n")
+                        writer.write("ETag: W/\"test-etag\"\r\n")
+                        writer.write("Content-Length: ${crlJson.length}\r\n")
+                        writer.write("\r\n")
+                        writer.write(crlJson)
+                    }
+                    writer.flush()
+                    client.close()
+                }
+            } catch (e: Exception) {
+            }
+        }
+        thread.start()
+
+        try {
+            KeyboxVerifier.setCrlUrlForTesting("http://localhost:$port")
+
+            // 1. Initial fetch
+            val res1 = KeyboxVerifier.fetchCrl()
+            assertEquals(setOf("3039"), res1)
+            assertEquals(1, requestCount.get())
+
+            // 2. Immediate second fetch - should be CACHED in memory (no network)
+            val res2 = KeyboxVerifier.fetchCrl()
+            assertEquals(setOf("3039"), res2)
+            assertEquals(1, requestCount.get())
+
+            // 3. countRevokedKeys - should also be cached
+            assertEquals(1, KeyboxVerifier.countRevokedKeys())
+            assertEquals(1, requestCount.get())
+
+            // 4. Force expiration by modifying private field via reflection?
+            // Actually let's just wait or use a mock clock if we had one.
+            // Since we can't easily mock time, let's use reflection to reset lastFetchTime.
+            val lastFetchTimeField = KeyboxVerifier::class.java.getDeclaredField("lastFetchTime")
+            lastFetchTimeField.isAccessible = true
+            lastFetchTimeField.set(KeyboxVerifier, 0L)
+
+            // 5. Fetch after expiration - should trigger network with If-None-Match
+            val res3 = KeyboxVerifier.fetchCrl()
+            assertEquals(setOf("3039"), res3)
+            assertEquals(2, requestCount.get()) // Incremented because of network request
+
+        } finally {
+            thread.interrupt()
+            server.close()
+        }
+    }
+}


### PR DESCRIPTION
💡 **What:** The optimization implemented a dual-layered caching strategy for the Certificate Revocation List (CRL) fetching process in `KeyboxVerifier.kt`. It includes an in-memory time-based cache (24h TTL) and support for HTTP conditional requests via the `ETag` / `If-None-Match` headers.

🎯 **Why:** Previously, every call to `fetchCrl` or `countRevokedKeys` (which occurred during dashboard loads and keybox verifications) triggered a full network request to Google's servers. This was inefficient, increased dashboard latency, and consumed unnecessary bandwidth.

📊 **Measured Improvement:** In local unit tests using a mock server, the optimization reduced network requests from N to 1 for multiple subsequent calls. For expired caches where the server content remained unchanged, bandwidth usage was reduced to a minimal `304 Not Modified` response instead of downloading the entire JSON payload.

---
*PR created automatically by Jules for task [7442184807969380699](https://jules.google.com/task/7442184807969380699) started by @tryigit*