### PR TITLE
fix: stabilize TEE chain and boot property views

### DIFF
--- a/module/template/post-fs-data.sh
+++ b/module/template/post-fs-data.sh
@@ -84,6 +84,13 @@ apply_early_properties() {
     }
   }
 
+  remove_prop() {
+    resetprop --delete "$1" >/dev/null 2>&1 || {
+      log -t CleveresTricky "Failed to remove a legacy boot property"
+      return 1
+    }
+  }
+
   hide_allowed=true
   if [ "$boot_mode" = auto ]; then
     for module_root in /data/adb/modules /data/adb/ksu/modules /data/adb/ap/modules; do
@@ -113,7 +120,15 @@ apply_early_properties() {
     apply_prop ro.build.tags release-keys || return 0
     apply_prop ro.vendor.boot.warranty_bit 0 || return 0
     apply_prop ro.vendor.warranty_bit 0 || return 0
-    apply_prop sys.oem_unlock_allowed 0 || return 0
+    android_sdk=$(getprop ro.build.version.sdk)
+    case "$android_sdk" in
+      ''|*[!0-9]*) android_sdk=0 ;;
+    esac
+    if [ "$android_sdk" -ge 36 ]; then
+      remove_prop sys.oem_unlock_allowed || return 0
+    else
+      apply_prop sys.oem_unlock_allowed 0 || return 0
+    fi
     apply_prop ro.secureboot.lockstate locked || return 0
     apply_prop ro.boot.realmebootstate green || return 0
     apply_prop ro.boot.realme.lockstate 1 || return 0

--- a/service/src/main/java/cleveres/tricky/cleverestech/BootLogic.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/BootLogic.kt
@@ -11,6 +11,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 object BootLogic {
     private const val CONFIG_PATH = "/data/adb/cleverestricky"
     private const val COMMAND_TIMEOUT_SECONDS = 10L
+    private const val ANDROID_16_SDK = 36
+    private const val OEM_UNLOCK_ALLOWED_PROPERTY = "sys.oem_unlock_allowed"
     private val nullDevice = File("/dev/null")
     private val ran = AtomicBoolean(false)
     private val configDir: File
@@ -160,12 +162,15 @@ object BootLogic {
                     "ro.build.tags" to "release-keys",
                     "ro.vendor.boot.warranty_bit" to "0",
                     "ro.vendor.warranty_bit" to "0",
-                    "sys.oem_unlock_allowed" to "0",
                     "ro.secureboot.lockstate" to "locked",
                     "ro.boot.realmebootstate" to "green",
                     "ro.boot.realme.lockstate" to "1",
                 ),
             )
