### PR TITLE
⚡ Optimize getAppConfig by short-circuiting empty trie lookups

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -109,12 +109,14 @@ object Config {
 
         val pkgs = getPackages(uid)
         var result: AppSpoofConfig? = null
-        val len = pkgs.size
-        for (i in 0 until len) {
-            val config = state.configs.get(pkgs[i])
-            if (config != null) {
-                result = config
-                break
+        if (!state.configs.isEmpty()) {
+            val len = pkgs.size
+            for (i in 0 until len) {
+                val config = state.configs.get(pkgs[i])
+                if (config != null) {
+                    result = config
+                    break
+                }
             }
         }
         state.cache[uid] = result ?: NULL_CONFIG


### PR DESCRIPTION
💡 **What:** Added a condition `if (!state.configs.isEmpty())` in `getAppConfig` to short-circuit the loop over packages.
🎯 **Why:** Resolves N+1 query overhead for empty configs during initial cache-miss lookups, where it redundantly performed Trie lookups for every package of a UID even when no config rules existed.
📊 **Measured Improvement:** Unable to provide reliable standalone JVM benchmark metrics due to lack of `kotlinc` or accessible standalone Kotlin runners in the environment, and tests involving Binder/PackageManager mocking added overhead that obfuscated raw performance deltas. The theoretical expectation is that avoiding the redundant O(N) Trie lookups (where N is the number of packages for the UID) reduces execution overhead in cache miss paths when no config rules are defined.

---
*PR created automatically by Jules for task [13345292370219252504](https://jules.google.com/task/13345292370219252504) started by @tryigit*