### PR TITLE
🔧 Bugfix: Fix IPv6 loopback validation breaking WebUI in AOSP

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -3320,9 +3320,16 @@ class WebServer(
         }
         fun isSafeHost(host: String?): Boolean {
             if (host == null) return false
-            val colonIdx = host.indexOf(':')
-            val h = (if (colonIdx != -1) host.substring(0, colonIdx) else host).lowercase()
-            return h == "localhost" || h == "127.0.0.1" || h == "[::1]"
+            var h = host
+            if (h.startsWith("[")) {
+                val end = h.indexOf(']')
+                if (end != -1) h = h.substring(1, end)
+            } else {
+                val colonIdx = h.indexOf(':')
+                if (colonIdx != -1) h = h.substring(0, colonIdx)
+            }
+            h = h.lowercase()
+            return h == "localhost" || h == "127.0.0.1" || h == "::1" || h == "0:0:0:0:0:0:0:1"
         }
 
         fun isSafePath(configDir: File, file: File): Boolean {


### PR DESCRIPTION
Fixes an issue where `[::1]:PORT` was incorrectly truncated to `[` in `isSafeHost`, causing 403 Forbidden on IPv6 loopback clients and breaking the WebUI on AOSP ROMs.

Corrected the parsing logic to check for bracketed IPv6 strings and safely strip the port.

---
*PR created automatically by Jules for task [10089855819965480582](https://jules.google.com/task/10089855819965480582) started by @tryigit*