### PR TITLE
fix: restore unit-test compilation after core protection refactor

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/ActionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ActionTest.kt
@@ -287,14 +287,19 @@ class ActionTest {
                 "spoof_enabled",
                 "spoof_build_identity",
                 "global_mode",
-                "tee_broken_mode",
                 "auto_keybox_check",
                 "random_on_boot",
-                "hide_sensitive_props",
-                "spoof_region_cn",
                 "telephony",
                 "rkp_passthrough",
                 "drm_passthrough",
+            )
+        val removedSettings =
+            listOf(
+                "tee_broken_mode",
+                "hide_sensitive_props",
+                "spoof_region_cn",
+                "rkp_bypass",
+                "spoof_props",
             )
 
         settings.forEach { setting ->
@@ -303,14 +308,13 @@ class ActionTest {
             assertTrue(getConfig().getBoolean(setting))
             assertTrue(File(configDir, setting).isFile)
         }
-        assertEquals(400, postForm("/api/toggle", mapOf("setting" to "rkp_bypass", "value" to "true")).first)
-        assertEquals(400, postForm("/api/toggle", mapOf("setting" to "spoof_props", "value" to "true")).first)
 
         var config = getConfig()
-        assertFalse(config.has("rkp_bypass"))
-        assertFalse(config.has("spoof_props"))
-        assertFalse(File(configDir, "rkp_bypass").exists())
-        assertFalse(File(configDir, "spoof_props").exists())
+        removedSettings.forEach { setting ->
+            assertEquals(400, postForm("/api/toggle", mapOf("setting" to setting, "value" to "true")).first)
+            assertFalse(config.has(setting))
+            assertFalse(File(configDir, setting).exists())
+        }
 
         settings.forEach { setting ->
             assertEquals(200, postForm("/api/toggle", mapOf("setting" to setting, "value" to "false")).first)
@@ -320,6 +324,7 @@ class ActionTest {
 
         config = getConfig()
         settings.forEach { setting -> assertFalse(config.getBoolean(setting)) }
+        removedSettings.forEach { setting -> assertFalse(config.has(setting)) }
     }
 
     @Test

--- a/service/src/test/java/cleveres/tricky/cleverestech/ActionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ActionTest.kt
@@ -289,6 +289,7 @@ class ActionTest {
                 "global_mode",
                 "auto_keybox_check",
                 "random_on_boot",
+                "spoof_region_cn",
                 "telephony",
                 "rkp_passthrough",
                 "drm_passthrough",
@@ -297,7 +298,6 @@ class ActionTest {
             listOf(
                 "tee_broken_mode",
                 "hide_sensitive_props",
-                "spoof_region_cn",
                 "rkp_bypass",
                 "spoof_props",
             )

--- a/service/src/test/java/cleveres/tricky/cleverestech/ConfigAppPrivacyTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ConfigAppPrivacyTest.kt
@@ -25,6 +25,8 @@ class ConfigAppPrivacyTest {
         SecureFile.impl = MockSecureFileOperations()
         configDir = tempFolder.newFolder("config")
         Config.setRootForTesting(configDir)
+        File(configDir, "spoof_enabled").createNewFile()
+        Config.refreshRuntimeSetting("spoof_enabled")
     }
 
     @After

--- a/service/src/test/java/cleveres/tricky/cleverestech/ConfigEnhancementTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ConfigEnhancementTest.kt
@@ -7,6 +7,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
+import java.nio.file.Files
 
 class ConfigEnhancementTest {
     @Test
@@ -56,36 +57,46 @@ class ConfigEnhancementTest {
 
     @Test
     fun testAttestationIdFallback() {
-        // Clear build vars
-        Config.updateBuildVars(null)
+        val root = Files.createTempDirectory("config_enhancement_").toFile()
+        try {
+            Config.reset()
+            Config.setRootForTesting(root)
+            File(root, "spoof_enabled").createNewFile()
+            Config.refreshRuntimeSetting("spoof_enabled")
 
-        // Create temp file for build vars
-        val f = File.createTempFile("spoof_build_vars", null)
-        f.deleteOnExit()
-        f.writeText(
-            """
-            MANUFACTURER=FallbackMan
-            MODEL=FallbackModel
-            ATTESTATION_ID_BRAND=ExplicitBrand
-            """.trimIndent(),
-        )
+            // Clear build vars
+            Config.updateBuildVars(null)
 
-        Config.updateBuildVars(f)
+            // Create temp file for build vars
+            val f = File(root, "spoof_build_vars")
+            f.writeText(
+                """
+                MANUFACTURER=FallbackMan
+                MODEL=FallbackModel
+                ATTESTATION_ID_BRAND=ExplicitBrand
+                """.trimIndent(),
+            )
 
-        // Verify Build Vars
-        assertEquals("FallbackMan", Config.getBuildVar("MANUFACTURER"))
+            Config.updateBuildVars(f)
 
-        // Verify Fallback to Build Var
-        val manBytes = Config.getAttestationId("MANUFACTURER", 0)
-        assertNotNull(manBytes)
-        assertEquals("FallbackMan", String(manBytes!!))
+            // Verify Build Vars
+            assertEquals("FallbackMan", Config.getBuildVar("MANUFACTURER"))
 
-        // Verify Explicit Override
-        val brandBytes = Config.getAttestationId("BRAND", 0)
-        assertNotNull(brandBytes)
-        assertEquals("ExplicitBrand", String(brandBytes!!))
+            // Verify Fallback to Build Var
+            val manBytes = Config.getAttestationId("MANUFACTURER", 0)
+            assertNotNull(manBytes)
+            assertEquals("FallbackMan", String(manBytes!!))
 
-        // Verify Missing
-        assertNull(Config.getAttestationId("MISSING", 0))
+            // Verify Explicit Override
+            val brandBytes = Config.getAttestationId("BRAND", 0)
+            assertNotNull(brandBytes)
+            assertEquals("ExplicitBrand", String(brandBytes!!))
+
+            // Verify Missing
+            assertNull(Config.getAttestationId("MISSING", 0))
+        } finally {
+            root.deleteRecursively()
+            Config.reset()
+        }
     }
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/ConfigIdentityOverridesTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ConfigIdentityOverridesTest.kt
@@ -7,6 +7,7 @@ import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import java.io.File
+import java.nio.file.Files
 
 class ConfigIdentityOverridesTest {
     @Before
@@ -21,7 +22,7 @@ class ConfigIdentityOverridesTest {
 
     @Test
     fun `identity engine gates attestation ids without clearing stored values`() {
-        val root = createTempDir(prefix = "identity_engine_").apply { deleteOnExit() }
+        val root = Files.createTempDirectory("identity_engine_").toFile().apply { deleteOnExit() }
         Config.setRootForTesting(root)
         val imei = RandomUtils.generateLuhn(15, "35")
         val vars = File(root, "spoof_build_vars").apply { writeText("ATTESTATION_ID_IMEI=$imei\n") }

--- a/service/src/test/java/cleveres/tricky/cleverestech/ConfigRkpProtectionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ConfigRkpProtectionTest.kt
@@ -48,7 +48,7 @@ class ConfigRkpProtectionTest {
         assertFalse(Config.needHack(10_108))
 
         invokeUpdater("updateSpoofEnabled", null)
-        assertFalse(Config.needHack(10_107))
+        assertTrue(Config.needHack(10_107))
     }
 
     private fun invokeUpdater(

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerIdentityTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerIdentityTest.kt
@@ -191,7 +191,7 @@ class WebServerIdentityTest {
 
     @Test
     fun `auto identity persists Pixel beta build fields without enabling identity engine`() {
-        val response = request("POST", "/api/auto_identity")
+        val response = request("POST", "/api/auto_identity", "")
         assertEquals(200, response.first)
         val data = JSONObject(response.second)
         assertEquals("Pixel Test", data.getString("model"))

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/CertHackOrderTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/CertHackOrderTest.java
@@ -60,8 +60,15 @@ public class CertHackOrderTest {
         field.set(Config.INSTANCE, map);
     }
 
+    private void setSpoofEnabled(boolean enabled) throws Exception {
+        Field field = Config.class.getDeclaredField("isSpoofEnabled");
+        field.setAccessible(true);
+        field.setBoolean(Config.INSTANCE, enabled);
+    }
+
     private void resetConfig() throws Exception {
         setAttestationId("BRAND", null);
+        setSpoofEnabled(false);
         Field moduleHash = Config.class.getDeclaredField("moduleHash");
         moduleHash.setAccessible(true);
         moduleHash.set(Config.INSTANCE, null);
@@ -111,6 +118,7 @@ public class CertHackOrderTest {
         resetConfig();
         byte[] expectedBrand = "Google".getBytes(StandardCharsets.UTF_8);
         setAttestationId("BRAND", expectedBrand);
+        setSpoofEnabled(true);
 
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", "BC");
         kpg.initialize(2048);


### PR DESCRIPTION
Follow-up to #897.

Fixes the CI regressions left after the core/identity split without changing the intended runtime behavior:
- replace deprecated Kotlin temp-dir usage that fails with warnings-as-errors
- align regression tests with identity-only Spoof Engine semantics and always-on core targeting
- keep legacy core toggles out of the WebUI while preserving the supported region spoof control
- send an explicit empty body for the Auto Identity POST test so the server's Content-Length policy stays intact
- revert the merged #899 Bouncy Castle 1.85.2 pins back to published 1.85 artifacts; the 1.85.2 pins make Gradle configuration fail before lint/tests can run

Core protection, identity behavior, Auto Identity, and the bottom mobile navigation introduced by #897 remain unchanged.