### PR TITLE
🔧 Bugfix: Fix Rust FFI panic boundaries and resolve Clippy warnings

### DIFF
--- a/rust/daemon/src/main.rs
+++ b/rust/daemon/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
 
     // Set process name
     unsafe {
-        libc::prctl(libc::PR_SET_NAME, b"kworker/u0:0-events\0".as_ptr() as *const libc::c_char);
+        libc::prctl(libc::PR_SET_NAME, c"kworker/u0:0-events".as_ptr() as *const libc::c_char);
     }
 
     // Start Netlink Process Connector monitoring
@@ -31,8 +31,8 @@ fn main() {
 fn check_debugger() -> bool {
     let status = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
     for line in status.lines() {
-        if line.starts_with("TracerPid:") {
-            if let Ok(pid) = line["TracerPid:".len()..].trim().parse::<i32>() {
+        if let Some(stripped) = line.strip_prefix("TracerPid:") {
+            if let Ok(pid) = stripped.trim().parse::<i32>() {
                 if pid != 0 {
                     return true;
                 }

--- a/rust/interceptor/src/lib.rs
+++ b/rust/interceptor/src/lib.rs
@@ -9,10 +9,13 @@ pub mod parcel_parser;
 
 #[no_mangle]
 pub extern "system" fn JNI_OnLoad(_vm: jni::JavaVM, _reserved: *mut std::ffi::c_void) -> jni::sys::jint {
-    init_logger("CleveresTrickyInterceptor");
-    info!("CleveresTricky Rust Interceptor loaded!");
-    binder_hook::init_frida_hooks();
-    jni::sys::JNI_VERSION_1_6
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        init_logger("CleveresTrickyInterceptor");
+        info!("CleveresTricky Rust Interceptor loaded!");
+        binder_hook::init_frida_hooks();
+        jni::sys::JNI_VERSION_1_6
+    }));
+    result.unwrap_or(jni::sys::JNI_ERR)
 }
 
 // ----------------------------------------------------------------------------
@@ -24,46 +27,49 @@ pub extern "system" fn Java_cleveres_tricky_cleverestech_RkpInterceptor_createPr
     env: JNIEnv<'local>,
     _class: JClass<'local>,
 ) -> jbyteArray {
-    info!("Executing RKP Spoofing entirely in Native Rust!");
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        info!("Executing RKP Spoofing entirely in Native Rust!");
 
-    // Fake ECC coordinates (32 bytes) and HMAC key
-    let x = vec![0x01; 32];
-    let y = vec![0x02; 32];
-    let hmac_key = vec![0xAA; 32];
+        // Fake ECC coordinates (32 bytes) and HMAC key
+        let x = vec![0x01; 32];
+        let y = vec![0x02; 32];
+        let hmac_key = vec![0xAA; 32];
 
-    // Generate COSE_Mac0 structure using our memory-safe Rust library
-    let maced_key = match cleverestricky_cbor_cose::cose::generate_maced_public_key(&x, &y, &hmac_key) {
-        Ok(k) => k,
-        Err(e) => {
-            error!("Failed to generate MACed public key: {}", e);
-            return std::ptr::null_mut();
+        // Generate COSE_Mac0 structure using our memory-safe Rust library
+        let maced_key = match cleverestricky_cbor_cose::cose::generate_maced_public_key(&x, &y, &hmac_key) {
+            Ok(k) => k,
+            Err(e) => {
+                error!("Failed to generate MACed public key: {}", e);
+                return std::ptr::null_mut();
+            }
+        };
+
+        // Build the attestation DeviceInfo
+        let device_info = cleverestricky_cbor_cose::cose::create_device_info_cbor(
+            Some(std::borrow::Cow::Borrowed("google")),
+            Some(std::borrow::Cow::Borrowed("Google")),
+            Some(std::borrow::Cow::Borrowed("husky")),
+            Some(std::borrow::Cow::Borrowed("Pixel 8 Pro")),
+            Some(std::borrow::Cow::Borrowed("husky")),
+        );
+
+        // Mock challenge
+        let challenge = b"cleveres_tricky_rkp_bypass";
+
+        // Create the final certificate request response
+        let cbor_payload = cleverestricky_cbor_cose::cose::create_certificate_request_response(
+            &[maced_key],
+            challenge,
+            &device_info,
+        );
+
+        match env.byte_array_from_slice(&cbor_payload) {
+            Ok(arr) => **arr,
+            Err(e) => {
+                error!("Failed to create JNI byte array: {:?}", e);
+                std::ptr::null_mut()
+            }
         }
-    };
-
-    // Build the attestation DeviceInfo
-    let device_info = cleverestricky_cbor_cose::cose::create_device_info_cbor(
-        Some(std::borrow::Cow::Borrowed("google")),
-        Some(std::borrow::Cow::Borrowed("Google")),
-        Some(std::borrow::Cow::Borrowed("husky")),
-        Some(std::borrow::Cow::Borrowed("Pixel 8 Pro")),
-        Some(std::borrow::Cow::Borrowed("husky")),
-    );
-
-    // Mock challenge
-    let challenge = b"cleveres_tricky_rkp_bypass";
-
-    // Create the final certificate request response
-    let cbor_payload = cleverestricky_cbor_cose::cose::create_certificate_request_response(
-        &[maced_key],
-        challenge,
-        &device_info,
-    );
-    
-    match env.byte_array_from_slice(&cbor_payload) {
-        Ok(arr) => **arr,
-        Err(e) => {
-            error!("Failed to create JNI byte array: {:?}", e);
-            std::ptr::null_mut()
-        }
-    }
+    }));
+    result.unwrap_or(std::ptr::null_mut())
 }

--- a/rust/shared/src/hardware_sim.rs
+++ b/rust/shared/src/hardware_sim.rs
@@ -7,6 +7,12 @@ pub struct TeeLatencySimulator {
     dist: LogNormal<f64>,
 }
 
+impl Default for TeeLatencySimulator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TeeLatencySimulator {
     pub fn new() -> Self {
         // Log-normal distribution parameters matching realistic TEE/StrongBox latency


### PR DESCRIPTION
Resolves bugs with JNI bindings propagating panics as well as various clippy warnings throughout the codebase.

---
*PR created automatically by Jules for task [2990416679672821701](https://jules.google.com/task/2990416679672821701) started by @tryigit*