### PR TITLE
🎨 Palette: WebUI/UX Enhancement

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -1419,7 +1419,7 @@ class WebServer(
 
 
         .autocomplete-items { position: absolute; border: 1px solid var(--border); border-bottom: none; border-top: none; z-index: 99; top: 100%; left: 0; right: 0; max-height: 200px; overflow-y: auto; background-color: var(--panel); border-radius: 0 0 6px 6px; box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
-        .autocomplete-items div { padding: 10px; cursor: pointer; background-color: var(--panel); border-bottom: 1px solid var(--border); color: var(--fg); font-size: 0.9em; }
+        .autocomplete-items div { padding: 10px; cursor: pointer; background-color: var(--panel); border-bottom: 1px solid var(--border); color: var(--fg); font-size: 0.9em; min-height: 44px; display: flex; align-items: center; }
         .autocomplete-items div:hover { background-color: #333; }
         .autocomplete-active { background-color: var(--accent) !important; color: #000 !important; }
 


### PR DESCRIPTION
As part of the continuous UX enhancement initiative for the CleveresTricky WebUI, I've identified and fixed an issue where the autocomplete dropdown items were too small to tap reliably on mobile screens. 

### Changes
- Modified CSS for `.autocomplete-items div` in `WebServer.kt`.
- Added `min-height: 44px` to meet mobile touch target accessibility guidelines.
- Added `display: flex; align-items: center;` to ensure text remains perfectly centered within the expanded touch area.

This allows users managing the WebUI from their phones to more easily select packages when creating App Rules. The changes have been verified via Playwright UI checks and Android unit tests.

---
*PR created automatically by Jules for task [12256188667375706166](https://jules.google.com/task/12256188667375706166) started by @tryigit*