### PR TITLE
Fixing "inject" not found at abi folders

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/DrmInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/DrmInterceptor.kt
@@ -306,7 +306,7 @@ object DrmInterceptor : BinderInterceptor() {
                         val allowedAbis = setOf("arm64-v8a", "armeabi-v7a", "x86_64", "x86")
                         val abi = android.os.Build.SUPPORTED_ABIS.firstOrNull { it in allowedAbis } ?: "arm64-v8a"
                         val p = ProcessBuilder(
-                            "$modulePath/lib/$abi/inject",
+                            "$modulePath/inject",
                             pid.toString(),
                             "$modulePath/libcleverestricky.so",
                             "entry"

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -206,7 +206,7 @@ object KeystoreInterceptor : BinderInterceptor() {
                 Logger.i("found keystore2 at pid=$pid, injecting libcleverestricky.so ...")
                 val allowedAbis = setOf("arm64-v8a", "armeabi-v7a", "x86_64", "x86")
                 val abi = android.os.Build.SUPPORTED_ABIS.firstOrNull { it in allowedAbis } ?: "arm64-v8a"
-                val injectPath = "/data/adb/modules/cleverestricky/lib/$abi/inject"
+                val injectPath = "/data/adb/modules/cleverestricky/inject"
                 val p = ProcessBuilder(
                     injectPath,
                     pid.toString(),

--- a/service/src/main/java/cleveres/tricky/cleverestech/TelephonyInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/TelephonyInterceptor.kt
@@ -246,7 +246,7 @@ object TelephonyInterceptor : BinderInterceptor() {
                 val allowedAbis = setOf("arm64-v8a", "armeabi-v7a", "x86_64", "x86")
                 val abi = android.os.Build.SUPPORTED_ABIS.firstOrNull { it in allowedAbis } ?: "arm64-v8a"
                 val p = ProcessBuilder(
-                    "$modulePath/lib/$abi/inject",
+                    "$modulePath/inject",
                     pid.toString(),
                     "$modulePath/libcleverestricky.so",
                     "entry"


### PR DESCRIPTION
The service app keeps erroring out by trying to find the injector executable at /data/adb/modules/cleverestricky/lib/$abi/injector instead of the module's root directory, it now points to the module's root directory instead of trying to execute the injector at the lib/$abi/ folder.