### PR TITLE
fix: complete attestation fallback and WebUI error handling

### DIFF
--- a/module/template/customize.sh
+++ b/module/template/customize.sh
@@ -138,7 +138,7 @@ done
 for config_file in spoof_build_vars security_patch.txt target.txt drm_packages.txt boot_props_mode \
   spoof_enabled spoof_switch_initialized spoof_build_identity global_mode tee_broken_mode \
   auto_keybox_check random_on_boot rkp_passthrough drm_passthrough hide_sensitive_props \
-  spoof_region_cn telephony privacy_seed app_config templates.json custom_templates module_hash \
+  spoof_region_cn telephony privacy_seed boot_key boot_hash app_config templates.json custom_templates module_hash \
   servers.json keybox.xml lang.json spoof_build_vars.next apply_profile; do
   config_path="$CONFIG_DIR/$config_file"
   if [ -e "$config_path" ] || [ -L "$config_path" ]; then

--- a/module/template/webroot/bridge.js
+++ b/module/template/webroot/bridge.js
@@ -48,9 +48,19 @@
 
         if (values.length === 1 && errno && typeof errno === 'object' && !Array.isArray(errno)) {
             const result = errno;
-            errno = result.errno ?? result.code ?? 0;
-            stdout = result.stdout ?? result.out ?? '';
-            stderr = result.stderr ?? result.err ?? '';
+            if ('errno' in result || 'stdout' in result || 'stderr' in result || 'code' in result || 'out' in result || 'err' in result) {
+                errno = result.errno ?? result.code ?? 0;
+                stdout = result.stdout ?? result.out ?? '';
+                stderr = result.stderr ?? result.err ?? '';
+            } else if (result.version === 1 && Number.isInteger(result.status)) {
+                errno = 0;
+                stdout = JSON.stringify(result);
+                stderr = '';
+            } else {
+                errno = -1;
+                stdout = '';
+                stderr = 'Unsupported native exec result';
+            }
         } else if (values.length === 1 && typeof errno === 'string') {
             const raw = errno.trim();
             let parsed = null;
@@ -95,7 +105,13 @@
                 settled = true;
                 clearTimeout(timer);
                 delete global[callbackName];
-                const result = normalizeExecResult(values);
+                let result;
+                try {
+                    result = normalizeExecResult(values);
+                } catch (error) {
+                    reject(error);
+                    return;
+                }
                 if (result.errno === 0) resolve(result.stdout);
                 else reject(new Error(result.stderr || result.stdout || `Native bridge failed with code ${result.errno}`));
             };

--- a/module/template/webroot/index.html
+++ b/module/template/webroot/index.html
@@ -694,26 +694,35 @@ try {
 }
         }
         let notifyTimeout;
