### PR TITLE
fix: harden build and runtime compatibility

### DIFF
--- a/module/build.gradle.kts
+++ b/module/build.gradle.kts
@@ -15,6 +15,7 @@ val verName: String by rootProject.extra
 val commitHash: String by rootProject.extra
 val abiList: List<String> by rootProject.extra
 val androidMinSdkVersion: Int by rootProject.extra
+val androidTargetSdkVersion: Int by rootProject.extra
 val author: String by rootProject.extra
 val description: String by rootProject.extra
 val moduleDescription = description
@@ -193,6 +194,7 @@ afterEvaluate {
                             "SONAME" to moduleId,
                             "SUPPORTED_ABIS" to supportedAbis,
                             "MIN_SDK" to androidMinSdkVersion.toString(),
+                            "MAX_SDK" to androidTargetSdkVersion.toString(),
                         )
                     filter<ReplaceTokens>("tokens" to tokens)
                     filter<FixCrLfFilter>("eol" to FixCrLfFilter.CrLf.newInstance("lf"))

--- a/module/template/customize.sh
+++ b/module/template/customize.sh
@@ -6,6 +6,7 @@ DEBUG=@DEBUG@
 SONAME=@SONAME@
 SUPPORTED_ABIS="@SUPPORTED_ABIS@"
 MIN_SDK=@MIN_SDK@
+MAX_SDK=@MAX_SDK@
 
 if [ "$BOOTMODE" ] && [ "$KSU" ]; then
   ui_print "- Installing from KernelSU app"
@@ -29,7 +30,6 @@ fi
 VERSION=$(grep_prop version "${TMPDIR}/module.prop")
 ui_print "- Installing $SONAME $VERSION"
 
-# check architecture
 case " $SUPPORTED_ABIS " in
   *" $ARCH "*) support=true ;;
   *) support=false ;;
@@ -40,16 +40,18 @@ else
   ui_print "- Device platform: $ARCH (Supported)"
 fi
 
-# Check Android API after validating the installer-provided value.
 case "$API" in
   ''|*[!0-9]*) abort "! Invalid Android SDK value: $API" ;;
 esac
 if [ "$API" -lt "$MIN_SDK" ]; then
   ui_print "! Unsupported sdk: $API"
   abort "! Minimal supported sdk is $MIN_SDK"
-else
-  ui_print "- Device sdk: $API (Supported)"
 fi
+if [ "$API" -gt "$MAX_SDK" ]; then
+  ui_print "! Unsupported sdk: $API"
+  abort "! Maximum validated sdk is $MAX_SDK"
+fi
+ui_print "- Device sdk: $API (Supported)"
 
 ui_print "- Extracting verify.sh"
 unzip -o "$ZIPFILE" 'verify.sh' -d "$TMPDIR" >&2 \
@@ -76,9 +78,9 @@ extract "$ZIPFILE" 'service.sh'      "$MODPATH"
 extract "$ZIPFILE" 'service.apk'     "$MODPATH"
 extract "$ZIPFILE" 'sepolicy.rule'   "$MODPATH"
 extract "$ZIPFILE" 'daemon'          "$MODPATH"
-chmod 755 "$MODPATH/daemon"
+chmod 755 "$MODPATH/daemon" || abort "! Could not make daemon executable"
 extract "$ZIPFILE" 'action.sh'       "$MODPATH"
-chmod 755 "$MODPATH/action.sh"
+chmod 755 "$MODPATH/action.sh" || abort "! Could not make action.sh executable"
 
 case "$ARCH" in
   "x64")
@@ -97,18 +99,21 @@ case "$ARCH" in
 esac
 
 chmod 755 "$MODPATH/inject" "$MODPATH/daemon" "$MODPATH/service.sh" \
-  "$MODPATH/post-fs-data.sh"
+  "$MODPATH/post-fs-data.sh" || abort "! Could not set module executable permissions"
 
 CONFIG_DIR=/data/adb/cleverestricky
 if [ -L "$CONFIG_DIR" ]; then
   abort "! Refusing symlinked configuration directory: $CONFIG_DIR"
 fi
+if [ -e "$CONFIG_DIR" ] && [ ! -d "$CONFIG_DIR" ]; then
+  abort "! Configuration path is not a directory: $CONFIG_DIR"
+fi
 if [ ! -d "$CONFIG_DIR" ]; then
   ui_print "- Creating configuration directory"
-  mkdir -p "$CONFIG_DIR"
+  mkdir -p "$CONFIG_DIR" || abort "! Could not create configuration directory"
 fi
-chmod 700 "$CONFIG_DIR"
-chown 0:0 "$CONFIG_DIR"
+chmod 700 "$CONFIG_DIR" || abort "! Could not secure configuration directory"
+chown 0:0 "$CONFIG_DIR" || abort "! Could not set configuration directory ownership"
 
 for config_file in spoof_build_vars security_patch.txt target.txt drm_packages.txt boot_props_mode \
   spoof_enabled spoof_switch_initialized spoof_build_identity global_mode tee_broken_mode \
@@ -119,17 +124,18 @@ for config_file in spoof_build_vars security_patch.txt target.txt drm_packages.t
   fi
 done
 
-# Migrate existing installations once without re-enabling a switch the user
-# intentionally disabled on a later update.
+FIRST_CONFIG_INIT=false
 if [ ! -e "$CONFIG_DIR/spoof_switch_initialized" ]; then
+  FIRST_CONFIG_INIT=true
   ui_print "- Enabling the master Spoof Engine switch"
   [ -e "$CONFIG_DIR/spoof_enabled" ] || : > "$CONFIG_DIR/spoof_enabled" \
     || abort "! Could not enable the Spoof Engine"
   : > "$CONFIG_DIR/spoof_switch_initialized" \
     || abort "! Could not write the Spoof Engine migration marker"
 fi
-chmod 600 "$CONFIG_DIR/spoof_switch_initialized"
-[ -e "$CONFIG_DIR/spoof_enabled" ] && chmod 600 "$CONFIG_DIR/spoof_enabled"
+chmod 600 "$CONFIG_DIR/spoof_switch_initialized" || abort "! Could not secure migration marker"
+[ ! -e "$CONFIG_DIR/spoof_enabled" ] || chmod 600 "$CONFIG_DIR/spoof_enabled" \
+  || abort "! Could not secure Spoof Engine switch"
 
 if [ ! -f "$CONFIG_DIR/spoof_build_vars" ]; then
   ui_print "- Adding default spoof_build_vars"
@@ -137,7 +143,7 @@ if [ ! -f "$CONFIG_DIR/spoof_build_vars" ]; then
   mv "$TMPDIR/spoof_build_vars" "$CONFIG_DIR/spoof_build_vars" \
     || abort "! Could not install spoof_build_vars"
 fi
-[ -f "$CONFIG_DIR/spoof_build_vars" ] && chmod 600 "$CONFIG_DIR/spoof_build_vars"
+chmod 600 "$CONFIG_DIR/spoof_build_vars" || abort "! Could not secure spoof_build_vars"
 
 if [ ! -f "$CONFIG_DIR/security_patch.txt" ]; then
   ui_print "- Adding default security_patch.txt"
@@ -145,7 +151,7 @@ if [ ! -f "$CONFIG_DIR/security_patch.txt" ]; then
   mv "$TMPDIR/security_patch.txt" "$CONFIG_DIR/security_patch.txt" \
     || abort "! Could not install security_patch.txt"
 fi
-[ -f "$CONFIG_DIR/security_patch.txt" ] && chmod 600 "$CONFIG_DIR/security_patch.txt"
+chmod 600 "$CONFIG_DIR/security_patch.txt" || abort "! Could not secure security_patch.txt"
 
 if [ ! -f "$CONFIG_DIR/target.txt" ]; then
   ui_print "- Adding default target scope"
@@ -153,17 +159,16 @@ if [ ! -f "$CONFIG_DIR/target.txt" ]; then
   mv "$TMPDIR/target.txt" "$CONFIG_DIR/target.txt" \
     || abort "! Could not install target.txt"
 fi
