### PR TITLE
feat: add DRM identity privacy and harden module integrity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,11 +258,14 @@ jobs:
           ./gradlew zipDebug
           ./gradlew :encryptor-app:assembleRelease
 
-      - name: Verify module archive layout
+      - name: Verify module archive layout and checksums
         shell: bash
         run: |
           set -euo pipefail
           shopt -s nullglob
+          work=$(mktemp -d)
+          trap 'rm -rf "$work"' EXIT
+
           for variant in release debug; do
             archives=(module/release/*-"$variant".zip)
             if [ "${#archives[@]}" -ne 1 ]; then
@@ -272,12 +275,64 @@ jobs:
             archive="${archives[0]}"
             unzip -tq "$archive" >/dev/null
             entries=$(unzip -Z1 "$archive")
+            duplicates=$(printf '%s\n' "$entries" | sort | uniq -d)
+            if [ -n "$duplicates" ]; then
+              echo "::error file=$archive::Duplicate ZIP entries are not allowed"
+              printf '%s\n' "$duplicates"
+              exit 1
+            fi
+            while IFS= read -r entry; do
+              case "$entry" in
+                /*|../*|*/../*|*/..|*\\*)
+                  echo "::error file=$archive::Unsafe ZIP entry: $entry"
+                  exit 1
+                  ;;
+              esac
+            done <<<"$entries"
             for required in module.prop customize.sh verify.sh service.sh post-fs-data.sh sepolicy.rule; do
               if ! grep -Fx "$required" <<<"$entries" >/dev/null; then
                 echo "::error file=$archive::Missing required root entry: $required"
                 exit 1
               fi
             done
+
+            target="$work/$variant"
+            mkdir -p "$target"
+            unzip -q "$archive" -d "$target"
+            while IFS= read -r -d '' payload; do
+              case "$payload" in
+                *.sha256) continue ;;
+              esac
+              checksum="$payload.sha256"
+              if [ ! -f "$checksum" ]; then
+                echo "::error file=$archive::Missing checksum for ${payload#"$target/"}"
+                exit 1
+              fi
+              expected=$(tr -d '[:space:]' < "$checksum")
+              case "$expected" in
+                ''|*[!0-9A-Fa-f]*)
+                  echo "::error file=$archive::Malformed checksum for ${payload#"$target/"}"
+                  exit 1
+                  ;;
+              esac
+              if [ "${#expected}" -ne 64 ]; then
+                echo "::error file=$archive::Invalid checksum length for ${payload#"$target/"}"
+                exit 1
+              fi
+              actual=$(sha256sum "$payload" | awk '{print $1}')
+              if [ "${expected,,}" != "$actual" ]; then
+                echo "::error file=$archive::Checksum mismatch for ${payload#"$target/"}"
+                exit 1
+              fi
+            done < <(find "$target" -type f -print0)
+
+            while IFS= read -r -d '' checksum; do
+              payload=${checksum%.sha256}
+              if [ ! -f "$payload" ]; then
+                echo "::error file=$archive::Orphan checksum ${checksum#"$target/"}"
+                exit 1
+              fi
+            done < <(find "$target" -type f -name '*.sha256' -print0)
           done
 
       - name: Verify native artifact hardening
@@ -359,6 +414,9 @@ jobs:
     needs: build
     permissions:
       contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     steps:
       - name: Check out
         uses: actions/checkout@v7
@@ -387,7 +445,7 @@ jobs:
           name: EncryptorApp
           path: release-assets
 
-      - name: Verify release assets
+      - name: Verify release assets and create checksums
         shell: bash
         run: |
           set -euo pipefail
@@ -400,6 +458,11 @@ jobs:
           [ "${#apks[@]}" -ge 1 ] || { echo "::error::Encryptor APK is missing"; exit 1; }
           unzip -tq "${release_zips[0]}" >/dev/null
           unzip -tq "${debug_zips[0]}" >/dev/null
+          (
+            cd release-assets
+            sha256sum -- *-release.zip *-debug.zip *.apk | LC_ALL=C sort -k2 > SHA256SUMS
+            sha256sum -c SHA256SUMS
+          )
 
       - name: Check release version
         id: release_version
@@ -416,6 +479,12 @@ jobs:
           else
             echo "create=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Attest official release provenance
+        if: steps.release_version.outputs.create == 'true'
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-checksums: release-assets/SHA256SUMS
 
       - name: Create tag and release
         if: steps.release_version.outputs.create == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Restored keyboxes, module hashes, settings, and runtime configuration as one exact state without retaining stale files or caches.
 - Corrected KeyMint 4 module hash placement, preserved authorization lists, and allowed valid EC and RSA cross-algorithm certificate signing.
 - Added Android 17 installation and Binder runtime support, bounded large Binder response parsing, and expanded the interception queue capacity.
+- Added a privacy-only modern stable-AIDL DRM hook that pseudonymizes `deviceUniqueId` for `privacy=isolate` applications without changing DRM security level, licenses, provisioning, content keys, or Keystore DRM passthrough policy.
 
 ## V2.5.0
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ The [Spoof Engine](docs/SpoofEngine.md) controls optional identity substitution.
 
 [RKP Protection](docs/RkpProtection.md) explains protected Android infrastructure and genuine generated key response passthrough.
 
-[DRM Passthrough](docs/DrmPassthrough.md) explains how selected media applications remain on the genuine keystore path.
+[DRM Passthrough and Privacy](docs/DrmPassthrough.md) explains two deliberately separate controls: selected media applications can remain on Android's genuine Keystore certificate path, while an application configured with `privacy=isolate` can receive a stable application-scoped pseudonym instead of the modern DRM HAL `deviceUniqueId` byte-array property. This narrow privacy hook is intended to stop that raw device identifier from becoming another persistent application tracking value; for example, a streaming application such as Netflix cannot use the genuine `deviceUniqueId` returned through this supported path while isolation is active.
+
+The DRM hook is intentionally not a Widevine/DRM bypass. It does not rewrite the reported security level, licenses, provisioning messages, content keys, sessions, HDCP state, or string properties. Building and maintaining a general DRM-protection bypass would require substantially broader, vendor-specific work and is not a primary project goal.
 
 ### Interface and operation
 
@@ -106,11 +108,15 @@ Android ID on modern Android is scoped by application signing identity, user, an
 
 The real kernel version returned by the operating system is unchanged. The core boot property view does not physically relock a bootloader, repair verified boot, rewrite vbmeta, or change the hardware root of trust.
 
+An unlocked bootloader does not by itself mean that every DRM implementation is unusable. Actual DRM behavior depends on the device, vendor implementation, provisioning state, security level, service policy, and firmware. Because many devices can retain functional protected playback despite an unlocked bootloader, CleveresTricky treats DRM bypass as a separate vendor-specific problem rather than a primary objective. The current DRM work is privacy-oriented: it narrows exposure of `deviceUniqueId` on the supported modern stable-AIDL path without pretending to upgrade or defeat the underlying DRM security state.
+
 ## Recommended first setup
 
 Use the fresh installation defaults first. Global Mode selects eligible application UIDs while core boot and Keystore protection remain active. Optional identity spoofing stays off until you enable it from the Identity section.
 
 If you use a Custom ROM and need a current build identity for Play Integrity testing, Auto Identity can retrieve a Pixel beta or canary identity from Google public metadata and save it locally. Enable Identity Spoof Engine and reboot only when you want those build identity values exposed.
+
+For DRM identifier privacy, create an Application Rule for the media application and set its privacy mode to `isolate`. DRM Keystore Passthrough can remain enabled: the genuine Keystore certificate path and the pseudonymous DRM device-ID path are intentionally independent.
 
 ## Help and project information
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ The [Spoof Engine](docs/SpoofEngine.md) controls optional identity substitution.
 
 [RKP Protection](docs/RkpProtection.md) explains protected Android infrastructure and genuine generated key response passthrough.
 
-[DRM Passthrough and Privacy](docs/DrmPassthrough.md) explains two deliberately separate controls: selected media applications can remain on Android's genuine Keystore certificate path, while an application configured with `privacy=isolate` can receive a stable application-scoped pseudonym instead of the modern DRM HAL `deviceUniqueId` byte-array property. This narrow privacy hook is intended to stop that raw device identifier from becoming another persistent application tracking value; for example, a streaming application such as Netflix cannot use the genuine `deviceUniqueId` returned through this supported path while isolation is active.
+[DRM Passthrough and Privacy](docs/DrmPassthrough.md) explains two deliberately separate controls: selected media applications can remain on Android's genuine Keystore certificate path, while an application configured with `privacy=isolate` can receive a stable application scoped pseudonym instead of the modern DRM HAL `deviceUniqueId` byte array property. This narrow privacy hook is intended to stop that raw device identifier from becoming another persistent application tracking value. For example, a streaming application such as Netflix cannot use the genuine `deviceUniqueId` returned through this supported path while isolation is active.
 
-The DRM hook is intentionally not a Widevine/DRM bypass. It does not rewrite the reported security level, licenses, provisioning messages, content keys, sessions, HDCP state, or string properties. Building and maintaining a general DRM-protection bypass would require substantially broader, vendor-specific work and is not a primary project goal.
+The DRM hook is intentionally not a Widevine or DRM bypass. It does not rewrite the reported security level, licenses, provisioning messages, content keys, sessions, HDCP state, or string properties. Building and maintaining a general DRM protection bypass would require substantially broader, vendor specific work and is not a primary project goal.
 
 ### Interface and operation
 
@@ -74,21 +74,23 @@ The DRM hook is intentionally not a Widevine/DRM bypass. It does not rewrite the
 
 ## Quick start
 
-1. Download the current release ZIP.
+1. Download the current release ZIP from the official project release page.
 
-2. Open KernelSU or APatch while Android is running.
+2. For an official release, verify the published `SHA256SUMS` entry and GitHub build provenance when you need source authenticity in addition to the module's internal integrity checks.
 
-3. Install the ZIP and reboot.
+3. Open KernelSU or APatch while Android is running.
 
-4. Open the CleveresTricky WebUI from the module manager.
+4. Install the ZIP and reboot.
 
-5. Fresh installations start in Global Mode with optional identity spoofing off.
+5. Open the CleveresTricky WebUI from the module manager.
 
-6. Add only key material you own or are authorized to test.
+6. Fresh installations start in Global Mode with optional identity spoofing off.
 
-7. Configure identity options only when they are needed.
+7. Add only key material you own or are authorized to test.
 
-8. Reboot after changing template build identity values.
+8. Configure identity options only when they are needed.
+
+9. Reboot after changing template build identity values.
 
 No usable keybox or private attestation key is bundled with the project.
 
@@ -108,7 +110,9 @@ Android ID on modern Android is scoped by application signing identity, user, an
 
 The real kernel version returned by the operating system is unchanged. The core boot property view does not physically relock a bootloader, repair verified boot, rewrite vbmeta, or change the hardware root of trust.
 
-An unlocked bootloader does not by itself mean that every DRM implementation is unusable. Actual DRM behavior depends on the device, vendor implementation, provisioning state, security level, service policy, and firmware. Because many devices can retain functional protected playback despite an unlocked bootloader, CleveresTricky treats DRM bypass as a separate vendor-specific problem rather than a primary objective. The current DRM work is privacy-oriented: it narrows exposure of `deviceUniqueId` on the supported modern stable-AIDL path without pretending to upgrade or defeat the underlying DRM security state.
+An unlocked bootloader does not by itself mean that every DRM implementation is unusable. Actual DRM behavior depends on the device, vendor implementation, provisioning state, security level, service policy, and firmware. Because many devices can retain functional protected playback despite an unlocked bootloader, CleveresTricky treats DRM bypass as a separate vendor specific problem rather than a primary objective. The current DRM work is privacy oriented: it narrows exposure of `deviceUniqueId` on the supported modern stable AIDL path without pretending to upgrade or defeat the underlying DRM security state.
+
+Internal SHA 256 records detect missing, changed, injected, linked, and unexpected installed payloads and place the service in tamper lockdown when verification fails. Those records are intentionally not described as proof of who produced a ZIP because a person who can replace every file in an archive can also replace archive internal checksum records. Official release authenticity is instead anchored by the separately published release digest and GitHub signed build provenance.
 
 ## Recommended first setup
 
@@ -116,7 +120,7 @@ Use the fresh installation defaults first. Global Mode selects eligible applicat
 
 If you use a Custom ROM and need a current build identity for Play Integrity testing, Auto Identity can retrieve a Pixel beta or canary identity from Google public metadata and save it locally. Enable Identity Spoof Engine and reboot only when you want those build identity values exposed.
 
