### PR TITLE
Fix WebUI missing /api/logs endpoint

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -1184,6 +1184,25 @@ class WebServer(
              }
         }
 
+
+        if (uri == "/api/logs" && method == Method.GET) {
+            return try {
+                val p = Runtime.getRuntime().exec(arrayOf("logcat", "-d", "-s", "cleverestricky:V"))
+                val logs = try {
+                    p.inputStream.bufferedReader().use { it.readText() }
+                } catch (e: Exception) {
+                    ""
+                } finally {
+                    try { p.errorStream.readBytes() } catch (_: Exception) {}
+                }
+                p.waitFor()
+                secureResponse(Response.Status.OK, "text/plain", logs.ifBlank { "No logs found." })
+            } catch (e: Exception) {
+                Logger.e("Failed to fetch logs", e)
+                secureResponse(Response.Status.INTERNAL_ERROR, "text/plain", "Failed to fetch logs")
+            }
+        }
+
         if (uri == "/api/stats" && method == Method.GET) {
             val count = fetchTelegramCount()
             val banned = fetchBannedCount()


### PR DESCRIPTION
This Pull Request fixes the "Failed to load logs" issue in the WebUI. 

The frontend WebUI attempts to fetch logs via `/api/logs`, but the endpoint handler was missing in `WebServer.kt`. This commit implements the `/api/logs` handler by securely invoking Android's `logcat` system for the `cleverestricky` tag, adhering strictly to Android native process integration guidelines, including properly reading and draining both the standard input and error streams. The module correctly does not generate an explicit local file in `/data/adb/cleverestricky`, but relies natively on `logcat`, resolving the user's report seamlessly inside the WebUI.

---
*PR created automatically by Jules for task [197120800861050821](https://jules.google.com/task/197120800861050821) started by @tryigit*