+            val sdk = getSystemProperty("ro.build.version.sdk").toIntOrNull()
+            if (sdk != null && sdk < ANDROID_16_SDK) {
+                properties[OEM_UNLOCK_ALLOWED_PROPERTY] = "0"
+            }
         }
 
         if (spoofCn) {
@@ -206,6 +211,7 @@ object BootLogic {
 
         resetPropBatch(properties)
         if (hideSensitive) {
+            removeLegacyOemUnlockProperty()
             listOf("ro.bootmode", "ro.boot.bootmode", "vendor.boot.bootmode").forEach(::hideBootMode)
         }
         val mismatches = properties.count { (name, value) -> getSystemProperty(name) != value }
@@ -213,6 +219,16 @@ object BootLogic {
             throw IOException("Could not verify $mismatches boot-property overrides")
         }
         Logger.i("Verified ${properties.size} app-visible boot-property overrides")
+    }
+
+    private fun removeLegacyOemUnlockProperty() {
+        val sdk = getSystemProperty("ro.build.version.sdk").toIntOrNull() ?: return
+        if (sdk < ANDROID_16_SDK) return
+
+        execChecked(arrayOf("resetprop", "--delete", OEM_UNLOCK_ALLOWED_PROPERTY))
+        if (getSystemProperty(OEM_UNLOCK_ALLOWED_PROPERTY).isNotEmpty()) {
+            throw IOException("Could not remove a legacy OEM-unlock property")
+        }
     }
 
     /** Uses one bounded shell process; all names and values are module constants. */

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -15,6 +15,7 @@ import kotlin.system.exitProcess
 
 @SuppressLint("BlockedPrivateApi")
 object KeystoreInterceptor : BinderInterceptor() {
+    private const val FIRST_APPLICATION_UID = 10_000
     private const val INJECTION_RETRY_INTERVAL_MS = 15_000L
 
     private val getKeyEntryTransaction =
@@ -43,7 +44,10 @@ object KeystoreInterceptor : BinderInterceptor() {
         data: Parcel,
     ): Result {
         if (target != keystore || code != getKeyEntryTransaction || !CertHack.canHack()) return Skip
-        return if (Config.needHack(callingUid)) Continue else Skip
+        val targeted = Config.needHack(callingUid)
+        val mayReadGrantedChain =
+            callingUid >= FIRST_APPLICATION_UID && CertHack.hasCachedCertificateChains()
+        return if (targeted || mayReadGrantedChain) Continue else Skip
     }
 
     override fun onPostTransact(
@@ -61,8 +65,7 @@ object KeystoreInterceptor : BinderInterceptor() {
             code != getKeyEntryTransaction ||
             reply == null ||
             resultCode != 0 ||
-            !CertHack.canHack() ||
-            !Config.needHack(callingUid)
+            !CertHack.canHack()
         ) {
             return Skip
         }
@@ -75,11 +78,16 @@ object KeystoreInterceptor : BinderInterceptor() {
         try {
             val response = reply.readTypedObject(KeyEntryResponse.CREATOR)
             val originalChain = Utils.getCertificateChain(response)
+            val targeted = Config.needHack(callingUid)
             val newChain =
                 if (originalChain == null) {
                     null
-                } else {
+                } else if (targeted) {
                     CertHack.hackCertificateChain(originalChain, callingUid).takeUnless { it === originalChain }
+                } else {
+                    // A grant or isolated process is allowed to observe the chain already returned
+                    // to the key owner, but it must not synthesize a new per-reader chain.
+                    CertHack.getCachedCertificateChain(originalChain)
                 }
 
             if (newChain != null) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -7,6 +7,7 @@ import android.system.keystore2.KeyMetadata
 import cleveres.tricky.cleverestech.binder.BinderInterceptor
 import cleveres.tricky.cleverestech.keystore.CertHack
 import cleveres.tricky.cleverestech.keystore.Utils
+import java.util.concurrent.locks.LockSupport
 
 /**
  * Rewrites only the certificate chain returned by a successful, genuine
@@ -15,6 +16,7 @@ import cleveres.tricky.cleverestech.keystore.Utils
  */
 class SecurityLevelInterceptor : BinderInterceptor() {
     companion object {
+        private const val GENERATE_KEY_EQUALIZATION_NANOS = 2_000_000L
         private val generateKeyTransaction =
             getTransactCode(IKeystoreSecurityLevel.Stub::class.java, "generateKey")
 
@@ -28,17 +30,22 @@ class SecurityLevelInterceptor : BinderInterceptor() {
         callingUid: Int,
         callingPid: Int,
         data: Parcel,
-    ): Result =
-        if (
+    ): Result {
+        return if (
             code == generateKeyTransaction &&
             !Config.isRkpPassthroughEnabled &&
             CertHack.canHack() &&
             Config.needHack(callingUid)
         ) {
+            // Keep attested and non-attested generateKey calls on the same small timing base.
+            // Certificate rewriting happens only for attested replies; without this common delay
+            // repeated samples expose that branch even though both operations otherwise succeed.
+            LockSupport.parkNanos(GENERATE_KEY_EQUALIZATION_NANOS)
             Continue
         } else {
             Skip
         }
+    }
 
     override fun onPostTransact(
         target: IBinder,

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -52,8 +52,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import cleveres.tricky.cleverestech.Config;
 import cleveres.tricky.cleverestech.Logger;
@@ -122,11 +120,8 @@ public final class CertHack {
     }
 
     private static volatile State state = new State(Collections.emptyMap(), Collections.emptyMap());
-    private static final Map<String, AtomicInteger> rotationCounters = new ConcurrentHashMap<>();
 
     static {
-        rotationCounters.put(KeyProperties.KEY_ALGORITHM_EC, new AtomicInteger(0));
-        rotationCounters.put(KeyProperties.KEY_ALGORITHM_RSA, new AtomicInteger(0));
         if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
             Security.addProvider(new BouncyCastleProvider());
         }
@@ -176,18 +171,16 @@ public final class CertHack {
 
     private static final class CacheKey {
         private final byte[] leafDigest;
-        private final byte[] callerPackageDigest;
-        private final Config.AttestationPatchLevels patchLevels;
-        private final int uid;
         private final int hashCode;
 
-        public CacheKey(byte[] leafEncoded, Config.AttestationPatchLevels patchLevels, int uid) {
+        public CacheKey(byte[] leafEncoded) {
             this.leafDigest = SHA256_DIGEST.get().digest(leafEncoded);
-            this.callerPackageDigest = Config.INSTANCE.getCallerPackageDigest(uid);
-            this.patchLevels = Objects.requireNonNull(patchLevels, "patchLevels");
-            this.uid = uid;
-            this.hashCode = 31 * (31 * (31 * Arrays.hashCode(leafDigest) + Arrays.hashCode(callerPackageDigest)) +
-                    patchLevels.hashCode()) + uid;
+            this.hashCode = Arrays.hashCode(leafDigest);
+        }
+
+        int indexForPool(int size) {
+            if (size <= 0) throw new IllegalArgumentException("Keybox pool is empty");
+            return (hashCode & 0x7FFFFFFF) % size;
         }
 
         @Override
@@ -195,9 +188,7 @@ public final class CertHack {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             CacheKey cacheKey = (CacheKey) o;
-            return uid == cacheKey.uid && patchLevels.equals(cacheKey.patchLevels) &&
-                    MessageDigest.isEqual(leafDigest, cacheKey.leafDigest) &&
-                    MessageDigest.isEqual(callerPackageDigest, cacheKey.callerPackageDigest);
+            return MessageDigest.isEqual(leafDigest, cacheKey.leafDigest);
         }
 
         @Override
@@ -406,7 +397,7 @@ public final class CertHack {
         }
     }
 
-    public static void setKeyboxes(List<KeyBox> boxes) {
+    public static synchronized void setKeyboxes(List<KeyBox> boxes) {
         if (boxes == null || boxes.isEmpty()) {
             Logger.i("clear all keyboxes");
             state = new State(Collections.emptyMap(), Collections.emptyMap());
@@ -445,14 +436,36 @@ public final class CertHack {
         setKeyboxes(parseKeyboxXml(reader));
     }
 
-    public static void clearCertificateCache() {
+    public static synchronized void clearCertificateCache() {
         State currentState = state;
         synchronized (currentState.certificateCache) {
             currentState.certificateCache.clear();
         }
     }
 
-    public static Certificate[] hackCertificateChain(Certificate[] caList, int uid) {
+    public static synchronized boolean hasCachedCertificateChains() {
+        return !state.certificateCache.isEmpty();
+    }
+
+    public static synchronized Certificate[] getCachedCertificateChain(Certificate[] caList) {
+        if (caList == null || caList.length == 0 || caList[0] == null) return null;
+        try {
+            byte[] leafEncoded = caList[0].getEncoded();
+            if (leafEncoded.length == 0 || leafEncoded.length > MAX_LEAF_CERTIFICATE_BYTES) return null;
+            Certificate[] cached = state.certificateCache.get(new CacheKey(leafEncoded));
+            return cached == null ? null : cached.clone();
+        } catch (Throwable error) {
+            Logger.e("Could not resolve a cached attestation chain", error);
+            return null;
+        }
+    }
+
+    /**
+     * Rewrites one key's attestation chain exactly once per active policy snapshot. The cache is
+     * keyed by the genuine leaf identity, not the reader UID: a granted alias must return the same
+     * certificate chain from generateKey and every later getKeyEntry path, including isolated UIDs.
+     */
+    public static synchronized Certificate[] hackCertificateChain(Certificate[] caList, int uid) {
         if (caList == null || caList.length == 0 || caList[0] == null) {
             throw new UnsupportedOperationException("Certificate chain is empty");
         }
@@ -463,14 +476,15 @@ public final class CertHack {
                 Logger.e("Attestation leaf certificate has an invalid size");
                 return caList;
             }
-            Config.AttestationPatchLevels patchLevels = Config.INSTANCE.getAttestationPatchLevels(uid);
-            CacheKey cacheKey = new CacheKey(leafEncoded, patchLevels, uid);
+            CacheKey cacheKey = new CacheKey(leafEncoded);
 
             Map<CacheKey, Certificate[]> cache = currentState.certificateCache;
             synchronized (cache) {
                 Certificate[] cached = cache.get(cacheKey);
                 if (cached != null) return cached.clone();
             }
+
+            Config.AttestationPatchLevels patchLevels = Config.INSTANCE.getAttestationPatchLevels(uid);
 
             X509Certificate leaf;
             if (caList[0] instanceof X509Certificate) {
@@ -602,10 +616,7 @@ public final class CertHack {
             List<KeyBox> list = selectKeyboxPool(candidates, preferredSignerAlgorithm);
             if (list.isEmpty()) throw new UnsupportedOperationException("No compatible keybox is available");
 
-            String selectedAlgorithm = normalizeAlgorithm(list.get(0).keyPair.getPrivate().getAlgorithm());
-            AtomicInteger rotationCounter = rotationCounters.get(selectedAlgorithm);
-            if (rotationCounter == null) throw new UnsupportedOperationException("Unsupported keybox algorithm");
-            int idx = (rotationCounter.getAndIncrement() & 0x7FFFFFFF) % list.size();
+            int idx = cacheKey.indexForPool(list.size());
             var k = list.get(idx);
             String signatureAlgorithm = signatureAlgorithmForKeybox(k);
             if (signatureAlgorithm == null) throw new UnsupportedOperationException("Unsupported keybox algorithm");

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/ModuleHashTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/ModuleHashTest.java
@@ -178,6 +178,72 @@ public class ModuleHashTest {
     }
 
     @Test
+    public void testGeneratedChainRemainsStableForGrantedIsolatedUid() throws Exception {
+        Field moduleHash = moduleHashField();
+        Field state = certHackStateField();
+        byte[] previousHash = (byte[]) moduleHash.get(Config.INSTANCE);
+        Object previousState = state.get(null);
+
+        try {
+            moduleHash.set(Config.INSTANCE, null);
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA", "BC");
+            generator.initialize(2048);
+
+            KeyPair originalPair = generator.generateKeyPair();
+            X509Certificate originalLeaf = generateSelfSignedCert(originalPair);
+            KeyPair firstKeyboxPair = generator.generateKeyPair();
+            KeyPair secondKeyboxPair = generator.generateKeyPair();
+            CertHack.KeyBox firstKeybox = new CertHack.KeyBox(
+                    firstKeyboxPair,
+                    Collections.singletonList(generateSelfSignedCert(firstKeyboxPair)),
+                    "first.xml");
+            CertHack.KeyBox secondKeybox = new CertHack.KeyBox(
+                    secondKeyboxPair,
+                    Collections.singletonList(generateSelfSignedCert(secondKeyboxPair)),
+                    "second.xml");
+
+            List<CertHack.KeyBox> pool = List.of(firstKeybox, secondKeybox);
+            Map<String, List<CertHack.KeyBox>> newKeyboxes = new HashMap<>();
+            newKeyboxes.put("RSA", pool);
+            Map<String, List<CertHack.KeyBox>> newKeyboxFiles = new HashMap<>();
+            newKeyboxFiles.put("first.xml", Collections.singletonList(firstKeybox));
+            newKeyboxFiles.put("second.xml", Collections.singletonList(secondKeybox));
+
+            Class<?> stateClass = Class.forName("cleveres.tricky.cleverestech.keystore.CertHack$State");
+            Constructor<?> ctor = stateClass.getDeclaredConstructor(Map.class, Map.class);
+            ctor.setAccessible(true);
+            state.set(null, ctor.newInstance(newKeyboxes, newKeyboxFiles));
+
+            Certificate[] original = new Certificate[] {originalLeaf};
+            Certificate[] generated = CertHack.hackCertificateChain(original, 10_001);
+            Assert.assertTrue(CertHack.hasCachedCertificateChains());
+
+            Certificate[] isolatedReadback = CertHack.getCachedCertificateChain(original);
+            Assert.assertNotNull(isolatedReadback);
+            Assert.assertArrayEquals(generated[0].getEncoded(), isolatedReadback[0].getEncoded());
+
+            Certificate[] differentReader = CertHack.hackCertificateChain(original, 99_008);
+            Assert.assertArrayEquals(generated[0].getEncoded(), differentReader[0].getEncoded());
+            Assert.assertEquals(generated.length, differentReader.length);
+            for (int index = 0; index < generated.length; index++) {
+                Assert.assertArrayEquals(generated[index].getEncoded(), differentReader[index].getEncoded());
+            }
+
+            CertHack.clearCertificateCache();
+            Assert.assertFalse(CertHack.hasCachedCertificateChains());
+            Certificate[] regenerated = CertHack.hackCertificateChain(original, 99_008);
+            Assert.assertEquals(generated.length, regenerated.length);
+            for (int index = 0; index < generated.length; index++) {
+                Assert.assertArrayEquals(generated[index].getEncoded(), regenerated[index].getEncoded());
+            }
+        } finally {
+            state.set(null, previousState);
+            moduleHash.set(Config.INSTANCE, previousHash);
+            CertHack.clearCertificateCache();
+        }
+    }
+
+    @Test
     public void testCrossAlgorithmKeyboxFallback() throws Exception {
         Field moduleHash = moduleHashField();
         Field state = certHackStateField();


### PR DESCRIPTION
## Summary

- key rewritten attestation chains by the genuine leaf identity and choose keyboxes deterministically
- reuse only an existing cached chain for grant and isolated-UID getKeyEntry readbacks
- add a common timing floor to targeted attested and non-attested generateKey calls
- remove the legacy OEM-unlock property on Android 16+, while preserving the older Android value
- add regression coverage for stable owner, grant, isolated-reader, and cache-rebuild chains

## Root cause

The certificate cache and keybox rotation were caller-specific, so the same key could expose different rewritten chains through generateKey, getKeyEntry, and grant-domain readers. Certificate rewriting also left a repeatable timing delta between attested and non-attested generation. Finally, Android 16 inherited a compatibility property that should no longer be materialized.

## Validation

- `bash -n module/template/post-fs-data.sh`
- `node --check module/template/webroot/bridge.js`
- `node module/webui-tests/bridge.test.js`
- `git diff --check`

The full Android Gradle suite was not available locally because the wrapper distribution and Android dependencies are not present in this environment.