### PR TITLE
fix: recover WebUI native responses

### DIFF
--- a/module/template/webroot/bridge.js
+++ b/module/template/webroot/bridge.js
@@ -10,6 +10,8 @@
     const chunkBytes = 48 * 1024;
     const maxUploadBytes = 20 * 1024 * 1024;
     const maxResponseBytes = 20 * 1024 * 1024;
+    const maxEnvelopeChars = 1024 * 1024;
+    const responseFields = new Set(['version', 'status', 'statusText', 'mimeType', 'size', 'body', 'downloadId']);
     let callbackCounter = 0;
 
     function encodeBytes(bytes) {
@@ -41,7 +43,54 @@
         return `CT_BRIDGE=''; for CT_PATH in ${paths}; do [ -x "$CT_PATH" ] && { CT_BRIDGE="$CT_PATH"; break; }; done; [ -n "$CT_BRIDGE" ] || { echo 'Native WebUI bridge is unavailable' >&2; exit 127; }; exec "$CT_BRIDGE" ${args.map(value => `'${value}'`).join(' ')}`;
     }
 
-    function normalizeExecResult(values) {
+    function validateResponseEnvelope(envelope) {
+        if (!envelope || typeof envelope !== 'object' || Array.isArray(envelope)) throw new Error('Invalid response envelope');
+        const keys = Object.keys(envelope);
+        if (!keys.every(key => responseFields.has(key)) || envelope.version !== 1 || !Number.isInteger(envelope.status) || envelope.status < 100 || envelope.status > 599) throw new Error('Invalid response envelope');
+        if (typeof envelope.statusText !== 'string' || envelope.statusText.length > 256 || /[\u0000-\u001F\u007F]/.test(envelope.statusText) || typeof envelope.mimeType !== 'string' || envelope.mimeType.length < 1 || envelope.mimeType.length > 256 || /[\u0000-\u001F\u007F]/.test(envelope.mimeType)) throw new Error('Invalid response metadata');
+        if (!Number.isSafeInteger(envelope.size) || envelope.size < 0 || envelope.size > maxResponseBytes) throw new Error('Invalid response size');
+        const hasBody = typeof envelope.body === 'string';
+        const hasDownload = typeof envelope.downloadId === 'string';
+        if (hasBody === hasDownload || (hasDownload && !/^[0-9a-f]{32}$/.test(envelope.downloadId))) throw new Error('Invalid response payload');
+        if (hasBody && (envelope.body.length > maxEnvelopeChars || !/^[A-Za-z0-9_-]*$/.test(envelope.body))) throw new Error('Invalid response payload');
+        return envelope;
+    }
+
+    function extractResponseEnvelope(value, depth = 0) {
+        if (value === null || value === undefined || depth > 4) return null;
+        if (typeof value === 'string') {
+            const raw = value.trim();
+            if (!raw || raw.length > maxEnvelopeChars) return null;
+            try {
+                return extractResponseEnvelope(JSON.parse(raw), depth + 1);
+            } catch (_) {
+                return null;
+            }
+        }
+        if (typeof value !== 'object' || Array.isArray(value)) return null;
+        try {
+            return JSON.stringify(validateResponseEnvelope(value));
+        } catch (_) {
+        }
+        for (const key of ['stdout', 'out', 'stderr', 'err', 'message', 'result', 'data', 'output']) {
+            if (key in value) {
+                const envelope = extractResponseEnvelope(value[key], depth + 1);
+                if (envelope) return envelope;
+            }
+        }
+        return null;
+    }
+
+    function normalizeExecResult(values, expectEnvelope = false) {
+        if (expectEnvelope) {
+            // Some WebUI hosts report a non-zero callback code while still returning the
+            // completed bridge response on stdout/stderr. Only recover an exact, bounded
+            // protocol envelope; normal command failures continue down the errno path.
+            for (const value of [values[1], values[0], values[2]]) {
+                const envelope = extractResponseEnvelope(value);
+                if (envelope) return { errno: 0, stdout: envelope, stderr: '' };
+            }
+        }
         let errno = values[0];
         let stdout = values[1];
         let stderr = values[2];
@@ -88,7 +137,7 @@
         };
     }
 
