### PR TITLE
⚡ Bolt: Optimize /proc file reads by eliminating redundant stat syscalls

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/DrmInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/DrmInterceptor.kt
@@ -198,24 +198,21 @@ object DrmInterceptor : BinderInterceptor() {
         if (cachedPid != null) {
             val buf = ByteArray(1024)
             kotlin.runCatching {
-                val cmdlineFile = File("/proc/$cachedPid/cmdline")
-                if (cmdlineFile.exists()) {
-                    val stream = java.io.FileInputStream(cmdlineFile)
-                    val length = try {
-                        stream.read(buf)
-                    } finally {
-                        stream.close()
-                    }
-                    if (length <= 0) return@runCatching
-                    var end = 0
-                    while (end < length && buf[end] != 0.toByte()) {
-                        end++
-                    }
-                    val argv0 = String(buf, 0, end)
-                    for (target in DRM_PROCESS_NAMES) {
-                        if (argv0 == target || argv0.endsWith("/$target")) {
-                            return cachedPid
-                        }
+                val stream = java.io.FileInputStream("/proc/$cachedPid/cmdline")
+                val length = try {
+                    stream.read(buf)
+                } finally {
+                    stream.close()
+                }
+                if (length <= 0) return@runCatching
+                var end = 0
+                while (end < length && buf[end] != 0.toByte()) {
+                    end++
+                }
+                val argv0 = String(buf, 0, end)
+                for (target in DRM_PROCESS_NAMES) {
+                    if (argv0 == target || argv0.endsWith("/$target")) {
+                        return cachedPid
                     }
                 }
             }

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -115,23 +115,20 @@ object KeystoreInterceptor : BinderInterceptor() {
         for (pidStr in pids) {
             if (pidStr.all { it.isDigit() }) {
                 kotlin.runCatching {
-                    val cmdlineFile = java.io.File("/proc/$pidStr/cmdline")
-                    if (cmdlineFile.exists()) {
-                        val stream = java.io.FileInputStream(cmdlineFile)
-                        val length = try {
-                            stream.read(buf)
-                        } finally {
-                            stream.close()
-                        }
-                        if (length <= 0) return@runCatching
-                        var end = 0
-                        while (end < length && buf[end] != 0.toByte()) {
-                            end++
-                        }
-                        val argv0 = String(buf, 0, end)
-                        if (argv0 == "keystore2" || argv0.endsWith("/keystore2")) {
-                            return pidStr.toInt()
-                        }
+                    val stream = java.io.FileInputStream("/proc/$pidStr/cmdline")
+                    val length = try {
+                        stream.read(buf)
+                    } finally {
+                        stream.close()
+                    }
+                    if (length <= 0) return@runCatching
+                    var end = 0
+                    while (end < length && buf[end] != 0.toByte()) {
+                        end++
+                    }
+                    val argv0 = String(buf, 0, end)
+                    if (argv0 == "keystore2" || argv0.endsWith("/keystore2")) {
+                        return pidStr.toInt()
                     }
                 }
             }

--- a/service/src/main/java/cleveres/tricky/cleverestech/TelephonyInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/TelephonyInterceptor.kt
@@ -156,23 +156,20 @@ object TelephonyInterceptor : BinderInterceptor() {
         if (cachedPid != null) {
             val buf = ByteArray(1024)
             kotlin.runCatching {
-                val cmdlineFile = File("/proc/$cachedPid/cmdline")
-                if (cmdlineFile.exists()) {
-                    val stream = java.io.FileInputStream(cmdlineFile)
-                    val length = try {
-                        stream.read(buf)
-                    } finally {
-                        stream.close()
-                    }
-                    if (length <= 0) return@runCatching
-                    var end = 0
-                    while (end < length && buf[end] != 0.toByte()) {
-                        end++
-                    }
-                    val argv0 = String(buf, 0, end)
-                    if (argv0 == "com.android.phone") {
-                        return cachedPid
-                    }
+                val stream = java.io.FileInputStream("/proc/$cachedPid/cmdline")
+                val length = try {
+                    stream.read(buf)
+                } finally {
+                    stream.close()
+                }
+                if (length <= 0) return@runCatching
+                var end = 0
+                while (end < length && buf[end] != 0.toByte()) {
+                    end++
+                }
+                val argv0 = String(buf, 0, end)
+                if (argv0 == "com.android.phone") {
+                    return cachedPid
                 }
             }
             cachedPhonePid = null
@@ -186,25 +183,22 @@ object TelephonyInterceptor : BinderInterceptor() {
         for (pidStr in pids) {
             if (pidStr.all { it.isDigit() }) {
                 kotlin.runCatching {
-                    val cmdlineFile = File("/proc/$pidStr/cmdline")
-                    if (cmdlineFile.exists()) {
-                        val stream = java.io.FileInputStream(cmdlineFile)
-                        val length = try {
-                            stream.read(buf)
-                        } finally {
-                            stream.close()
-                        }
-                        if (length <= 0) return@runCatching
-                        var end = 0
-                        while (end < length && buf[end] != 0.toByte()) {
-                            end++
-                        }
-                        val argv0 = String(buf, 0, end)
-                        if (argv0 == "com.android.phone") {
-                            val pid = pidStr.toInt()
-                            cachedPhonePid = pid
-                            return pid
-                        }
+                    val stream = java.io.FileInputStream("/proc/$pidStr/cmdline")
+                    val length = try {
+                        stream.read(buf)
+                    } finally {
+                        stream.close()
+                    }
+                    if (length <= 0) return@runCatching
+                    var end = 0
+                    while (end < length && buf[end] != 0.toByte()) {
+                        end++
+                    }
+                    val argv0 = String(buf, 0, end)
+                    if (argv0 == "com.android.phone") {
+                        val pid = pidStr.toInt()
+                        cachedPhonePid = pid
+                        return pid
                     }
                 }
             }


### PR DESCRIPTION
⚡ Bolt: Optimize /proc/ file reads by eliminating redundant stat syscalls

Replaced `File.exists()` checks with direct `FileInputStream` instantiation inside `runCatching` blocks across `DrmInterceptor`, `KeystoreInterceptor`, and `TelephonyInterceptor`. This EAFP pattern avoids redundant `stat` syscalls, significantly improving performance in hot paths processing `/proc/$pid/cmdline`.

---
*PR created automatically by Jules for task [18331321704068007001](https://jules.google.com/task/18331321704068007001) started by @tryigit*