### PR TITLE
Fix runtime lifecycle and compatibility edge cases

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,6 @@ fun execute(
 val gitCommitCount = execute("git", "rev-list", "HEAD", "--count").toInt()
 val gitCommitHash = execute("git", "rev-parse", "--verify", "--short", "HEAD")
 
-// also the soname
 val moduleId by extra("cleverestricky")
 val moduleName by extra("CleveresTricky")
 val author by extra("tryigitx")
@@ -62,7 +61,7 @@ fun Project.configureBaseExtension() {
 
         defaultConfig {
             minSdk = androidMinSdkVersion
-            targetSdk = androidCompileSdkVersion
+            targetSdk = androidTargetSdkVersion
             versionCode = verCode
             versionName = verName
         }

--- a/module/template/service.sh
+++ b/module/template/service.sh
@@ -1,7 +1,4 @@
 #!/system/bin/sh
-# shellcheck disable=SC2034
-DEBUG=@DEBUG@
-
 MODDIR=${0%/*}
 
 (
@@ -9,7 +6,20 @@ retry_delay=2
 max_retry_delay=60
 stable_runtime=120
 
+module_stopping() {
+  [ -e "$MODDIR/disable" ] || [ -e "$MODDIR/remove" ]
+}
+
 while true; do
+  if module_stopping; then
+    log -t CleveresTricky "Module disabled or pending removal; daemon supervisor stopped"
+    break
+  fi
+  if [ ! -x "$MODDIR/daemon" ]; then
+    log -t CleveresTricky "Daemon executable is unavailable; daemon supervisor stopped"
+    break
+  fi
+
   chcon u:object_r:system_file:s0 "$MODDIR/daemon" 2>/dev/null
   chcon u:object_r:system_file:s0 "$MODDIR/inject" 2>/dev/null
   find "$MODDIR" -maxdepth 1 -type f \( -name '*.apk' -o -name '*.so' \) \
@@ -23,6 +33,11 @@ while true; do
 
   if [ "$runtime" -ge "$stable_runtime" ]; then
     retry_delay=2
+  fi
+
+  if module_stopping; then
+    log -t CleveresTricky "Module disabled or pending removal after daemon exit; supervisor stopped"
+    break
   fi
 
   log -t CleveresTricky \

--- a/rust/native-core/src/injector_support.rs
+++ b/rust/native-core/src/injector_support.rs
@@ -87,7 +87,7 @@ pub fn extract_scm_rights_fd(input: &[u8]) -> Option<i32> {
 
         let step = align_cmsg(header.length)?;
         if step == 0 || step > input.len().saturating_sub(offset) {
-            break;
+            return None;
         }
         offset += step;
     }
@@ -356,6 +356,36 @@ mod tests {
                 .cast::<CmsgHeader>()
                 .write_unaligned(header)
         };
+        assert_eq!(extract_scm_rights_fd(&input), None);
+    }
+
+    #[test]
+    fn rejects_truncated_control_message_padding_after_rights() {
+        let data_offset = align_cmsg(mem::size_of::<CmsgHeader>()).unwrap();
+        let mut input = Vec::new();
+        append_cmsg(
+            &mut input,
+            CmsgHeader {
+                length: data_offset + mem::size_of::<i32>(),
+                level: SOL_SOCKET,
+                kind: SCM_RIGHTS,
+            },
+            &41i32.to_ne_bytes(),
+        );
+        let start = input.len();
+        let header = CmsgHeader {
+            length: mem::size_of::<CmsgHeader>() + 1,
+            level: SOL_SOCKET,
+            kind: 2,
+        };
+        input.resize(start + header.length, 0);
+        unsafe {
+            input
+                .as_mut_ptr()
+                .add(start)
+                .cast::<CmsgHeader>()
+                .write_unaligned(header);
+        }
         assert_eq!(extract_scm_rights_fd(&input), None);
     }
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/CboxManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CboxManager.kt
@@ -103,6 +103,7 @@ object CboxManager {
         if (!isSafeCbox(file)) return false
 
         var sourceDigest: ByteArray? = null
+        var verificationDigest: ByteArray? = null
         return try {
             val digest = MessageDigest.getInstance("SHA-256")
             val payload =
@@ -132,9 +133,23 @@ object CboxManager {
                 return false
             }
 
+            val beforeModified = file.lastModified()
+            val beforeSize = file.length()
+            verificationDigest = digestFile(file)
+            val afterModified = file.lastModified()
+            val afterSize = file.length()
+            if (
+                beforeModified != afterModified ||
+                beforeSize != afterSize ||
+                !MessageDigest.isEqual(sourceDigest, verificationDigest)
+            ) {
+                Logger.e("CBOX source changed while it was being unlocked: $filename")
+                return false
+            }
+
             writeCache(file, payload.xmlContent, sourceDigest)
             unlockedCache[filename] =
-                UnlockedEntry(file.lastModified(), file.length(), verified.toList())
+                UnlockedEntry(afterModified, afterSize, verified.toList())
             lockedFiles.remove(filename)
             true
         } catch (e: Exception) {
@@ -142,6 +157,7 @@ object CboxManager {
             false
         } finally {
             sourceDigest?.fill(0)
+            verificationDigest?.fill(0)
         }
     }
 
@@ -229,8 +245,9 @@ object CboxManager {
                 .toByteArray(StandardCharsets.UTF_8)
         var encrypted: ByteArray? = null
         try {
-            encrypted = DeviceKeyManager.encrypt(plaintext)
-                ?: throw IllegalStateException("Device cache encryption is unavailable")
+            encrypted =
+                DeviceKeyManager.encrypt(plaintext)
+                    ?: throw IllegalStateException("Device cache encryption is unavailable")
             SecureFile.writeBytes(cacheFileFor(file), encrypted)
         } finally {
             plaintext.fill(0)

--- a/service/src/main/java/cleveres/tricky/cleverestech/FilePoller.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/FilePoller.kt
@@ -44,11 +44,8 @@ class FilePoller(
         if (isRunning) return
         isRunning = true
         lastSnapshot = snapshot()
-
-        val observerStarted = startObserver()
-        if (!observerStarted) {
-            scheduleFallbackPolling()
-        }
+        startObserver()
+        scheduleFallbackPolling()
     }
 
     private fun startObserver(): Boolean {
@@ -71,14 +68,19 @@ class FilePoller(
                         event: Int,
                         path: String?,
                     ) {
-                        if (path == file.name) checkForChange()
+                        if (path != file.name) return
+                        try {
+                            checkForChange()
+                        } catch (error: Throwable) {
+                            Logger.e("FilePoller: Observer check failed for ${file.name}", error)
+                        }
                     }
                 }
             fileObserver.startWatching()
             observer = fileObserver
             true
         } catch (error: Throwable) {
-            Logger.e("FilePoller: Could not start FileObserver for ${file.name}; enabling fallback polling", error)
+            Logger.e("FilePoller: Could not start FileObserver for ${file.name}; periodic polling remains active", error)
             false
         }
     }
@@ -90,7 +92,7 @@ class FilePoller(
                     try {
                         checkForChange()
                     } catch (error: Throwable) {
-                        Logger.e("FilePoller: Fallback check failed for ${file.name}", error)
+                        Logger.e("FilePoller: Periodic check failed for ${file.name}", error)
                     }
                 },
                 intervalMs,

--- a/service/src/main/java/cleveres/tricky/cleverestech/FilePoller.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/FilePoller.kt
@@ -106,8 +106,8 @@ class FilePoller(
         if (!isRunning) return
         val current = snapshot()
         if (current == lastSnapshot) return
-        lastSnapshot = current
         onModified(file)
+        lastSnapshot = current
     }
 
     @Synchronized

--- a/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
@@ -12,7 +12,13 @@ private const val CONFIG_DIR_MODE = 448
 
 fun main(args: Array<String>) {
     Logger.i("Welcome to Service!")
-    val isTampered = !Verification.check()
+    val isTampered =
+        try {
+            !Verification.check()
+        } catch (error: Exception) {
+            Logger.e("Module verification failed unexpectedly", error)
+            true
+        }
     if (isTampered) {
         Logger.e("TAMPER DETECTED: Disabling all interceptors and running in safe mode.")
     }
@@ -64,8 +70,8 @@ fun main(args: Array<String>) {
             BootLogic.run()
         } catch (e: Exception) {
             Logger.e("Failed to initialize Config/BootLogic", e)
-            Logger.e("Main: Interceptors remain disabled because initialization did not complete")
-            while (true) delay(60_000)
+            Logger.e("Main: Exiting so the module supervisor can retry initialization")
+            return@runBlocking
         }
 
         KeyboxAutoCleaner.start()

--- a/service/src/main/java/cleveres/tricky/cleverestech/Verification.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Verification.kt
@@ -9,8 +9,17 @@ object Verification {
     private val MODULE_PATH = getModuleDir()
     private val IGNORED_FILES = setOf("disable", "remove", "update", "system.prop", "tampered", "web_port")
 
-    @OptIn(ExperimentalStdlibApi::class)
     fun check(root: File = File(MODULE_PATH)): Boolean {
+        return try {
+            checkInternal(root)
+        } catch (error: Exception) {
+            Logger.e("Module verification failed with an I/O or parsing error", error)
+            false
+        }
+    }
+
+    @OptIn(ExperimentalStdlibApi::class)
+    private fun checkInternal(root: File): Boolean {
         if (!Files.isDirectory(root.toPath(), LinkOption.NOFOLLOW_LINKS)) {
             Logger.e("Module directory not found: ${root.absolutePath}")
             return false
@@ -53,9 +62,7 @@ object Verification {
         var isTampered = false
 
         allFiles.forEach { file ->
-            // Skip checksum files themselves
             if (file.name.endsWith(".sha256")) return@forEach
-            // Skip ignored files
             if (file.parentFile?.absolutePath == root.absolutePath && IGNORED_FILES.contains(file.name)) return@forEach
 
             if (file.length() !in 0..MAX_MODULE_FILE_BYTES) {
@@ -75,7 +82,6 @@ object Verification {
             if (!expected.equals(actual, ignoreCase = true)) {
                 Logger.e("Verification failed: Checksum mismatch for file: ${file.path}. Expected $expected, got $actual")
                 isTampered = true
-                return@forEach
             }
         }
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/DeviceKeyManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/DeviceKeyManager.kt
@@ -21,7 +21,6 @@ object DeviceKeyManager {
     private const val AES_MODE = "AES/GCM/NoPadding"
     private const val TAG = "DeviceKeyManager"
 
-    // Fallback if AndroidKeyStore is unavailable (e.g. some root environments)
     @Volatile
     private var fallbackKey: SecretKey? = null
 
@@ -46,26 +45,34 @@ object DeviceKeyManager {
             throw IOException("Fallback key path is not a regular file")
         }
         try {
-            val ks = KeyStore.getInstance(ANDROID_KEYSTORE)
-            ks.load(null)
-            if (!ks.containsAlias(KEY_ALIAS)) {
-                val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE)
-                keyGenerator.init(
-                    KeyGenParameterSpec.Builder(KEY_ALIAS, KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT)
-                        .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-                        .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-                        .setKeySize(256)
-                        .build(),
-                )
-                keyGenerator.generateKey()
-            }
-            require(ks.getEntry(KEY_ALIAS, null) is KeyStore.SecretKeyEntry) {
-                "AndroidKeyStore did not return the generated AES key"
-            }
-        } catch (e: Throwable) {
-            Logger.e("$TAG: AndroidKeyStore failed, using fallback file key: ${e.message}")
+            initializeAndroidKeyStore()
+        } catch (error: Exception) {
+            Logger.e("$TAG: AndroidKeyStore failed, using fallback file key: ${error.message}")
             useFallback = true
             loadFallbackKey(rootDir)
+        } catch (error: LinkageError) {
+            Logger.e("$TAG: AndroidKeyStore API unavailable, using fallback file key: ${error.message}")
+            useFallback = true
+            loadFallbackKey(rootDir)
+        }
+    }
+
+    private fun initializeAndroidKeyStore() {
+        val ks = KeyStore.getInstance(ANDROID_KEYSTORE)
+        ks.load(null)
+        if (!ks.containsAlias(KEY_ALIAS)) {
+            val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE)
+            keyGenerator.init(
+                KeyGenParameterSpec.Builder(KEY_ALIAS, KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT)
+                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                    .setKeySize(256)
+                    .build(),
+            )
+            keyGenerator.generateKey()
+        }
+        require(ks.getEntry(KEY_ALIAS, null) is KeyStore.SecretKeyEntry) {
+            "AndroidKeyStore did not return the generated AES key"
         }
     }
 
@@ -125,7 +132,6 @@ object DeviceKeyManager {
                 val encrypted = cipher.doFinal(data)
                 ciphertext = encrypted
 
-                // Format: [1 byte IV len] [IV] [ciphertext + GCM tag]
                 val result = ByteArray(1 + iv.size + encrypted.size)
                 result[0] = iv.size.toByte()
                 System.arraycopy(iv, 0, result, 1, iv.size)

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxAutoCleaner.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxAutoCleaner.kt
@@ -32,6 +32,7 @@ object KeyboxAutoCleaner {
     private val keyboxDir = File(configDir, "keyboxes")
     private val revokedDir = File(keyboxDir, "revoked")
     private val toggleFile = File(configDir, "auto_keybox_check")
+    private val spoofEnabledFile = File(configDir, "spoof_enabled")
     private val webPortFile = File(configDir, "web_port")
 
     fun start() {
@@ -71,16 +72,24 @@ object KeyboxAutoCleaner {
         }
     }
 
+    private fun isEnabledNow(): Boolean =
+        Config.isSpoofEnabled && isRegularFile(spoofEnabledFile) && isRegularFile(toggleFile)
+
     private fun runCheck() {
-        if (!isRegularFile(toggleFile)) return
+        if (!isEnabledNow()) return
 
         Logger.i("AutoCleaner: Starting daily revocation check...")
         val results = KeyboxVerifier.verify(configDir)
         var revokedCount = 0
+        var cancelled = false
 
         SecureFile.mkdirs(revokedDir, 448)
 
         for (res in results) {
+            if (!isEnabledNow()) {
+                cancelled = true
+                break
+            }
             if (res.status == KeyboxVerifier.Status.REVOKED || res.status == KeyboxVerifier.Status.INVALID) {
                 Logger.i("AutoCleaner: Keybox ${res.filename} is ${res.status}. Moving to revoked.")
                 val file = res.file
@@ -110,15 +119,18 @@ object KeyboxAutoCleaner {
             }
         }
 
-        cleveres.tricky.cleverestech.Config.updateKeyBoxesSync()
-        if (revokedCount > 0) notifyUser(revokedCount)
-        Logger.i("AutoCleaner: Finished check. Revoked/Invalid files moved: $revokedCount")
+        Config.updateKeyBoxesSync()
+        if (!cancelled && revokedCount > 0) notifyUser(revokedCount)
+        if (cancelled) {
+            Logger.i("AutoCleaner: Check stopped because automatic cleanup was disabled")
+        } else {
+            Logger.i("AutoCleaner: Finished check. Revoked/Invalid files moved: $revokedCount")
+        }
     }
 
     private fun notifyUser(count: Int) {
         try {
             val url = readWebUiUrl() ?: return
-            // Post a high-priority, actionable notification
             val cmd =
                 arrayOf(
                     "cmd",
@@ -155,12 +167,6 @@ object KeyboxAutoCleaner {
         }
     }
 
-    /**
-     * Reads the `web_port` metadata file (`port|token`) and returns the tokenized WebUI URL.
-     *
-     * Returns null if the file is missing or malformed so a notification never
-     * exposes a guessed or unauthenticated endpoint.
-     */
     private fun readWebUiUrl(): String? {
         return try {
             if (!isRegularFile(webPortFile) || webPortFile.length() !in 1..256) return null

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/SecureFile.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/SecureFile.kt
@@ -262,10 +262,14 @@ object SecureFile {
             try {
                 Os.chmod(file.absolutePath, mode)
                 return
-            } catch (_: Exception) {
-                // Android host-side unit tests do not provide a working Os stub.
-            } catch (_: LinkageError) {
-                // Fall back to java.io permission APIs on non-Android runtimes.
+            } catch (error: Exception) {
+                if (isAndroidRuntime()) {
+                    throw IOException("Could not set mode on $file", error)
+                }
+            } catch (error: LinkageError) {
+                if (isAndroidRuntime()) {
+                    throw IOException("Could not access chmod for $file", error)
+                }
             }
 
             file.setReadable(false, false)
@@ -285,9 +289,15 @@ object SecureFile {
             }
         }
 
+        private fun isAndroidRuntime(): Boolean {
+            val runtimeName = System.getProperty("java.runtime.name").orEmpty()
+            val vmName = System.getProperty("java.vm.name").orEmpty()
+            return runtimeName.contains("Android", ignoreCase = true) || vmName.equals("Dalvik", ignoreCase = true)
+        }
+
         private companion object {
-            const val FILE_MODE = 0b110_000_000 // 0600
-            const val DIRECTORY_MODE = 0b111_000_000 // 0700
+            const val FILE_MODE = 0b110_000_000
+            const val DIRECTORY_MODE = 0b111_000_000
         }
     }
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/FilePollerTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/FilePollerTest.kt
@@ -7,6 +7,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
+import java.lang.reflect.InvocationTargetException
 
 class FilePollerTest {
     @get:Rule
@@ -69,5 +70,25 @@ class FilePollerTest {
         checkForChange()
 
         assertEquals(0, callbackCount)
+    }
+
+    @Test
+    fun testFailedCallbackRetriesSameChange() {
+        var callbackCount = 0
+        poller =
+            FilePoller(testFile, 60_000L) {
+                callbackCount++
+                if (callbackCount == 1) throw IllegalStateException("first attempt fails")
+            }
+        poller.start()
+
+        testFile.writeText("modified-content")
+        try {
+            checkForChange()
+        } catch (_: InvocationTargetException) {
+        }
+        checkForChange()
+
+        assertEquals(2, callbackCount)
     }
 }


### PR DESCRIPTION
Deep bug-fix sweep focused on lifecycle correctness, fail-closed I/O, platform compatibility, and bounded native parsing.

Current fixes:
- Use the configured Android targetSdk value instead of coupling targetSdk to compileSdk.
- Stop the module daemon supervisor when the module is disabled, pending removal, or its daemon executable disappears.
- Keep periodic file snapshots active alongside FileObserver so silent observer loss cannot permanently hide file changes.
- Exit after Config/BootLogic initialization failure so the module supervisor can perform a bounded retry instead of leaving a permanently non-operational process alive.
- Treat module verification I/O/parsing failures as tamper-safe verification failures instead of uncaught process crashes.
- Fail closed on Android chmod errors while retaining a host-JVM fallback for unit tests.
- Reject truncated ancillary control-message streams after SCM_RIGHTS parsing and cover the case with a Rust regression test.

The compatibility and security scan is still in progress. This PR will not be merged until the remaining review passes are complete and the full CI pipeline is green.