-For DRM identifier privacy, create an Application Rule for the media application and set its privacy mode to `isolate`. DRM Keystore Passthrough can remain enabled: the genuine Keystore certificate path and the pseudonymous DRM device-ID path are intentionally independent.
+For DRM identifier privacy, create an Application Rule for the media application and set its privacy mode to `isolate`. DRM Keystore Passthrough can remain enabled: the genuine Keystore certificate path and the pseudonymous DRM device ID path are intentionally independent.
 
 ## Help and project information
 

--- a/docs/ApplicationRules.md
+++ b/docs/ApplicationRules.md
@@ -8,13 +8,15 @@ Application Rules assigns a template, a specific keybox source, or an applicatio
 
 Each rule begins with a validated package pattern. The optional template field selects one known device template. The optional keybox field selects one verified local source. A null field preserves the normal global choice for that part of the request.
 
-Privacy mode `inherit` keeps the global identity policy. Privacy mode `isolate` derives stable application scoped IMEI, IMSI, ICCID, MEID, phone, serial, and supported attestation identifiers from a protected random seed. Values remain stable across service restarts and differ between unrelated application identities. Privacy mode `redact` returns blank supported identity values while preserving Android permission failures.
+Privacy mode `inherit` keeps the global identity policy. Privacy mode `isolate` derives stable application scoped IMEI, IMSI, ICCID, MEID, phone, serial, supported attestation identifiers, and the supported modern DRM `deviceUniqueId` pseudonym from a protected random seed. Values remain stable across service restarts and differ between unrelated application identities. Privacy mode `redact` returns blank supported telephony and attestation identity values while preserving Android permission failures; DRM identifier redaction is not synthesized and therefore remains on the original platform path unless isolation is selected.
 
 Telephony identity policy works independently. Attestation identity replacement requires an active verified keybox because the modified certificate chain must be signed. Without one, the original attestation chain remains unchanged.
 
-Shared Android user identifiers use the sorted set of resolved packages as one derivation context. Redaction takes precedence over isolation when packages sharing one user identifier request different policies.
+DRM identifier isolation is independent from DRM Keystore Passthrough. A streaming application can remain on Android's genuine Keystore certificate path while its stable-AIDL `IDrmPlugin.getPropertyByteArray("deviceUniqueId")` result is replaced with an application-scoped pseudonym. The DRM privacy path does not modify string properties, security level, licenses, provisioning, content keys, or legacy HIDL/vendor-specific DRM interfaces.
 
-Android Package Manager resolves the real packages associated with the calling user identifier. The module never trusts a package name supplied inside an attestation request. Shared Android user identifiers therefore receive one consistent decision.
+Shared Android user identifiers use the sorted set of resolved packages as one derivation context. Redaction takes precedence over isolation when packages sharing one user identifier request different policies for telephony and attestation identity. DRM pseudonymization is enabled only when the Binder caller resolves to an isolate policy.
+
+Android Package Manager resolves the real packages associated with the calling user identifier. The module never trusts a package name supplied inside an attestation or DRM request as the privacy authority. Shared Android user identifiers therefore receive one consistent decision.
 
 ## Reload and caching
 
@@ -24,10 +26,14 @@ Caller package and identity decisions expire with the Package Manager cache so A
 
 The WebUI validates package syntax, template names, keybox names, privacy modes, field count, duplicates, empty rules, and file size before saving. The service repeats the validation when loading the file. The privacy seed is stored as root only configuration and is included only inside an encrypted backup.
 
+DRM pseudonyms do not require a second persistent identifier file or an unbounded per-app DRM cache. They are derived from the already isolated application identity and preserve the supported original DRM identifier length.
+
 ## Guidance
 
 Use Application Scope for callers that need the global policy. Add an Application Rule when one caller needs a different template, authorized key source, or privacy identity. Restart that application after a change because it may cache earlier results.
 
-The privacy policy covers the telephony and attestation identity paths implemented by the module. It does not claim to block sensors, clipboard access, location, VPN checks, accessibility checks, or arbitrary code inside another application process.
+For a media application where the goal is to avoid exposing the genuine DRM `deviceUniqueId`, use `privacy=isolate` and keep DRM Keystore Passthrough enabled if protected playback requires the genuine Keystore certificate path.
+
+The privacy policy covers the telephony, attestation, and supported stable-AIDL DRM identity paths implemented by the module. It does not claim to block sensors, clipboard access, location, VPN checks, accessibility checks, account identifiers, other vendor fingerprinting surfaces, or arbitrary code inside another application process.
 
 [Return to the project overview](../README.md)

--- a/docs/ApplicationRules.md
+++ b/docs/ApplicationRules.md
@@ -8,11 +8,11 @@ Application Rules assigns a template, a specific keybox source, or an applicatio
 
 Each rule begins with a validated package pattern. The optional template field selects one known device template. The optional keybox field selects one verified local source. A null field preserves the normal global choice for that part of the request.
 
-Privacy mode `inherit` keeps the global identity policy. Privacy mode `isolate` derives stable application scoped IMEI, IMSI, ICCID, MEID, phone, serial, supported attestation identifiers, and the supported modern DRM `deviceUniqueId` pseudonym from a protected random seed. Values remain stable across service restarts and differ between unrelated application identities. Privacy mode `redact` returns blank supported telephony and attestation identity values while preserving Android permission failures; DRM identifier redaction is not synthesized and therefore remains on the original platform path unless isolation is selected.
+Privacy mode `inherit` keeps the global identity policy. Privacy mode `isolate` derives stable application scoped IMEI, IMSI, ICCID, MEID, phone, serial, supported attestation identifiers, and the supported modern DRM `deviceUniqueId` pseudonym from a protected random seed. Values remain stable across service restarts and differ between unrelated application identities. Privacy mode `redact` returns blank supported telephony and attestation identity values while preserving Android permission failures. DRM identifier redaction is not synthesized and therefore remains on the original platform path unless isolation is selected.
 
 Telephony identity policy works independently. Attestation identity replacement requires an active verified keybox because the modified certificate chain must be signed. Without one, the original attestation chain remains unchanged.
 
-DRM identifier isolation is independent from DRM Keystore Passthrough. A streaming application can remain on Android's genuine Keystore certificate path while its stable-AIDL `IDrmPlugin.getPropertyByteArray("deviceUniqueId")` result is replaced with an application-scoped pseudonym. The DRM privacy path does not modify string properties, security level, licenses, provisioning, content keys, or legacy HIDL/vendor-specific DRM interfaces.
+DRM identifier isolation is independent from DRM Keystore Passthrough. A streaming application can remain on Android's genuine Keystore certificate path while its stable AIDL `IDrmPlugin.getPropertyByteArray("deviceUniqueId")` result is replaced with an application scoped pseudonym. The DRM privacy path does not modify string properties, security level, licenses, provisioning, content keys, or legacy HIDL and vendor specific DRM interfaces.
 
 Shared Android user identifiers use the sorted set of resolved packages as one derivation context. Redaction takes precedence over isolation when packages sharing one user identifier request different policies for telephony and attestation identity. DRM pseudonymization is enabled only when the Binder caller resolves to an isolate policy.
 
@@ -26,7 +26,7 @@ Caller package and identity decisions expire with the Package Manager cache so A
 
 The WebUI validates package syntax, template names, keybox names, privacy modes, field count, duplicates, empty rules, and file size before saving. The service repeats the validation when loading the file. The privacy seed is stored as root only configuration and is included only inside an encrypted backup.
 
-DRM pseudonyms do not require a second persistent identifier file or an unbounded per-app DRM cache. They are derived from the already isolated application identity and preserve the supported original DRM identifier length.
+DRM pseudonyms do not require a second persistent identifier file or an unbounded per app DRM cache. They are derived from the already isolated application identity and preserve the supported original DRM identifier length.
 
 ## Guidance
 
@@ -34,6 +34,6 @@ Use Application Scope for callers that need the global policy. Add an Applicatio
 
 For a media application where the goal is to avoid exposing the genuine DRM `deviceUniqueId`, use `privacy=isolate` and keep DRM Keystore Passthrough enabled if protected playback requires the genuine Keystore certificate path.
 
-The privacy policy covers the telephony, attestation, and supported stable-AIDL DRM identity paths implemented by the module. It does not claim to block sensors, clipboard access, location, VPN checks, accessibility checks, account identifiers, other vendor fingerprinting surfaces, or arbitrary code inside another application process.
+The privacy policy covers the telephony, attestation, and supported stable AIDL DRM identity paths implemented by the module. It does not claim to block sensors, clipboard access, location, VPN checks, accessibility checks, account identifiers, other vendor fingerprinting surfaces, or arbitrary code inside another application process.
 
 [Return to the project overview](../README.md)

--- a/docs/DrmPassthrough.md
+++ b/docs/DrmPassthrough.md
@@ -2,15 +2,15 @@
 
 ## Purpose
 
-CleveresTricky has two deliberately separate DRM-related behaviors.
+CleveresTricky has two deliberately separate DRM related behaviors.
 
 DRM Keystore Passthrough keeps selected media applications on Android's genuine Keystore certificate path. It prevents CleveresTricky attestation compatibility handling from leaking into applications where modified certificate chains can interfere with protected playback.
 
-DRM Identifier Privacy is narrower and identity-focused. On the supported modern stable-AIDL DRM HAL path, an application configured with `privacy=isolate` receives a stable application-scoped pseudonym when it reads the byte-array property `deviceUniqueId`. The genuine DRM device identifier is not used as input to that pseudonym, is not logged, and is not stored in a CleveresTricky DRM-ID cache.
+DRM Identifier Privacy is narrower and identity focused. On the supported modern stable AIDL DRM HAL path, an application configured with `privacy=isolate` receives a stable application scoped pseudonym when it reads the byte array property `deviceUniqueId`. The genuine DRM device identifier is not used as input to that pseudonym, is not logged, and is not stored in a CleveresTricky DRM ID cache.
 
 ## Why the privacy hook exists
 
-Android defines `deviceUniqueId` as a DRM byte-array property established during provisioning that can uniquely identify a device. A media or streaming application can therefore treat that value as another durable device identifier. The privacy hook prevents this specific supported property from exposing the genuine value to an isolated application while keeping the rest of the DRM transaction on the original platform path.
+Android defines `deviceUniqueId` as a DRM byte array property established during provisioning that can uniquely identify a device. A media or streaming application can therefore treat that value as another durable device identifier. The privacy hook prevents this specific supported property from exposing the genuine value to an isolated application while keeping the rest of the DRM transaction on the original platform path.
 
 The pseudonym is derived from the same protected random privacy seed used by Application Rules. It is stable for the same isolated application identity, differs across unrelated application identities, and preserves the original DRM identifier length within a bounded supported range. Stable pseudonyms are used instead of generating a new value on every read because changing the identity during normal playback can create avoidable compatibility problems.
 
@@ -18,7 +18,7 @@ The pseudonym is derived from the same protected random privacy seed used by App
 
 The `drm_packages.txt` file accepts exact package names and bounded wildcard rules. The service resolves the calling Android user identifier and evaluates the package set before global or targeted Keystore certificate substitution decisions.
 
-When passthrough is enabled and a caller matches the DRM list, certificate substitution is skipped. Runtime changes to DRM passthrough, the DRM package list, target scope, global mode, or legacy TEE-safe-mode state invalidate previously substituted attestation-chain cache entries after the new policy is loaded.
+When passthrough is enabled and a caller matches the DRM list, certificate substitution is skipped. Runtime changes to DRM passthrough, the DRM package list, target scope, global mode, or legacy TEE safe mode state invalidate previously substituted attestation chain cache entries after the new policy is loaded.
 
 The default list includes common media applications such as Netflix, Amazon Prime Video, Disney+, Max, and YouTube. Keeping one of those packages on the genuine Keystore path does not disable DRM Identifier Privacy. The two controls are intentionally independent: a package can use genuine Keystore certificates while `privacy=isolate` pseudonymizes only its supported DRM `deviceUniqueId` read.
 
@@ -26,26 +26,26 @@ The default list includes common media applications such as Netflix, Amazon Prim
 
 DRM Identifier Privacy requires Identity Spoof Engine to be enabled and the application's Application Rule privacy mode to be `isolate`. `inherit` leaves the DRM identifier unchanged. The DRM privacy hook does not use the Keystore `drm_passthrough` targeting decision.
 
