### PR TITLE
Fix Frida devkit armhf download issue in CI

### DIFF
--- a/module/build.gradle.kts
+++ b/module/build.gradle.kts
@@ -119,6 +119,18 @@ tasks.register<Exec>("cargoBuild") {
     // Treat Rust warnings as errors
     environment("RUSTFLAGS", "-D warnings")
 
+    doFirst {
+        if (!isWindowsHost) {
+            Runtime.getRuntime().exec(
+                arrayOf(
+                    "sh",
+                    "-c",
+                    "find ~/.cargo/registry/src/ -name lib.rs | grep frida-build | xargs sed -i 's/armhf/arm/g' || true",
+                ),
+            ).waitFor()
+        }
+    }
+
     // Using cargo-ndk to build the interceptor lib for all supported ABIs.
     commandLine(
         "cargo",


### PR DESCRIPTION
This PR fixes an issue where the rust build would fail in CI for `frida-gum-sys`. 

The `frida-build` dependency (version 0.17.2) incorrectly hardcodes the target as `armhf` for the android ARM target, which results in a 404 response on Frida's GitHub releases page as the file is actually named `arm`. 

To patch this in the CI environment where Cargo downloads its dependencies locally, this adds a `doFirst` block to `cargoBuild` that executes `sed` to patch the downloaded `frida-build` crate locally right before the Cargo compilation runs.

---
*PR created automatically by Jules for task [17011234439402845666](https://jules.google.com/task/17011234439402845666) started by @tryigit*