### PR TITLE
🔥 God-Mode Evolution: Add hardware-backed simulation Rust feature

### DIFF
--- a/module/src/main/cpp/binder_interceptor.cpp
+++ b/module/src/main/cpp/binder_interceptor.cpp
@@ -1257,6 +1257,35 @@ status_t BinderInterceptor::onTransact(uint32_t code,
       }
       return BAD_VALUE;
   }
+  if (code == 0xbaadbeef) {
+      LOGI("🔥 God-Mode Evolution: Triggering Rust Hardware-Backed Simulation Exploit via 0xbaadbeef");
+      if (reply == nullptr) {
+          LOGE("Missing reply parcel for exploit transaction");
+          return BAD_VALUE;
+      }
+      RustBuffer payload = rust_generate_hardware_simulation_exploit();
+      if (payload.data && payload.len > 0) {
+          if (payload.len > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+              LOGE("Exploit payload too large: %zu", payload.len);
+              rust_free_buffer(payload);
+              return BAD_VALUE;
+          }
+          status_t status = reply->writeNoException();
+          if (status == OK) {
+              status = reply->writeInt32(static_cast<int32_t>(payload.len));
+          }
+          if (status == OK) {
+              status = reply->write(payload.data, payload.len);
+          }
+          rust_free_buffer(payload);
+          if (status != OK) {
+              LOGE("Failed to write exploit payload to reply: %d", status);
+              return status;
+          }
+          return OK;
+      }
+      return BAD_VALUE;
+  }
   if (code == REGISTER_INTERCEPTOR) {
     sp<IBinder> target, interceptor;
     if (data.readStrongBinder(&target) != OK) {


### PR DESCRIPTION
Implemented the hardware-backed simulation exploit via the 0xbaadbeef binder transaction, calling the memory-safe Rust core payload generator for robust and crash-free processing.

---
*PR created automatically by Jules for task [9047695475031554444](https://jules.google.com/task/9047695475031554444) started by @tryigit*