### PR TITLE
ci: make dependency updates safer and PR checks change-aware

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,13 @@ updates:
     open-pull-requests-limit: 10
     allow:
       - dependency-type: "direct"
-      - dependency-type: "indirect"
+    groups:
+      bouncycastle:
+        patterns:
+          - "org.bouncycastle:*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,36 +7,131 @@ on:
     branches: [ "master" ]
   workflow_dispatch:
 
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
 jobs:
+  changes:
+    name: "🧭 Change Detection"
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      gradle: ${{ steps.filter.outputs.gradle }}
+      shell: ${{ steps.filter.outputs.shell }}
+      webui: ${{ steps.filter.outputs.webui }}
+      build: ${{ steps.filter.outputs.build }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed files
+        id: filter
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_EVENT_NAME" != "pull_request" ]]; then
+            for key in rust gradle shell webui build; do
+              echo "$key=true" >> "$GITHUB_OUTPUT"
+            done
+            exit 0
+          fi
+
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          changed_files=$(git diff --name-only "$base" "$head")
+          printf '%s\n' "$changed_files"
+
+          has_match() {
+            grep -Eq "$1" <<<"$changed_files"
+          }
+
+          rust=false
+          gradle=false
+          shell=false
+          webui=false
+          build=false
+
+          if has_match '^rust/'; then
+            rust=true
+          fi
+
+          if has_match '(^|/)(build\.gradle(\.kts)?|gradle\.properties)$|^settings\.gradle\.kts$|^gradle/|\.(kt|kts|java|xml)$'; then
+            gradle=true
+          fi
+
+          if has_match '\.sh$'; then
+            shell=true
+          fi
+
+          if has_match '^module/(template/webroot|webui-tests)/'; then
+            webui=true
+          fi
+
+          if grep -Ev '^(README\.md$|docs/|\.github/)' <<<"$changed_files" | grep -q .; then
+            build=true
+          fi
+
+          echo "rust=$rust" >> "$GITHUB_OUTPUT"
+          echo "gradle=$gradle" >> "$GITHUB_OUTPUT"
+          echo "shell=$shell" >> "$GITHUB_OUTPUT"
+          echo "webui=$webui" >> "$GITHUB_OUTPUT"
+          echo "build=$build" >> "$GITHUB_OUTPUT"
+
   quality-gate:
     name: "🛡️ Quality Gate & Linting"
     runs-on: ubuntu-latest
+    needs: changes
     steps:
       - name: Check out
         uses: actions/checkout@v7
 
+      - name: Validate Bouncy Castle coordinates
+        if: needs.changes.outputs.gradle == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          for artifact in bcpkix-jdk18on bcprov-jdk18on; do
+            version=$(sed -n "s/^${artifact} = \"\([^\"]*\)\"/\1/p" gradle/libs.versions.toml | head -n1)
+            if [[ -z "$version" ]]; then
+              echo "::error::Missing version for $artifact"
+              exit 1
+            fi
+            url="https://repo.maven.apache.org/maven2/org/bouncycastle/${artifact}/${version}/${artifact}-${version}.pom"
+            echo "Checking $artifact:$version"
+            curl --fail --silent --show-error --location --retry 3 --retry-all-errors --output /dev/null "$url"
+          done
+
       - name: Setup Java
+        if: needs.changes.outputs.gradle == 'true'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21
 
       - name: Setup Gradle
+        if: needs.changes.outputs.gradle == 'true'
         uses: gradle/actions/setup-gradle@v6.3.0
 
       - name: "🐚 Shell Script Linting (Shellcheck)"
+        if: needs.changes.outputs.shell == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y shellcheck
           shellcheck module/template/*.sh
 
       - name: "🎨 Kotlin Format & Quality (Ktlint)"
+        if: needs.changes.outputs.gradle == 'true'
         run: ./gradlew ktlintCheck
 
       - name: "📱 Android Static Analysis (Lint)"
+        if: needs.changes.outputs.gradle == 'true'
         run: ./gradlew :service:lintDebug :stub:lintDebug :encryptor-app:lintDebug
 
       - name: Native source and documentation policy
@@ -103,7 +198,8 @@ jobs:
   rust-test:
     name: "🦀 Rust Checks & Tests"
     runs-on: ubuntu-latest
-    needs: quality-gate
+    needs: [changes, quality-gate]
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true' }}
     env:
       RUSTFLAGS: "-D warnings"
     defaults:
@@ -144,7 +240,8 @@ jobs:
   build:
     name: "🛠️ Build Module"
     runs-on: ubuntu-latest
-    needs: rust-test
+    needs: [changes, quality-gate, rust-test]
+    if: ${{ always() && needs.quality-gate.result == 'success' && (needs.rust-test.result == 'success' || needs.rust-test.result == 'skipped') && (github.event_name != 'pull_request' || needs.changes.outputs.build == 'true') }}
     steps:
       - name: Check out
         uses: actions/checkout@v7
@@ -198,6 +295,7 @@ jobs:
           [ "$errors" -eq 0 ]
 
       - name: Native WebUI syntax validation
+        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.webui == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -212,6 +310,7 @@ jobs:
           NODE
 
       - name: Native WebUI behavior tests
+        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.webui == 'true' }}
         run: node module/webui-tests/bridge.test.js
 
       - name: Setup Java
@@ -232,12 +331,14 @@ jobs:
           targets: aarch64-linux-android,x86_64-linux-android
 
       - name: Lint Android Rust targets
+        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true' }}
         working-directory: rust
         run: |
           cargo clippy --workspace --all-targets --target aarch64-linux-android -- -D warnings
           cargo clippy --workspace --all-targets --target x86_64-linux-android -- -D warnings
 
       - name: Run Unit Tests
+        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.gradle == 'true' }}
         id: unit_tests
         run: ./gradlew testDebugUnitTest --console=plain --stacktrace
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,12 @@ fun Project.configureBaseExtension() {
             versionName = verName
         }
 
+        lint {
+            checkReleaseBuilds = false
+            abortOnError = true
+            warningsAsErrors = true
+        }
+
         compileOptions {
             sourceCompatibility = androidSourceCompatibility
             targetCompatibility = androidTargetCompatibility
@@ -86,6 +92,7 @@ fun Project.configureBaseExtension() {
         lint {
             checkReleaseBuilds = false
             abortOnError = true
+            warningsAsErrors = true
         }
 
         compileOptions {
@@ -111,7 +118,7 @@ subprojects {
 
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
         compilerOptions {
-            allWarningsAsErrors.set(!name.contains("UnitTest") && !project.name.contains("encryptor-app"))
+            allWarningsAsErrors.set(true)
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.warning.mode=fail
 android.useAndroidX=true
 android.suppressUnsupportedCompileSdk=36

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 agp = "9.3.1"
 bcpkix-jdk18on = "1.85"
+bcprov-jdk18on = "1.85.2"
 kotlin = "2.4.10"
 annotation = "1.10.0"
 junit = "4.13.2"
@@ -16,6 +17,7 @@ nanohttpd = { module = "org.nanohttpd:nanohttpd", version = "2.3.1" }
 junit = { module = "junit:junit", version.ref = "junit" }
 annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 bcpkix-jdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bcpkix-jdk18on" }
+bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bcprov-jdk18on" }
 cxx = { module = "org.lsposed.libcxx:libcxx", version = "29.0.14206865" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -80,6 +80,7 @@ android {
     lint {
         checkReleaseBuilds = false
         abortOnError = true
+        warningsAsErrors = true
     }
 
     buildFeatures {
@@ -108,17 +109,11 @@ kotlin {
     }
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-    if (name.contains("UnitTest", ignoreCase = true)) {
-        compilerOptions.allWarningsAsErrors.set(false)
-        compilerOptions.suppressWarnings.set(true)
-    }
-}
-
 dependencies {
     compileOnly(project(":stub"))
     implementation(libs.annotation)
     implementation(libs.bcpkix.jdk18on)
+    implementation(libs.bcprov.jdk18on)
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
     testImplementation(libs.junit)
     testImplementation(project(":stub"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,8 +28,6 @@ gradle.rootProject {
                 force("io.netty:netty-codec-http2:4.2.17.Final")
                 force("io.netty:netty-codec:4.2.17.Final")
                 force("io.netty:netty-handler-proxy:4.2.17.Final")
-                force("org.bouncycastle:bcpkix-jdk18on:1.85")
-                force("org.bouncycastle:bcprov-jdk18on:1.85")
                 force("ch.qos.logback:logback-core:1.6.1")
                 force("ch.qos.logback:logback-classic:1.6.1")
             }
@@ -40,8 +38,6 @@ gradle.rootProject {
                 force("io.netty:netty-codec-http2:4.2.17.Final")
                 force("io.netty:netty-codec:4.2.17.Final")
                 force("io.netty:netty-handler-proxy:4.2.17.Final")
-                force("org.bouncycastle:bcpkix-jdk18on:1.85")
-                force("org.bouncycastle:bcprov-jdk18on:1.85")
                 force("ch.qos.logback:logback-core:1.6.1")
                 force("ch.qos.logback:logback-classic:1.6.1")
             }


### PR DESCRIPTION
Superseded by #903 after master advanced with #901. #903 contains the same CI/Dependabot hardening rebased onto current master.