### PR TITLE
fix: GSF ID randomization and CRL test resolution

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -938,6 +938,7 @@ object Config {
             val btMac = RandomUtils.generateRandomMac()
             val simIso = RandomUtils.generateRandomSimIso()
             val simCarrier = RandomUtils.generateRandomCarrier()
+            val gsfId = RandomUtils.generateRandomGsfId()
 
             val sb = StringBuilder()
 
@@ -969,6 +970,7 @@ object Config {
                                 l.startsWith("ATTESTATION_ID_WIFI_MAC") ||
                                 l.startsWith("ATTESTATION_ID_BT_MAC") ||
                                 l.startsWith("SIM_COUNTRY_ISO") ||
+                                l.startsWith("GSF_ID") ||
                                 l.startsWith("SIM_OPERATOR_NAME")) {
                                 return@forEach
                             }
@@ -990,6 +992,7 @@ object Config {
             sb.append("ATTESTATION_ID_BT_MAC=$btMac\n")
             sb.append("SIM_COUNTRY_ISO=$simIso\n")
             sb.append("SIM_OPERATOR_NAME=$simCarrier\n")
+            sb.append("GSF_ID=$gsfId\n")
 
             // Random location if enabled
             if (File(root, SPOOF_LOCATION_FILE).exists()) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/RandomUtils.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/RandomUtils.kt
@@ -76,6 +76,15 @@ object RandomUtils {
         return sb.toString()
     }
 
+    fun generateRandomGsfId(): String {
+        val rng = secureRandom
+        val sb = StringBuilder(16)
+        repeat(16) {
+            sb.append(HEX_POOL[rng.nextInt(HEX_POOL.length)])
+        }
+        return sb.toString()
+    }
+
     fun generateRandomSimIso(): String {
         return COUNTRIES[secureRandom.nextInt(COUNTRIES.size)]
     }

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierCacheTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierCacheTest.kt
@@ -63,16 +63,16 @@ class KeyboxVerifierCacheTest {
 
             // 1. Initial fetch
             val res1 = KeyboxVerifier.fetchCrl()
-            assertEquals(setOf("3039"), res1)
+            assertEquals(setOf("3039", "0000000000000000000000000000000000003039", "0000000000000000000000000000000000000000000000000000000000003039", "00000000000000000000000000003039"), res1)
             assertEquals(1, requestCount.get())
 
             // 2. Immediate second fetch - should be CACHED in memory (no network)
             val res2 = KeyboxVerifier.fetchCrl()
-            assertEquals(setOf("3039"), res2)
+            assertEquals(setOf("3039", "0000000000000000000000000000000000003039", "0000000000000000000000000000000000000000000000000000000000003039", "00000000000000000000000000003039"), res2)
             assertEquals(1, requestCount.get())
 
             // 3. countRevokedKeys - should also be cached
-            assertEquals(1, KeyboxVerifier.countRevokedKeys())
+            assertEquals(4, KeyboxVerifier.countRevokedKeys())
             assertEquals(1, requestCount.get())
 
             // 4. Force expiration by modifying private field via reflection?
@@ -84,7 +84,7 @@ class KeyboxVerifierCacheTest {
 
             // 5. Fetch after expiration - should trigger network with If-None-Match
             val res3 = KeyboxVerifier.fetchCrl()
-            assertEquals(setOf("3039"), res3)
+            assertEquals(setOf("3039", "0000000000000000000000000000000000003039", "0000000000000000000000000000000000000000000000000000000000003039", "00000000000000000000000000003039"), res3)
             assertEquals(2, requestCount.get()) // Incremented because of network request
 
         } finally {


### PR DESCRIPTION
This PR resolves the failing unit test `KeyboxVerifierCacheTest` caused by changes in `KeyboxVerifier.kt` regarding how revoked keys are evaluated. Additionally, it implements a new feature to spoof a randomized `GSF_ID` alongside existing spoofed variables (like IMEI and Android ID).

---
*PR created automatically by Jules for task [14340428991003224560](https://jules.google.com/task/14340428991003224560) started by @tryigit*