### PR TITLE
🔧 Bugfix: fix inject binary packaging issue in gradle script

### DIFF
--- a/module/build.gradle.kts
+++ b/module/build.gradle.kts
@@ -153,11 +153,11 @@ tasks.register<Exec>("cargoBuild") {
                 into(layout.buildDirectory.dir("rust_outputs/lib/$androidAbi"))
                 rename { "libcleverestricky.so" }
             }
-
             // Copy daemon executable
             copy {
                 from("$baseTarget/$rustAbi/release/daemon")
-                into(layout.buildDirectory.dir("rust_outputs/lib/$androidAbi/inject"))
+                into(layout.buildDirectory.dir("rust_outputs/lib/$androidAbi"))
+                rename { "inject" }
             }
         }
     }


### PR DESCRIPTION
The `cargoBuild` task in `module/build.gradle.kts` was incorrectly copying the compiled `daemon` binary into a directory named `inject` (resulting in `lib/<abi>/inject/daemon`) instead of renaming the file to `inject` directly inside the ABI folder. 

This commit updates the gradle `copy` block to target the ABI directory via `into()` and uses `rename { "inject" }` to ensure the binary is correctly placed and named in the resulting zip, resolving installation failures complaining about missing `inject` executable.

---
*PR created automatically by Jules for task [9650432353158682687](https://jules.google.com/task/9650432353158682687) started by @tryigit*