+        const maxEncodedUiMessageLength = 16 * 1024;
         function normalizeUiMessage(value) {
 let message = String(value ?? '');
 try {
     const envelope = JSON.parse(message);
     if (envelope && envelope.version === 1 && Number.isInteger(envelope.status) && typeof envelope.body === 'string') {
-        const padded = envelope.body.replace(/-/g, '+').replace(/_/g, '/') + '==='.slice((envelope.body.length + 3) % 4);
-        const bytes = Uint8Array.from(atob(padded), char => char.charCodeAt(0));
-        const body = new TextDecoder('utf-8', { fatal: false }).decode(bytes).trim();
-        if (body) {
-            try {
-                const parsedBody = JSON.parse(body);
-                message = parsedBody.error || parsedBody.message || parsedBody.details || body;
-            } catch (_) {
-                message = body;
-            }
+        const status = `HTTP ${envelope.status} ${envelope.statusText || ''}`.trim();
+        if (envelope.body.length > maxEncodedUiMessageLength) {
+            message = `${status}: response body is too large to display`;
         } else {
-            message = `HTTP ${envelope.status} ${envelope.statusText || ''}`.trim();
+            if (!/^[A-Za-z0-9_-]*$/.test(envelope.body)) throw new Error('Invalid response payload');
+            const padded = envelope.body.replace(/-/g, '+').replace(/_/g, '/') + '==='.slice((envelope.body.length + 3) % 4);
+            const bytes = Uint8Array.from(atob(padded), char => char.charCodeAt(0));
+            const body = new TextDecoder('utf-8', { fatal: false }).decode(bytes).trim();
+            if (body) {
+                try {
+                    const parsedBody = JSON.parse(body);
+                    const detail = parsedBody.error || parsedBody.message || parsedBody.details;
+                    message = typeof detail === 'string' ? detail : body;
+                } catch (_) {
+                    message = body;
+                }
+            } else {
+                message = status;
+            }
         }
     }
 } catch (_) {}
+message = String(message);
 if (message.length > 1200) message = message.slice(0, 1197) + '...';
 return message;
         }

--- a/module/webui-tests/bridge.test.js
+++ b/module/webui-tests/bridge.test.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const vm = require('vm');
 
 const bridgeSource = fs.readFileSync('module/template/webroot/bridge.js', 'utf8');
+const indexSource = fs.readFileSync('module/template/webroot/index.html', 'utf8');
 
 function encodeBody(value) {
     return Buffer.from(value, 'utf8').toString('base64url');
@@ -52,6 +53,20 @@ function createBridge(callbackFactory) {
     return context.CleveresBridge;
 }
 
+function loadMessageNormalizer() {
+    const start = indexSource.indexOf('const maxEncodedUiMessageLength');
+    const end = indexSource.indexOf('\n        function notify', start);
+    assert.ok(start >= 0 && end > start, 'UI message normalizer source is missing');
+    const context = {
+        TextDecoder,
+        Uint8Array,
+        atob: value => Buffer.from(value, 'base64').toString('binary')
+    };
+    vm.createContext(context);
+    vm.runInContext(`${indexSource.slice(start, end)}; this.normalizeUiMessage = normalizeUiMessage;`, context);
+    return context.normalizeUiMessage;
+}
+
 async function main() {
     const raw = envelope();
 
@@ -59,7 +74,8 @@ async function main() {
         callback => callback(0, raw, ''),
         callback => callback(raw),
         callback => callback({ errno: 0, stdout: raw, stderr: '' }),
-        callback => callback(JSON.stringify({ errno: 0, stdout: raw, stderr: '' }))
+        callback => callback(JSON.stringify({ errno: 0, stdout: raw, stderr: '' })),
+        callback => callback(JSON.parse(raw))
     ]) {
         const bridge = createBridge(callbackFactory);
         const response = await bridge.fetch('/api/config');
@@ -73,6 +89,21 @@ async function main() {
 
     const malformed = createBridge(callback => callback('{"version":1,"status":200}'));
     await assert.rejects(() => malformed.fetch('/api/config'), /Invalid response/);
+
+    const unsupported = createBridge(callback => callback({ unexpected: true }));
+    await assert.rejects(() => unsupported.fetch('/api/config'), /Unsupported native exec result/);
+
+    const normalizeUiMessage = loadMessageNormalizer();
+    assert.strictEqual(normalizeUiMessage(envelope('{"error":"keybox rejected"}')), 'keybox rejected');
+    assert.strictEqual(normalizeUiMessage('<img src=x onerror=alert(1)>'), '<img src=x onerror=alert(1)>');
+    const oversized = JSON.stringify({
+        version: 1,
+        status: 500,
+        statusText: 'Server Error',
+        body: 'A'.repeat(16 * 1024 + 1)
+    });
+    assert.strictEqual(normalizeUiMessage(oversized), 'HTTP 500 Server Error: response body is too large to display');
+    assert.ok(indexSource.includes('text.textContent = normalizeUiMessage(msg);'));
 
     console.log('Native WebUI bridge compatibility tests passed');
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/Util.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Util.kt
@@ -5,7 +5,12 @@ package cleveres.tricky.cleverestech
 import android.content.pm.IPackageManager
 import android.os.Build
 import android.os.SystemProperties
+import cleveres.tricky.cleverestech.util.SecureFile
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.LinkOption
 import java.security.MessageDigest
+import java.security.SecureRandom
 import java.time.LocalDate
 
 var systemPropertiesGet: (String, String?) -> String? = { key, def -> SystemProperties.get(key, def) }
@@ -52,6 +57,14 @@ val bootKey by lazy {
     getBootKeyFromProp() ?: getVerifiedBootKeyDigest()
 }
 
+val persistentBootKey by lazy {
+    BootIdentityStore.bootKey()
+}
+
+val persistentBootHash by lazy {
+    BootIdentityStore.bootHash()
+}
+
 private fun getVerifiedBootKeyDigest(): ByteArray? {
     val slot = systemPropertiesGet("ro.boot.slot_suffix", "") ?: ""
     val paths = mutableListOf<String>()
@@ -75,9 +88,91 @@ private fun getVerifiedBootKeyDigest(): ByteArray? {
 private fun decodeBootDigest(value: String?): ByteArray? {
     if (value?.length != 64) return null
     val decoded = runCatching { value.hexToByteArray() }.getOrNull() ?: return null
-    if (decoded.size == 32 && decoded.any { it != 0.toByte() }) return decoded
+    if (decoded.isUsableBootDigest()) return decoded
     decoded.fill(0)
     return null
+}
+
+internal fun ByteArray?.isUsableBootDigest(): Boolean =
+    this != null && size == BOOT_DIGEST_BYTES && any { it != 0.toByte() }
+
+internal object BootIdentityStore {
+    private const val BOOT_KEY_FILE = "boot_key"
+    private const val BOOT_HASH_FILE = "boot_hash"
+    private val lock = Any()
+
+    @Volatile
+    private var root = File("/data/adb/cleverestricky")
+
+    fun bootKey(): ByteArray? = getOrCreate(BOOT_KEY_FILE)
+
+    fun bootHash(): ByteArray? = getOrCreate(BOOT_HASH_FILE)
+
+    private fun getOrCreate(filename: String): ByteArray? =
+        synchronized(lock) {
+            val file = File(root, filename)
+            readDigest(file)?.let { return@synchronized it }
+
+            val generated = generateDigest() ?: return@synchronized null
+            try {
+                SecureFile.writeText(file, generated.toHexString())
+            } catch (error: Exception) {
+                Logger.e("Could not persist $filename; using an in-memory boot identity for this runtime", error)
+            }
+            generated
+        }
+
+    private fun readDigest(file: File): ByteArray? {
+        val path = file.toPath()
+        if (!Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) return null
+        val size = runCatching { Files.size(path) }.getOrNull() ?: return null
+        if (size !in 64L..65L) return null
+
+        val encoded = ByteArray(66)
+        return try {
+            var total = 0
+            Files.newInputStream(path, LinkOption.NOFOLLOW_LINKS).use { input ->
+                while (total < encoded.size) {
+                    val count = input.read(encoded, total, encoded.size - total)
+                    if (count < 0) break
+                    if (count == 0) continue
+                    total += count
+                }
+            }
+            if (total > 65) return null
+            decodeBootDigest(encoded.copyOf(total).toString(Charsets.UTF_8).trim())
+        } catch (error: Exception) {
+            Logger.e("Could not read persisted ${file.name}", error)
+            null
+        } finally {
+            encoded.fill(0)
+        }
+    }
+
+    private fun generateDigest(): ByteArray? =
+        runCatching {
+            val random = SecureRandom()
+            repeat(4) {
+                val generated = ByteArray(BOOT_DIGEST_BYTES)
+                random.nextBytes(generated)
+                if (generated.isUsableBootDigest()) return@runCatching generated
+                generated.fill(0)
+            }
+            error("SecureRandom repeatedly returned an invalid boot digest")
+        }.onFailure { Logger.e("Could not generate a boot identity fallback", it) }
+            .getOrNull()
+
+    @androidx.annotation.VisibleForTesting
+    fun setRootForTesting(newRoot: File) {
+        synchronized(lock) {
+            root = newRoot
+        }
+    }
+
+    @androidx.annotation.VisibleForTesting
+    fun resetRootForTesting() {
+        setRootForTesting(File("/data/adb/cleverestricky"))
+    }
 }
 
 @OptIn(ExperimentalStdlibApi::class)
@@ -91,6 +186,8 @@ fun getBootKeyFromProp(): ByteArray? {
 
 @OptIn(ExperimentalStdlibApi::class)
 fun getBootHashFromProp(): ByteArray? = decodeBootDigest(systemPropertiesGet("ro.boot.vbmeta.digest", null))
+
+private const val BOOT_DIGEST_BYTES = 32
 
 val patchLevel by lazy {
     runCatching { Build.VERSION.SECURITY_PATCH.convertPatchLevel(false) }

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -627,7 +627,7 @@ public final class CertHack {
             signer = new JcaContentSignerBuilder(signatureAlgorithm)
                     .build(k.keyPair.getPrivate());
 
-            byte[] verifiedBootKey = UtilKt.getBootKey();
+            byte[] verifiedBootKey = usableBootDigest(UtilKt.getBootKey());
             byte[] verifiedBootHash = null;
             try {
                 if (rootOfTrust == null || !(rootOfTrust instanceof ASN1Sequence r)) {
@@ -635,15 +635,21 @@ public final class CertHack {
                             + (rootOfTrust == null ? "null" : rootOfTrust.getClass().getName()));
                 }
                 if (verifiedBootKey == null) {
-                    verifiedBootKey = getByteArrayFromAsn1(r.getObjectAt(0));
+                    verifiedBootKey = usableBootDigest(getByteArrayFromAsn1(r.getObjectAt(0)));
                 }
-                verifiedBootHash = getByteArrayFromAsn1(r.getObjectAt(3));
+                verifiedBootHash = usableBootDigest(getByteArrayFromAsn1(r.getObjectAt(3)));
             } catch (Throwable t) {
                 Logger.e("Failed to read the original root-of-trust fields", t);
             }
 
+            if (verifiedBootKey == null) {
+                verifiedBootKey = usableBootDigest(UtilKt.getPersistentBootKey());
+            }
             if (verifiedBootHash == null) {
-                verifiedBootHash = UtilKt.getBootHash();
+                verifiedBootHash = usableBootDigest(UtilKt.getBootHash());
+            }
+            if (verifiedBootHash == null) {
+                verifiedBootHash = usableBootDigest(UtilKt.getPersistentBootHash());
             }
             if (verifiedBootKey == null || verifiedBootHash == null) {
                 Logger.e("Verified boot key/hash is unavailable; preserving the original certificate chain");
@@ -694,6 +700,13 @@ public final class CertHack {
             Logger.e("Exception in hackCertificateChain", t);
         }
         return caList;
+    }
+
+    private static byte[] usableBootDigest(byte[] value) {
+        if (value == null || value.length != 32) return null;
+        int aggregate = 0;
+        for (byte current : value) aggregate |= current & 0xFF;
+        return aggregate == 0 ? null : value;
     }
 
     private static String normalizeAlgorithm(String algorithm) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/UtilTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/UtilTest.kt
@@ -2,12 +2,19 @@ package cleveres.tricky.cleverestech
 
 import org.junit.After
 import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 
 @OptIn(ExperimentalStdlibApi::class)
 class UtilTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
     private val originalFetcher = systemPropertiesGet
     private val properties = mutableMapOf<String, String>()
 
@@ -22,6 +29,7 @@ class UtilTest {
     @After
     fun tearDown() {
         systemPropertiesGet = originalFetcher
+        BootIdentityStore.resetRootForTesting()
     }
 
     private fun setProp(
@@ -96,5 +104,34 @@ class UtilTest {
 
         val result = getBootKeyFromProp()
         assertNull(result)
+    }
+
+    @Test
+    fun testPersistentBootDigests_areStableDistinctAndNonZero() {
+        val root = temporaryFolder.newFolder("boot-identity")
+        BootIdentityStore.setRootForTesting(root)
+
+        val firstKey = requireNotNull(BootIdentityStore.bootKey())
+        val secondKey = requireNotNull(BootIdentityStore.bootKey())
+        val bootHash = requireNotNull(BootIdentityStore.bootHash())
+
+        assertTrue(firstKey.isUsableBootDigest())
+        assertTrue(bootHash.isUsableBootDigest())
+        assertArrayEquals(firstKey, secondKey)
+        assertFalse(firstKey.contentEquals(bootHash))
+        assertTrue(root.resolve("boot_key").readText().matches(Regex("[0-9a-f]{64}")))
+        assertTrue(root.resolve("boot_hash").readText().matches(Regex("[0-9a-f]{64}")))
+    }
+
+    @Test
+    fun testPersistentBootDigest_replacesZeroSentinel() {
+        val root = temporaryFolder.newFolder("zero-boot-identity")
+        root.resolve("boot_key").writeText("0".repeat(64))
+        BootIdentityStore.setRootForTesting(root)
+
+        val bootKey = requireNotNull(BootIdentityStore.bootKey())
+
+        assertTrue(bootKey.isUsableBootDigest())
+        assertFalse(root.resolve("boot_key").readText().trim().all { it == '0' })
     }
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/ModuleHashTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/ModuleHashTest.java
@@ -146,14 +146,35 @@ public class ModuleHashTest {
                 }
             }
             Assert.assertTrue("ModuleHash tag 724 not found", found);
+            boolean foundRootOfTrust = false;
             for (ASN1Encodable encodable : teeEnforced) {
-                Assert.assertNotEquals(724, ((ASN1TaggedObject) encodable).getTagNo());
+                ASN1TaggedObject taggedObject = (ASN1TaggedObject) encodable;
+                Assert.assertNotEquals(724, taggedObject.getTagNo());
+                if (taggedObject.getTagNo() == 704) {
+                    foundRootOfTrust = true;
+                    ASN1Sequence rootOfTrust = ASN1Sequence.getInstance(taggedObject.getBaseObject());
+                    byte[] bootKey = ASN1OctetString.getInstance(rootOfTrust.getObjectAt(0)).getOctets();
+                    byte[] bootHash = ASN1OctetString.getInstance(rootOfTrust.getObjectAt(3)).getOctets();
+                    Assert.assertEquals(32, bootKey.length);
+                    Assert.assertEquals(32, bootHash.length);
+                    Assert.assertFalse("Verified boot key must not be all zero", isAllZero(bootKey));
+                    Assert.assertFalse("Verified boot hash must not be all zero", isAllZero(bootHash));
+                    Assert.assertTrue(ASN1Boolean.getInstance(rootOfTrust.getObjectAt(1)).isTrue());
+                    Assert.assertEquals(0, ASN1Enumerated.getInstance(rootOfTrust.getObjectAt(2)).getValue().intValue());
+                }
             }
+            Assert.assertTrue("RootOfTrust tag 704 not found", foundRootOfTrust);
         } finally {
             state.set(null, previousState);
             moduleHash.set(Config.INSTANCE, previousHash);
             CertHack.clearCertificateCache();
         }
+    }
+
+    private static boolean isAllZero(byte[] value) {
+        int aggregate = 0;
+        for (byte current : value) aggregate |= current & 0xFF;
+        return aggregate == 0;
     }
 
     @Test


### PR DESCRIPTION
## Context

Follow-up to #892 after reviewing the remaining RootOfTrust fallback and native WebUI response paths.

## Fixes

- Reject all-zero 32-byte boot keys and hashes from every source, including the original attestation RootOfTrust.
- Fall back to stable, securely generated boot identity values when no usable property, vbmeta value, or attested digest exists.
- Persist fallback values atomically under the module data directory and preserve their ownership and permissions during upgrades.
- Accept direct native response-envelope callback objects while reporting unsupported callback shapes explicitly.
- Bound encoded error processing before Base64 decoding so oversized native responses cannot inflate into a large notification.
- Keep rendered error details text-only and retain the existing display-length limit.

## Regression coverage

- Adds boot identity persistence, non-zero sentinel, and RootOfTrust substitution tests.
- Extends browserless WebUI bridge tests for legacy callbacks, wrapper objects, direct envelopes, unsupported shapes, XSS-safe rendering, and oversized bodies.

Local checks completed: WebUI bridge tests, JavaScript syntax, inline-script parsing, shell syntax, and `git diff --check`. Android unit tests and the full packaging/native checks are delegated to GitHub Actions.