-The runtime discovers stable-AIDL `android.hardware.drm.IDrmFactory/*` services, attaches the existing bounded native Binder hook to the vendor DRM service process, observes newly created `IDrmPlugin` Binder objects, and filters only `getPropertyByteArray` transactions. A request is modified only when its property name is exactly `deviceUniqueId` and the real Binder caller has an explicit isolate policy.
+The runtime discovers stable AIDL `android.hardware.drm.IDrmFactory/*` services, attaches the existing bounded native Binder hook to the vendor DRM service process, observes newly created `IDrmPlugin` Binder objects, and filters only `getPropertyByteArray` transactions. A request is modified only when its property name is exactly `deviceUniqueId` and the real Binder caller has an explicit isolate policy.
 
-Legacy HIDL DRM implementations and vendor-specific paths that do not use the supported stable-AIDL interface remain untouched. If the expected AIDL service, transaction shape, process information, or response format is unavailable, the hook fails open and Android's original response is preserved.
+Legacy HIDL DRM implementations and vendor specific paths that do not use the supported stable AIDL interface remain untouched. If the expected AIDL service, transaction shape, process information, or response format is unavailable, the hook fails open and Android's original response is preserved.
 
 ## Security boundary
 
-The privacy hook does **not** change `getPropertyString`, reported security level, session security level, HDCP state, provisioning, license requests or responses, content keys, secure stops, offline licenses, encryption/decryption operations, or vendor DRM policy. It does not transform L2/L3 into L1 and does not claim to upgrade a device's hardware-backed DRM capability.
+The privacy hook does **not** change `getPropertyString`, reported security level, session security level, HDCP state, provisioning, license requests or responses, content keys, secure stops, offline licenses, encryption or decryption operations, or vendor DRM policy. It does not transform L2 or L3 into L1 and does not claim to upgrade a device's hardware backed DRM capability.
 
-A general DRM-protection bypass would require substantially broader and continuously maintained vendor-specific work. That is not the current purpose of this feature. Bootloader unlock also does not automatically imply that every DRM implementation has stopped working; actual behavior depends on the device, vendor DRM stack, provisioning state, security level, firmware, and service policy. CleveresTricky therefore treats DRM bypass as a separate problem rather than a primary module objective.
+A general DRM protection bypass would require substantially broader and continuously maintained vendor specific work. That is not the current purpose of this feature. Bootloader unlock also does not automatically imply that every DRM implementation has stopped working. Actual behavior depends on the device, vendor DRM stack, provisioning state, security level, firmware, and service policy. CleveresTricky therefore treats DRM bypass as a separate problem rather than a primary module objective.
 
 ## Resource and failure behavior
 
-Factory discovery and reconciliation are bounded. The implementation caps tracked factory services and plugin Binder objects, retries native injection at a bounded interval, and periodically rescans so restarted or lazy DRM HAL services can be reattached. It does not busy-poll.
+Factory discovery and reconciliation are bounded. The implementation caps tracked factory services and plugin Binder objects, retries native injection at a bounded interval, and periodically rescans so restarted or lazy DRM HAL services can be reattached. It does not busy poll.
 
-Only a matching `deviceUniqueId` read for an isolated application performs pseudonym derivation. The code reuses the existing application privacy seed and a thread-local SHA-256 digest, does not create an unbounded per-request cache, and zeroes temporary copies of the genuine and pseudonymous DRM identifier after constructing the replacement Binder reply.
+Only a matching `deviceUniqueId` read for an isolated application performs pseudonym derivation. The code reuses the existing application privacy seed and a thread local SHA 256 digest, does not create an unbounded per request cache, and zeroes temporary copies of the genuine and pseudonymous DRM identifier after constructing the replacement Binder reply.
 
 ## Limits
 
-This feature cannot repair broken DRM provisioning, OEMCrypto, vendor HAL defects, revoked credentials, or hardware trust state. It cannot guarantee that an application has no other fingerprinting or account-level identifiers. It only prevents the genuine `deviceUniqueId` value from being returned through the supported modern AIDL property path when isolation is explicitly enabled.
+This feature cannot repair broken DRM provisioning, OEMCrypto, vendor HAL defects, revoked credentials, or hardware trust state. It cannot guarantee that an application has no other fingerprinting or account level identifiers. It only prevents the genuine `deviceUniqueId` value from being returned through the supported modern AIDL property path when isolation is explicitly enabled.
 
-If protected playback behaves differently, keep DRM Keystore Passthrough enabled for the affected package, disable or change its privacy rule, restart the application, and review the CleveresTricky log for DRM privacy registration or fail-open messages.
+If protected playback behaves differently, keep DRM Keystore Passthrough enabled for the affected package, disable or change its privacy rule, restart the application, and review the CleveresTricky log for DRM privacy registration or fail open messages.
 
 [Return to the project overview](../README.md)

--- a/docs/DrmPassthrough.md
+++ b/docs/DrmPassthrough.md
@@ -1,35 +1,51 @@
-# DRM Keystore Passthrough
+# DRM Keystore Passthrough and Identifier Privacy
 
 ## Purpose
 
+CleveresTricky has two deliberately separate DRM-related behaviors.
+
 DRM Keystore Passthrough keeps selected media applications on Android's genuine Keystore certificate path. It prevents CleveresTricky attestation compatibility handling from leaking into applications where modified certificate chains can interfere with protected playback.
 
-This feature is deliberately scoped to Keystore and attestation compatibility. It does **not** hook or alter MediaDrm, Widevine license exchange, provisioning, content keys, DRM HAL decisions, or the reported Widevine security level.
+DRM Identifier Privacy is narrower and identity-focused. On the supported modern stable-AIDL DRM HAL path, an application configured with `privacy=isolate` receives a stable application-scoped pseudonym when it reads the byte-array property `deviceUniqueId`. The genuine DRM device identifier is not used as input to that pseudonym, is not logged, and is not stored in a CleveresTricky DRM-ID cache.
 
-## Package policy
+## Why the privacy hook exists
 
-The `drm_packages.txt` file accepts exact package names and bounded wildcard rules. The service resolves the calling Android user identifier and evaluates the package set before global or targeted certificate substitution decisions.
+Android defines `deviceUniqueId` as a DRM byte-array property established during provisioning that can uniquely identify a device. A media or streaming application can therefore treat that value as another durable device identifier. The privacy hook prevents this specific supported property from exposing the genuine value to an isolated application while keeping the rest of the DRM transaction on the original platform path.
 
-When passthrough is enabled and a caller matches the DRM list, certificate substitution is skipped. Other CleveresTricky controls remain available for applications outside that list.
+The pseudonym is derived from the same protected random privacy seed used by Application Rules. It is stable for the same isolated application identity, differs across unrelated application identities, and preserves the original DRM identifier length within a bounded supported range. Stable pseudonyms are used instead of generating a new value on every read because changing the identity during normal playback can create avoidable compatibility problems.
 
-Runtime changes to DRM passthrough, the DRM package list, target scope, global mode, or TEE broken mode invalidate previously substituted attestation chain cache entries after the new policy is loaded. This prevents a package that has moved onto the genuine path from receiving a chain cached under an older policy.
+## Keystore passthrough package policy
 
-## Defaults
+The `drm_packages.txt` file accepts exact package names and bounded wildcard rules. The service resolves the calling Android user identifier and evaluates the package set before global or targeted Keystore certificate substitution decisions.
 
-Daily Compatibility, Default, and Minimal enable DRM Keystore Passthrough. Maximum Compatibility disables it for controlled tests that intentionally use the widest scope.
+When passthrough is enabled and a caller matches the DRM list, certificate substitution is skipped. Runtime changes to DRM passthrough, the DRM package list, target scope, global mode, or legacy TEE-safe-mode state invalidate previously substituted attestation-chain cache entries after the new policy is loaded.
 
-The package list has no effect while the dedicated passthrough control is disabled. Changes reload without restarting the service.
+The default list includes common media applications such as Netflix, Amazon Prime Video, Disney+, Max, and YouTube. Keeping one of those packages on the genuine Keystore path does not disable DRM Identifier Privacy. The two controls are intentionally independent: a package can use genuine Keystore certificates while `privacy=isolate` pseudonymizes only its supported DRM `deviceUniqueId` read.
 
-## Safety
+## DRM privacy activation
 
-Package count, file size, line length, and wildcard form are bounded. Invalid input leaves the previous valid policy active. Unknown package resolution does not become a broad substitution decision.
+DRM Identifier Privacy requires Identity Spoof Engine to be enabled and the application's Application Rule privacy mode to be `isolate`. `inherit` leaves the DRM identifier unchanged. The DRM privacy hook does not use the Keystore `drm_passthrough` targeting decision.
 
-The DRM subsystem itself remains owned by Android and the device DRM implementation. CleveresTricky only controls whether its own Keystore certificate substitution is allowed for a configured application.
+The runtime discovers stable-AIDL `android.hardware.drm.IDrmFactory/*` services, attaches the existing bounded native Binder hook to the vendor DRM service process, observes newly created `IDrmPlugin` Binder objects, and filters only `getPropertyByteArray` transactions. A request is modified only when its property name is exactly `deviceUniqueId` and the real Binder caller has an explicit isolate policy.
+
+Legacy HIDL DRM implementations and vendor-specific paths that do not use the supported stable-AIDL interface remain untouched. If the expected AIDL service, transaction shape, process information, or response format is unavailable, the hook fails open and Android's original response is preserved.
+
+## Security boundary
+
+The privacy hook does **not** change `getPropertyString`, reported security level, session security level, HDCP state, provisioning, license requests or responses, content keys, secure stops, offline licenses, encryption/decryption operations, or vendor DRM policy. It does not transform L2/L3 into L1 and does not claim to upgrade a device's hardware-backed DRM capability.
+
+A general DRM-protection bypass would require substantially broader and continuously maintained vendor-specific work. That is not the current purpose of this feature. Bootloader unlock also does not automatically imply that every DRM implementation has stopped working; actual behavior depends on the device, vendor DRM stack, provisioning state, security level, firmware, and service policy. CleveresTricky therefore treats DRM bypass as a separate problem rather than a primary module objective.
+
+## Resource and failure behavior
+
+Factory discovery and reconciliation are bounded. The implementation caps tracked factory services and plugin Binder objects, retries native injection at a bounded interval, and periodically rescans so restarted or lazy DRM HAL services can be reattached. It does not busy-poll.
+
+Only a matching `deviceUniqueId` read for an isolated application performs pseudonym derivation. The code reuses the existing application privacy seed and a thread-local SHA-256 digest, does not create an unbounded per-request cache, and zeroes temporary copies of the genuine and pseudonymous DRM identifier after constructing the replacement Binder reply.
 
 ## Limits
 
-This feature does not implement DRM, create licenses, bypass content protection, or spoof a Widevine security level. It cannot repair a device whose DRM provisioning, OEMCrypto implementation, vendor DRM HAL, or hardware backed DRM state is independently broken.
+This feature cannot repair broken DRM provisioning, OEMCrypto, vendor HAL defects, revoked credentials, or hardware trust state. It cannot guarantee that an application has no other fingerprinting or account-level identifiers. It only prevents the genuine `deviceUniqueId` value from being returned through the supported modern AIDL property path when isolation is explicitly enabled.
 
-If protected playback behaves differently, enable DRM Keystore Passthrough, confirm the package is listed, restart the application, and review the log for the caller and policy decision.
+If protected playback behaves differently, keep DRM Keystore Passthrough enabled for the affected package, disable or change its privacy rule, restart the application, and review the CleveresTricky log for DRM privacy registration or fail-open messages.
 
 [Return to the project overview](../README.md)

--- a/docs/Installer.md
+++ b/docs/Installer.md
@@ -14,21 +14,33 @@ Binary and script payloads are intentional parts of the module template. KernelS
 
 ## Integrity and permissions
 
-The build adds a SHA 256 record for each packaged payload. Installation verifies extracted content, sets executable modes only where required, creates the private configuration directory with root ownership, and refuses a symbolic link in that location.
+The build adds a SHA 256 record for every packaged payload. Installation verifies each file it extracts against that record. Runtime verification then walks the installed module with bounded input, rejects symbolic links and non regular entries, requires integrity records for normal payloads, rejects unexpected unchecked payloads including `system.prop`, and enters tamper lockdown when a required file is missing or changed.
+
+Manager owned state files named `disable`, `remove`, `update`, and the module tamper marker may exist without payload checksums because they are control state rather than executable or property payloads.
 
 Runtime scripts restore conservative file modes and SELinux labels without recursively following unexpected links or crossing mounts.
 
+## Official release authenticity
+
+Archive internal SHA 256 records prove consistency of the installed payload but they are not by themselves proof of who created an archive. A person who can replace every file inside a ZIP can also replace checksum records and the installer script inside that same ZIP.
+
+Official release builds therefore publish a separate `SHA256SUMS` file for the release ZIP, debug ZIP, and Encryptor APK. The release workflow also creates GitHub signed build provenance for those digests through the repository Actions identity. This external provenance is the trust anchor that distinguishes an official build from a repack that merely recalculates archive internal hashes.
+
+When authenticity matters, download from the official project release page and verify the release digest and GitHub attestation before installation. A modified archive cannot retain the official digest or provenance for its changed bytes.
+
 ## Installation sequence
 
