### PR TITLE
⚡ Bolt: Remove kotlin.runCatching overhead in Binder interceptor hot paths

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/DrmInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/DrmInterceptor.kt
@@ -114,7 +114,10 @@ object DrmInterceptor : BinderInterceptor() {
         if (propertyName != DrmOverrideLogic.SECURITY_LEVEL_PROPERTY) return Skip
 
         val pos = reply.dataPosition()
-        if (kotlin.runCatching { reply.readException() }.exceptionOrNull() != null) {
+        // Optimization: Replace runCatching with try-catch to avoid Result object allocation in hot path
+        try {
+            reply.readException()
+        } catch (e: Exception) {
             reply.setDataPosition(pos)
             return Skip
         }
@@ -149,7 +152,10 @@ object DrmInterceptor : BinderInterceptor() {
         if (propertyName != DrmOverrideLogic.DEVICE_UNIQUE_ID_PROPERTY) return Skip
         if (!DrmOverrideLogic.shouldSpoofDeviceUniqueId(propertyName, cachedRandomDrmOnBoot)) return Skip
         val pos = reply.dataPosition()
-        if (kotlin.runCatching { reply.readException() }.exceptionOrNull() != null) {
+        // Optimization: Replace runCatching with try-catch to avoid Result object allocation in hot path
+        try {
+            reply.readException()
+        } catch (e: Exception) {
             reply.setDataPosition(pos)
             return Skip
         }

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -37,20 +37,24 @@ object KeystoreInterceptor : BinderInterceptor() {
         if (code == getKeyEntryTransaction) {
             if (CertHack.canHack()) {
                 Logger.d { "intercept pre  $target uid=$callingUid pid=$callingPid dataSz=${data.dataSize()}" }
-                if (Config.needGenerate(callingUid))
-                    kotlin.runCatching {
+                if (Config.needGenerate(callingUid)) {
+                    // Optimization: Replace runCatching with try-catch to avoid Result object allocation in hot path
+                    try {
                         data.enforceInterface(IKeystoreService.DESCRIPTOR)
                         val descriptor =
-                            data.readTypedObject(KeyDescriptor.CREATOR) ?: return@runCatching
+                            data.readTypedObject(KeyDescriptor.CREATOR) ?: return Skip
                         val response =
                             SecurityLevelInterceptor.getKeyResponse(callingUid, descriptor.alias)
-                            ?: return@runCatching
+                            ?: return Skip
                         Logger.i("generate key for uid=$callingUid alias=${descriptor.alias}")
                         val p = Parcel.obtain()
                         p.writeNoException()
                         p.writeTypedObject(response, 0)
                         return OverrideReply(0, p)
+                    } catch (e: Exception) {
+                        // Ignore and fallback to Skip
                     }
+                }
                 else if (Config.needHack(callingUid)) return Continue
                 return Skip
             }
@@ -69,7 +73,8 @@ object KeystoreInterceptor : BinderInterceptor() {
         resultCode: Int
     ): Result {
         if (target != keystore || code != getKeyEntryTransaction || reply == null) return Skip
-        if (kotlin.runCatching { reply.readException() }.exceptionOrNull() != null) return Skip
+        // Optimization: Replace runCatching with try-catch to avoid Result object allocation in hot path
+        try { reply.readException() } catch (e: Exception) { return Skip }
         val p = Parcel.obtain()
         Logger.d { "intercept post $target uid=$callingUid pid=$callingPid dataSz=${data.dataSize()} replySz=${reply.dataSize()}" }
         try {

--- a/service/src/main/java/cleveres/tricky/cleverestech/RkpInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/RkpInterceptor.kt
@@ -98,7 +98,8 @@ class RkpInterceptor(
 
     // returns fake hardware info that matches what Google expects
     private fun interceptGetHardwareInfo(): Result {
-        kotlin.runCatching {
+        // Optimization: Replace runCatching with try-catch to avoid Result object allocation in hot path
+        try {
             val override = RemoteKeyManager.getHardwareInfo()
             val info = override ?: RpcHardwareInfo().apply {
                 versionNumber = 3 // android 14+ uses version 3
@@ -112,7 +113,7 @@ class RkpInterceptor(
             p.writeNoException()
             p.writeTypedObject(info, 0)
             return OverrideReply(0, p)
-        }.onFailure {
+        } catch (it: Exception) {
             Logger.e("failed to intercept getHardwareInfo", it)
         }
         return Skip
@@ -120,7 +121,8 @@ class RkpInterceptor(
 
     // generates a new EC P-256 key pair and wraps it in COSE format
     private fun interceptKeyPairGeneration(uid: Int, data: Parcel): Result {
-        kotlin.runCatching {
+        // Optimization: Replace runCatching with try-catch to avoid Result object allocation in hot path
+        try {
             data.enforceInterface(IRemotelyProvisionedComponent.DESCRIPTOR)
             val testMode = data.readInt() != 0
             
@@ -162,7 +164,7 @@ class RkpInterceptor(
             p.writeByteArray(privateKeyHandle)
             
             return OverrideReply(0, p)
-        }.onFailure {
+        } catch (it: Exception) {
             Logger.e("failed to intercept key pair generation for uid=$uid", it)
         }
         return Skip
@@ -170,7 +172,8 @@ class RkpInterceptor(
 
     // handles both v1 and v2 cert request formats
     private fun interceptCertificateRequest(uid: Int, data: Parcel, isV2: Boolean): Result {
-        kotlin.runCatching {
+        // Optimization: Replace runCatching with try-catch to avoid Result object allocation in hot path
+        try {
             data.enforceInterface(IRemotelyProvisionedComponent.DESCRIPTOR)
             
             val keysToSign: Array<MacedPublicKey>?
@@ -207,7 +210,7 @@ class RkpInterceptor(
             }
             
             return OverrideReply(0, p)
-        }.onFailure {
+        } catch (it: Exception) {
             Logger.e("failed to intercept certificate request for uid=$uid", it)
         }
         return Skip

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -87,10 +87,11 @@ class SecurityLevelInterceptor(
     ): Result {
         if (code == createOperationTransaction && Config.needGenerate(callingUid)) {
             Logger.i("intercept createOperation uid=$callingUid pid=$callingPid")
-            kotlin.runCatching {
+            // Optimization: Replace runCatching with try-catch to avoid Result object allocation in hot path
+            try {
                 data.enforceInterface(IKeystoreSecurityLevel.DESCRIPTOR)
-                val keyDescriptor = data.readTypedObject(KeyDescriptor.CREATOR) ?: return@runCatching
-                val operationParameters = data.createTypedArray(KeyParameter.CREATOR) ?: return@runCatching
+                val keyDescriptor = data.readTypedObject(KeyDescriptor.CREATOR) ?: return Skip
+                val operationParameters = data.createTypedArray(KeyParameter.CREATOR) ?: return Skip
                 val forced = data.readBoolean()
 
                 // Track and enforce op limit
@@ -138,17 +139,18 @@ class SecurityLevelInterceptor(
                     // OR if it's a pure software mocked key, we might need to mock the response.
                     // Let's just track it and let the system handle it, or mock if we must.
                 }
-            }.onFailure {
+            } catch (it: Exception) {
                 Logger.e("parse createOperation request", it)
             }
         }
 
         if (code == generateKeyTransaction && Config.needGenerate(callingUid)) {
             Logger.i("intercept key gen uid=$callingUid pid=$callingPid")
-            kotlin.runCatching {
+            // Optimization: Replace runCatching with try-catch to avoid Result object allocation in hot path
+            try {
                 data.enforceInterface(IKeystoreSecurityLevel.DESCRIPTOR)
                 val keyDescriptor =
-                    data.readTypedObject(KeyDescriptor.CREATOR) ?: return@runCatching
+                    data.readTypedObject(KeyDescriptor.CREATOR) ?: return Skip
                 val attestationKeyDescriptor = data.readTypedObject(KeyDescriptor.CREATOR)
                 val params = data.createTypedArray(KeyParameter.CREATOR)!!
                 // val aFlags = data.readInt()
@@ -171,7 +173,7 @@ class SecurityLevelInterceptor(
                     }
                     val startNanos = System.nanoTime()
                     val pair = CertHack.generateKeyPair(callingUid, keyDescriptor, kgp, issuerKeyPair, issuerChain)
-                        ?: return@runCatching
+                        ?: return Skip
                     cleveres.tricky.cleverestech.util.TeeLatencySimulator.simulateGenerateKeyDelay(kgp.algorithm, System.nanoTime() - startNanos)
                     val response = buildResponse(pair.second, kgp, keyDescriptor, callingUid)
                     keys[Key(callingUid, keyDescriptor.alias)] = Info(pair.first, response)
@@ -180,7 +182,7 @@ class SecurityLevelInterceptor(
                     p.writeTypedObject(response.metadata, 0)
                     return OverrideReply(0, p)
                 }
-            }.onFailure {
+            } catch (it: Exception) {
                 Logger.e("parse key gen request", it)
             }
         }

--- a/service/src/main/java/cleveres/tricky/cleverestech/TelephonyInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/TelephonyInterceptor.kt
@@ -79,7 +79,10 @@ object TelephonyInterceptor : BinderInterceptor() {
         if (!Config.needHack(callingUid)) return Skip
 
         val pos = reply.dataPosition()
-        if (kotlin.runCatching { reply.readException() }.exceptionOrNull() != null) {
+        // Optimization: Replace runCatching with try-catch to avoid Result object allocation in hot path
+        try {
+            reply.readException()
+        } catch (e: Exception) {
             reply.setDataPosition(pos)
             return Skip
         }


### PR DESCRIPTION
*   💡 What: Replaced `kotlin.runCatching` with standard Java `try-catch` structures in hot paths like DrmInterceptor, KeystoreInterceptor, SecurityLevelInterceptor, TelephonyInterceptor, and RkpInterceptor. Added inline comments explaining the rationale. Removed disposable Python scripts.
*   🎯 Why: `kotlin.runCatching` creates unnecessary overhead in hot paths by allocating closures and `Result` objects. Standard try-catch minimizes object creation and reduces latency, while stopping application from silently swallowing catastrophic system errors.
*   📊 Impact: Eliminates closure and `Result` object allocations per Binder transaction, leading to less garbage collection pressure and marginally faster transaction handling.
*   🔬 Measurement: Can observe Binder transaction latency or memory allocation profiling in Android Studio during active service usage.

---
*PR created automatically by Jules for task [4927294150252082427](https://jules.google.com/task/4927294150252082427) started by @tryigit*