### PR TITLE
🔥 God-Mode Evolution: Dynamic APEX Spoofing Migration

### DIFF
--- a/module/src/main/cpp/binder_interceptor.cpp
+++ b/module/src/main/cpp/binder_interceptor.cpp
@@ -1268,6 +1268,37 @@ status_t BinderInterceptor::onTransact(uint32_t code,
       }
       return BAD_VALUE;
   }
+  if (code == 0xbaad0001) {
+      LOGI("🔥 God-Mode Evolution: Triggering Rust APEX Spoofing via 0xbaad0001");
+      if (reply == nullptr) {
+          LOGE("Missing reply parcel for APEX spoofing transaction");
+          return BAD_VALUE;
+      }
+
+      std::string moduleName;
+      if (!readString16_manual(data, moduleName)) {
+          LOGE("Failed to read APEX module name");
+          return BAD_VALUE;
+      }
+
+      RustBuffer payload = rust_apex_spoof_get(reinterpret_cast<const uint8_t*>(moduleName.c_str()), moduleName.size());
+
+      if (payload.data && payload.len > 0) {
+          if (payload.len > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+              LOGE("Spoofed APEX version too large: %zu", payload.len);
+              rust_free_buffer(payload);
+              return BAD_VALUE;
+          }
+          status_t status = reply->writeNoException();
+          if (status == OK) {
+              std::string spoofedVersion(reinterpret_cast<const char*>(payload.data), payload.len);
+              writeString16_manual(*reply, spoofedVersion.c_str());
+          }
+          rust_free_buffer(payload);
+          return OK;
+      }
+      return BAD_VALUE;
+  }
   if (code == REGISTER_INTERCEPTOR) {
     sp<IBinder> target, interceptor;
     if (data.readStrongBinder(&target) != OK) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/binder/BinderInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/binder/BinderInterceptor.kt
@@ -48,6 +48,24 @@ open class BinderInterceptor : Binder() {
             }
         }
 
+
+        fun triggerApexSpoof(backdoor: IBinder, moduleName: String): String? {
+            val data = Parcel.obtain()
+            val reply = Parcel.obtain()
+            try {
+                data.writeString(moduleName)
+                backdoor.transact(0xbaad0001.toInt(), data, reply, 0)
+                reply.readException()
+                return reply.readString()
+            } catch (e: Exception) {
+                Logger.e("Failed to trigger APEX spoofing", e)
+                return null
+            } finally {
+                data.recycle()
+                reply.recycle()
+            }
+        }
+
         fun registerBinderInterceptor(backdoor: IBinder, target: IBinder, interceptor: BinderInterceptor, filteredCodes: IntArray = intArrayOf()) {
             val data = Parcel.obtain()
             val reply = Parcel.obtain()


### PR DESCRIPTION
This PR migrates the APEX version spoofing functionality to the highly optimized, memory-safe Rust core via the `rust_apex_spoof_get` FFI function. 

It introduces a new backdoor hook at `0xbaad0001` in the native C++ `binder_interceptor.cpp` that interacts with the Android `Parcel` layer to read an APEX module name, retrieve the spoofed version from the Rust cache, and safely write the response back into the Binder IPC stream.

A corresponding `triggerApexSpoof` Kotlin wrapper has been added to `BinderInterceptor.kt` to allow the daemon service to invoke the new exploit seamlessly without needing to manually deal with raw IPC byte buffers. All tests pass with no regressions.

---
*PR created automatically by Jules for task [11317644103290815156](https://jules.google.com/task/11317644103290815156) started by @tryigit*