### PR TITLE
Fix FilePoller replacement detection and callback state

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/FilePoller.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/FilePoller.kt
@@ -2,8 +2,10 @@ package cleveres.tricky.cleverestech
 
 import android.os.FileObserver
 import java.io.File
+import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.LinkOption
+import java.nio.file.attribute.BasicFileAttributes
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -17,6 +19,7 @@ class FilePoller(
         val exists: Boolean,
         val lastModified: Long,
         val length: Long,
+        val fileKey: Any?,
     )
 
     @Volatile
@@ -125,11 +128,25 @@ class FilePoller(
     }
 
     private fun snapshot(): Snapshot {
-        val exists = Files.isRegularFile(file.toPath(), LinkOption.NOFOLLOW_LINKS)
-        return Snapshot(
-            exists = exists,
-            lastModified = if (exists) file.lastModified() else 0L,
-            length = if (exists) file.length() else 0L,
-        )
+        return try {
+            val attributes =
+                Files.readAttributes(
+                    file.toPath(),
+                    BasicFileAttributes::class.java,
+                    LinkOption.NOFOLLOW_LINKS,
+                )
+            if (!attributes.isRegularFile) {
+                Snapshot(false, 0L, 0L, null)
+            } else {
+                Snapshot(
+                    exists = true,
+                    lastModified = attributes.lastModifiedTime().toMillis(),
+                    length = attributes.size(),
+                    fileKey = attributes.fileKey(),
+                )
+            }
+        } catch (_: IOException) {
+            Snapshot(false, 0L, 0L, null)
+        }
     }
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/FilePoller.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/FilePoller.kt
@@ -109,8 +109,14 @@ class FilePoller(
         if (!isRunning) return
         val current = snapshot()
         if (current == lastSnapshot) return
-        onModified(file)
+        val previous = lastSnapshot
         lastSnapshot = current
+        try {
+            onModified(file)
+        } catch (error: Throwable) {
+            lastSnapshot = previous
+            throw error
+        }
     }
 
     @Synchronized

--- a/service/src/test/java/cleveres/tricky/cleverestech/FilePollerTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/FilePollerTest.kt
@@ -67,6 +67,24 @@ class FilePollerTest {
     }
 
     @Test
+    fun testCallbackBaselineUpdatePreventsDuplicateTrigger() {
+        var callbackCount = 0
+        poller =
+            FilePoller(testFile, intervalMs) {
+                callbackCount++
+                testFile.writeText("callback-content")
+                poller.updateLastModified()
+            }
+        poller.start()
+
+        testFile.writeText("external-content")
+        checkForChange()
+        checkForChange()
+
+        assertEquals(1, callbackCount)
+    }
+
+    @Test
     fun testNoFalsePositives() {
         var callbackCount = 0
         poller = FilePoller(testFile, intervalMs) { callbackCount++ }

--- a/service/src/test/java/cleveres/tricky/cleverestech/FilePollerTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/FilePollerTest.kt
@@ -17,7 +17,7 @@ class FilePollerTest {
 
     private lateinit var testFile: File
     private lateinit var poller: FilePoller
-    private val intervalMs = 100L
+    private val intervalMs = 60_000L
 
     @Before
     fun setUp() {
@@ -112,7 +112,7 @@ class FilePollerTest {
     fun testFailedCallbackRetriesSameChange() {
         var callbackCount = 0
         poller =
-            FilePoller(testFile, 60_000L) {
+            FilePoller(testFile, intervalMs) {
                 callbackCount++
                 if (callbackCount == 1) throw IllegalStateException("first attempt fails")
             }

--- a/service/src/test/java/cleveres/tricky/cleverestech/FilePollerTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/FilePollerTest.kt
@@ -8,6 +8,8 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
 import java.lang.reflect.InvocationTargetException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 
 class FilePollerTest {
     @get:Rule
@@ -43,6 +45,22 @@ class FilePollerTest {
         poller.start()
 
         testFile.writeText("modified-content")
+        checkForChange()
+
+        assertEquals(testFile, callbackFile)
+    }
+
+    @Test
+    fun testAtomicReplacementWithSameMetadataDetected() {
+        var callbackFile: File? = null
+        poller = FilePoller(testFile, intervalMs) { callbackFile = it }
+        poller.start()
+
+        val originalTimestamp = Files.getLastModifiedTime(testFile.toPath())
+        val replacement = tempFolder.newFile("replacement.txt")
+        replacement.writeText("changed")
+        Files.setLastModifiedTime(replacement.toPath(), originalTimestamp)
+        Files.move(replacement.toPath(), testFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
         checkForChange()
 
         assertEquals(testFile, callbackFile)


### PR DESCRIPTION
Fix two FilePoller correctness issues and remove scheduler races from its JVM tests.

Changes:
- include filesystem identity in snapshots so same-size, same-mtime atomic replacements are detected
- preserve callback-driven updateLastModified() baselines instead of overwriting them after a successful callback
- keep failed callbacks retryable by restoring the previous snapshot on failure
- add deterministic regression coverage for atomic replacement and callback baseline updates
- use a long fallback interval in reflection-driven JVM tests so the scheduler cannot race manual probes

Scope is limited to FilePoller and its unit tests.