-    function execNative(args, timeoutMs) {
+    function execNative(args, timeoutMs, expectEnvelope = false) {
         if (!nativeApi || typeof nativeApi.exec !== 'function') return Promise.reject(new Error('Open this page from the KernelSU or APatch WebUI button'));
         const boundedTimeout = Math.min(Math.max(Number(timeoutMs) || 60000, 1000), 125000);
         return new Promise((resolve, reject) => {
@@ -107,7 +156,7 @@
                 delete global[callbackName];
                 let result;
                 try {
-                    result = normalizeExecResult(values);
+                    result = normalizeExecResult(values, expectEnvelope);
                 } catch (error) {
                     reject(error);
                     return;
@@ -290,12 +339,12 @@
         if (bytes.length > 1024 * 1024) throw new Error('Request is too large');
         let raw;
         if (bytes.length <= chunkBytes) {
-            raw = await execNative(['call', encodeBytes(bytes), String(timeoutMs)], timeoutMs);
+            raw = await execNative(['call', encodeBytes(bytes), String(timeoutMs)], timeoutMs, true);
         } else {
             const stageId = await createStage('request', timeoutMs);
             try {
                 await appendStage('request', stageId, bytes, timeoutMs);
-                raw = await execNative(['call-file', stageId, String(timeoutMs)], timeoutMs);
+                raw = await execNative(['call-file', stageId, String(timeoutMs)], timeoutMs, true);
             } catch (error) {
                 await dropStage('request', stageId);
                 throw error;
@@ -307,15 +356,9 @@
         } catch (_) {
             throw new Error('Invalid response from native bridge');
         }
-        if (!envelope || typeof envelope !== 'object' || Array.isArray(envelope)) throw new Error('Invalid response envelope');
-        const keys = Object.keys(envelope);
-        const allowedFields = new Set(['version', 'status', 'statusText', 'mimeType', 'size', 'body', 'downloadId']);
-        if (!keys.every(key => allowedFields.has(key)) || envelope.version !== 1 || !Number.isInteger(envelope.status) || envelope.status < 100 || envelope.status > 599) throw new Error('Invalid response envelope');
-        if (typeof envelope.statusText !== 'string' || envelope.statusText.length > 256 || /[\u0000-\u001F\u007F]/.test(envelope.statusText) || typeof envelope.mimeType !== 'string' || envelope.mimeType.length < 1 || envelope.mimeType.length > 256 || /[\u0000-\u001F\u007F]/.test(envelope.mimeType)) throw new Error('Invalid response metadata');
-        if (!Number.isSafeInteger(envelope.size) || envelope.size < 0 || envelope.size > maxResponseBytes) throw new Error('Invalid response size');
+        validateResponseEnvelope(envelope);
         const hasBody = typeof envelope.body === 'string';
         const hasDownload = typeof envelope.downloadId === 'string';
-        if (hasBody === hasDownload || (hasDownload && !/^[0-9a-f]{32}$/.test(envelope.downloadId))) throw new Error('Invalid response payload');
         const response = new NativeResponse(envelope, timeoutMs);
         if (hasBody) {
             const decoded = decodeBytes(envelope.body);
@@ -388,5 +431,5 @@
     } catch (_) {
     }
 
-    global.CleveresBridge = Object.freeze({ fetch: nativeFetch, exportBlob, exportResponse, listPackages });
+    global.CleveresBridge = Object.freeze({ revision: 4, fetch: nativeFetch, exportBlob, exportResponse, listPackages });
 })(window);

--- a/module/template/webroot/index.html
+++ b/module/template/webroot/index.html
@@ -504,7 +504,7 @@ input[type="text"], input[type="tel"], input[type="password"], input[type="searc
         </div>
     </div>
 
-    <script src="bridge.js"></script>
+    <script src="bridge.js?revision=4"></script>
     <script>
         window.addEventListener('unhandledrejection', function(event) {
 if (event.reason && event.reason.message && event.reason.message.includes('fetch')) {

--- a/module/webui-tests/bridge.test.js
+++ b/module/webui-tests/bridge.test.js
@@ -75,7 +75,12 @@ async function main() {
         callback => callback(raw),
         callback => callback({ errno: 0, stdout: raw, stderr: '' }),
         callback => callback(JSON.stringify({ errno: 0, stdout: raw, stderr: '' })),
-        callback => callback(JSON.parse(raw))
+        callback => callback(JSON.parse(raw)),
+        callback => callback(1, raw, ''),
+        callback => callback(1, '', raw),
+        callback => callback(raw, '', 0),
+        callback => callback({ errno: 1, stderr: raw }),
+        callback => callback(new Error(raw))
     ]) {
         const bridge = createBridge(callbackFactory);
         const response = await bridge.fetch('/api/config');
@@ -93,6 +98,27 @@ async function main() {
     const unsupported = createBridge(callback => callback({ unexpected: true }));
     await assert.rejects(() => unsupported.fetch('/api/config'), /Unsupported native exec result/);
 
+    const incompleteErrorEnvelope = createBridge(callback => callback(1, '', '{"version":1,"status":200}'));
+    await assert.rejects(() => incompleteErrorEnvelope.fetch('/api/config'), /version.*status|Native bridge failed|Invalid response/i);
+
+    const emptyListRaw = envelope('[]');
+    const errorChannelSuccess = createBridge(callback => callback(1, '', emptyListRaw));
+    const emptyListResponse = await errorChannelSuccess.fetch('/api/keyboxes');
+    assert.strictEqual(emptyListResponse.ok, true);
+    assert.deepStrictEqual(Array.from(await emptyListResponse.json()), []);
+
+    const bootPolicyBridge = createBridge(callback => callback(1, '', envelope('auto\n')));
+    const bootPolicyResponse = await bootPolicyBridge.fetch('/api/file?filename=boot_props_mode');
+    assert.strictEqual((await bootPolicyResponse.text()).trim(), 'auto');
+
+    const resourceBody = JSON.stringify({ real_ram_kb: 4096, real_cpu: 1.5, environment: 'KernelSU' });
+    const resourceBridge = createBridge(callback => callback(1, envelope(resourceBody), ''));
+    const resourceResponse = await resourceBridge.fetch('/api/resource_usage');
+    assert.deepStrictEqual(
+        JSON.parse(JSON.stringify(await resourceResponse.json())),
+        JSON.parse(resourceBody)
+    );
+
     const normalizeUiMessage = loadMessageNormalizer();
     assert.strictEqual(normalizeUiMessage(envelope('{"error":"keybox rejected"}')), 'keybox rejected');
     assert.strictEqual(normalizeUiMessage('<img src=x onerror=alert(1)>'), '<img src=x onerror=alert(1)>');
@@ -104,6 +130,7 @@ async function main() {
     });
     assert.strictEqual(normalizeUiMessage(oversized), 'HTTP 500 Server Error: response body is too large to display');
     assert.ok(indexSource.includes('text.textContent = normalizeUiMessage(msg);'));
+    assert.ok(indexSource.includes('<script src="bridge.js?revision=4"></script>'));
 
     console.log('Native WebUI bridge compatibility tests passed');
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerUXTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerUXTest.kt
@@ -135,7 +135,7 @@ class WebServerUXTest {
         assertTrue(html.contains("height: min(500px, 60dvh) !important"))
         assertTrue(html.contains("async function fetchAuth"))
         assertTrue(html.contains("window.CleveresBridge.fetch(url, options)"))
-        assertTrue(html.contains("<script src=\"bridge.js\"></script>"))
+        assertTrue(html.contains("<script src=\"bridge.js?revision=4\"></script>"))
         assertTrue(html.contains("function downloadBlob"))
         assertTrue(html.contains("if (files && files[0]) loadFileContent(files[0]);"))
         assertFalse(html.contains("kbFilePicker').files = files"))


### PR DESCRIPTION
## Root cause

Android WebView could keep the previous `bridge.js` under the unchanged subresource URL after a module update. In addition, some WebUI hosts return a completed CleveresTricky response envelope on stdout or stderr while reporting a non-zero callback code. The UI treated that transport result as an error even though the enclosed HTTP response was successful.

## Fix

- Cache-bust the native bridge script and expose its revision.
- Recover only exact, bounded, fully validated CleveresTricky protocol envelopes from supported callback channels and wrapper shapes.
- Preserve normal errno handling for every value that is not a valid protocol envelope.
- Reuse the same strict envelope validation before constructing the WebUI response.
- Cover the reported empty keybox list, boot-property policy, and resource-usage response paths.

## Validation

- `node module/webui-tests/bridge.test.js`
- `node --check module/template/webroot/bridge.js`
- Inline `index.html` JavaScript parse check
- `git diff --check`