### PR TITLE
⚡ [Fix] Keep WebUI token in URL to prevent navigation lockouts

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -1889,13 +1889,16 @@ class WebServer(
         let token = urlParams.get('token');
         if (token) {
             localStorage.setItem('ct_token', token);
-            // Clean up URL to prevent token leakage and allow clean reloads
-            window.history.replaceState({}, document.title, window.location.pathname);
         } else {
             token = localStorage.getItem('ct_token');
+            if (token) {
+                // If token was only found in localStorage, append it to URL so page refreshes don't lose it if localStorage clears
+                urlParams.set('token', token);
+                window.history.replaceState({}, document.title, window.location.pathname + '?' + urlParams.toString());
+            }
         }
         if (!token) {
-            document.body.innerHTML = '<div style="padding: 20px; text-align: center; color: white; background: #121212; height: 100vh; font-family: sans-serif;"><h2>Missing Token</h2><p>Please open WebUI from the Magisk or KernelSU app action menu.</p><button onclick="window.location.href = \'/\'" style="padding: 10px 20px; margin-top: 20px; background: #3b82f6; color: white; border: none; border-radius: 4px; min-height: 44px; min-width: 44px;">Retry</button></div>';
+            document.body.innerHTML = '<div style="padding: 20px; text-align: center; color: white; background: #121212; height: 100vh; font-family: sans-serif;"><h2>Missing Token</h2><p>Please open WebUI from the Magisk or KernelSU app action menu.</p><button onclick="window.location.reload()" style="padding: 10px 20px; margin-top: 20px; background: #3b82f6; color: white; border: none; border-radius: 4px; min-height: 44px; min-width: 44px;">Retry</button></div>';
             throw new Error('No token');
         }
         function getAuthUrl(path) { return path; }


### PR DESCRIPTION
Fixes #669.

### What
- Stop using `window.history.replaceState` to strip the `ct_token` from the URL.
- Re-append the token to the URL if it was loaded from `localStorage`.
- Update the "Missing Token" retry button to invoke `window.location.reload()` instead of redirecting to the root `/` path (which guarantees token loss).

### Why
- Previously, the WebUI JavaScript stripped the token from the URL upon loading to prevent token leakage. However, when a user navigated away (e.g., using the Android back button) and subsequently re-opened the WebUI from the Magisk/KernelSU app action intent, the browser often prioritized the existing tab state (which lacked the token) or cleared the associated `localStorage` across the session, leading to "Unauthorized" / "Failed to fetch" lockouts that only a system reboot could resolve.
- By preserving the token in the URL, `urlParams.get('token')` guarantees reliable authentication even after accidental navigation, intent redelivery, or browser cache clearing.

### Measured Improvement
- Ensures continuous module UI accessibility and prevents 401 Unauthorized API fetch lockouts.

---
*PR created automatically by Jules for task [8796677514850217148](https://jules.google.com/task/8796677514850217148) started by @tryigit*