### PR TITLE
🎨 Palette: WebUI/UX Enhancement

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -1263,7 +1263,7 @@ class WebServer(
         .island.error .error-icon { display: block; }
         .success-icon { display: none; margin-right: 10px; color: var(--success); font-size: 1.2em; font-weight: bold; }
         .island.normal .success-icon { display: block; }
-        .island-close { background: transparent; border: none; color: #888; font-size: 1.5em; padding: 0; margin-left: 15px; cursor: pointer; min-height: 44px; min-width: 44px; display: flex; align-items: center; justify-content: center; touch-action: manipulation; }
+        .island-close { background: transparent; border: none; color: #888; font-size: 1.5em; padding: 0; margin-left: 15px; cursor: pointer; min-height: 44px; min-width: 44px; display: flex; align-items: center; justify-content: center; touch-action: manipulation; pointer-events: auto; }
         .island-close:hover { color: #fff; }
         #islandText { flex: 1; }
         @keyframes spin { to { transform: rotate(360deg); } }


### PR DESCRIPTION
As requested, I found and fixed a micro-UX flaw in the CleveresTricky WebUI.

The toast notification overlay (`.island-container`) correctly uses `pointer-events: none;` to ensure it doesn't block background clicks on the page, but the close button (`.island-close`) previously did not explicitly declare `pointer-events: auto;`. This inherited the parent's `none` styling, making the button unclickable and causing click events to be swallowed.

By injecting `pointer-events: auto;` into the `.island-close` class in `WebServer.kt`, the button can now be properly tapped on mobile without breaking the background's clickability.

Tested successfully locally using the provided test suites.

---
*PR created automatically by Jules for task [10531736750236563628](https://jules.google.com/task/10531736750236563628) started by @tryigit*