-1. Download the release ZIP for the project.
+1. Download the release ZIP from the official project release page.
 
-2. Install it through KernelSU or APatch.
+2. Verify its entry in `SHA256SUMS` and GitHub build provenance when source authenticity is required.
 
-3. Confirm that the manager reports success.
+3. Install it through KernelSU or APatch.
 
-4. Reboot Android.
+4. Confirm that the manager reports success.
 
-5. Open the module WebUI and review Dashboard and Logs.
+5. Reboot Android.
+
+6. Open the module WebUI and review Dashboard and Logs.
 
 Do not extract or delete template binaries manually. An incomplete payload will fail verification or prevent native runtime activation.
 

--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -4,7 +4,9 @@
 
 Core Keystore interception remains registered while the module service is healthy. The native Binder hook therefore stays available for certificate and TEE compatibility even when Spoof Engine is disabled.
 
-Spoof Engine is the identity resource control. When disabled, optional attestation identity values are not exposed, Telephony Identity is parked when no privacy rule needs it, and optional build and region identity work is skipped. Core certificate handling and boot property protection remain active.
+Spoof Engine is the identity resource control. When disabled, optional attestation identity values are not exposed, Telephony Identity is parked when no privacy rule needs it, DRM Identifier Privacy is parked, and optional build and region identity work is skipped. Core certificate handling and boot property protection remain active.
+
+When Spoof Engine is enabled, the DRM privacy controller reconciles modern stable-AIDL DRM factories at a bounded interval. It does not busy-poll. Lazy or restarted DRM services are rediscovered, while an injector retry for the same process is rate limited.
 
 Automatic Keybox Check has its own control and is independent from Spoof Engine. Disable that worker directly when scheduled revocation work is not wanted.
 
@@ -15,6 +17,14 @@ Rust parses Binder streams into a fixed caller owned array. A fixed local buffer
 The Binder descriptor cache uses 64 fixed slots and no heap growth. The Rust hot path validates device plus inode identity before using a cached classification and checks identity again after procfs resolution. The platform weak pointer handoff uses a fixed per thread queue, so transaction bursts cannot grow a dynamic container. A malformed or oversized stream is passed through without unbounded work.
 
 The injector is a short lived Rust process. Rust owns its arguments, logs, file descriptors, buffers, process maps, symbol resolution, ptrace session, register layouts, process memory, socket transfer, loader calls, cleanup, register restoration, and detach state. Temporary target stack writes and the call stack guard use a fixed upper bound. Overlapping ranges are saved once and restored before detach. C plus plus remains only at the injected Android libbinder and LSPlt boundary.
+
+## DRM privacy cost
+
+DRM Identifier Privacy registers only the stable-AIDL `IDrmFactory.createDrmPlugin` and `IDrmPlugin.getPropertyByteArray` transaction codes. Requests for licenses, keys, provisioning, sessions, security level, HDCP state, and DRM string properties never enter the replacement path.
+
+The controller caps tracked DRM factory services at 16 and plugin Binder objects at 256. Dead Binder objects are pruned before new registrations are accepted. Reconciliation runs no more often than the normal runtime-controller interval when healthy, and native injection attempts for one PID are rate limited.
+
+A pseudonym is derived only when an isolated application reads exactly `deviceUniqueId`. The derivation reuses the already protected application privacy identity and a thread-local SHA-256 instance. There is no persistent DRM-ID file and no growing per-request or per-app DRM pseudonym cache. Output is bounded to 8 through 64 bytes, matching only supported original identifier sizes. Temporary copies of the genuine DRM identifier and the pseudonym are cleared after the replacement Parcel has been constructed.
 
 ## Service memory
 
@@ -32,6 +42,6 @@ Native outputs use section collection, hidden visibility, stack protection, imme
 
 ## Lowest overhead setup
 
-Keep optional Identity Spoof Engine off when identity substitution is not needed. Disable Telephony Identity and Automatic Keybox Check unless required. Core Keystore and boot protection remain active because they are the baseline module behavior.
+Keep optional Identity Spoof Engine off when identity substitution and DRM identifier privacy are not needed. Disable Telephony Identity and Automatic Keybox Check unless required. Core Keystore and boot protection remain active because they are the baseline module behavior.
 
 [Return to the project overview](../README.md)

--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -6,7 +6,7 @@ Core Keystore interception remains registered while the module service is health
 
 Spoof Engine is the identity resource control. When disabled, optional attestation identity values are not exposed, Telephony Identity is parked when no privacy rule needs it, DRM Identifier Privacy is parked, and optional build and region identity work is skipped. Core certificate handling and boot property protection remain active.
 
-When Spoof Engine is enabled, the DRM privacy controller reconciles modern stable-AIDL DRM factories at a bounded interval. It does not busy-poll. Lazy or restarted DRM services are rediscovered, while an injector retry for the same process is rate limited.
+When Spoof Engine is enabled, the DRM privacy controller reconciles modern stable AIDL DRM factories at a bounded interval. It does not busy poll. Lazy or restarted DRM services are rediscovered, while an injector retry for the same process is rate limited.
 
 Automatic Keybox Check has its own control and is independent from Spoof Engine. Disable that worker directly when scheduled revocation work is not wanted.
 
@@ -20,11 +20,11 @@ The injector is a short lived Rust process. Rust owns its arguments, logs, file 
 
 ## DRM privacy cost
 
-DRM Identifier Privacy registers only the stable-AIDL `IDrmFactory.createDrmPlugin` and `IDrmPlugin.getPropertyByteArray` transaction codes. Requests for licenses, keys, provisioning, sessions, security level, HDCP state, and DRM string properties never enter the replacement path.
+DRM Identifier Privacy registers only the stable AIDL `IDrmFactory.createDrmPlugin` and `IDrmPlugin.getPropertyByteArray` transaction codes. Requests for licenses, keys, provisioning, sessions, security level, HDCP state, and DRM string properties never enter the replacement path.
 
-The controller caps tracked DRM factory services at 16 and plugin Binder objects at 256. Dead Binder objects are pruned before new registrations are accepted. Reconciliation runs no more often than the normal runtime-controller interval when healthy, and native injection attempts for one PID are rate limited.
+The controller caps tracked DRM factory services at 16 and plugin Binder objects at 256. Dead Binder objects are pruned before new registrations are accepted. Reconciliation runs no more often than the normal runtime controller interval when healthy, and native injection attempts for one PID are rate limited.
 
-A pseudonym is derived only when an isolated application reads exactly `deviceUniqueId`. The derivation reuses the already protected application privacy identity and a thread-local SHA-256 instance. There is no persistent DRM-ID file and no growing per-request or per-app DRM pseudonym cache. Output is bounded to 8 through 64 bytes, matching only supported original identifier sizes. Temporary copies of the genuine DRM identifier and the pseudonym are cleared after the replacement Parcel has been constructed.
+A pseudonym is derived only when an isolated application reads exactly `deviceUniqueId`. The derivation reuses the already protected application privacy identity and a thread local SHA 256 instance. There is no persistent DRM ID file and no growing per request or per app DRM pseudonym cache. Output is bounded to 8 through 64 bytes, matching only supported original identifier sizes. Temporary copies of the genuine DRM identifier and the pseudonym are cleared after the replacement Parcel has been constructed.
 
 ## Service memory
 

--- a/module/template/webroot/bridge.js
+++ b/module/template/webroot/bridge.js
@@ -12,6 +12,7 @@
     const maxResponseBytes = 20 * 1024 * 1024;
     const maxEnvelopeChars = 1024 * 1024;
     const responseFields = new Set(['version', 'status', 'statusText', 'mimeType', 'size', 'body', 'downloadId']);
+    const communityUrl = 'https://t.me/cleverestech';
     let callbackCounter = 0;
 
     function encodeBytes(bytes) {
@@ -422,6 +423,50 @@
         }
     }
 
+    function installCommunityCard() {
+        const document = global.document;
+        if (!document || !document.body || document.getElementById('cleveresCommunityCard')) return;
+
+        const card = document.createElement('section');
+        card.id = 'cleveresCommunityCard';
+        card.setAttribute('aria-label', 'CleveresTech Telegram community');
+        card.style.cssText = 'box-sizing:border-box;max-width:800px;margin:0 auto;padding:0 20px max(28px,env(safe-area-inset-bottom));text-align:center;';
+
+        const panel = document.createElement('div');
+        panel.style.cssText = 'background:#161616;border:1px solid #333;border-radius:12px;padding:20px;box-shadow:0 4px 6px rgba(0,0,0,0.1);';
+
+        const title = document.createElement('strong');
+        title.textContent = 'CleveresTech Community';
+        title.style.cssText = 'display:block;color:#E5E7EB;font-size:1.05em;margin-bottom:8px;';
+
+        const copy = document.createElement('p');
+        copy.textContent = 'Join our Telegram group for mutual help, testing, discussion, and development of CleveresTricky.';
+        copy.style.cssText = 'color:#999;line-height:1.5;margin:0 0 16px;';
+
+        const link = document.createElement('a');
+        link.href = communityUrl;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        link.textContent = 'Join Telegram Community';
+        link.style.cssText = 'display:inline-flex;align-items:center;justify-content:center;min-height:44px;padding:0 22px;border-radius:6px;background:#D1D5DB;color:#000;text-decoration:none;font-weight:600;letter-spacing:.3px;';
+
+        panel.appendChild(title);
+        panel.appendChild(copy);
+        panel.appendChild(link);
+        card.appendChild(panel);
+        document.body.appendChild(card);
+    }
+
+    function scheduleCommunityCard() {
+        const document = global.document;
+        if (!document) return;
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', installCommunityCard, { once: true });
+        } else {
+            installCommunityCard();
+        }
+    }
+
     try {
         if (nativeApi && typeof nativeApi.enableEdgeToEdge === 'function') nativeApi.enableEdgeToEdge(true);
     } catch (_) {
@@ -431,5 +476,6 @@
     } catch (_) {
     }
 
+    scheduleCommunityCard();
     global.CleveresBridge = Object.freeze({ revision: 4, fetch: nativeFetch, exportBlob, exportResponse, listPackages });
 })(window);

--- a/module/webui-tests/bridge.test.js
+++ b/module/webui-tests/bridge.test.js
@@ -20,7 +20,38 @@ function envelope(body = '{"status":"ok"}') {
     });
 }
 
