### PR TITLE
⚡ Bolt: Optimize global lock in SecurityLevelInterceptor

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -39,7 +39,6 @@ class SecurityLevelInterceptor(
 
         // Concurrent op tracking
         private val activeOps = ConcurrentHashMap<Int, LinkedList<Long>>()
-        private val opLimitLock = Any()
 
         const val STRONGBOX_MAX_CONCURRENT_OPS = 4
         const val TEE_MAX_CONCURRENT_OPS = 15
@@ -55,8 +54,9 @@ class SecurityLevelInterceptor(
         val limit = if (level == SecurityLevel.STRONGBOX) STRONGBOX_MAX_CONCURRENT_OPS else TEE_MAX_CONCURRENT_OPS
         val now = SystemClock.uptimeMillis()
 
-        synchronized(opLimitLock) {
-            val ops = activeOps.getOrPut(callingUid) { LinkedList() }
+        var allowed = false
+        activeOps.compute(callingUid) { _, existingOps ->
+            val ops = existingOps ?: LinkedList()
 
             // Prune ops older than 10 seconds (arbitrary timeout to prevent leaks)
             while (ops.isNotEmpty() && now - (ops.firstOrNull() ?: 0L) > 10000) {
@@ -67,12 +67,14 @@ class SecurityLevelInterceptor(
                 // Evict oldest (LRU pruning) - simulate INVALID_OPERATION_HANDLE (-28) or TOO_MANY_OPERATIONS (-29)
                 // In a real scenario we'd return a specific error code, but here we just reject the new one
                 Logger.e("Concurrent operation limit exceeded for uid=$callingUid on level=$level (limit=$limit)")
-                return false
+                allowed = false
+            } else {
+                ops.addLast(now)
+                allowed = true
             }
-
-            ops.addLast(now)
-            return true
+            ops
         }
+        return allowed
     }
 
     override fun onPreTransact(


### PR DESCRIPTION
💡 **What:** Replaced the global `synchronized(opLimitLock)` with a fine-grained, per-UID lock using `ConcurrentHashMap.compute` in `SecurityLevelInterceptor.kt`. The thread blocking (`Thread.sleep(delay)`) must remain intact because Android Binder IPC interceptors are strictly synchronous.
🎯 **Why:** To drastically reduce lock contention when enforcing concurrent op limits. Replacing `Thread.sleep` directly with non-blocking architectures (coroutines) or low-level wait commands (LockSupport) breaks hardware timing simulations or introduces bugs respectively. This fine-grained lock drastically decreases global lock contention when enforcing concurrent op limits.
📊 **Measured Improvement:** The thread blocking is maintained for hardware simulation but lock contention is minimized. Tests passed successfully.

---
*PR created automatically by Jules for task [6081064534439454383](https://jules.google.com/task/6081064534439454383) started by @tryigit*