-[ -f "$CONFIG_DIR/target.txt" ] && chmod 600 "$CONFIG_DIR/target.txt"
+chmod 600 "$CONFIG_DIR/target.txt" || abort "! Could not secure target.txt"
 
-INSTALL_COMPAT_DEFAULTS=false
+INSTALL_COMPAT_DEFAULTS=$FIRST_CONFIG_INIT
 if [ ! -f "$CONFIG_DIR/drm_packages.txt" ]; then
-  INSTALL_COMPAT_DEFAULTS=true
   ui_print "- Adding default DRM passthrough scope"
   extract "$ZIPFILE" 'drm_packages.txt' "$TMPDIR"
   mv "$TMPDIR/drm_packages.txt" "$CONFIG_DIR/drm_packages.txt" \
     || abort "! Could not install drm_packages.txt"
 fi
-[ -f "$CONFIG_DIR/drm_packages.txt" ] && chmod 600 "$CONFIG_DIR/drm_packages.txt"
+chmod 600 "$CONFIG_DIR/drm_packages.txt" || abort "! Could not secure drm_packages.txt"
 
 if [ ! -f "$CONFIG_DIR/boot_props_mode" ]; then
   ui_print "- Adding automatic boot-property policy"
@@ -171,28 +176,33 @@ if [ ! -f "$CONFIG_DIR/boot_props_mode" ]; then
   mv "$TMPDIR/boot_props_mode" "$CONFIG_DIR/boot_props_mode" \
     || abort "! Could not install boot_props_mode"
 fi
-[ -f "$CONFIG_DIR/boot_props_mode" ] && chmod 600 "$CONFIG_DIR/boot_props_mode"
+chmod 600 "$CONFIG_DIR/boot_props_mode" || abort "! Could not secure boot_props_mode"
 
 if [ "$INSTALL_COMPAT_DEFAULTS" = true ] && [ ! -e "$CONFIG_DIR/auto_keybox_check" ]; then
   ui_print "- Enabling daily keybox revocation checks"
   : > "$CONFIG_DIR/auto_keybox_check" \
     || abort "! Could not enable keybox revocation checks"
 fi
-[ -e "$CONFIG_DIR/auto_keybox_check" ] && chmod 600 "$CONFIG_DIR/auto_keybox_check"
+[ ! -e "$CONFIG_DIR/auto_keybox_check" ] || chmod 600 "$CONFIG_DIR/auto_keybox_check" \
+  || abort "! Could not secure keybox revocation switch"
 for default_flag in rkp_passthrough drm_passthrough hide_sensitive_props; do
   if [ "$INSTALL_COMPAT_DEFAULTS" = true ] && [ ! -e "$CONFIG_DIR/$default_flag" ]; then
     ui_print "- Enabling $default_flag"
     : > "$CONFIG_DIR/$default_flag" \
       || abort "! Could not enable $default_flag"
   fi
-  [ -e "$CONFIG_DIR/$default_flag" ] && chmod 600 "$CONFIG_DIR/$default_flag"
+  [ ! -e "$CONFIG_DIR/$default_flag" ] || chmod 600 "$CONFIG_DIR/$default_flag" \
+    || abort "! Could not secure $default_flag"
 done
 chown 0:0 "$CONFIG_DIR/spoof_build_vars" "$CONFIG_DIR/security_patch.txt" \
   "$CONFIG_DIR/target.txt" "$CONFIG_DIR/drm_packages.txt" \
-  "$CONFIG_DIR/boot_props_mode" "$CONFIG_DIR/spoof_switch_initialized"
-[ -e "$CONFIG_DIR/auto_keybox_check" ] && chown 0:0 "$CONFIG_DIR/auto_keybox_check"
-[ -e "$CONFIG_DIR/spoof_enabled" ] && chown 0:0 "$CONFIG_DIR/spoof_enabled"
-[ -e "$CONFIG_DIR/spoof_build_identity" ] && chown 0:0 "$CONFIG_DIR/spoof_build_identity"
-[ -e "$CONFIG_DIR/rkp_passthrough" ] && chown 0:0 "$CONFIG_DIR/rkp_passthrough"
-[ -e "$CONFIG_DIR/drm_passthrough" ] && chown 0:0 "$CONFIG_DIR/drm_passthrough"
-[ -e "$CONFIG_DIR/hide_sensitive_props" ] && chown 0:0 "$CONFIG_DIR/hide_sensitive_props"
+  "$CONFIG_DIR/boot_props_mode" "$CONFIG_DIR/spoof_switch_initialized" \
+  || abort "! Could not set configuration file ownership"
+[ ! -e "$CONFIG_DIR/auto_keybox_check" ] || chown 0:0 "$CONFIG_DIR/auto_keybox_check" \
+  || abort "! Could not set keybox revocation switch ownership"
+[ ! -e "$CONFIG_DIR/spoof_enabled" ] || chown 0:0 "$CONFIG_DIR/spoof_enabled" \
+  || abort "! Could not set Spoof Engine switch ownership"
+[ ! -e "$CONFIG_DIR/spoof_build_identity" ] || chown 0:0 "$CONFIG_DIR/spoof_build_identity"
+[ ! -e "$CONFIG_DIR/rkp_passthrough" ] || chown 0:0 "$CONFIG_DIR/rkp_passthrough"
+[ ! -e "$CONFIG_DIR/drm_passthrough" ] || chown 0:0 "$CONFIG_DIR/drm_passthrough"
+[ ! -e "$CONFIG_DIR/hide_sensitive_props" ] || chown 0:0 "$CONFIG_DIR/hide_sensitive_props"

