### PR TITLE
Enable plain attestation forging in AUTO mode

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -44,9 +44,11 @@ object Config {
     @Volatile
     private var targetState = TargetState(PackageTrie(), PackageTrie())
     @Volatile
-    private var isGlobalMode = false
+    var isGlobalMode = false
+        private set
     @Volatile
-    private var isTeeBrokenMode = false
+    var isTeeBrokenMode = false
+        private set
     @Volatile
     private var isAutoTeeBroken = false
     private val isTeeBroken get() = isTeeBrokenMode || isAutoTeeBroken

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -37,9 +37,12 @@ object KeystoreInterceptor : BinderInterceptor() {
         if (code == getKeyEntryTransaction) {
             if (CertHack.canHack()) {
                 Logger.d { "intercept pre  $target uid=$callingUid pid=$callingPid dataSz=${data.dataSize()}" }
-                if (Config.needGenerate(callingUid)) {
+                val needGenerate = Config.needGenerate(callingUid)
+                val isAutoMode = !Config.isGlobalMode && !Config.isTeeBrokenMode
+                if (needGenerate || isAutoMode) {
                     // Optimization: Replace runCatching with try-catch to avoid Result object allocation in hot path
                     var p: Parcel? = null
+                    val startPos = data.dataPosition()
                     try {
                         data.enforceInterface(IKeystoreService.DESCRIPTOR)
                         val descriptor =
@@ -54,10 +57,11 @@ object KeystoreInterceptor : BinderInterceptor() {
                         return OverrideReply(0, p)
                     } catch (e: Exception) {
                         p?.recycle()
+                        data.setDataPosition(startPos)
                         // Ignore and fallback to Skip
                     }
                 }
-                else if (Config.needHack(callingUid)) return Continue
+                if (Config.needHack(callingUid)) return Continue
                 return Skip
             }
         }

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -144,20 +144,24 @@ class SecurityLevelInterceptor(
             }
         }
 
-        if (code == generateKeyTransaction && Config.needGenerate(callingUid)) {
-            Logger.i("intercept key gen uid=$callingUid pid=$callingPid")
+        if (code == generateKeyTransaction) {
             // Optimization: Replace runCatching with try-catch to avoid Result object allocation in hot path
             var p: Parcel? = null
             try {
+                val startPos = data.dataPosition()
                 data.enforceInterface(IKeystoreSecurityLevel.DESCRIPTOR)
                 val keyDescriptor =
                     data.readTypedObject(KeyDescriptor.CREATOR) ?: return Skip
                 val attestationKeyDescriptor = data.readTypedObject(KeyDescriptor.CREATOR)
                 val params = data.createTypedArray(KeyParameter.CREATOR) ?: return Skip
-                // val aFlags = data.readInt()
-                // val entropy = data.createByteArray()
                 val kgp = KeyGenParameters(params)
-                if (kgp.attestationChallenge != null) {
+
+                val needGenerate = Config.needGenerate(callingUid)
+                val isAutoMode = !Config.isGlobalMode && !Config.isTeeBrokenMode
+
+                if (needGenerate || (isAutoMode && kgp.attestationChallenge != null)) {
+                    Logger.i("intercept key gen uid=$callingUid pid=$callingPid")
+                    if (kgp.attestationChallenge != null) {
                     var issuerKeyPair: KeyPair? = null
                     var issuerChain: List<Certificate>? = null
 
@@ -182,7 +186,9 @@ class SecurityLevelInterceptor(
                     p.writeNoException()
                     p.writeTypedObject(response.metadata, 0)
                     return OverrideReply(0, p)
+                    }
                 }
+                data.setDataPosition(startPos)
             } catch (it: Exception) {
                 p?.recycle()
                 Logger.e("parse key gen request", it)

--- a/service/src/main/java/cleveres/tricky/cleverestech/binder/BinderInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/binder/BinderInterceptor.kt
@@ -148,11 +148,11 @@ open class BinderInterceptor : Binder() {
                     localResult
                 } finally {
                     // Only recycle if they are not being passed down in an Override result
-                    if (localResult !is OverrideData || (localResult as OverrideData).data !== theData) {
+                    if (localResult !is OverrideData || localResult.data !== theData) {
                         theData.recycle()
                     }
                     if (theReply != null) {
-                        if (localResult !is OverrideReply || (localResult as OverrideReply).reply !== theReply) {
+                        if (localResult !is OverrideReply || localResult.reply !== theReply) {
                             theReply.recycle()
                         }
                     }


### PR DESCRIPTION
- Updated `Config.kt` to expose `isGlobalMode` and `isTeeBrokenMode` so that other classes can check if AUTO mode is active (`!Config.isGlobalMode && !Config.isTeeBrokenMode`).
- Modified `SecurityLevelInterceptor.kt` to intercept key generation requests when `Config.needGenerate` is true, OR when AUTO mode is active and an attestation challenge is present. This correctly creates a synthetic chain rooted under the Google root key.
- Modified `KeystoreInterceptor.kt` similarly to allow intercepting `getKeyEntryTransaction`.
- Modified `BinderInterceptor.kt` to fix unnecessary casting and warnings.
- Added data position reset `data.setDataPosition(startPos)` in `catch` blocks to safely revert when exceptions occur during speculative Parcel reading.

---
*PR created automatically by Jules for task [2983883863765446208](https://jules.google.com/task/2983883863765446208) started by @tryigit*