### PR TITLE
Fix Android 16 (API 36) startup issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ The native Binder hook uses an **Adaptive Interception** architecture that is im
 |----------|----------|------|
 | 1 | **BTF Kernel Introspection** | Kernel 5.4+ with `CONFIG_DEBUG_INFO_BTF` -- reads `/sys/kernel/btf/vmlinux` for exact struct layouts |
 | 2 | **Runtime Heuristic Probing** | Sends a dummy `PING_TRANSACTION` at startup and analyzes the response to discover struct field positions |
-| 3 | **Static Fallback Database** | Known offset maps for Android 8 (API 26) through Android 15+ (API 35) across kernel 4.4 -- 6.6 |
+| 3 | **Static Fallback Database** | Known offset maps for Android 8 (API 26) through Android 16+ (API 36) across kernel 4.4 -- 6.6 |
 
 **Safety guarantees:**
 

--- a/module/src/main/cpp/binder_interceptor.cpp
+++ b/module/src/main/cpp/binder_interceptor.cpp
@@ -409,6 +409,9 @@ const FallbackOffsetEntry FallbackDatabase::s_entries[] = {
     // API 35 (Android 15), kernel 6.1.x / 6.6.x
     {35, 6, 1,  104, 112,  0, 8, 16, 20, 24, 28, 32, 48, 48},
     {35, 6, 6,  104, 112,  0, 8, 16, 20, 24, 28, 32, 48, 48},
+    // API 36 (Android 16), kernel 6.1.x / 6.6.x
+    {36, 6, 1,  104, 112,  0, 8, 16, 20, 24, 28, 32, 48, 48},
+    {36, 6, 6,  104, 112,  0, 8, 16, 20, 24, 28, 32, 48, 48},
 };
 
 const size_t FallbackDatabase::s_entry_count =

--- a/service/src/test/java/cleveres/tricky/cleverestech/AdaptiveBinderInterceptorSafetyTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/AdaptiveBinderInterceptorSafetyTest.kt
@@ -225,9 +225,9 @@ class AdaptiveBinderInterceptorSafetyTest {
     @Test
     fun testHasMultipleAndroidVersionEntries() {
         assertTrue(
-            "Fallback database must cover multiple Android API levels (26-35+)",
-            cppContent.contains("26") && cppContent.contains("35") ||
-                cppContent.contains("android_8") && cppContent.contains("android_15")
+            "Fallback database must cover multiple Android API levels (26-36+)",
+            cppContent.contains("26") && cppContent.contains("36") ||
+                cppContent.contains("android_8") && cppContent.contains("android_16")
         )
     }
 


### PR DESCRIPTION
This PR fixes an issue where the module fails to start on Android 16 (API 36) devices, such as the OnePlus 13, by adding Android API 36 support in the Static Fallback Database (`module/src/main/cpp/binder_interceptor.cpp`). 

The `s_entries` database within `FallbackDatabase` now includes layout offsets for API 36 on kernel versions `6.1.x` and `6.6.x`. Test assertions and the README.md have been updated to reflect the new supported API 36 fallback coverage.

---
*PR created automatically by Jules for task [5916652555198321702](https://jules.google.com/task/5916652555198321702) started by @tryigit*