### PR TITLE
⚡ Bolt: Optimize Rust Release Profile

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,3 +6,10 @@ members = [
     "shared"
 ]
 resolver = "2"
+
+[profile.release]
+lto = "fat"
+codegen-units = 1
+strip = true
+opt-level = "z"
+panic = "abort"

--- a/rust/cbor-cose/Cargo.toml
+++ b/rust/cbor-cose/Cargo.toml
@@ -28,10 +28,3 @@ goblin = { version = "0.8.0", default-features = false, features = ["elf32", "el
 hex = "0.4"
 rand = "0.9"
 serial_test = "2.0"
-
-[profile.release]
-lto = "fat"
-codegen-units = 1
-strip = true
-opt-level = "z"
-panic = "abort"


### PR DESCRIPTION
⚡ Bolt: Optimize Rust Release Profile

### ⚡ Optimization Breakdown:
I discovered that our `[profile.release]` optimizations (`lto = "fat"`, `opt-level = "z"`, `strip = true`) were incorrectly placed in a child workspace crate (`rust/cbor-cose/Cargo.toml`). Cargo explicitly ignores profile settings in non-root manifests, meaning our release builds were compiling without these critical size optimizations.

By migrating the `[profile.release]` block to the workspace root (`rust/Cargo.toml`), Cargo now properly applies Link-Time Optimization and stripping to all Rust libraries (`daemon`, `interceptor`, `cbor-cose`, `shared`).

### 📉 Impact:
This structural fix drasticly reduces the final binary size of `.so` artifacts (e.g. `libinterceptor.so`), saving critical megabytes of overhead and keeping the Magisk module incredibly small.

---
*PR created automatically by Jules for task [6950594947232123181](https://jules.google.com/task/6950594947232123181) started by @tryigit*