### PR TITLE
⚡ Document performance constraint for Thread.sleep in Binder interceptor

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -119,6 +119,10 @@ class SecurityLevelInterceptor(
                         }
 
                         // StrongBox timing simulation
+                        // Note: Do NOT replace Thread.sleep with coroutines (e.g. runBlocking { delay() }).
+                        // In Android Binder IPC interceptors (onPreTransact), execution is strictly synchronous.
+                        // Non-blocking coroutines would break timing simulations by returning immediately,
+                        // and runBlocking adds heavy overhead while still blocking the underlying thread.
                         val delay = if (kgp.purpose.contains(android.hardware.security.keymint.KeyPurpose.SIGN)) 80L else 250L
                         Thread.sleep(delay)
                     }


### PR DESCRIPTION
💡 **What:** Documented why replacing the blocking `Thread.sleep` call with coroutines is a performance anti-pattern in `SecurityLevelInterceptor.kt`.

🎯 **Why:** The task was to optimize a "Blocking Thread.sleep in Binder Transact" issue. The rationale suggested replacing it with a non-blocking delay or offloading to a different thread.
However, in Android Binder IPC interceptors (`onPreTransact`), execution is strictly synchronous. This specific line `Thread.sleep` simulates hardware StrongBox delay. Making it non-blocking or offloading to another thread causes it to return immediately and completely breaks the simulation. Using `runBlocking { delay() }` adds massive coroutine infrastructure overhead while *still* blocking the underlying thread.
Because modifying this single method block to be async is mathematically and logically impossible without refactoring the entire C++ Android HAL and Java Binder layers, the actual improvement here is documenting the reason why this specific pattern must remain `Thread.sleep`. This prevents linters, users, or future code maintainers from applying the anti-pattern suggested in the rationale.

📊 **Measured Improvement:**
N/A - The code functions properly as-is, and attempting to apply the requested coroutine replacement would have introduced heavy regressions or completely broken the timing simulation. I have kept the `Thread.sleep` intact and added an explicit comment.

---
*PR created automatically by Jules for task [1303475027550552099](https://jules.google.com/task/1303475027550552099) started by @tryigit*