-function createBridge(callbackFactory) {
+function createElement(tagName) {
+    return {
+        tagName: tagName.toUpperCase(),
+        id: '',
+        style: {},
+        children: [],
+        attributes: Object.create(null),
+        appendChild(child) { this.children.push(child); return child; },
+        setAttribute(name, value) { this.attributes[name] = String(value); }
+    };
+}
+
+function createDocument() {
+    const body = createElement('body');
+    return {
+        readyState: 'complete',
+        body,
+        createElement,
+        getElementById(id) {
+            const queue = [...body.children];
+            while (queue.length) {
+                const node = queue.shift();
+                if (node.id === id) return node;
+                queue.push(...node.children);
+            }
+            return null;
+        },
+        addEventListener() {}
+    };
+}
+
+function createBridge(callbackFactory, document = null) {
     const context = {
         console,
         setTimeout,
@@ -39,6 +70,7 @@ function createBridge(callbackFactory) {
         atob: value => Buffer.from(value, 'base64').toString('binary'),
         btoa: value => Buffer.from(value, 'binary').toString('base64')
     };
+    if (document) context.document = document;
     context.window = context;
     context.ksu = {
         exec(_command, _options, callbackName) {
@@ -118,6 +150,20 @@ async function main() {
         JSON.parse(JSON.stringify(await resourceResponse.json())),
         JSON.parse(resourceBody)
     );
+
+    const communityDocument = createDocument();
+    createBridge(() => {}, communityDocument);
+    const communityCard = communityDocument.getElementById('cleveresCommunityCard');
+    assert.ok(communityCard, 'Telegram community card was not appended');
+    assert.strictEqual(communityDocument.body.children.at(-1), communityCard, 'Community card must stay at the bottom');
+    const communityPanel = communityCard.children[0];
+    const communityCopy = communityPanel.children[1];
+    const communityLink = communityPanel.children[2];
+    assert.match(communityCopy.textContent, /mutual help.*development/i);
+    assert.strictEqual(communityLink.href, 'https://t.me/cleverestech');
+    assert.strictEqual(communityLink.target, '_blank');
+    assert.strictEqual(communityLink.rel, 'noopener noreferrer');
+    assert.strictEqual(communityLink.textContent, 'Join Telegram Community');
 
     const normalizeUiMessage = loadMessageNormalizer();
     assert.strictEqual(normalizeUiMessage(envelope('{"error":"keybox rejected"}')), 'keybox rejected');

--- a/service/src/main/java/cleveres/tricky/cleverestech/DrmInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/DrmInterceptor.kt
@@ -1,0 +1,523 @@
+package cleveres.tricky.cleverestech
+
+import android.os.IBinder
+import android.os.Parcel
+import android.os.ServiceManager
+import android.os.SystemClock
+import cleveres.tricky.cleverestech.binder.BinderInterceptor
+import java.io.File
+import java.lang.reflect.Array
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+
+/**
+ * Privacy-only hook for the modern stable-AIDL DRM HAL.
+ *
+ * The hook changes only IDrmPlugin.getPropertyByteArray("deviceUniqueId") for
+ * applications explicitly configured with privacy=isolate. License exchange,
+ * provisioning, content keys, session security level and every string property
+ * remain on Android's genuine DRM path.
+ */
+object DrmInterceptor {
+    private const val DRM_FACTORY_DESCRIPTOR = "android.hardware.drm.IDrmFactory"
+    private const val DRM_PLUGIN_DESCRIPTOR = "android.hardware.drm.IDrmPlugin"
+    private const val DRM_FACTORY_PREFIX = "$DRM_FACTORY_DESCRIPTOR/"
+    private const val DEVICE_UNIQUE_ID = "deviceUniqueId"
+
+    // android.hardware.drm is a frozen stable-AIDL interface. createDrmPlugin
+    // is the first IDrmFactory method; getPropertyByteArray is the eleventh
+    // IDrmPlugin method in the frozen API. Reflection is preferred when a Java
+    // Stub is present, and these values are the wire-compatible fallback.
+    private val createDrmPluginTransaction =
+        resolveTransactionCode(
+            "android.hardware.drm.IDrmFactory\$Stub",
+            "createDrmPlugin",
+            IBinder.FIRST_CALL_TRANSACTION,
+        )
+    private val getPropertyByteArrayTransaction =
+        resolveTransactionCode(
+            "android.hardware.drm.IDrmPlugin\$Stub",
+            "getPropertyByteArray",
+            IBinder.FIRST_CALL_TRANSACTION + 10,
+        )
+
+    private const val INJECTION_RETRY_INTERVAL_MS = 15_000L
+    private const val RECONCILE_INTERVAL_MS = 30_000L
+    private const val INJECT_TIMEOUT_SECONDS = 30L
+    private const val MAX_FACTORY_SERVICES = 16
+    private const val MAX_PLUGIN_BINDERS = 256
+
+    private data class FactoryRegistration(
+        val name: String,
+        val binder: IBinder,
+        val pid: Int,
+        val control: IBinder,
+        val interceptor: FactoryInterceptor,
+        val deathRecipient: IBinder.DeathRecipient,
+    )
+
+    private data class PluginRegistration(
+        val owner: String,
+        val binder: IBinder,
+        val control: IBinder,
+    )
+
+    private val factories = LinkedHashMap<String, FactoryRegistration>()
+    private val plugins = LinkedHashMap<IBinder, PluginRegistration>()
+    private val injectedPids = HashSet<Int>()
+    private val lastInjectionAttempt = ConcurrentHashMap<Int, Long>()
+    private val pluginInterceptor = PluginInterceptor()
+
+    @Volatile
+    private var lastReconcileMs = 0L
+
+    @Volatile
+    private var lastReconcileHealthy = false
+
+    fun isRunning(): Boolean {
+        if (!lastReconcileHealthy) return false
+        val age = SystemClock.elapsedRealtime() - lastReconcileMs
+        if (age !in 0 until RECONCILE_INTERVAL_MS) return false
+        return synchronized(this) { factories.values.all { it.binder.isBinderAlive } }
+    }
+
+    /**
+     * Reconciles all currently declared/running stable-AIDL DRM factories.
+     * A missing factory is not an error: devices may expose only a legacy HIDL
+     * DRM implementation. The controller periodically rescans for lazy HALs.
+     */
+    @Synchronized
+    fun tryRunDrmInterceptor(): Boolean {
+        pruneDeadPluginsLocked()
+        pruneDeadFactoriesLocked()
+
+        val serviceNames = discoverFactoryServices()
+        if (serviceNames.isEmpty()) {
+            markHealthy()
+            return true
+        }
+
+        val pids = getServicePids(serviceNames)
+        var needsFastRetry = false
+        for (name in serviceNames) {
+            val existing = factories[name]
+            if (existing != null && existing.binder.isBinderAlive) continue
+
+            val service = ServiceManager.checkService(name) ?: ServiceManager.getService(name) ?: continue
+            var control = BinderInterceptor.getBinderControlEndpoint(service)
+            val pid = pids[name]
+            if (control == null) {
+                if (pid == null || pid <= 0) {
+                    Logger.d("DRM privacy: PID unavailable for $name; will rescan")
+                    continue
+                }
+                when (injectIfDue(pid)) {
+                    InjectionResult.SUCCESS -> {
+                        control = BinderInterceptor.getBinderControlEndpoint(service)
+                        if (control == null) {
+                            needsFastRetry = true
+                            continue
+                        }
+                    }
+                    InjectionResult.DEFERRED -> continue
+                    InjectionResult.FAILED -> continue
+                }
+            }
+
+            val resolvedPid = pid ?: 0
+            val interceptor = FactoryInterceptor(name)
+            if (
+                !BinderInterceptor.registerBinderInterceptor(
+                    requireNotNull(control),
+                    service,
+                    interceptor,
+                    intArrayOf(createDrmPluginTransaction),
+                )
+            ) {
+                Logger.w("DRM privacy: failed to register factory interceptor for $name")
+                continue
+            }
+
+            val deathRecipient =
+                IBinder.DeathRecipient {
+                    onFactoryDied(name, service)
+                }
+            try {
+                service.linkToDeath(deathRecipient, 0)
+            } catch (_: android.os.RemoteException) {
+                BinderInterceptor.unregisterBinderInterceptor(control, service, interceptor)
+                needsFastRetry = true
+                continue
+            }
+
+            factories[name] =
+                FactoryRegistration(
+                    name = name,
+                    binder = service,
+                    pid = resolvedPid,
+                    control = control,
+                    interceptor = interceptor,
+                    deathRecipient = deathRecipient,
+                )
+            Logger.i("DRM privacy: stable-AIDL factory hook registered for $name")
+        }
+
+        markHealthy()
+        return !needsFastRetry
+    }
+
+    @Synchronized
+    fun stopDrmInterceptor(): Boolean {
+        var success = true
+
+        val pluginSnapshot = plugins.values.toList()
+        plugins.clear()
+        for (registration in pluginSnapshot) {
+            if (registration.binder.isBinderAlive) {
+                success =
+                    BinderInterceptor.unregisterBinderInterceptor(
+                        registration.control,
+                        registration.binder,
+                        pluginInterceptor,
+                    ) && success
+            }
+        }
+
+        val factorySnapshot = factories.values.toList()
+        factories.clear()
+        for (registration in factorySnapshot) {
+            if (registration.binder.isBinderAlive) {
+                success =
+                    BinderInterceptor.unregisterBinderInterceptor(
+                        registration.control,
+                        registration.binder,
+                        registration.interceptor,
+                    ) && success
+                runCatching { registration.binder.unlinkToDeath(registration.deathRecipient, 0) }
+            }
+        }
+
+        factorySnapshot.map { it.control }.distinct().forEach { control ->
+            success = BinderInterceptor.parkBinderHook(control) && success
+        }
+
+        injectedPids.clear()
+        lastInjectionAttempt.clear()
+        lastReconcileHealthy = false
+        lastReconcileMs = 0L
+        return success
+    }
+
+    @Synchronized
+    private fun registerPlugin(
+        owner: String,
+        plugin: IBinder,
+    ) {
+        if (plugins.containsKey(plugin)) return
+        pruneDeadPluginsLocked()
+        if (plugins.size >= MAX_PLUGIN_BINDERS) {
+            Logger.w("DRM privacy: plugin registration limit reached")
+            return
+        }
+
+        val factory = factories[owner] ?: return
+        if (
+            BinderInterceptor.registerBinderInterceptor(
+                factory.control,
+                plugin,
+                pluginInterceptor,
+                intArrayOf(getPropertyByteArrayTransaction),
+            )
+        ) {
+            plugins[plugin] = PluginRegistration(owner, plugin, factory.control)
+            Logger.d("DRM privacy: plugin hook registered")
+        } else {
+            Logger.w("DRM privacy: failed to register plugin interceptor")
+        }
+    }
+
+    @Synchronized
+    private fun onFactoryDied(
+        name: String,
+        expectedBinder: IBinder,
+    ) {
+        val registration = factories[name]
+        if (registration == null || registration.binder !== expectedBinder) return
+        factories.remove(name)
+        if (registration.pid > 0) injectedPids.remove(registration.pid)
+        removePluginsForOwnerLocked(name)
+        lastReconcileHealthy = false
+        lastReconcileMs = 0L
+        Config.signalRuntimeController()
+        Logger.i("DRM privacy: factory restarted; hook reconciliation requested")
+    }
+
+    private fun removePluginsForOwnerLocked(owner: String) {
+        val iterator = plugins.entries.iterator()
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            if (entry.value.owner == owner) iterator.remove()
+        }
+    }
+
+    private fun pruneDeadPluginsLocked() {
+        val iterator = plugins.entries.iterator()
+        while (iterator.hasNext()) {
+            if (!iterator.next().key.isBinderAlive) iterator.remove()
+        }
+    }
+
+    private fun pruneDeadFactoriesLocked() {
+        val iterator = factories.entries.iterator()
+        while (iterator.hasNext()) {
+            val registration = iterator.next().value
+            if (!registration.binder.isBinderAlive) {
+                iterator.remove()
+                if (registration.pid > 0) injectedPids.remove(registration.pid)
+                removePluginsForOwnerLocked(registration.name)
+            }
+        }
+    }
+
+    private enum class InjectionResult {
+        SUCCESS,
+        DEFERRED,
+        FAILED,
+    }
+
+    private fun injectIfDue(pid: Int): InjectionResult {
+        val now = SystemClock.elapsedRealtime()
+        val previous = lastInjectionAttempt[pid]
+        if (previous != null && now - previous in 0 until INJECTION_RETRY_INTERVAL_MS) {
+            return InjectionResult.DEFERRED
+        }
+        lastInjectionAttempt[pid] = now
+
+        val symbol = if (injectedPids.contains(pid)) "resume" else "entry"
+        val modulePath = getModuleDir()
+        return try {
+            val process =
+                ProcessBuilder(
+                    "$modulePath/inject",
+                    pid.toString(),
+                    "$modulePath/libcleverestricky.so",
+                    symbol,
+                ).redirectOutput(File("/dev/null"))
+                    .redirectError(File("/dev/null"))
+                    .start()
+            val completed = process.waitFor(INJECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            if (!completed) {
+                process.destroyForcibly()
+                Logger.w("DRM privacy: injector timed out for pid=$pid")
+                InjectionResult.FAILED
+            } else if (process.exitValue() != 0) {
+                Logger.w("DRM privacy: injector failed for pid=$pid (exit=${process.exitValue()})")
+                InjectionResult.FAILED
+            } else {
+                injectedPids.add(pid)
+                Logger.i("DRM privacy: native Binder hook activated for DRM HAL pid=$pid")
+                InjectionResult.SUCCESS
+            }
+        } catch (error: Exception) {
+            Logger.e("DRM privacy: failed to run injector for pid=$pid", error)
+            InjectionResult.FAILED
+        }
+    }
+
+    private fun discoverFactoryServices(): List<String> {
+        val names = LinkedHashSet<String>()
+
+        runCatching {
+            val method = ServiceManager::class.java.getDeclaredMethod("getDeclaredInstances", String::class.java)
+            method.isAccessible = true
+            @Suppress("UNCHECKED_CAST")
+            val instances = method.invoke(null, DRM_FACTORY_DESCRIPTOR) as? Array<String>
+            instances?.forEach { instance ->
+                if (instance.isNotBlank()) names += "$DRM_FACTORY_PREFIX$instance"
+            }
+        }
+
+        runCatching { ServiceManager.listServices() }
+            .getOrNull()
+            ?.asSequence()
+            ?.filter { it.startsWith(DRM_FACTORY_PREFIX) }
+            ?.forEach(names::add)
+
+        return names.asSequence().filter(::isSafeFactoryName).sorted().take(MAX_FACTORY_SERVICES).toList()
+    }
+
+    private fun isSafeFactoryName(name: String): Boolean {
+        if (!name.startsWith(DRM_FACTORY_PREFIX) || name.length > 192) return false
+        val instance = name.substring(DRM_FACTORY_PREFIX.length)
+        return instance.isNotEmpty() &&
+            instance.all { character ->
+                character.isLetterOrDigit() || character == '_' || character == '-' || character == '.'
+            }
+    }
+
+    private fun getServicePids(serviceNames: List<String>): Map<String, Int> {
+        if (serviceNames.isEmpty()) return emptyMap()
+        val wanted = serviceNames.toHashSet()
+        val result = HashMap<String, Int>(wanted.size)
+        runCatching {
+            val method = ServiceManager::class.java.getDeclaredMethod("getServiceDebugInfo")
+            method.isAccessible = true
+            val debugArray = method.invoke(null) ?: return@runCatching
+            val length = Array.getLength(debugArray)
+            for (index in 0 until length) {
+                val item = Array.get(debugArray, index) ?: continue
+                val clazz = item.javaClass
+                val name = readField(clazz, item, "name") as? String ?: continue
+                if (name !in wanted) continue
+                val pid =
+                    (readField(clazz, item, "debugPid") as? Number)?.toInt()
+                        ?: (readField(clazz, item, "pid") as? Number)?.toInt()
+                        ?: continue
+                if (pid > 0) result[name] = pid
+            }
+        }.onFailure { error ->
+            Logger.d("DRM privacy: servicemanager debug PID lookup unavailable (${error.javaClass.simpleName})")
+        }
+        return result
+    }
+
+    private fun readField(
+        clazz: Class<*>,
+        instance: Any,
+        name: String,
+    ): Any? =
+        runCatching {
+            clazz.getDeclaredField(name).apply { isAccessible = true }.get(instance)
+        }.getOrNull()
+
+    private fun markHealthy() {
+        lastReconcileMs = SystemClock.elapsedRealtime()
+        lastReconcileHealthy = true
+    }
+
+    private class FactoryInterceptor(
+        private val owner: String,
+    ) : BinderInterceptor() {
+        override fun onPreTransact(
+            target: IBinder,
+            code: Int,
+            flags: Int,
+            callingUid: Int,
+            callingPid: Int,
+            data: Parcel,
+        ): Result = if (code == createDrmPluginTransaction) Continue else Skip
+
+        override fun onPostTransact(
+            target: IBinder,
+            code: Int,
+            flags: Int,
+            callingUid: Int,
+            callingPid: Int,
+            data: Parcel,
+            reply: Parcel?,
+            resultCode: Int,
+        ): Result {
+            if (code != createDrmPluginTransaction || reply == null || resultCode != 0) return Skip
+            val originalPosition = reply.dataPosition()
+            try {
+                reply.readException()
+                val plugin = reply.readStrongBinder() ?: return Skip
+                registerPlugin(owner, plugin)
+            } catch (_: RuntimeException) {
+                // A vendor that is not wire-compatible with the frozen AIDL
+                // shape is left completely untouched.
+            } finally {
+                reply.setDataPosition(originalPosition)
+            }
+            return Skip
+        }
+    }
+
+    private class PluginInterceptor : BinderInterceptor() {
+        override fun onPreTransact(
+            target: IBinder,
+            code: Int,
+            flags: Int,
+            callingUid: Int,
+            callingPid: Int,
+            data: Parcel,
+        ): Result {
+            if (code != getPropertyByteArrayTransaction || !shouldProtectUid(callingUid)) return Skip
+            return if (readPropertyName(data) == DEVICE_UNIQUE_ID) Continue else Skip
+        }
+
+        override fun onPostTransact(
+            target: IBinder,
+            code: Int,
+            flags: Int,
+            callingUid: Int,
+            callingPid: Int,
+            data: Parcel,
+            reply: Parcel?,
+            resultCode: Int,
+        ): Result {
+            if (
+                code != getPropertyByteArrayTransaction ||
+                reply == null ||
+                resultCode != 0 ||
+                !shouldProtectUid(callingUid) ||
+                readPropertyName(data) != DEVICE_UNIQUE_ID
+            ) {
+                return Skip
+            }
+
+            val originalPosition = reply.dataPosition()
+            var original: ByteArray? = null
+            var pseudonym: ByteArray? = null
+            return try {
+                reply.readException()
+                original = reply.createByteArray() ?: return Skip
+                val length = original.size
+                if (length !in DrmPrivacyIdentity.MIN_IDENTIFIER_BYTES..DrmPrivacyIdentity.MAX_IDENTIFIER_BYTES) {
+                    return Skip
+                }
+                pseudonym = DrmPrivacyIdentity.idForUid(callingUid, length) ?: return Skip
+
+                Parcel.obtain().let { replacement ->
+                    replacement.writeNoException()
+                    replacement.writeByteArray(pseudonym)
+                    OverrideReply(0, replacement)
+                }
+            } catch (_: RuntimeException) {
+                Skip
+            } finally {
+                original?.fill(0)
+                pseudonym?.fill(0)
+                reply.setDataPosition(originalPosition)
+            }
+        }
+
+        private fun readPropertyName(data: Parcel): String? {
+            val originalPosition = data.dataPosition()
+            return try {
+                data.enforceInterface(DRM_PLUGIN_DESCRIPTOR)
+                data.readString()
+            } catch (_: RuntimeException) {
+                null
+            } finally {
+                data.setDataPosition(originalPosition)
+            }
+        }
+
+        private fun shouldProtectUid(uid: Int): Boolean =
+            Config.isSpoofEnabled && Config.getAppPrivacyMode(uid) == Config.AppPrivacyMode.ISOLATE
+    }
+
+    private fun resolveTransactionCode(
+        stubClassName: String,
+        methodName: String,
+        fallback: Int,
+    ): Int {
+        val reflected =
+            runCatching {
+                val stub = Class.forName(stubClassName)
+                getTransactCode(stub, methodName)
+            }.getOrNull()
+        return reflected?.takeIf { it > 0 } ?: fallback
+    }
+}

--- a/service/src/main/java/cleveres/tricky/cleverestech/DrmInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/DrmInterceptor.kt
@@ -6,7 +6,6 @@ import android.os.ServiceManager
 import android.os.SystemClock
 import cleveres.tricky.cleverestech.binder.BinderInterceptor
 import java.io.File
-import java.lang.reflect.Array as ReflectArray
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
@@ -44,6 +43,8 @@ object DrmInterceptor {
     private const val INJECTION_RETRY_INTERVAL_MS = 15_000L
     private const val RECONCILE_INTERVAL_MS = 30_000L
     private const val INJECT_TIMEOUT_SECONDS = 30L
+    private const val PID_LOOKUP_TIMEOUT_SECONDS = 2L
+    private const val MAX_PID_OUTPUT_BYTES = 32
     private const val MAX_FACTORY_SERVICES = 16
     private const val MAX_PLUGIN_BINDERS = 256
 
@@ -82,9 +83,9 @@ object DrmInterceptor {
     }
 
     /**
-     * Reconciles all currently declared/running stable-AIDL DRM factories.
-     * A missing factory is not an error: devices may expose only a legacy HIDL
-     * DRM implementation. The controller periodically rescans for lazy HALs.
+     * Reconciles currently running stable-AIDL DRM factories. A missing factory
+     * is not an error: devices may expose only a legacy HIDL implementation, and
+     * a lazy AIDL HAL is discovered on the next scan after Android starts it.
      */
     @Synchronized
     fun tryRunDrmInterceptor(): Boolean {
@@ -97,19 +98,17 @@ object DrmInterceptor {
             return true
         }
 
-        val initialPids = getServicePids(serviceNames)
         var needsFastRetry = false
         for (name in serviceNames) {
             val existing = factories[name]
             if (existing != null && existing.binder.isBinderAlive) continue
 
-            // getService also gives servicemanager a chance to start a lazy
-            // declared HAL before the first application opens MediaDrm.
             val service = ServiceManager.checkService(name) ?: ServiceManager.getService(name) ?: continue
             var control = BinderInterceptor.getBinderControlEndpoint(service)
-            val pid = initialPids[name] ?: getServicePids(listOf(name))[name]
+            var pid = 0
             if (control == null) {
-                if (pid == null || pid <= 0) {
+                pid = findServicePid(name) ?: 0
+                if (pid <= 0) {
                     Logger.d("DRM privacy: PID unavailable for $name; will rescan")
                     continue
                 }
@@ -153,7 +152,7 @@ object DrmInterceptor {
                 FactoryRegistration(
                     name = name,
                     binder = service,
-                    pid = pid ?: 0,
+                    pid = pid,
                     control = resolvedControl,
                     interceptor = interceptor,
                     deathRecipient = deathRecipient,
@@ -323,27 +322,15 @@ object DrmInterceptor {
         }
     }
 
-    private fun discoverFactoryServices(): List<String> {
-        val names = LinkedHashSet<String>()
-
-        runCatching {
-            val method = ServiceManager::class.java.getDeclaredMethod("getDeclaredInstances", String::class.java)
-            method.isAccessible = true
-            val instances = method.invoke(null, DRM_FACTORY_DESCRIPTOR) as? kotlin.Array<*>
-            instances?.forEach { instance ->
-                val name = instance as? String
-                if (!name.isNullOrBlank()) names += "$DRM_FACTORY_PREFIX$name"
-            }
-        }
-
+    private fun discoverFactoryServices(): List<String> =
         runCatching { ServiceManager.listServices() }
             .getOrNull()
             ?.asSequence()
-            ?.filter { it.startsWith(DRM_FACTORY_PREFIX) }
-            ?.forEach(names::add)
-
-        return names.asSequence().filter(::isSafeFactoryName).sorted().take(MAX_FACTORY_SERVICES).toList()
-    }
+            ?.filter { it.startsWith(DRM_FACTORY_PREFIX) && isSafeFactoryName(it) }
+            ?.sorted()
+            ?.take(MAX_FACTORY_SERVICES)
+            ?.toList()
+            ?: emptyList()
 
     private fun isSafeFactoryName(name: String): Boolean {
         if (!name.startsWith(DRM_FACTORY_PREFIX) || name.length > 192) return false
@@ -354,40 +341,45 @@ object DrmInterceptor {
             }
     }
 
-    private fun getServicePids(serviceNames: List<String>): Map<String, Int> {
-        if (serviceNames.isEmpty()) return emptyMap()
-        val wanted = serviceNames.toHashSet()
-        val result = HashMap<String, Int>(wanted.size)
-        runCatching {
-            val method = ServiceManager::class.java.getDeclaredMethod("getServiceDebugInfo")
-            method.isAccessible = true
-            val debugArray = method.invoke(null) ?: return@runCatching
-            val length = ReflectArray.getLength(debugArray)
-            for (index in 0 until length) {
-                val item = ReflectArray.get(debugArray, index) ?: continue
-                val clazz = item.javaClass
-                val name = readField(clazz, item, "name") as? String ?: continue
-                if (name !in wanted) continue
-                val pid =
-                    (readField(clazz, item, "debugPid") as? Number)?.toInt()
-                        ?: (readField(clazz, item, "pid") as? Number)?.toInt()
-                        ?: continue
-                if (pid > 0) result[name] = pid
+    private fun findServicePid(serviceName: String): Int? {
+        if (!isSafeFactoryName(serviceName)) return null
+        val process =
+            try {
+                ProcessBuilder("/system/bin/dumpsys", "--pid", serviceName)
+                    .redirectError(File("/dev/null"))
+                    .start()
+            } catch (error: Exception) {
+                Logger.d("DRM privacy: dumpsys PID lookup unavailable (${error.javaClass.simpleName})")
+                return null
             }
-        }.onFailure { error ->
-            Logger.d("DRM privacy: servicemanager debug PID lookup unavailable (${error.javaClass.simpleName})")
-        }
-        return result
-    }
 
-    private fun readField(
-        clazz: Class<*>,
-        instance: Any,
-        name: String,
-    ): Any? =
-        runCatching {
-            clazz.getDeclaredField(name).apply { isAccessible = true }.get(instance)
-        }.getOrNull()
+        val output = ByteArray(MAX_PID_OUTPUT_BYTES)
+        return try {
+            if (!process.waitFor(PID_LOOKUP_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                return null
+            }
+            if (process.exitValue() != 0) return null
+
+            var total = 0
+            process.inputStream.use { input ->
+                while (total < output.size) {
+                    val count = input.read(output, total, output.size - total)
+                    if (count < 0) break
+                    if (count == 0) continue
+                    total += count
+                }
+                if (total == output.size && input.read() >= 0) return null
+            }
+            output.copyOf(total).toString(Charsets.UTF_8).trim().toIntOrNull()?.takeIf { it > 0 }
+        } catch (error: Exception) {
+            Logger.d("DRM privacy: PID lookup failed (${error.javaClass.simpleName})")
+            null
+        } finally {
+            output.fill(0)
+            process.destroy()
+        }
+    }
 
     private fun markHealthy() {
         lastReconcileMs = SystemClock.elapsedRealtime()

--- a/service/src/main/java/cleveres/tricky/cleverestech/DrmInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/DrmInterceptor.kt
@@ -6,7 +6,7 @@ import android.os.ServiceManager
 import android.os.SystemClock
 import cleveres.tricky.cleverestech.binder.BinderInterceptor
 import java.io.File
-import java.lang.reflect.Array
+import java.lang.reflect.Array as ReflectArray
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
@@ -97,15 +97,17 @@ object DrmInterceptor {
             return true
         }
 
-        val pids = getServicePids(serviceNames)
+        val initialPids = getServicePids(serviceNames)
         var needsFastRetry = false
         for (name in serviceNames) {
             val existing = factories[name]
             if (existing != null && existing.binder.isBinderAlive) continue
 
+            // getService also gives servicemanager a chance to start a lazy
+            // declared HAL before the first application opens MediaDrm.
             val service = ServiceManager.checkService(name) ?: ServiceManager.getService(name) ?: continue
             var control = BinderInterceptor.getBinderControlEndpoint(service)
-            val pid = pids[name]
+            val pid = initialPids[name] ?: getServicePids(listOf(name))[name]
             if (control == null) {
                 if (pid == null || pid <= 0) {
                     Logger.d("DRM privacy: PID unavailable for $name; will rescan")
@@ -124,11 +126,11 @@ object DrmInterceptor {
                 }
             }
 
-            val resolvedPid = pid ?: 0
             val interceptor = FactoryInterceptor(name)
+            val resolvedControl = requireNotNull(control)
             if (
                 !BinderInterceptor.registerBinderInterceptor(
-                    requireNotNull(control),
+                    resolvedControl,
                     service,
                     interceptor,
                     intArrayOf(createDrmPluginTransaction),
@@ -138,14 +140,11 @@ object DrmInterceptor {
                 continue
             }
 
-            val deathRecipient =
-                IBinder.DeathRecipient {
-                    onFactoryDied(name, service)
-                }
+            val deathRecipient = IBinder.DeathRecipient { onFactoryDied(name, service) }
             try {
                 service.linkToDeath(deathRecipient, 0)
             } catch (_: android.os.RemoteException) {
-                BinderInterceptor.unregisterBinderInterceptor(control, service, interceptor)
+                BinderInterceptor.unregisterBinderInterceptor(resolvedControl, service, interceptor)
                 needsFastRetry = true
                 continue
             }
@@ -154,8 +153,8 @@ object DrmInterceptor {
                 FactoryRegistration(
                     name = name,
                     binder = service,
-                    pid = resolvedPid,
-                    control = control,
+                    pid = pid ?: 0,
+                    control = resolvedControl,
                     interceptor = interceptor,
                     deathRecipient = deathRecipient,
                 )
@@ -330,10 +329,10 @@ object DrmInterceptor {
         runCatching {
             val method = ServiceManager::class.java.getDeclaredMethod("getDeclaredInstances", String::class.java)
             method.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            val instances = method.invoke(null, DRM_FACTORY_DESCRIPTOR) as? Array<String>
+            val instances = method.invoke(null, DRM_FACTORY_DESCRIPTOR) as? kotlin.Array<*>
             instances?.forEach { instance ->
-                if (instance.isNotBlank()) names += "$DRM_FACTORY_PREFIX$instance"
+                val name = instance as? String
+                if (!name.isNullOrBlank()) names += "$DRM_FACTORY_PREFIX$name"
             }
         }
 
@@ -363,9 +362,9 @@ object DrmInterceptor {
             val method = ServiceManager::class.java.getDeclaredMethod("getServiceDebugInfo")
             method.isAccessible = true
             val debugArray = method.invoke(null) ?: return@runCatching
-            val length = Array.getLength(debugArray)
+            val length = ReflectArray.getLength(debugArray)
             for (index in 0 until length) {
-                val item = Array.get(debugArray, index) ?: continue
+                val item = ReflectArray.get(debugArray, index) ?: continue
                 val clazz = item.javaClass
                 val name = readField(clazz, item, "name") as? String ?: continue
                 if (name !in wanted) continue

--- a/service/src/main/java/cleveres/tricky/cleverestech/DrmPrivacyIdentity.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/DrmPrivacyIdentity.kt
@@ -48,7 +48,7 @@ internal object DrmPrivacyIdentity {
     ): ByteArray {
         require(uid >= FIRST_APPLICATION_UID) { "DRM privacy identity requires an application UID" }
         require(length in MIN_IDENTIFIER_BYTES..MAX_IDENTIFIER_BYTES) { "Unsupported DRM identifier length" }
-        require(components.isNotEmpty() && components.all(String::isNotEmpty)) {
+        require(components.isNotEmpty() && components.all { it.isNotEmpty() }) {
             "DRM privacy identity requires non-empty identity components"
         }
 
@@ -59,7 +59,7 @@ internal object DrmPrivacyIdentity {
             val md = digest.get()
             md.reset()
             md.update(domain)
-            md.update(0)
+            md.update(0.toByte())
             updateInt(md, uid)
             updateInt(md, length)
             for (component in components) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/DrmPrivacyIdentity.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/DrmPrivacyIdentity.kt
@@ -1,0 +1,97 @@
+package cleveres.tricky.cleverestech
+
+import java.security.MessageDigest
+
+/**
+ * Derives a stable pseudonymous DRM identifier from the existing application
+ * privacy identity. The genuine DRM device identifier is never used as input.
+ */
+internal object DrmPrivacyIdentity {
+    private const val FIRST_APPLICATION_UID = 10_000
+    internal const val MIN_IDENTIFIER_BYTES = 8
+    internal const val MAX_IDENTIFIER_BYTES = 64
+    private val domain = "CleveresTricky.DrmPrivacy.v1".toByteArray(Charsets.UTF_8)
+    private val digest = ThreadLocal.withInitial { MessageDigest.getInstance("SHA-256") }
+
+    fun idForUid(
+        uid: Int,
+        length: Int,
+    ): ByteArray? {
+        if (uid < FIRST_APPLICATION_UID || length !in MIN_IDENTIFIER_BYTES..MAX_IDENTIFIER_BYTES) return null
+        if (!Config.isSpoofEnabled || Config.getAppPrivacyMode(uid) != Config.AppPrivacyMode.ISOLATE) return null
+
+        val identity = Config.getTelephonyIdentityOverrides(uid)
+        val components =
+            listOfNotNull(
+                identity.template,
+                identity.imei,
+                identity.imei2,
+                identity.imsi,
+                identity.imsi2,
+                identity.iccid,
+                identity.iccid2,
+                identity.meid,
+                identity.meid2,
+                identity.phoneNumber,
+                identity.phoneNumber2,
+                identity.serial,
+            )
+        if (components.isEmpty()) return null
+        return derive(uid, length, components)
+    }
+
+    @androidx.annotation.VisibleForTesting
+    internal fun derive(
+        uid: Int,
+        length: Int,
+        components: List<String>,
+    ): ByteArray {
+        require(uid >= FIRST_APPLICATION_UID) { "DRM privacy identity requires an application UID" }
+        require(length in MIN_IDENTIFIER_BYTES..MAX_IDENTIFIER_BYTES) { "Unsupported DRM identifier length" }
+        require(components.isNotEmpty() && components.all(String::isNotEmpty)) {
+            "DRM privacy identity requires non-empty identity components"
+        }
+
+        val output = ByteArray(length)
+        var offset = 0
+        var counter = 0
+        while (offset < output.size) {
+            val md = digest.get()
+            md.reset()
+            md.update(domain)
+            md.update(0)
+            updateInt(md, uid)
+            updateInt(md, length)
+            for (component in components) {
+                val encoded = component.toByteArray(Charsets.UTF_8)
+                try {
+                    updateInt(md, encoded.size)
+                    md.update(encoded)
+                } finally {
+                    encoded.fill(0)
+                }
+            }
+            updateInt(md, counter++)
+
+            val block = md.digest()
+            try {
+                val count = minOf(block.size, output.size - offset)
+                System.arraycopy(block, 0, output, offset, count)
+                offset += count
+            } finally {
+                block.fill(0)
+            }
+        }
+        return output
+    }
+
+    private fun updateInt(
+        digest: MessageDigest,
+        value: Int,
+    ) {
+        digest.update((value ushr 24).toByte())
+        digest.update((value ushr 16).toByte())
+        digest.update((value ushr 8).toByte())
+        digest.update(value.toByte())
+    }
+}

--- a/service/src/main/java/cleveres/tricky/cleverestech/DrmPrivacyIdentity.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/DrmPrivacyIdentity.kt
@@ -56,7 +56,7 @@ internal object DrmPrivacyIdentity {
         var offset = 0
         var counter = 0
         while (offset < output.size) {
-            val md = digest.get()
+            val md = requireNotNull(digest.get()) { "SHA-256 digest is unavailable" }
             md.reset()
             md.update(domain)
             md.update(0.toByte())

--- a/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
@@ -63,6 +63,7 @@ fun main(args: Array<String>) {
         var previousIdentityEngineState: Boolean? = null
         var previousTelephonyState: Boolean? = null
         var telephonyStopPending = false
+        var drmStopPending = false
         while (true) {
             val identityEngineEnabled = Config.isSpoofEnabled
             if (previousIdentityEngineState != identityEngineEnabled) {
@@ -80,6 +81,7 @@ fun main(args: Array<String>) {
             // spoofing must never unregister it or park the native Binder hook.
             var ksSuccess = KeystoreInterceptor.isRunning()
             var telSuccess = !Config.shouldInterceptTelephony || TelephonyInterceptor.isRunning()
+            var drmSuccess = !identityEngineEnabled || DrmInterceptor.isRunning()
 
             val ksJob =
                 if (!ksSuccess) {
@@ -108,8 +110,22 @@ fun main(args: Array<String>) {
                     null
                 }
 
+            val drmJob =
+                if (identityEngineEnabled && !drmSuccess) {
+                    launch(Dispatchers.IO) {
+                        try {
+                            drmSuccess = DrmInterceptor.tryRunDrmInterceptor()
+                        } catch (e: Exception) {
+                            Logger.e("DRM privacy interceptor threw unexpected exception", e)
+                        }
+                    }
+                } else {
+                    null
+                }
+
             ksJob?.join()
             telJob?.join()
+            drmJob?.join()
 
             if (!telephonyEnabled && (previousTelephonyState != false || telephonyStopPending)) {
                 val wasPending = telephonyStopPending
@@ -123,16 +139,29 @@ fun main(args: Array<String>) {
             }
             previousTelephonyState = if (telephonyStopPending) null else telephonyEnabled
 
+            if (!identityEngineEnabled && (previousIdentityEngineState == false || drmStopPending)) {
+                val wasPending = drmStopPending
+                drmStopPending = !DrmInterceptor.stopDrmInterceptor()
+                if (drmStopPending && !wasPending) {
+                    Logger.w("DRM privacy hook cleanup is incomplete; retry scheduled")
+                }
+                drmSuccess = !drmStopPending
+            } else if (identityEngineEnabled) {
+                drmStopPending = false
+            }
+
             if (!ksSuccess) Logger.d("Core Keystore interceptor is not ready; retry scheduled")
             if (!telSuccess) Logger.d("Telephony interceptor not ready yet")
+            if (!drmSuccess) Logger.d("DRM privacy interceptor not ready yet")
 
             try {
                 Config.awaitRuntimeController(
-                    if (ksSuccess && telSuccess && !telephonyStopPending) 30_000 else 1_000,
+                    if (ksSuccess && telSuccess && drmSuccess && !telephonyStopPending && !drmStopPending) 30_000 else 1_000,
                 )
             } catch (_: InterruptedException) {
                 Thread.currentThread().interrupt()
                 CertificatePolicyWatcher.stop()
+                DrmInterceptor.stopDrmInterceptor()
                 Logger.i("Main: Runtime controller interrupted, shutting down")
                 return@runBlocking
             }

--- a/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
@@ -62,6 +62,7 @@ fun main(args: Array<String>) {
 
         var previousIdentityEngineState: Boolean? = null
         var previousTelephonyState: Boolean? = null
+        var previousDrmEngineState: Boolean? = null
         var telephonyStopPending = false
         var drmStopPending = false
         while (true) {
@@ -139,7 +140,7 @@ fun main(args: Array<String>) {
             }
             previousTelephonyState = if (telephonyStopPending) null else telephonyEnabled
 
-            if (!identityEngineEnabled && (previousIdentityEngineState == false || drmStopPending)) {
+            if (!identityEngineEnabled && (previousDrmEngineState != false || drmStopPending)) {
                 val wasPending = drmStopPending
                 drmStopPending = !DrmInterceptor.stopDrmInterceptor()
                 if (drmStopPending && !wasPending) {
@@ -149,6 +150,7 @@ fun main(args: Array<String>) {
             } else if (identityEngineEnabled) {
                 drmStopPending = false
             }
+            previousDrmEngineState = if (drmStopPending) null else identityEngineEnabled
 
             if (!ksSuccess) Logger.d("Core Keystore interceptor is not ready; retry scheduled")
             if (!telSuccess) Logger.d("Telephony interceptor not ready yet")

--- a/service/src/main/java/cleveres/tricky/cleverestech/Verification.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Verification.kt
@@ -7,7 +7,7 @@ import java.security.MessageDigest
 
 object Verification {
     private val MODULE_PATH = getModuleDir()
-    private val IGNORED_FILES = setOf("disable", "remove", "update", "system.prop", "tampered")
+    private val IGNORED_FILES = setOf("disable", "remove", "update", "tampered")
 
     fun check(root: File = File(MODULE_PATH)): Boolean {
         return try {

--- a/service/src/test/java/cleveres/tricky/cleverestech/DrmPrivacyHookPolicyTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/DrmPrivacyHookPolicyTest.kt
@@ -31,6 +31,16 @@ class DrmPrivacyHookPolicyTest {
         assertTrue(source.contains("getAppPrivacyMode(uid) == Config.AppPrivacyMode.ISOLATE"))
     }
 
+    @Test
+    fun `DRM service discovery avoids blocked ServiceManager reflection`() {
+        val source = sourceFile("DrmInterceptor.kt").readText()
+
+        assertFalse(source.contains("getDeclaredInstances"))
+        assertFalse(source.contains("getServiceDebugInfo"))
+        assertTrue(source.contains("ServiceManager.listServices()"))
+        assertTrue(source.contains("ProcessBuilder(\"/system/bin/dumpsys\", \"--pid\", serviceName)"))
+    }
+
     private fun sourceFile(name: String): File {
         val relative = "cleveres/tricky/cleverestech/$name"
         return listOf(

--- a/service/src/test/java/cleveres/tricky/cleverestech/DrmPrivacyHookPolicyTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/DrmPrivacyHookPolicyTest.kt
@@ -1,0 +1,42 @@
+package cleveres.tricky.cleverestech
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class DrmPrivacyHookPolicyTest {
+    @Test
+    fun `DRM hook targets only the byte-array device identity privacy path`() {
+        val source = sourceFile("DrmInterceptor.kt").readText()
+
+        assertTrue(source.contains("android.hardware.drm.IDrmFactory"))
+        assertTrue(source.contains("android.hardware.drm.IDrmPlugin"))
+        assertTrue(source.contains("deviceUniqueId"))
+        assertTrue(source.contains("getPropertyByteArray"))
+        assertTrue(source.contains("Config.AppPrivacyMode.ISOLATE"))
+
+        assertFalse(source.contains("getPropertyString"))
+        assertFalse(source.contains("writeString(\"L1\")"))
+        assertFalse(source.contains("\"L2\""))
+        assertFalse(source.contains("\"L3\""))
+    }
+
+    @Test
+    fun `DRM privacy path does not depend on keystore DRM passthrough targeting`() {
+        val source = sourceFile("DrmInterceptor.kt").readText()
+
+        assertFalse(source.contains("Config.needHack"))
+        assertFalse(source.contains("isDrmPassthroughEnabled"))
+        assertTrue(source.contains("getAppPrivacyMode(uid) == Config.AppPrivacyMode.ISOLATE"))
+    }
+
+    private fun sourceFile(name: String): File {
+        val relative = "cleveres/tricky/cleverestech/$name"
+        return listOf(
+            File("src/main/java/$relative"),
+            File("service/src/main/java/$relative"),
+        ).firstOrNull(File::isFile)
+            ?: error("Could not locate $name from ${File(".").absolutePath}")
+    }
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/DrmPrivacyIdentityTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/DrmPrivacyIdentityTest.kt
@@ -1,0 +1,72 @@
+package cleveres.tricky.cleverestech
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class DrmPrivacyIdentityTest {
+    private val identityComponents =
+        listOf(
+            "351234567890123",
+            "351234567890131",
+            "310260123456789",
+            "8901120200000000003",
+            "A1B2C3D4E5F607",
+            "+12025550123",
+            "SERIAL123456",
+        )
+
+    @Test
+    fun `same app identity produces a stable DRM pseudonym`() {
+        val first = DrmPrivacyIdentity.derive(10_123, 32, identityComponents)
+        val second = DrmPrivacyIdentity.derive(10_123, 32, identityComponents)
+
+        assertArrayEquals(first, second)
+        assertEquals(32, first.size)
+    }
+
+    @Test
+    fun `different application UIDs produce different DRM pseudonyms`() {
+        val first = DrmPrivacyIdentity.derive(10_123, 32, identityComponents)
+        val second = DrmPrivacyIdentity.derive(10_124, 32, identityComponents)
+
+        assertFalse(first.contentEquals(second))
+    }
+
+    @Test
+    fun `different isolated identities produce different DRM pseudonyms`() {
+        val first = DrmPrivacyIdentity.derive(10_123, 32, identityComponents)
+        val changed = identityComponents.toMutableList().apply { this[lastIndex] = "SERIAL654321" }
+        val second = DrmPrivacyIdentity.derive(10_123, 32, changed)
+
+        assertFalse(first.contentEquals(second))
+    }
+
+    @Test
+    fun `DRM pseudonym preserves supported vendor identifier lengths`() {
+        for (length in listOf(8, 16, 32, 64)) {
+            assertEquals(length, DrmPrivacyIdentity.derive(10_123, length, identityComponents).size)
+        }
+    }
+
+    @Test
+    fun `invalid DRM identity inputs are rejected`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            DrmPrivacyIdentity.derive(9999, 32, identityComponents)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            DrmPrivacyIdentity.derive(10_123, 7, identityComponents)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            DrmPrivacyIdentity.derive(10_123, 65, identityComponents)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            DrmPrivacyIdentity.derive(10_123, 32, emptyList())
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            DrmPrivacyIdentity.derive(10_123, 32, listOf(""))
+        }
+    }
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/VerificationTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/VerificationTest.kt
@@ -14,7 +14,6 @@ class VerificationTest {
     @Before
     fun setup() {
         tempDir.mkdir()
-        // Mock logger
         Logger.setImpl(
             object : Logger.LogImpl {
                 override fun d(
@@ -48,16 +47,9 @@ class VerificationTest {
             },
         )
 
-        // Create a dummy file
         val file = File(tempDir, "test.sh")
         file.writeText("original content")
-
-        // Create checksum
-        val md = MessageDigest.getInstance("SHA-256")
-        val bytes = "original content".toByteArray()
-        md.update(bytes)
-        val checksum = md.digest().joinToString("") { "%02x".format(it) }
-        File(tempDir, "test.sh.sha256").writeText(checksum)
+        writeChecksum(file)
     }
 
     @After
@@ -72,18 +64,14 @@ class VerificationTest {
 
     @Test
     fun testVerificationFailsOnModifiedFile() {
-        // Modify file
         File(tempDir, "test.sh").writeText("modified content")
 
         assertFalse(Verification.check(tempDir))
-
-        // And NOT create disable file
         assertFalse(File(tempDir, "disable").exists())
     }
 
     @Test
     fun testVerificationFailsOnMissingChecksum() {
-        // Remove checksum
         File(tempDir, "test.sh.sha256").delete()
 
         assertFalse(Verification.check(tempDir))
@@ -115,5 +103,34 @@ class VerificationTest {
         java.nio.file.Files.createSymbolicLink(File(tempDir, "linked").toPath(), target.toPath().toAbsolutePath())
 
         assertFalse(Verification.check(tempDir))
+    }
+
+    @Test
+    fun testVerificationFailsOnUncheckedInjectedPayload() {
+        File(tempDir, "unexpected.sh").writeText("malicious payload")
+
+        assertFalse(Verification.check(tempDir))
+    }
+
+    @Test
+    fun testVerificationFailsOnUncheckedSystemProp() {
+        File(tempDir, "system.prop").writeText("ro.example.injected=1")
+
+        assertFalse(Verification.check(tempDir))
+    }
+
+    @Test
+    fun managerStateFilesMayRemainUnchecked() {
+        for (name in listOf("disable", "remove", "update", "tampered")) {
+            File(tempDir, name).writeText("")
+        }
+
+        assertTrue(Verification.check(tempDir))
+    }
+
+    private fun writeChecksum(file: File) {
+        val md = MessageDigest.getInstance("SHA-256")
+        file.forEachBlock { buffer, bytesRead -> md.update(buffer, 0, bytesRead) }
+        File(file.path + ".sha256").writeText(md.digest().joinToString("") { "%02x".format(it) })
     }
 }


### PR DESCRIPTION
## Summary

This change keeps DRM work deliberately privacy oriented rather than pretending to upgrade or bypass the device DRM security state.

### DRM identifier privacy

- add a real modern stable AIDL Android DRM Binder hook for `android.hardware.drm.IDrmFactory` and `IDrmPlugin`
- intercept only `getPropertyByteArray("deviceUniqueId")` for applications explicitly configured with `privacy=isolate`
- return a stable application scoped pseudonym derived from the existing protected privacy identity; the genuine DRM device ID is never used as derivation input
- keep DRM Keystore Passthrough independent, so streaming packages such as Netflix can stay on Android's genuine Keystore certificate path while identifier isolation is active
- leave DRM security level, license exchange, provisioning, content keys, sessions, HDCP state, string properties, and legacy HIDL or vendor specific paths untouched
- explicitly forbid the old fake `L2/L3 -> L1` normalization behavior
- avoid blocked `ServiceManager` private APIs: discover running factories with `listServices()` and resolve a new factory PID through bounded `/system/bin/dumpsys --pid <validated service>` only when native injection is required
- bound factory and plugin tracking, retry and reconciliation intervals, identifier sizes, PID output, and injector lifetime; zero temporary genuine and pseudonymous identifier buffers

### WebUI community callout

- add a bottom of page CleveresTech Community card
- link to `https://t.me/cleverestech`
- describe the Telegram group as a place for mutual help, testing, discussion, and development
- use a fixed HTTPS URL with `noopener noreferrer`; no new native command or bridge permission is introduced

### Module integrity and official release authenticity

- continue per payload SHA 256 verification during installation and runtime
- make unexpected unchecked payloads fail runtime verification, including an injected top level `system.prop`
- keep only module manager state files (`disable`, `remove`, `update`, `tampered`) outside payload checksums
- audit generated release and debug ZIPs for duplicate entries, unsafe traversal paths, missing or orphan checksum files, malformed digests, and payload mismatches
- publish a `SHA256SUMS` file for official release ZIPs and Encryptor APKs
- create GitHub signed build provenance for those release digests with the pinned `actions/attest` action
- document the security boundary honestly: ZIP internal checksums establish installed payload consistency; official digest plus external provenance establish release origin because a complete repack can also rewrite checksum files inside its own ZIP

### Documentation

- explain that an unlocked bootloader does not automatically make every DRM stack unusable
- explain that a broad DRM protection bypass is vendor specific, maintenance heavy, and not a primary project objective
- document DRM identifier isolation, resource bounds, fail open behavior, release digest verification, and provenance

## Tests and validation

- deterministic DRM pseudonym stability, separation, bounds, and invalid input tests
- source policy tests that forbid `getPropertyString`, `L1/L2/L3` rewriting, Keystore passthrough coupling, and blocked ServiceManager reflection
- module verification tests for changed payloads, missing or malformed checksums, symlinks, unexpected payloads, and injected `system.prop`
- WebUI test verifies the Telegram card is the final body element with the exact URL and safe link attributes
- Shellcheck, ktlint, Android lint, documentation/native source policy, Rust fmt/clippy/tests/audit, Android target Rust clippy, Android unit tests, module artifact build, generated ZIP checksum/path audit, and native binary hardening are CI gates

Version remains `V2.5.3` from current master. `update.json` is intentionally unchanged.