--- a/module/template/post-fs-data.sh
+++ b/module/template/post-fs-data.sh
@@ -1,12 +1,14 @@
 #!/system/bin/sh
 MODDIR=${0%/*}
 CONFIG_DIR="/data/adb/cleverestricky"
+CONFIG_ROOT_SAFE=false
 
-# Keep private material root-only. Apply labels without recursively crossing
-# into unexpected mounts or following symlinks.
 if [ -d "$CONFIG_DIR" ] && [ ! -L "$CONFIG_DIR" ]; then
-  chown 0:0 "$CONFIG_DIR" 2>/dev/null
-  chmod 700 "$CONFIG_DIR"
+  if chown 0:0 "$CONFIG_DIR" 2>/dev/null && chmod 700 "$CONFIG_DIR"; then
+    CONFIG_ROOT_SAFE=true
+  else
+    log -t CleveresTricky "Config root permissions could not be secured; early config processing was skipped"
+  fi
   chcon u:object_r:system_file:s0 "$CONFIG_DIR" 2>/dev/null
   find "$CONFIG_DIR" -xdev -maxdepth 2 -type d -exec chmod 700 {} + 2>/dev/null
   find "$CONFIG_DIR" -xdev -maxdepth 2 -type f -exec chmod 600 {} + 2>/dev/null
@@ -14,18 +16,12 @@ if [ -d "$CONFIG_DIR" ] && [ ! -L "$CONFIG_DIR" ]; then
     -exec chcon u:object_r:system_file:s0 {} + 2>/dev/null
 fi
 
-# Apply boot-only property views before Zygote snapshots android.os.Build.
-# Every value comes from a fixed property name or a strictly bounded config
-# field, and resetprop receives it as a quoted argument rather than shell code.
 promote_staged_identity() {
   staged_file="$CONFIG_DIR/spoof_build_vars.next"
   active_file="$CONFIG_DIR/spoof_build_vars"
 
+  [ "$CONFIG_ROOT_SAFE" = true ] || return 0
   if [ ! -e "$staged_file" ] && [ ! -L "$staged_file" ]; then
-    return 0
-  fi
-  if [ ! -d "$CONFIG_DIR" ] || [ -L "$CONFIG_DIR" ]; then
-    log -t CleveresTricky "Unsafe config directory; staged identity was ignored"
     return 0
   fi
   if [ -L "$staged_file" ]; then
@@ -55,8 +51,10 @@ promote_staged_identity() {
     return 0
   fi
 
-  chown 0:0 "$staged_file" 2>/dev/null
-  chmod 600 "$staged_file" || return 0
+  if ! chown 0:0 "$staged_file" 2>/dev/null || ! chmod 600 "$staged_file"; then
+    log -t CleveresTricky "Staged identity permissions could not be secured"
+    return 0
+  fi
   chcon u:object_r:system_file:s0 "$staged_file" 2>/dev/null
   if mv -f "$staged_file" "$active_file"; then
     log -t CleveresTricky "Activated the prepared identity snapshot"
@@ -66,6 +64,7 @@ promote_staged_identity() {
 }
 
 apply_early_properties() {
+  [ "$CONFIG_ROOT_SAFE" = true ] || return 0
   [ -f "$CONFIG_DIR/spoof_enabled" ] || return 0
   [ ! -L "$CONFIG_DIR/spoof_enabled" ] || return 0
   command -v resetprop >/dev/null 2>&1 || {
@@ -227,10 +226,7 @@ apply_early_properties() {
 promote_staged_identity
 apply_early_properties
 
-# Label the service archive and injected native payloads for platform access.
 find "$MODDIR" -maxdepth 1 -name '*.apk' -exec chcon u:object_r:system_file:s0 {} + 2>/dev/null
 find "$MODDIR" -maxdepth 1 -name '*.so' -exec chcon u:object_r:system_file:s0 {} + 2>/dev/null
-
-# Executables need to be executable by daemon
 [ -f "$MODDIR/inject" ] && chcon u:object_r:system_file:s0 "$MODDIR/inject" 2>/dev/null
 [ -f "$MODDIR/daemon" ] && chcon u:object_r:system_file:s0 "$MODDIR/daemon" 2>/dev/null

--- a/service/src/main/java/cleveres/tricky/cleverestech/CboxManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CboxManager.kt
@@ -13,6 +13,7 @@ import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.security.DigestInputStream
 import java.security.MessageDigest
+import java.util.PriorityQueue
 import java.util.concurrent.ConcurrentHashMap
 
 private fun ByteArray.indexOfFrom(
@@ -59,12 +60,6 @@ object CboxManager {
                 Logger.e("Failed to scan CBOX directory", error)
                 return
             }
-        if (files == null) {
-            unlockedCache.clear()
-            lockedFiles.clear()
-            Logger.e("CBOX pool rejected because it exceeds the file limit")
-            return
-        }
         val currentFiles = files.mapTo(HashSet()) { it.name }
         val revoked = if (files.isEmpty()) emptySet() else KeyboxVerifier.fetchCrl()
 
@@ -183,18 +178,21 @@ object CboxManager {
     fun isLocked(filename: String): Boolean = lockedFiles.contains(filename)
 
     @Throws(IOException::class)
-    private fun listCboxFiles(directory: File): List<File>? {
-        val files = ArrayList<File>(MAX_CBOX_FILES)
+    private fun listCboxFiles(directory: File): List<File> {
+        val files = PriorityQueue<File>(MAX_CBOX_FILES, compareByDescending { it.name })
         Files.newDirectoryStream(directory.toPath()).use { entries ->
             for (path in entries) {
                 val file = path.toFile()
                 if (!validFilename.matches(file.name) || !isSafeCbox(file)) continue
-                files.add(file)
-                if (files.size >= MAX_CBOX_FILES) break
+                if (files.size < MAX_CBOX_FILES) {
+                    files.add(file)
+                } else if (file.name < files.peek().name) {
+                    files.poll()
+                    files.add(file)
+                }
             }
         }
-        files.sortBy { it.name }
-        return files
+        return files.sortedBy { it.name }
     }
 
     private fun loadCached(

--- a/service/src/main/java/cleveres/tricky/cleverestech/CboxManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CboxManager.kt
@@ -186,7 +186,7 @@ object CboxManager {
                 if (!validFilename.matches(file.name) || !isSafeCbox(file)) continue
                 if (files.size < MAX_CBOX_FILES) {
                     files.add(file)
-                } else if (file.name < files.peek().name) {
+                } else if (file.name < requireNotNull(files.peek()).name) {
                     files.poll()
                     files.add(file)
                 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/CboxManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CboxManager.kt
@@ -6,6 +6,7 @@ import cleveres.tricky.cleverestech.util.DeviceKeyManager
 import cleveres.tricky.cleverestech.util.KeyboxVerifier
 import cleveres.tricky.cleverestech.util.SecureFile
 import java.io.File
+import java.io.IOException
 import java.io.StringReader
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -50,9 +51,20 @@ object CboxManager {
         }
 
         val files =
-            directory.listFiles { file ->
-                validFilename.matches(file.name) && isSafeCbox(file)
-            }?.sortedBy { it.name }.orEmpty()
+            try {
+                listCboxFiles(directory)
+            } catch (error: IOException) {
+                unlockedCache.clear()
+                lockedFiles.clear()
+                Logger.e("Failed to scan CBOX directory", error)
+                return
+            }
+        if (files == null) {
+            unlockedCache.clear()
+            lockedFiles.clear()
+            Logger.e("CBOX pool rejected because it exceeds the file limit")
+            return
+        }
         val currentFiles = files.mapTo(HashSet()) { it.name }
         val revoked = if (files.isEmpty()) emptySet() else KeyboxVerifier.fetchCrl()
 
@@ -170,6 +182,21 @@ object CboxManager {
 
     fun isLocked(filename: String): Boolean = lockedFiles.contains(filename)
 
+    @Throws(IOException::class)
+    private fun listCboxFiles(directory: File): List<File>? {
+        val files = ArrayList<File>(MAX_CBOX_FILES)
+        Files.newDirectoryStream(directory.toPath()).use { entries ->
+            for (path in entries) {
+                val file = path.toFile()
+                if (!validFilename.matches(file.name) || !isSafeCbox(file)) continue
+                if (files.size >= MAX_CBOX_FILES) return null
+                files.add(file)
+            }
+        }
+        files.sortBy { it.name }
+        return files
+    }
+
     private fun loadCached(
         file: File,
         revoked: Set<String>,
@@ -282,12 +309,19 @@ object CboxManager {
         directory: File,
         currentFiles: Set<String>,
     ) {
-        directory
-            .listFiles { file -> file.name.endsWith(".cbox.cache", ignoreCase = true) }
-            ?.forEach { cache ->
-                val sourceName = cache.name.removeSuffix(".cache")
-                if (sourceName !in currentFiles) deleteCacheSafely(cache)
+        try {
+            Files.newDirectoryStream(directory.toPath()) { path ->
+                path.fileName.toString().endsWith(".cbox.cache", ignoreCase = true)
+            }.use { entries ->
+                for (path in entries) {
+                    val cache = path.toFile()
+                    val sourceName = cache.name.removeSuffix(".cache")
+                    if (sourceName !in currentFiles) deleteCacheSafely(cache)
+                }
             }
+        } catch (error: IOException) {
+            Logger.w("Could not scan orphaned CBOX caches")
+        }
     }
 
     private fun deleteCacheSafely(file: File) {
@@ -320,5 +354,6 @@ object CboxManager {
     private const val MIN_CBOX_BYTES = 4L + 4L + 16L + 12L + 16L
     private const val MAX_CBOX_BYTES = 10L * 1024 * 1024 + 36L
     private const val MAX_CACHE_BYTES = 16L * 1024 * 1024
+    private const val MAX_CBOX_FILES = 64
     private const val MAX_PASSWORD_CHARS = 1024
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/CboxManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CboxManager.kt
@@ -189,8 +189,8 @@ object CboxManager {
             for (path in entries) {
                 val file = path.toFile()
                 if (!validFilename.matches(file.name) || !isSafeCbox(file)) continue
-                if (files.size >= MAX_CBOX_FILES) return null
                 files.add(file)
+                if (files.size >= MAX_CBOX_FILES) break
             }
         }
         files.sortBy { it.name }

--- a/service/src/main/java/cleveres/tricky/cleverestech/DeviceTemplateManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/DeviceTemplateManager.kt
@@ -3,7 +3,11 @@ package cleveres.tricky.cleverestech
 import cleveres.tricky.cleverestech.util.SecureFile
 import org.json.JSONArray
 import org.json.JSONObject
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.IOException
+import java.nio.ByteBuffer
+import java.nio.charset.CodingErrorAction
 import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.util.concurrent.ExecutorService
@@ -15,7 +19,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 
 data class DeviceTemplate(
-    val id: String, // unique ID, e.g. "pixel8pro"
+    val id: String,
     val manufacturer: String,
     val model: String,
     val fingerprint: String,
@@ -70,15 +74,19 @@ object DeviceTemplateManager {
                 }
             },
         ).apply { allowCoreThreadTimeOut(true) }
+
+    @Volatile
     private var initFuture: Future<*>? = null
     private val initializationGeneration = AtomicLong()
 
     @androidx.annotation.VisibleForTesting
+    @Synchronized
     fun setExecutorForTesting(newExecutor: ExecutorService) {
+        initializationGeneration.incrementAndGet()
+        cancelPendingInitialization()
         executor = newExecutor
     }
 
-    // Compatibility examples. They are not a claim about Play Integrity eligibility.
     private val builtInTemplates =
         listOf(
             DeviceTemplate(
@@ -200,18 +208,25 @@ object DeviceTemplateManager {
             ),
         )
 
+    @Synchronized
     fun initialize(configDir: File) {
         val generation = initializationGeneration.incrementAndGet()
-        synchronized(this) {
-            templates = builtInTemplates.associateByTo(LinkedHashMap()) { it.id.lowercase() }
-            cachedList = null
-        }
+        templates = builtInTemplates.associateByTo(LinkedHashMap()) { it.id.lowercase() }
+        cachedList = null
+        cancelPendingInitialization()
+        initFuture = executor.submit { loadCustomTemplates(configDir, generation) }
+    }
 
-        // Load user-provided templates without blocking service startup.
-        initFuture =
-            executor.submit {
-                loadCustomTemplates(configDir, generation)
-            }
+    @Synchronized
+    private fun cancelPendingInitialization() {
+        val previous = initFuture ?: return
+        previous.cancel(false)
+        val threadPool = executor as? ThreadPoolExecutor
+        if (previous is Runnable && threadPool != null) {
+            threadPool.remove(previous)
+            threadPool.purge()
+        }
+        initFuture = null
     }
 
     private fun loadCustomTemplates(
@@ -221,8 +236,13 @@ object DeviceTemplateManager {
         val file = File(configDir, TEMPLATES_FILE)
         if (Files.isRegularFile(file.toPath(), LinkOption.NOFOLLOW_LINKS)) {
             try {
-                require(file.length() in 1..MAX_TEMPLATES_BYTES) { "templates.json has an invalid size" }
-                val json = file.readText()
+                val beforeLength = file.length()
+                val beforeModified = file.lastModified()
+                require(beforeLength in 1..MAX_TEMPLATES_BYTES) { "templates.json has an invalid size" }
+                val json = readTextBounded(file)
+                require(
+                    file.length() == beforeLength && file.lastModified() == beforeModified,
+                ) { "templates.json changed while it was being read" }
                 val array = JSONArray(json)
                 require(array.length() <= MAX_TEMPLATES) { "templates.json contains too many templates" }
                 val list = ArrayList<DeviceTemplate>()
@@ -246,7 +266,6 @@ object DeviceTemplateManager {
                 Logger.e("Failed to load templates.json", e)
             }
         } else if (!file.exists()) {
-            // Save built-ins to file for user editing
             synchronized(this) {
                 if (initializationGeneration.get() != generation) return
                 saveTemplatesInternal(configDir)
@@ -256,11 +275,44 @@ object DeviceTemplateManager {
         }
     }
 
+    private fun readTextBounded(file: File): String {
+        val output = ByteArrayOutputStream(minOf(file.length(), 64 * 1024L).toInt())
+        Files.newInputStream(file.toPath()).use { input ->
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            var total = 0L
+            while (true) {
+                val count = input.read(buffer)
+                if (count < 0) break
+                if (count == 0) continue
+                total += count
+                if (total > MAX_TEMPLATES_BYTES) throw IOException("templates.json exceeds its size limit")
+                output.write(buffer, 0, count)
+            }
+        }
+        val bytes = output.toByteArray()
+        return try {
+            Charsets.UTF_8.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .decode(ByteBuffer.wrap(bytes))
+                .toString()
+        } finally {
+            bytes.fill(0)
+        }
+    }
+
     private fun waitForInit() {
-        try {
-            initFuture?.get()
-        } catch (e: Exception) {
-            Logger.e("Error waiting for template initialization", e)
+        while (true) {
+            val future = synchronized(this) { initFuture } ?: return
+            try {
+                future.get()
+            } catch (_: java.util.concurrent.CancellationException) {
+                continue
+            } catch (e: Exception) {
+                Logger.e("Error waiting for template initialization", e)
+                return
+            }
+            if (synchronized(this) { future === initFuture }) return
         }
     }
 
@@ -325,21 +377,21 @@ object DeviceTemplateManager {
     private fun saveTemplatesInternal(configDir: File) {
         try {
             val array = JSONArray()
-            templates.values.forEach { t ->
+            templates.values.forEach { template ->
                 val obj = JSONObject()
-                obj.put("id", t.id)
-                obj.put("manufacturer", t.manufacturer)
-                obj.put("model", t.model)
-                obj.put("fingerprint", t.fingerprint)
-                obj.put("brand", t.brand)
-                obj.put("product", t.product)
-                obj.put("device", t.device)
-                obj.put("release", t.release)
-                obj.put("buildId", t.buildId)
-                obj.put("incremental", t.incremental)
-                obj.put("type", t.type)
-                obj.put("tags", t.tags)
-                obj.put("securityPatch", t.securityPatch)
+                obj.put("id", template.id)
+                obj.put("manufacturer", template.manufacturer)
+                obj.put("model", template.model)
+                obj.put("fingerprint", template.fingerprint)
+                obj.put("brand", template.brand)
+                obj.put("product", template.product)
+                obj.put("device", template.device)
+                obj.put("release", template.release)
+                obj.put("buildId", template.buildId)
+                obj.put("incremental", template.incremental)
+                obj.put("type", template.type)
+                obj.put("tags", template.tags)
+                obj.put("securityPatch", template.securityPatch)
                 array.put(obj)
             }
             SecureFile.writeText(File(configDir, TEMPLATES_FILE), array.toString(4))

--- a/service/src/main/java/cleveres/tricky/cleverestech/ServerManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ServerManager.kt
@@ -100,7 +100,6 @@ object ServerManager {
                 if (!wasPlaintext) stored.fill(0)
                 plaintext.fill(0)
             }
-            // Migrate legacy plaintext credentials to encrypted storage.
             if (wasPlaintext) saveServers()
         } catch (e: Exception) {
             serversList.clear()
@@ -316,9 +315,7 @@ object ServerManager {
         value: String,
     ) {
         require(validHeaderName.matches(name)) { "Invalid authentication header name" }
-        require(
-            name.lowercase() !in restrictedHeaders,
-        ) { "Restricted authentication header" }
+        require(name.lowercase() !in restrictedHeaders) { "Restricted authentication header" }
         require(value.length <= 8192 && '\r' !in value && '\n' !in value) {
             "Invalid authentication header value"
         }
@@ -387,7 +384,6 @@ object ServerManager {
             conn.instanceFollowRedirects = false
             conn.setRequestProperty("Accept-Encoding", "identity")
 
-            // Apply Auth
             when (server.authType) {
                 "BEARER" -> {
                     val token = server.authData.optString("token")
@@ -415,10 +411,10 @@ object ServerManager {
                 }
                 "CUSTOM" -> {
                     val headers = server.authData.optJSONObject("headers")
-                    headers?.keys()?.forEach { k ->
-                        val value = headers.getString(k)
-                        requireSafeHeader(k, value)
-                        conn.setRequestProperty(k, value)
+                    headers?.keys()?.forEach { key ->
+                        val value = headers.getString(key)
+                        requireSafeHeader(key, value)
+                        conn.setRequestProperty(key, value)
                     }
                 }
             }
@@ -429,8 +425,7 @@ object ServerManager {
                 return false
             }
 
-            // Cap response size to prevent OOM from malicious servers
-            val maxResponseSize = 10 * 1024 * 1024 // 10MB
+            val maxResponseSize = 10 * 1024 * 1024
             val contentLength = conn.contentLengthLong
             if (contentLength > maxResponseSize) {
                 server.lastStatus = "RESPONSE_TOO_LARGE"
@@ -445,18 +440,17 @@ object ServerManager {
                         )
                     val chunk = ByteArray(8192)
                     var totalRead = 0
-                    var n: Int
-                    while (input.read(chunk).also { n = it } != -1) {
-                        totalRead += n
+                    var count: Int
+                    while (input.read(chunk).also { count = it } != -1) {
+                        totalRead += count
                         if (totalRead > maxResponseSize) {
                             throw SecurityException("Server response exceeds ${maxResponseSize / 1024 / 1024}MB limit")
                         }
-                        buffer.write(chunk, 0, n)
+                        buffer.write(chunk, 0, count)
                     }
                     buffer.toByteArray()
                 }
 
-            // Process Content
             val result =
                 try {
                     processContent(bytes, server)
@@ -518,61 +512,54 @@ object ServerManager {
         val magic = if (bytes.size >= 4) String(bytes.copyOfRange(0, 4), StandardCharsets.US_ASCII) else ""
 
         if (magic == "CBOX") {
-            // Direct CBOX
-            val pwd = server.contentPassword ?: ""
-            val stream = ByteArrayInputStream(bytes)
-            val payload = CboxDecryptor.decrypt(stream, pwd)
+            val password = server.contentPassword ?: ""
+            val payload = CboxDecryptor.decrypt(ByteArrayInputStream(bytes), password)
             if (payload != null) {
-                // Verify signature if key provided
-                if (!server.contentPublicKey.isNullOrBlank()) {
-                    if (!CboxDecryptor.verifySignature(payload, server.contentPublicKey!!)) {
-                        Logger.e("Signature verification failed for server ${server.name}")
-                        return Pair(emptyList(), null)
-                    }
+                if (!server.contentPublicKey.isNullOrBlank() &&
+                    !CboxDecryptor.verifySignature(payload, server.contentPublicKey!!)
+                ) {
+                    Logger.e("Signature verification failed for server ${server.name}")
+                    return Pair(emptyList(), null)
                 }
-                val kbs = CertHack.parseKeyboxXml(StringReader(payload.xmlContent), "server_${server.name}")
-                if (kbs.isNotEmpty()) {
-                    return Pair(kbs, payload.xmlContent)
+                val keyboxes = CertHack.parseKeyboxXml(StringReader(payload.xmlContent), "server_${server.name}")
+                if (keyboxes.isNotEmpty()) {
+                    return Pair(keyboxes, payload.xmlContent)
                 }
             }
         } else if (bytes.size > 4 && bytes[0] == 0x50.toByte() && bytes[1] == 0x4B.toByte()) {
-            // ZIP
-            val stream = ByteArrayInputStream(bytes)
-            val pack = ZipProcessor.process(stream)
+            val pack = ZipProcessor.process(ByteArrayInputStream(bytes))
             if (pack != null) {
                 try {
                     val allKeys = ArrayList<CertHack.KeyBox>()
-                    val pwd = pack.password ?: server.contentPassword ?: ""
-                    // Only a key configured out-of-band is a trust anchor.
-                    val pubKey = server.contentPublicKey
+                    val password = pack.password ?: server.contentPassword ?: ""
+                    val publicKey = server.contentPublicKey
 
                     for ((name, content) in pack.cboxFiles) {
-                        val cboxStream = ByteArrayInputStream(content)
-                        val payload = CboxDecryptor.decrypt(cboxStream, pwd)
+                        val payload = CboxDecryptor.decrypt(ByteArrayInputStream(content), password)
                         if (payload == null) {
                             Logger.e("Could not decrypt zip entry $name")
                             return Pair(emptyList(), null)
                         }
-                        if (!pubKey.isNullOrBlank() &&
-                            !CboxDecryptor.verifySignature(payload, pubKey)
+                        if (!publicKey.isNullOrBlank() &&
+                            !CboxDecryptor.verifySignature(payload, publicKey)
                         ) {
                             Logger.e("Signature verification failed for zip entry $name")
                             return Pair(emptyList(), null)
                         }
-                        val kbs =
+                        val keyboxes =
                             CertHack.parseKeyboxXml(
                                 StringReader(payload.xmlContent),
                                 "server_${server.name}_$name",
                             )
-                        if (kbs.isEmpty()) {
+                        if (keyboxes.isEmpty()) {
                             Logger.e("Zip entry contains no valid keybox records: $name")
                             return Pair(emptyList(), null)
                         }
-                        if (kbs.size > MAX_REMOTE_KEYBOXES - allKeys.size) {
+                        if (keyboxes.size > MAX_REMOTE_KEYBOXES - allKeys.size) {
                             Logger.e("Server archive exceeds the keybox-count limit")
                             return Pair(emptyList(), null)
                         }
-                        allKeys.addAll(kbs)
+                        allKeys.addAll(keyboxes)
                     }
 
                     if (allKeys.isNotEmpty()) {
@@ -583,16 +570,15 @@ object ServerManager {
                 }
             }
         } else {
-            // Assume Plain XML
             if (!server.contentPublicKey.isNullOrBlank()) {
                 Logger.e("Signed server refused unsigned plain XML")
                 return Pair(emptyList(), null)
             }
             val xml = String(bytes, StandardCharsets.UTF_8)
             if (xml.contains("AndroidAttestation")) {
-                val kbs = CertHack.parseKeyboxXml(StringReader(xml), "server_${server.name}")
-                if (kbs.isNotEmpty()) {
-                    return Pair(kbs, xml)
+                val keyboxes = CertHack.parseKeyboxXml(StringReader(xml), "server_${server.name}")
+                if (keyboxes.isNotEmpty()) {
+                    return Pair(keyboxes, xml)
                 }
             }
         }
@@ -605,13 +591,13 @@ object ServerManager {
     ) {
         val plaintext = xml.toByteArray(StandardCharsets.UTF_8)
         try {
-            val enc = DeviceKeyManager.encrypt(plaintext)
-            if (enc != null) {
+            val encrypted = DeviceKeyManager.encrypt(plaintext)
+            if (encrypted != null) {
                 try {
                     val file = File(Config.keyboxDirectory.parentFile, "server_cache_$serverId.enc")
-                    SecureFile.writeBytes(file, enc)
+                    SecureFile.writeBytes(file, encrypted)
                 } finally {
-                    enc.fill(0)
+                    encrypted.fill(0)
                 }
             }
         } catch (e: Exception) {
@@ -721,6 +707,7 @@ object ServerManager {
         scheduler.scheduleWithFixedDelay(
             {
                 try {
+                    if (!Config.isSpoofEnabled) return@scheduleWithFixedDelay
                     val now = System.currentTimeMillis()
                     val dueServers =
                         serversList
@@ -728,8 +715,10 @@ object ServerManager {
                                 server.enabled &&
                                     server.autoRefresh &&
                                     (
-                                        server.lastChecked == 0L ||
-                                            now - server.lastChecked >= TimeUnit.HOURS.toMillis(server.refreshIntervalHours.toLong())
+                                        server.lastChecked <= 0L ||
+                                            server.lastChecked > now ||
+                                            now - server.lastChecked >=
+                                            TimeUnit.HOURS.toMillis(server.refreshIntervalHours.toLong())
                                     )
                             }
                             .sortedBy { it.priority }
@@ -754,8 +743,6 @@ object ServerManager {
     }
 
     private const val MAX_SERVERS = 64
-
-    // Keep canonical cache documents within CertHack's per-document parser bound.
     private const val MAX_REMOTE_KEYBOXES = 64
     private const val MAX_CONFIG_BYTES = 2L * 1024 * 1024
     private const val MAX_CACHE_BYTES = 16L * 1024 * 1024

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -32,6 +32,7 @@ object KeyboxVerifier {
     private const val DEFAULT_CRL_URL = "https://android.googleapis.com/attestation/status"
     private const val MAX_CRL_BYTES = 8L * 1024 * 1024
     private const val MAX_CRL_ENTRIES = 1_000_000
+    private const val MAX_CRL_KEY_CHARS = 128
     private const val MAX_KEYBOX_XML_BYTES = 10L * 1024 * 1024
     private const val MAX_KEYBOX_FILES = 64
 
@@ -66,7 +67,7 @@ object KeyboxVerifier {
     private var cachedCrl: Set<String>? = null
     private var cachedEtag: String? = null
     private var lastFetchTime: Long = 0
-    private const val CACHE_TTL = 24 * 60 * 60 * 1000L // 24 hours
+    private const val CACHE_TTL = 24 * 60 * 60 * 1000L
     private val cacheLock = java.util.concurrent.locks.ReentrantLock()
 
     private fun isHex(str: String): Boolean {
@@ -97,23 +98,30 @@ object KeyboxVerifier {
             return listOf(Result(File(""), "Global", Status.ERROR, "Config directory not found"))
         }
 
-        // Check legacy keybox.xml
         val legacyFile = File(configDir, "keybox.xml")
         if (isSafeKeyboxFile(legacyFile)) {
             results.add(checkFile(legacyFile, revokedSerials))
         }
 
-        // Check jukebox files
         val keyboxDir = File(configDir, "keyboxes")
         if (Files.isDirectory(keyboxDir.toPath(), LinkOption.NOFOLLOW_LINKS)) {
-            val files =
-                keyboxDir
-                    .listFiles { file ->
-                        file.name.endsWith(".xml", ignoreCase = true) && isSafeKeyboxFile(file)
-                    }.orEmpty()
-            if (files.size > MAX_KEYBOX_FILES) {
-                return listOf(Result(File(""), "Global", Status.ERROR, "Too many keybox files"))
+            val files = ArrayList<File>(MAX_KEYBOX_FILES)
+            try {
+                Files.newDirectoryStream(keyboxDir.toPath()).use { entries ->
+                    for (path in entries) {
+                        val file = path.toFile()
+                        if (!file.name.endsWith(".xml", ignoreCase = true) || !isSafeKeyboxFile(file)) continue
+                        if (files.size >= MAX_KEYBOX_FILES) {
+                            return listOf(Result(File(""), "Global", Status.ERROR, "Too many keybox files"))
+                        }
+                        files.add(file)
+                    }
+                }
+            } catch (error: IOException) {
+                Logger.e("Failed to scan keybox directory", error)
+                return listOf(Result(File(""), "Global", Status.ERROR, "Failed to scan keybox directory"))
             }
+            files.sortBy { it.name }
             for (file in files) {
                 results.add(checkFile(file, revokedSerials))
             }
@@ -127,7 +135,11 @@ object KeyboxVerifier {
         val now = System.currentTimeMillis()
         cacheLock.lock()
         try {
-            if (cachedCrl != null && (now - lastFetchTime) < CACHE_TTL) {
+            if (
+                cachedCrl != null &&
+                now >= lastFetchTime &&
+                now - lastFetchTime < CACHE_TTL
+            ) {
                 return cachedCrl
             }
 
@@ -224,8 +236,9 @@ object KeyboxVerifier {
                     entriesFound = true
                     jsonReader.beginObject()
                     while (jsonReader.hasNext()) {
-                        jsonReader.nextName() // Skip key
-                        jsonReader.skipValue() // Skip value
+                        val key = jsonReader.nextName()
+                        if (key.length > MAX_CRL_KEY_CHARS) throw IOException("CRL entry key is too long")
+                        jsonReader.skipValue()
                         count++
                         if (count > MAX_CRL_ENTRIES) throw IOException("CRL has too many entries")
                     }
@@ -241,7 +254,7 @@ object KeyboxVerifier {
         } finally {
             try {
                 jsonReader.close()
-            } catch (e: Exception) {
+            } catch (_: Exception) {
             }
         }
         return if (entriesFound) count else -1
@@ -263,7 +276,8 @@ object KeyboxVerifier {
                     while (jsonReader.hasNext()) {
                         if (++entriesProcessed > MAX_CRL_ENTRIES) throw IOException("CRL has too many entries")
                         val decStr = jsonReader.nextName()
-                        jsonReader.skipValue() // Value is "REVOKED"
+                        if (decStr.length > MAX_CRL_KEY_CHARS) throw IOException("CRL entry key is too long")
+                        jsonReader.skipValue()
                         processEntry(decStr, set)
                     }
                     jsonReader.endObject()
@@ -282,7 +296,7 @@ object KeyboxVerifier {
         } finally {
             try {
                 jsonReader.close()
-            } catch (e: Exception) {
+            } catch (_: Exception) {
             }
         }
 
@@ -296,17 +310,17 @@ object KeyboxVerifier {
         decStr: String,
         set: HashSet<String>,
     ) {
-        var added = false
+        if (decStr.isEmpty() || decStr.length > MAX_CRL_KEY_CHARS) {
+            Logger.e("Rejected invalid CRL entry key length")
+            return
+        }
 
-        // Try treating as Decimal first (Spec compliant)
-        var isDecimal = true
+        var added = false
+        var isDecimal = decStr[0] != '-'
         if (decStr.length > 1 && decStr.startsWith("0")) {
             isDecimal = false
-        } else {
-            for (i in 0 until decStr.length) {
-                if (i == 0 && decStr[i] == '-' && decStr.length > 1) {
-                    continue
-                }
+        } else if (isDecimal) {
+            for (i in decStr.indices) {
                 if (!Character.isDigit(decStr[i])) {
                     isDecimal = false
                     break
@@ -314,51 +328,38 @@ object KeyboxVerifier {
             }
         }
 
-        if (isDecimal && decStr.isNotEmpty()) {
+        if (isDecimal) {
             try {
                 val hexStr = java.math.BigInteger(decStr).toString(16)
                 set.add(hexStr)
-
-                // BigInteger removes leading zeros. Hashes are fixed length (MD5=32, SHA1=40, SHA256=64).
-                // If this decimal is actually a hash, we might need the padded version.
                 val hexLen = hexStr.length
                 for (targetLen in HASH_LENGTHS) {
                     if (hexLen < targetLen) {
                         set.add(ZEROS.substring(0, targetLen - hexLen) + hexStr)
                     }
                 }
-
                 added = true
-            } catch (e: Exception) {
-                // Should not happen, but safe fallback
+            } catch (_: Exception) {
             }
         }
 
-        // Ambiguity handling
-        // If the string matches a hash length and format, we include it as a raw hex string
-        // regardless of whether it was also parsed as a decimal serial number.
-        // This prevents "Fail Open" scenarios where a hash composed entirely of digits
-        // would otherwise be ignored as a hash.
         if (decStr.length == 32 || decStr.length == 40 || decStr.length == 64) {
             if (isHex(decStr)) {
                 set.add(decStr.lowercase())
             }
         }
 
-        if (!added) {
-            // Try treating as Hex (literal) as fallback
-            if (isHex(decStr)) {
-                try {
-                    val hexStr = java.math.BigInteger(decStr, 16).toString(16)
-                    set.add(hexStr)
-                    added = true
-                } catch (e: Exception) {
-                }
+        if (!added && isHex(decStr)) {
+            try {
+                val hexStr = java.math.BigInteger(decStr, 16).toString(16)
+                set.add(hexStr)
+                added = true
+            } catch (_: Exception) {
             }
         }
 
         if (!added) {
-            Logger.e("Failed to parse CRL entry key: $decStr")
+            Logger.e("Failed to parse CRL entry key")
         }
     }
 
@@ -414,10 +415,8 @@ object KeyboxVerifier {
         if (chain.isEmpty()) return Status.INVALID
 
         for (cert in chain) {
-            if (cert is X509Certificate) {
-                if (isRevoked(cert, revokedSerials)) {
-                    return Status.REVOKED
-                }
+            if (cert is X509Certificate && isRevoked(cert, revokedSerials)) {
+                return Status.REVOKED
             }
         }
         return Status.VALID
@@ -428,22 +427,13 @@ object KeyboxVerifier {
         cert: X509Certificate,
         revokedSerials: Set<String>,
     ): Boolean {
-        // 1. Serial Number (Hex)
         val sn = cert.serialNumber.toString(16)
         if (revokedSerials.contains(sn)) return true
 
-        // 2. Key ID Checks (Hash of Public Key)
         val publicKeyEncoded = cert.publicKey.encoded
-
-        // SHA-1 (40 chars)
         if (checkHash(publicKeyEncoded, "SHA-1", revokedSerials)) return true
-
-        // SHA-256 (64 chars)
         if (checkHash(publicKeyEncoded, "SHA-256", revokedSerials)) return true
-
-        // MD5 (32 chars)
         if (checkHash(publicKeyEncoded, "MD5", revokedSerials)) return true
-
         return false
     }
 
@@ -473,10 +463,9 @@ object KeyboxVerifier {
                 md.reset()
             }
             val digest = md.digest(data)
-            // Convert to Hex String (Zero Padded)
             val hex = digest.toHexString(hexFormat)
             return set.contains(hex)
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             return false
         }
     }

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -316,11 +316,12 @@ object KeyboxVerifier {
         }
 
         var added = false
-        var isDecimal = decStr[0] != '-'
-        if (decStr.length > 1 && decStr.startsWith("0")) {
+        val digitStart = if (decStr[0] == '-') 1 else 0
+        var isDecimal = digitStart < decStr.length
+        if (isDecimal && decStr.length - digitStart > 1 && decStr[digitStart] == '0') {
             isDecimal = false
         } else if (isDecimal) {
-            for (i in decStr.indices) {
+            for (i in digitStart until decStr.length) {
                 if (!Character.isDigit(decStr[i])) {
                     isDecimal = false
                     break
@@ -330,12 +331,15 @@ object KeyboxVerifier {
 
         if (isDecimal) {
             try {
-                val hexStr = java.math.BigInteger(decStr).toString(16)
+                val number = java.math.BigInteger(decStr)
+                val hexStr = number.toString(16)
                 set.add(hexStr)
-                val hexLen = hexStr.length
-                for (targetLen in HASH_LENGTHS) {
-                    if (hexLen < targetLen) {
-                        set.add(ZEROS.substring(0, targetLen - hexLen) + hexStr)
+                if (number.signum() >= 0) {
+                    val hexLen = hexStr.length
+                    for (targetLen in HASH_LENGTHS) {
+                        if (hexLen < targetLen) {
+                            set.add(ZEROS.substring(0, targetLen - hexLen) + hexStr)
+                        }
                     }
                 }
                 added = true

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/PackageTrie.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/PackageTrie.kt
@@ -4,61 +4,47 @@ import java.util.Arrays
 
 class PackageTrie<T> {
     private class Node<T> {
-        // Optimization: Use parallel arrays instead of HashMap to reduce memory overhead and avoid boxing.
-        // For trie nodes, the number of children is usually small (often 1), making linear scan faster than hashing.
-        // UPDATED: Keys are kept sorted to allow binary search, improving lookup time for nodes with many children.
         var keys: CharArray = CharArray(0)
         var children: Array<Node<T>?> = emptyArray()
-
         var value: T? = null
+        var hasValue = false
         var isWildcard = false
         var wildcardValue: T? = null
 
         fun getChild(char: Char): Node<T>? {
             val k = keys
             val len = k.size
-            // Optimization: Linear scan for small arrays (<= 4 elements) is faster than binary search overhead.
-            // Most trie nodes for package names are linear chains (1 child) or small branches.
             if (len <= 4) {
                 for (i in 0 until len) {
                     if (k[i] == char) return children[i]
                 }
                 return null
             }
-            // Optimized binary search for O(log N) lookup
             val idx = Arrays.binarySearch(k, char)
             return if (idx >= 0) children[idx] else null
         }
 
         fun addChild(char: Char): Node<T> {
             val k = keys
-            // Check if child already exists using binary search
             val idx = Arrays.binarySearch(k, char)
             if (idx >= 0) {
                 return children[idx]!!
             }
 
-            // Not found, insert at sorted position
             val insertAt = -(idx + 1)
-
             val newSize = k.size + 1
             val newKeys = CharArray(newSize)
-
-            // Generic array creation workaround
             val newChildren = arrayOfNulls<Node<T>>(newSize)
 
-            // Copy before insertion point
             if (insertAt > 0) {
                 System.arraycopy(k, 0, newKeys, 0, insertAt)
                 System.arraycopy(children, 0, newChildren, 0, insertAt)
             }
 
-            // Insert new child
             newKeys[insertAt] = char
             val newNode = Node<T>()
             newChildren[insertAt] = newNode
 
-            // Copy after insertion point
             if (insertAt < k.size) {
                 System.arraycopy(k, insertAt, newKeys, insertAt + 1, k.size - insertAt)
                 System.arraycopy(children, insertAt, newChildren, insertAt + 1, children.size - insertAt)
@@ -66,7 +52,6 @@ class PackageTrie<T> {
 
             keys = newKeys
             children = newChildren
-
             return newNode
         }
     }
@@ -79,32 +64,30 @@ class PackageTrie<T> {
         rule: String,
         value: T,
     ) {
-        size++
         var current = root
-        var effectiveRule = rule
-        var isWildcardRule = false
-        if (rule.endsWith("*")) {
-            effectiveRule = rule.dropLast(1)
-            isWildcardRule = true
-        }
+        val isWildcardRule = rule.endsWith("*")
+        val effectiveRule = if (isWildcardRule) rule.dropLast(1) else rule
 
         for (char in effectiveRule) {
             current = current.addChild(char)
         }
 
         if (isWildcardRule) {
+            if (!current.isWildcard) size++
             current.isWildcard = true
             current.wildcardValue = value
         } else {
+            if (!current.hasValue) size++
+            current.hasValue = true
             current.value = value
         }
     }
 
     fun clear() {
-        // Clear root children to release memory
         root.keys = CharArray(0)
         root.children = emptyArray()
         root.value = null
+        root.hasValue = false
         root.isWildcard = false
         root.wildcardValue = null
         size = 0
@@ -112,24 +95,19 @@ class PackageTrie<T> {
 
     fun get(pkgName: String): T? {
         var current = root
-        // Keep track of the most specific wildcard match found so far
         var bestMatch: T? = if (current.isWildcard) current.wildcardValue else null
 
-        for (i in pkgName.indices) {
-            val char = pkgName[i]
+        for (char in pkgName) {
             val next = current.getChild(char) ?: return bestMatch
             current = next
             if (current.isWildcard) {
                 bestMatch = current.wildcardValue
             }
         }
-        // If we reached the end of the string, check for exact match value first, then fallback to wildcard
-        return current.value ?: bestMatch
+        return if (current.hasValue) current.value else bestMatch
     }
 
-    fun matches(pkgName: String): Boolean {
-        return get(pkgName) != null
-    }
+    fun matches(pkgName: String): Boolean = get(pkgName) != null
 
     fun isEmpty() = size == 0
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierTest.kt
@@ -2,37 +2,32 @@ package cleveres.tricky.cleverestech.util
 
 import cleveres.tricky.cleverestech.keystore.CertHack
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.mockito.Mockito
+import java.io.IOException
 import java.security.cert.X509Certificate
+import java.nio.file.Files
 
 class KeyboxVerifierTest {
     @Test
     fun `verifyKeybox returns VALID for unrevoked certificate`() {
-        // Arrange
         val mockCert = Mockito.mock(X509Certificate::class.java)
-        // Not revoked serial
         Mockito.`when`(mockCert.serialNumber).thenReturn(java.math.BigInteger("123456"))
         val mockPublicKey = Mockito.mock(java.security.PublicKey::class.java)
         Mockito.`when`(mockPublicKey.encoded).thenReturn(ByteArray(0))
         Mockito.`when`(mockCert.publicKey).thenReturn(mockPublicKey)
 
-        // Mock KeyBox to return our mock cert
         val mockKeyBox = Mockito.mock(CertHack.KeyBox::class.java)
         Mockito.`when`(mockKeyBox.certificates()).thenReturn(listOf(mockCert))
 
-        val revokedSerials = setOf("deadbeef", "cafebabe")
+        val result = KeyboxVerifier.verifyKeybox(mockKeyBox, setOf("deadbeef", "cafebabe"))
 
-        // Act
-        val result = KeyboxVerifier.verifyKeybox(mockKeyBox, revokedSerials)
-
-        // Assert
         assertEquals(KeyboxVerifier.Status.VALID, result)
     }
 
     @Test
     fun `verifyKeybox returns REVOKED for revoked serial`() {
-        // Arrange
         val mockCert = Mockito.mock(X509Certificate::class.java)
         val revokedSerial = "deadbeef"
         Mockito.`when`(mockCert.serialNumber).thenReturn(java.math.BigInteger(revokedSerial, 16))
@@ -40,27 +35,43 @@ class KeyboxVerifierTest {
         val mockKeyBox = Mockito.mock(CertHack.KeyBox::class.java)
         Mockito.`when`(mockKeyBox.certificates()).thenReturn(listOf(mockCert))
 
-        val revokedSerials = setOf(revokedSerial, "cafebabe")
+        val result = KeyboxVerifier.verifyKeybox(mockKeyBox, setOf(revokedSerial, "cafebabe"))
 
-        // Act
-        val result = KeyboxVerifier.verifyKeybox(mockKeyBox, revokedSerials)
-
-        // Assert
         assertEquals(KeyboxVerifier.Status.REVOKED, result)
     }
 
     @Test
     fun `verifyKeybox returns INVALID for empty chain`() {
-        // Arrange
         val mockKeyBox = Mockito.mock(CertHack.KeyBox::class.java)
         Mockito.`when`(mockKeyBox.certificates()).thenReturn(emptyList())
 
-        val revokedSerials = emptySet<String>()
+        val result = KeyboxVerifier.verifyKeybox(mockKeyBox, emptySet())
 
-        // Act
-        val result = KeyboxVerifier.verifyKeybox(mockKeyBox, revokedSerials)
-
-        // Assert
         assertEquals(KeyboxVerifier.Status.INVALID, result)
+    }
+
+    @Test
+    fun `parseCrl rejects oversized entry keys`() {
+        val key = "1".repeat(129)
+        assertThrows(IOException::class.java) {
+            KeyboxVerifier.parseCrl("""{"entries":{"$key":"REVOKED"}}""")
+        }
+    }
+
+    @Test
+    fun `verify rejects keybox directories above the file limit`() {
+        val configDir = Files.createTempDirectory("keybox-verifier-limit").toFile()
+        try {
+            val keyboxDir = configDir.resolve("keyboxes").apply { mkdirs() }
+            repeat(65) { index -> keyboxDir.resolve("keybox-$index.xml").writeText("x") }
+
+            val results = KeyboxVerifier.verify(configDir) { emptySet() }
+
+            assertEquals(1, results.size)
+            assertEquals(KeyboxVerifier.Status.ERROR, results.single().status)
+            assertEquals("Too many keybox files", results.single().details)
+        } finally {
+            configDir.deleteRecursively()
+        }
     }
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/PackageTrieTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/PackageTrieTest.kt
@@ -22,11 +22,9 @@ class PackageTrieTest {
         val trie = PackageTrie<String>()
         trie.add("com.google.*", "config_google")
 
-        // "com.google.*" means prefix "com.google." so "com.google" (exact) is not matched by wildcard unless explicit
         assertNull(trie.get("com.google"))
         assertEquals("config_google", trie.get("com.google.android"))
         assertEquals("config_google", trie.get("com.google.android.gms"))
-
         assertNull(trie.get("com.goo"))
     }
 
@@ -38,8 +36,6 @@ class PackageTrieTest {
 
         assertEquals("generic", trie.get("com.google.android"))
         assertEquals("specific", trie.get("com.google.maps"))
-
-        // Exact match doesn't imply prefix match unless wildcard is used
         assertEquals("generic", trie.get("com.google.maps.beta"))
     }
 
@@ -63,26 +59,34 @@ class PackageTrieTest {
     }
 
     @Test
-    fun testBranchingOptimization() {
+    fun testBranchingLookup() {
         val trie = PackageTrie<String>()
-        // Small branching (<= 4)
         trie.add("a", "1")
         trie.add("b", "2")
         trie.add("c", "3")
         trie.add("d", "4")
+        trie.add("e", "5")
+        trie.add("f", "6")
 
         assertEquals("1", trie.get("a"))
         assertEquals("2", trie.get("b"))
         assertEquals("3", trie.get("c"))
         assertEquals("4", trie.get("d"))
-        assertNull(trie.get("e"))
-
-        // Large branching (> 4) to trigger binary search path
-        trie.add("e", "5")
-        trie.add("f", "6")
-
-        assertEquals("1", trie.get("a"))
         assertEquals("5", trie.get("e"))
         assertEquals("6", trie.get("f"))
+        assertNull(trie.get("g"))
+    }
+
+    @Test
+    fun duplicateRulesDoNotInflateSize() {
+        val trie = PackageTrie<String>()
+        trie.add("com.example.app", "first")
+        trie.add("com.example.app", "second")
+        trie.add("com.example.*", "wildcard-first")
+        trie.add("com.example.*", "wildcard-second")
+
+        assertEquals(2, trie.size)
+        assertEquals("second", trie.get("com.example.app"))
+        assertEquals("wildcard-second", trie.get("com.example.other"))
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,8 +28,8 @@ gradle.rootProject {
                 force("io.netty:netty-codec-http2:4.2.17.Final")
                 force("io.netty:netty-codec:4.2.17.Final")
                 force("io.netty:netty-handler-proxy:4.2.17.Final")
-                force("org.bouncycastle:bcpkix-jdk18on:1.85.2")
-                force("org.bouncycastle:bcprov-jdk18on:1.85.2")
+                force("org.bouncycastle:bcpkix-jdk18on:1.85")
+                force("org.bouncycastle:bcprov-jdk18on:1.85")
                 force("ch.qos.logback:logback-core:1.6.1")
                 force("ch.qos.logback:logback-classic:1.6.1")
             }
@@ -40,8 +40,8 @@ gradle.rootProject {
                 force("io.netty:netty-codec-http2:4.2.17.Final")
                 force("io.netty:netty-codec:4.2.17.Final")
                 force("io.netty:netty-handler-proxy:4.2.17.Final")
-                force("org.bouncycastle:bcpkix-jdk18on:1.85.2")
-                force("org.bouncycastle:bcprov-jdk18on:1.85.2")
+                force("org.bouncycastle:bcpkix-jdk18on:1.85")
+                force("org.bouncycastle:bcprov-jdk18on:1.85")
                 force("ch.qos.logback:logback-core:1.6.1")
                 force("ch.qos.logback:logback-classic:1.6.1")
             }


### PR DESCRIPTION
## Summary
- restore resolvable build dependency pins and keep current Gradle wrapper compatibility
- harden KernelSU/APatch module installation, SDK validation, config ownership, and early-boot handling
- bound CBOX, keybox, CRL, template, and remote-server processing to fail closed on malformed or unsafe input
- fix template initialization races, stale-clock refresh handling, and trie lookup edge cases
- extend regression coverage for keybox verification and package matching

## Validation
- preserve the already-merged FilePoller and BinderInterceptor fixes from current master
- run the repository Build workflow and unit tests before marking ready or merging