### PR TITLE
🔧 Bugfix: Fix invalid double dereference in JNI array FFI boundary

### DIFF
--- a/rust/interceptor/src/lib.rs
+++ b/rust/interceptor/src/lib.rs
@@ -69,7 +69,7 @@ pub extern "system" fn Java_cleveres_tricky_cleverestech_RkpInterceptor_createPr
                     );
 
                 match env.byte_array_from_slice(&cbor_payload) {
-                    Ok(arr) => Ok(**arr),
+                    Ok(arr) => Ok(arr.into_raw()),
                     Err(e) => {
                         error!("Failed to create JNI byte array: {:?}", e);
                         Ok(std::ptr::null_mut())


### PR DESCRIPTION
Fixes a compilation issue / potential use-after-free at the JNI/Rust boundary when extracting a `jbyteArray`. Modern `jni` crate releases require `into_raw()` to consume the local reference.

---
*PR created automatically by Jules for task [15414070221497929700](https://jules.google.com/task/15414070221497929700) started by @tryigit*