### PR TITLE
🔧 Bugfix: Prevent double-free native crash in BinderInterceptor Parcel recycling

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/binder/BinderInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/binder/BinderInterceptor.kt
@@ -269,11 +269,14 @@ open class BinderInterceptor : Binder() {
                 Skip
             }
 
-        if (result !is OverrideData || result.data !== request) request.recycle()
-        response?.let { responseParcel ->
-            if (result !is OverrideReply || result.reply !== responseParcel) {
-                responseParcel.recycle()
-            }
+        val retainedData = (result as? OverrideData)?.data
+        val retainedReply = (result as? OverrideReply)?.reply
+
+        if (request !== retainedData && request !== retainedReply) {
+            request.recycle()
+        }
+        if (response != null && response !== retainedData && response !== retainedReply) {
+            response.recycle()
         }
         return result
     }


### PR DESCRIPTION
Fixed a critical double-free bug in `BinderInterceptor.kt`. When `OverrideReply` was returned utilizing the existing `request` parcel, the parcel was erroneously recycled since the check only evaluated `OverrideData`. Refactored `readPostTransaction` to correctly extract whichever Parcel was retained (either `data` or `reply`) and only recycle the unretained parcels.

---
*PR created automatically by Jules for task [5889776289001738293](https://jules.google.com/task/5889776289001738293) started by @tryigit*