### PR TITLE
🔧 Bugfix: Resolve Rust crypto trait dependency conflict

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -116,15 +116,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +214,7 @@ name = "cleverestricky-cbor-cose"
 version = "0.1.1"
 dependencies = [
  "coset",
+ "digest",
  "goblin",
  "hex",
  "hmac",
@@ -230,10 +222,10 @@ dependencies = [
  "minreq",
  "p256",
  "rand 0.10.2",
- "rand_core 0.9.5",
+ "rand_core 0.6.4",
  "rustc-hash",
  "serial_test",
- "sha2 0.11.0",
+ "sha2",
 ]
 
 [[package]]
@@ -260,12 +252,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "coset"
@@ -324,15 +310,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "cstr_core"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,7 +342,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -376,21 +353,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "const-oid 0.9.6",
- "crypto-common 0.1.6",
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.1",
- "const-oid 0.10.2",
- "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -417,7 +383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -438,7 +404,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
@@ -710,7 +676,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -751,15 +717,6 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "hyper"
@@ -1225,7 +1182,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -1831,18 +1788,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -1852,7 +1798,7 @@ dependencies = [
  "android_logger",
  "libc",
  "log",
- "rand 0.10.2",
+ "rand 0.8.6",
  "rand_distr",
 ]
 
@@ -1884,7 +1830,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "rand_core 0.6.4",
 ]
 

--- a/rust/cbor-cose/Cargo.toml
+++ b/rust/cbor-cose/Cargo.toml
@@ -15,11 +15,12 @@ fingerprint = ["dep:minreq"]
 
 [dependencies]
 hmac = "0.12"
-sha2 = "0.11"
+digest = "0.10"
+sha2 = "0.10"
 minreq = { version = "3.0", features = ["https-rustls"], optional = true }
 coset = "0.4"
 p256 = { version = "0.13", features = ["arithmetic", "ecdsa", "std"] }
-rand_core = { version = "0.9", features = ["std"] }
+rand_core = { version = "0.6.4", features = ["std"] }
 libc = "0.2"
 rustc-hash = "2.1.2"
 goblin = { version = "0.10.7", default-features = false, features = ["elf32", "elf64", "endian_fd"] }

--- a/rust/shared/Cargo.toml
+++ b/rust/shared/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 [dependencies]
 libc = "0.2"
 log = "0.4"
-rand = "0.10"
+rand = "0.8"
 rand_distr = "0.4"
 android_logger = "0.15"


### PR DESCRIPTION
Downgraded `sha2` to `0.10` and `rand` to `0.8`, and explicitly pinned `rand_core` to `0.6.4` and `digest` to `0.10` in Cargo.toml files.
This aligns the underlying trait versions expected by `hmac 0.12` and `p256 0.13`, resolving compilation errors (like `unresolved import rand_core::OsRng` and `Trait not implemented for Sha256`) that previously broke `cargo build` and `gradlew build`.

---
*PR created automatically by Jules for task [6446472612541119389](https://jules.google.com/task/6446472612541119389) started by @tryigit*