### PR TITLE
fix(ci): Disable dependency graph submission in gradle setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -439,6 +439,8 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
         with:
           gradle-home-cache-cleanup: true
+          add-job-summary: never
+          dependency-graph: disabled
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v4
@@ -558,6 +560,8 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
         with:
           gradle-home-cache-cleanup: true
+          add-job-summary: never
+          dependency-graph: disabled
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v4


### PR DESCRIPTION
This pull request fixes a GitHub Actions workflow issue where the dependency graph submission would fail with a 500 error. It disables dependency graph generation via the `setup-gradle` action and also disables job summaries for `setup-gradle`.

---
*PR created automatically by Jules for task [5752665389671682488](https://jules.google.com/task/5752665389671682488) started by @tryigit*