### PR TITLE
Fix mobile policy UX, Auto Identity stalls, and TEE/keybox consistency

### DIFF
--- a/module/template/customize.sh
+++ b/module/template/customize.sh
@@ -87,9 +87,11 @@ if [ -d "$MODPATH/webroot" ]; then
 fi
 extract "$ZIPFILE" 'webroot/index.html' "$MODPATH"
 extract "$ZIPFILE" 'webroot/bridge.js'  "$MODPATH"
+extract "$ZIPFILE" 'webroot/policy.js'  "$MODPATH"
 if [ -L "$MODPATH/webroot" ] || [ ! -d "$MODPATH/webroot" ] || \
   [ -L "$MODPATH/webroot/index.html" ] || [ ! -f "$MODPATH/webroot/index.html" ] || \
-  [ -L "$MODPATH/webroot/bridge.js" ] || [ ! -f "$MODPATH/webroot/bridge.js" ]; then
+  [ -L "$MODPATH/webroot/bridge.js" ] || [ ! -f "$MODPATH/webroot/bridge.js" ] || \
+  [ -L "$MODPATH/webroot/policy.js" ] || [ ! -f "$MODPATH/webroot/policy.js" ]; then
   abort "! Native WebUI files are unsafe"
 fi
 rm -f "$MODPATH/action.sh" "$MODPATH/action.sh.sha256" || abort "! Could not remove legacy WebUI launcher"

--- a/module/template/service.sh
+++ b/module/template/service.sh
@@ -7,10 +7,134 @@ retry_delay=2
 max_retry_delay=60
 stable_runtime=120
 
+has_legacy_optional_policy() {
+  for flag in spoof_enabled spoof_build_identity telephony random_on_boot spoof_region_cn; do
+    if [ -f "$CONFIG_DIR/$flag" ] && [ ! -L "$CONFIG_DIR/$flag" ]; then
+      return 0
+    fi
+  done
+  if [ -f "$CONFIG_DIR/security_patch.txt" ] && [ ! -L "$CONFIG_DIR/security_patch.txt" ] &&
+    grep -q '^[[:space:]]*[^#[:space:]]' "$CONFIG_DIR/security_patch.txt" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+bootstrap_default_policy() {
+  state="$CONFIG_DIR/policy_state_v2.json"
+  [ -d "$CONFIG_DIR" ] && [ ! -L "$CONFIG_DIR" ] || return 0
+  if [ -e "$state" ] || [ -L "$state" ]; then
+    return 0
+  fi
+
+  # Do not reinterpret an upgrading user's legacy identity/security settings.
+  # This bootstrap is only for a clean policy surface.
+  if has_legacy_optional_policy; then
+    return 0
+  fi
+
+  patch_enabled=false
+  patch_mode=device_default
+  rom_patch=$(getprop ro.build.version.security_patch 2>/dev/null)
+  now=$(date +%Y-%m-%d 2>/dev/null)
+
+  case "$rom_patch:$now" in
+    [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]:[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])
+      patch_year=${rom_patch%%-*}
+      patch_rest=${rom_patch#*-}
+      patch_month=${patch_rest%%-*}
+      patch_day=${patch_rest##*-}
+      now_year=${now%%-*}
+      now_rest=${now#*-}
+      now_month=${now_rest%%-*}
+      now_day=${now_rest##*-}
+
+      patch_month=${patch_month#0}; [ -n "$patch_month" ] || patch_month=0
+      patch_day=${patch_day#0}; [ -n "$patch_day" ] || patch_day=0
+      now_month=${now_month#0}; [ -n "$now_month" ] || now_month=0
+      now_day=${now_day#0}; [ -n "$now_day" ] || now_day=0
+
+      case "$patch_year:$patch_month:$patch_day:$now_year:$now_month:$now_day" in
+        *[!0-9:]*|'') ;;
+        *)
+          patch_serial=$((patch_year * 12 + patch_month))
+          now_serial=$((now_year * 12 + now_month))
+          month_age=$((now_serial - patch_serial))
+          if [ "$month_age" -gt 6 ] || { [ "$month_age" -eq 6 ] && [ "$now_day" -gt "$patch_day" ]; }; then
+            patch_enabled=true
+            patch_mode=automatic
+          fi
+          ;;
+      esac
+      ;;
+  esac
+
+  tmp="$CONFIG_DIR/.policy_state_v2.json.$$"
+  umask 077
+  if ! cat > "$tmp" <<EOF
+{"version":2,"features":{"buildIdentity":false,"attestationIdentity":false,"telephonyIdentity":false,"regionIdentity":false,"identityRefresh":false,"securityPatch":$patch_enabled},"securityPatch":{"automaticThresholdMonths":6,"system":{"mode":"$patch_mode"},"vendor":{"mode":"$patch_mode"},"boot":{"mode":"$patch_mode"}},"profiles":[],"activeProfile":null}
+EOF
+  then
+    rm -f "$tmp"
+    return 0
+  fi
+  chown 0:0 "$tmp" 2>/dev/null || { rm -f "$tmp"; return 0; }
+  chmod 600 "$tmp" 2>/dev/null || { rm -f "$tmp"; return 0; }
+  chcon u:object_r:system_file:s0 "$tmp" 2>/dev/null
+  if mv -f "$tmp" "$state"; then
+    if [ "$patch_enabled" = true ]; then
+      log -t CleveresTricky "Security Patch + Auto Security Patch enabled: ROM patch is older than six months"
+    else
+      log -t CleveresTricky "Initialized policy defaults: Global Mode independent, Identity and Security Patch off"
+    fi
+  else
+    rm -f "$tmp"
+  fi
+}
+
+mirror_root_keyboxes() {
+  [ -d "$CONFIG_DIR" ] && [ ! -L "$CONFIG_DIR" ] || return 0
+  keybox_dir="$CONFIG_DIR/keyboxes"
+  if [ -e "$keybox_dir" ] || [ -L "$keybox_dir" ]; then
+    [ -d "$keybox_dir" ] && [ ! -L "$keybox_dir" ] || return 0
+  else
+    mkdir -p "$keybox_dir" 2>/dev/null || return 0
+  fi
+  chown 0:0 "$keybox_dir" 2>/dev/null
+  chmod 700 "$keybox_dir" 2>/dev/null
+  chcon u:object_r:system_file:s0 "$keybox_dir" 2>/dev/null
+
+  for source in "$CONFIG_DIR"/*.xml "$CONFIG_DIR"/*.cbox; do
+    [ -f "$source" ] && [ ! -L "$source" ] || continue
+    base=${source##*/}
+    # keybox.xml is the legacy primary source and is already loaded directly.
+    [ "$base" != "keybox.xml" ] || continue
+    case "$base" in
+      .*|*[!A-Za-z0-9_.-]*) continue ;;
+    esac
+    lower=$(printf '%s' "$base" | tr '[:upper:]' '[:lower:]')
+    case "$lower" in *.xml|*.cbox) ;; *) continue ;; esac
+
+    destination="$keybox_dir/$base"
+    [ ! -L "$destination" ] || continue
+    tmp="$keybox_dir/.${base}.tmp.$$"
+    if cp -f "$source" "$tmp" 2>/dev/null; then
+      chown 0:0 "$tmp" 2>/dev/null
+      chmod 600 "$tmp" 2>/dev/null
+      chcon u:object_r:system_file:s0 "$tmp" 2>/dev/null
+      mv -f "$tmp" "$destination" 2>/dev/null || rm -f "$tmp"
+    else
+      rm -f "$tmp"
+    fi
+  done
+}
+
 if [ -d "$CONFIG_DIR" ] && [ ! -L "$CONFIG_DIR" ]; then
   chown 0:0 "$CONFIG_DIR" 2>/dev/null
   chmod 700 "$CONFIG_DIR" 2>/dev/null
   chcon u:object_r:system_file:s0 "$CONFIG_DIR" 2>/dev/null
+  bootstrap_default_policy
+  mirror_root_keyboxes
   find "$CONFIG_DIR" -xdev -maxdepth 2 -type d -exec chmod 700 {} + 2>/dev/null
   find "$CONFIG_DIR" -xdev -maxdepth 2 -type f -exec chmod 600 {} + 2>/dev/null
   find "$CONFIG_DIR" -xdev -maxdepth 2 -type f -exec chcon u:object_r:system_file:s0 {} + 2>/dev/null

--- a/module/template/service.sh
+++ b/module/template/service.sh
@@ -55,7 +55,7 @@ bootstrap_default_policy() {
       now_day=${now_day#0}; [ -n "$now_day" ] || now_day=0
 
       case "$patch_year:$patch_month:$patch_day:$now_year:$now_month:$now_day" in
-        *[!0-9:]*|'') ;;
+        *[!0-9:]*) ;;
         *)
           patch_serial=$((patch_year * 12 + patch_month))
           now_serial=$((now_year * 12 + now_month))
@@ -105,7 +105,9 @@ mirror_root_keyboxes() {
   chcon u:object_r:system_file:s0 "$keybox_dir" 2>/dev/null
 
   for source in "$CONFIG_DIR"/*.xml "$CONFIG_DIR"/*.cbox; do
-    [ -f "$source" ] && [ ! -L "$source" ] || continue
+    if [ ! -f "$source" ] || [ -L "$source" ]; then
+      continue
+    fi
     base=${source##*/}
     # keybox.xml is the legacy primary source and is already loaded directly.
     [ "$base" != "keybox.xml" ] || continue

--- a/module/template/webroot/policy.js
+++ b/module/template/webroot/policy.js
@@ -1,641 +1,1026 @@
 (function (global) {
-    'use strict';
+'use strict';
 
-    const bridge = global.CleveresBridge;
-    if (!bridge) return;
+const bridge = global.CleveresBridge;
+if (!bridge) return;
 
-    const featureKeys = [
-        ['buildIdentity', 'Device / Build Identity', 'Requires reboot for early-boot Build fields.'],
-        ['attestationIdentity', 'Attestation Identity', 'Controls optional attestation identity substitution only.'],
-        ['telephonyIdentity', 'Telephony Identity', 'Starts telephony identity work only when needed.'],
-        ['regionIdentity', 'Region Identity', 'Controls optional region and hardware-region presentation.'],
-        ['identityRefresh', 'Identity Refresh', 'Generates next-boot identity changes only while enabled.']
+const FEATURE_KEYS = [
+  ['buildIdentity', 'Build identity', 'Boot fingerprint, model and build fields. Requires a reboot when early-boot properties change.'],
+  ['attestationIdentity', 'Attestation identity', 'Uses the configured attestation identity only for selected targets; genuine hardware key operations remain on Android.'],
+  ['telephonyIdentity', 'Telephony identity', 'Controls optional IMEI/IMSI/ICCID/phone presentation for selected apps.'],
+  ['regionIdentity', 'Region identity', 'Controls optional region/hardware-region presentation. Some values require a reboot.'],
+  ['identityRefresh', 'Identity refresh', 'Prepares a new identity for the next boot only while this option is enabled.']
+];
+const PATCH_COMPONENTS = [['system', 'System'], ['vendor', 'Vendor'], ['boot', 'Boot']];
+const PATCH_MODES = [
+  ['device_default', 'Device default'],
+  ['prop', 'ROM property'],
+  ['manual', 'Manual date'],
+  ['automatic', 'Automatic'],
+  ['no', 'Omit']
+];
+const PROFILE_FEATURES = FEATURE_KEYS.concat([
+  ['securityPatch', 'Security Patch', 'Override the Security Patch feature only for apps assigned to this profile.']
+]);
+
+let policyState = null;
+let legacyConfig = null;
+let packages = [];
+let keyboxes = [];
+let templates = [];
+let selectedProfileIndex = -1;
+let saving = false;
+
+function onReady(fn) {
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', fn, {once:true});
+  else queueMicrotask(fn);
+}
+
+async function request(path, options) {
+  const response = await bridge.fetch(path, options || {});
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || `Request failed (${response.status})`);
+  }
+  const type = response.headers.get('content-type') || '';
+  return type.includes('application/json') ? response.json() : response.text();
+}
+
+function notify(message, type) {
+  if (typeof global.notify === 'function') global.notify(message, type || 'normal');
+}
+
+function safeClone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function stateForSave(source) {
+  const features = source.features || {};
+  const patch = source.securityPatch || {};
+  const normalizedPatch = {};
+  PATCH_COMPONENTS.forEach(([key]) => {
+    const value = patch[key] || {mode:'device_default'};
+    normalizedPatch[key] = {mode: value.mode || 'device_default'};
+    if (normalizedPatch[key].mode === 'manual' && value.value) normalizedPatch[key].value = value.value;
+  });
+  return {
+    version: Number(source.version) || 2,
+    features: {
+      buildIdentity: Boolean(features.buildIdentity),
+      attestationIdentity: Boolean(features.attestationIdentity),
+      telephonyIdentity: Boolean(features.telephonyIdentity),
+      regionIdentity: Boolean(features.regionIdentity),
+      identityRefresh: Boolean(features.identityRefresh),
+      securityPatch: Boolean(features.securityPatch)
+    },
+    securityPatch: {
+      automaticThresholdMonths: Math.min(24, Math.max(1, Number(patch.automaticThresholdMonths) || 6)),
+      system: normalizedPatch.system,
+      vendor: normalizedPatch.vendor,
+      boot: normalizedPatch.boot
+    },
+    profiles: Array.isArray(source.profiles) ? source.profiles.map(normalizeProfile) : [],
+    activeProfile: source.activeProfile || null
+  };
+}
+
+function normalizeProfile(profile) {
+  const p = profile || {};
+  const features = {};
+  if (p.features && typeof p.features === 'object') {
+    PROFILE_FEATURES.forEach(([key]) => {
+      if (typeof p.features[key] === 'boolean') features[key] = p.features[key];
+    });
+  }
+  const patch = {};
+  PATCH_COMPONENTS.forEach(([key]) => {
+    const value = p.securityPatch && p.securityPatch[key];
+    if (value && typeof value === 'object' && value.mode) {
+      patch[key] = {mode:value.mode};
+      if (value.mode === 'manual' && value.value) patch[key].value = value.value;
+    }
+  });
+  return {
+    name: String(p.name || '').trim(),
+    applications: Array.isArray(p.applications) ? [...new Set(p.applications.map(String).map(v => v.trim()).filter(Boolean))] : [],
+    template: p.template || null,
+    keybox: p.keybox || null,
+    privacy: ['inherit','isolate','redact'].includes(p.privacy) ? p.privacy : 'inherit',
+    features,
+    securityPatch: patch,
+    // Preserve old hidden passthrough fields for compatibility, but never expose them as user settings.
+    rkpPassthrough: typeof p.rkpPassthrough === 'boolean' ? p.rkpPassthrough : null,
+    drmPassthrough: typeof p.drmPassthrough === 'boolean' ? p.drmPassthrough : null
+  };
+}
+
+async function savePolicy(mutator, successMessage) {
+  if (!policyState || saving) return;
+  saving = true;
+  document.documentElement.classList.add('ct-saving');
+  try {
+    const next = safeClone(policyState);
+    mutator(next);
+    const body = new URLSearchParams();
+    body.set('data', JSON.stringify(stateForSave(next)));
+    policyState = await request('/api/policy_state', {method:'POST', body});
+    renderAll();
+    notify(successMessage || 'Saved');
+  } catch (error) {
+    notify(error.message || 'Could not save policy', 'error');
+    renderAll();
+  } finally {
+    saving = false;
+    document.documentElement.classList.remove('ct-saving');
+  }
+}
+
+function injectStyles() {
+  if (document.getElementById('ctPolicyUxStyle')) return;
+  const style = document.createElement('style');
+  style.id = 'ctPolicyUxStyle';
+  style.textContent = `
+    .ct-feature-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}
+    .ct-feature-card{border:1px solid var(--border);border-radius:12px;padding:14px;background:#1a1a1a;min-width:0}
+    .ct-feature-card .row{margin:0}
+    .ct-feature-card strong{display:block;color:#fff}
+    .ct-feature-card p{margin:6px 0 0;color:#999;font-size:.84em;line-height:1.45}
+    .ct-subcontrols{margin-top:12px;padding-top:10px;border-top:1px solid var(--border)}
+    .ct-subcontrols[hidden]{display:none!important}
+    .ct-subcontrols .row{margin-bottom:10px}
+    .ct-subcontrols .row:last-child{margin-bottom:0}
+    .ct-help{margin-top:10px;border-top:1px dashed #333;padding-top:8px}
+    .ct-help summary{cursor:pointer;color:#bbb;font-size:.85em;min-height:34px;display:flex;align-items:center}
+    .ct-help p{margin:5px 0 0!important}
+    .ct-banner{border:1px solid #5c4b19;background:rgba(245,158,11,.09);border-radius:10px;padding:13px 14px;margin-bottom:16px;color:#f3d68a;line-height:1.45}
+    .ct-action-grid{display:grid!important;grid-template-columns:repeat(3,minmax(0,1fr));gap:10px!important;width:100%}
+    .ct-action-grid>button{width:100%!important;min-width:0!important;white-space:normal;overflow-wrap:anywhere;line-height:1.25;padding:12px 10px!important}
+    .ct-toolbar{display:flex;gap:10px;flex-wrap:wrap}
+    .ct-toolbar button{flex:1 1 160px;min-width:0}
+    .ct-choice-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}
+    .ct-inline-note{font-size:.82em;color:#999;line-height:1.45;margin:8px 0 0}
+    .ct-chip-wrap{display:flex;gap:7px;flex-wrap:wrap;margin-top:8px}
+    .ct-chip{display:inline-flex;gap:7px;align-items:center;border:1px solid #3a3a3a;border-radius:999px;padding:6px 9px;font-size:.8em;background:#1c1c1c}
+    .ct-chip button{min-width:28px;min-height:28px;padding:0;border-radius:50%;font-size:16px}
+    .ct-profile-item{display:flex;align-items:center;gap:10px;border-bottom:1px solid var(--border);padding:10px 0}
+    .ct-profile-item:last-child{border-bottom:0}
+    .ct-profile-item .ct-profile-copy{flex:1;min-width:0}
+    .ct-profile-item .ct-profile-copy small{display:block;color:#888;margin-top:3px;overflow-wrap:anywhere}
+    .ct-profile-item button{flex:0 0 auto;padding:9px 12px}
+    .ct-patch-advanced{margin-top:12px}
+    .ct-patch-component{border:1px solid var(--border);border-radius:10px;padding:12px;margin-bottom:10px}
+    .ct-patch-component:last-child{margin-bottom:0}
+    .ct-community-slot #cleveresCommunityCard{margin:0!important;padding:0!important;max-width:none!important}
+    .ct-community-slot #cleveresCommunityCard>.panel{margin-bottom:0!important}
+    .ct-community-slot{margin-bottom:20px}
+    .ct-saving button,.ct-saving input,.ct-saving select,.ct-saving textarea{pointer-events:none}
+    #dashboard,#info,#spoof,#profiles,#patch,#effective,#apps{padding-bottom:max(120px,calc(78px + env(safe-area-inset-bottom)))!important}
+    @media(max-width:640px){
+      .ct-feature-grid,.ct-choice-grid{grid-template-columns:1fr}
+      .ct-action-grid{grid-template-columns:1fr!important}
+      .identity-actions{display:grid!important;grid-template-columns:1fr!important;width:100%}
+      .identity-actions>button{width:100%!important;min-width:0!important;white-space:normal}
+      .grid-2{grid-template-columns:1fr!important}
+      .panel{padding:16px}
+      .ct-profile-item{align-items:flex-start;flex-wrap:wrap}
+      .ct-profile-item button{width:100%}
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function makeTab(id, title, afterId) {
+  if (document.getElementById(`tab_${id}`)) return;
+  const tabs = document.querySelector('.tabs');
+  const after = document.getElementById(`tab_${afterId}`);
+  if (!tabs) return;
+  const tab = document.createElement('div');
+  tab.className = 'tab';
+  tab.id = `tab_${id}`;
+  tab.setAttribute('role','tab');
+  tab.setAttribute('tabindex','-1');
+  tab.setAttribute('aria-selected','false');
+  tab.setAttribute('aria-controls',id);
+  tab.textContent = title;
+  tab.onclick = () => global.switchTab(id);
+  tab.onkeydown = event => global.handleTabNavigation && global.handleTabNavigation(event,id);
+  if (after && after.nextSibling) tabs.insertBefore(tab, after.nextSibling);
+  else tabs.appendChild(tab);
+}
+
+function makePage(id, afterId) {
+  let page = document.getElementById(id);
+  if (page) return page;
+  page = document.createElement('div');
+  page.id = id;
+  page.className = 'content';
+  page.setAttribute('role','tabpanel');
+  page.setAttribute('aria-labelledby',`tab_${id}`);
+  const after = document.getElementById(afterId);
+  if (after && after.nextSibling) after.parentNode.insertBefore(page, after.nextSibling);
+  else document.body.appendChild(page);
+  return page;
+}
+
+function hideLegacySurfaces() {
+  const oldIdentityToggle = document.getElementById('spoof_enabled');
+  if (oldIdentityToggle && oldIdentityToggle.closest('.panel')) oldIdentityToggle.closest('.panel').style.display = 'none';
+
+  const globalToggle = document.getElementById('global_mode');
+  if (globalToggle) {
+    const panel = globalToggle.closest('.panel');
+    if (panel && /System Control/i.test(panel.textContent || '')) panel.style.display = 'none';
+  }
+
+  ['status_rkp','status_drm'].forEach(id => {
+    const node = document.getElementById(id);
+    if (node && node.parentElement) node.parentElement.style.display = 'none';
+  });
+
+  const rkpToggle = document.getElementById('rkp_passthrough');
+  if (rkpToggle) {
+    const row = rkpToggle.closest('.row');
+    if (row) row.style.display = 'none';
+  }
+
+  // The Resources renderer is legacy code. Remove the retired RKP control whenever that
+  // tab has been refreshed without keeping a permanent MutationObserver alive.
+  const info = document.getElementById('info');
+  if (info) {
+    const rkpResource = info.querySelector('#res_toggle_rkp_passthrough');
+    if (rkpResource) {
+      const row = rkpResource.closest('tr') || rkpResource.closest('.row');
+      if (row) row.style.display = 'none';
+    }
+  }
+}
+
+function markIdentityActionGroups() {
+  const spoof = document.getElementById('spoof');
+  if (!spoof) return;
+  spoof.querySelectorAll('button').forEach(button => {
+    const text = (button.textContent || '').trim().toUpperCase();
+    if (text.includes('AUTO IDENTITY') || text.includes('RANDOMIZE ALL') || text === 'APPLY IDENTITY' || text === 'CLEAR ALL') {
+      const parent = button.parentElement;
+      if (parent && parent.children.length >= 2) parent.classList.add('ct-action-grid');
+    }
+  });
+}
+
+function identityEnabled() {
+  if (!policyState || !policyState.features) return false;
+  return FEATURE_KEYS.some(([key]) => Boolean(policyState.features[key]));
+}
+
+function allIdentityFeaturesEnabled() {
+  return policyState && FEATURE_KEYS.every(([key]) => Boolean(policyState.features[key]));
+}
+
+function helpMarkup(text) {
+  return `<details class="ct-help"><summary>What does this do?</summary><p>${escapeHtml(text)}</p></details>`;
+}
+
+function cardMarkup(id, title, description, checked, children) {
+  return `<div class="ct-feature-card">
+    <div class="row">
+      <label for="${id}" style="flex:1;min-width:0;padding-right:12px"><strong>${escapeHtml(title)}</strong><span class="res-desc">${escapeHtml(description)}</span></label>
+      <input id="${id}" type="checkbox" class="toggle" ${checked ? 'checked' : ''}>
+    </div>
+    ${children || ''}
+  </div>`;
+}
+
+function buildFeatureCenterMarkup(prefix) {
+  const f = policyState ? policyState.features : {};
+  const identityOn = identityEnabled();
+  const patchOn = Boolean(f && f.securityPatch);
+  const globalOn = Boolean(legacyConfig && legacyConfig.global_mode);
+  const keyboxOn = Boolean(legacyConfig && legacyConfig.auto_keybox_check);
+
+  const identityChildren = `<div class="ct-subcontrols" id="${prefix}_identity_children" ${identityOn ? '' : 'hidden'}>
+    ${FEATURE_KEYS.map(([key,title,desc]) => `<div class="row"><label for="${prefix}_${key}" style="flex:1;padding-right:10px"><strong>${escapeHtml(title)}</strong><span class="res-desc">${escapeHtml(desc)}</span></label><input id="${prefix}_${key}" data-policy-feature="${key}" type="checkbox" class="toggle" ${f && f[key] ? 'checked' : ''}></div>`).join('')}
+  </div>`;
+  const patchChildren = `<div class="ct-subcontrols" id="${prefix}_patch_children" ${patchOn ? '' : 'hidden'}>
+    <div class="row"><label for="${prefix}_auto_patch" style="flex:1;padding-right:10px"><strong>Auto Security Patch</strong><span class="res-desc">When the captured ROM patch is older than the age threshold, resolve a recent patch automatically.</span></label><input id="${prefix}_auto_patch" type="checkbox" class="toggle" ${isAutoPatch() ? 'checked' : ''}></div>
+    <button type="button" data-open-tab="patch" style="width:100%;margin-top:5px">Advanced Security Patch</button>
+  </div>`;
+
+  return `<div class="ct-feature-grid">
+    ${cardMarkup(`${prefix}_global`, 'Global Mode', 'Applies target rules globally when no narrower application rule wins. Fresh installs default to ON.', globalOn, helpMarkup('Global Mode is the module-wide scope switch. Identity remains independent and defaults to off.'))}
+    ${cardMarkup(`${prefix}_identity`, 'Identity', 'Optional identity substitution. Turn it on first, then choose only the child identity paths you want.', identityOn, identityChildren + helpMarkup('The parent switch enables/disables the optional identity family. Child controls appear only while Identity is enabled. Core Keystore/TEE protection is not this switch.'))}
+    ${cardMarkup(`${prefix}_patch`, 'Security Patch', 'Independent attestation patch policy. Default is off; fresh installs auto-enable it only when the ROM patch is more than six months old.', patchOn, patchChildren + helpMarkup('Security Patch is separate from Identity. Automatic mode keeps recent captured patch data and only advances stale values.'))}
+    ${cardMarkup(`${prefix}_keybox`, 'Auto Keybox Check', 'Checks configured keyboxes against the module revocation source when you choose to enable it.', keyboxOn, helpMarkup('This is optional network-backed keybox hygiene and can stay off if you prefer manual management.'))}
+    <div class="ct-feature-card">
+      <strong>DRM Identifier Privacy</strong>
+      <p>Profile privacy <b>Isolate</b> replaces only DRM <code>deviceUniqueId</code> with a stable app-scoped pseudonymous ID. Licenses, provisioning and security level stay on the genuine DRM path.</p>
+      ${helpMarkup('Use Profiles → Privacy → Isolate for apps that should not share the genuine DRM device identifier. The pseudonym is stable for the app instead of changing on every request.')}
+      <button type="button" data-open-tab="profiles" style="width:100%;margin-top:10px">Configure app profiles</button>
+    </div>
+    <div class="ct-feature-card">
+      <strong>Keybox / TEE path</strong>
+      <p>Keyboxes are selected per profile or from the stored pool. Files placed directly in <code>/data/adb/cleverestricky</code> are mirrored into the managed keybox directory at service start.</p>
+      ${helpMarkup('The core Keystore hook remains separate from Identity. Stored keybox chains are cached to avoid repeating expensive certificate work.')}
+      <button type="button" data-open-tab="keys" style="width:100%;margin-top:10px">Open keyboxes</button>
+    </div>
+  </div>`;
+}
+
+function renderFeatureCenters() {
+  if (!policyState) return;
+  ['ct_dashboard_controls','ct_resources_controls'].forEach((id,index) => {
+    const panel = document.getElementById(id);
+    if (!panel) return;
+    const prefix = index === 0 ? 'ct_dash' : 'ct_res';
+    panel.querySelector('.ct-control-host').innerHTML = buildFeatureCenterMarkup(prefix);
+    bindFeatureCenter(panel, prefix);
+  });
+}
+
+function bindFeatureCenter(panel, prefix) {
+  const globalToggle = panel.querySelector(`#${prefix}_global`);
+  const keyboxToggle = panel.querySelector(`#${prefix}_keybox`);
+  const identityToggle = panel.querySelector(`#${prefix}_identity`);
+  const patchToggle = panel.querySelector(`#${prefix}_patch`);
+  const autoPatch = panel.querySelector(`#${prefix}_auto_patch`);
+
+  if (globalToggle) globalToggle.onchange = () => setLegacyToggle('global_mode', globalToggle.checked);
+  if (keyboxToggle) keyboxToggle.onchange = () => setLegacyToggle('auto_keybox_check', keyboxToggle.checked);
+
+  if (identityToggle) {
+    identityToggle.onchange = () => {
+      const enabled = identityToggle.checked;
+      savePolicy(next => {
+        FEATURE_KEYS.forEach(([key]) => { next.features[key] = enabled; });
+      }, enabled ? 'Identity enabled' : 'Identity disabled');
+    };
+  }
+
+  panel.querySelectorAll('[data-policy-feature]').forEach(toggle => {
+    toggle.onchange = () => {
+      const key = toggle.dataset.policyFeature;
+      savePolicy(next => { next.features[key] = toggle.checked; }, `${toggle.closest('.row').querySelector('strong').textContent} updated`);
+    };
+  });
+
+  if (patchToggle) {
+    patchToggle.onchange = () => {
+      const enabled = patchToggle.checked;
+      savePolicy(next => {
+        next.features.securityPatch = enabled;
+        if (enabled && !next.securityPatch) next.securityPatch = defaultPatch();
+      }, enabled ? 'Security Patch enabled' : 'Security Patch disabled');
+    };
+  }
+
+  if (autoPatch) {
+    autoPatch.onchange = () => {
+      const enabled = autoPatch.checked;
+      savePolicy(next => {
+        PATCH_COMPONENTS.forEach(([key]) => {
+          const current = next.securityPatch[key] || {mode:'device_default'};
+          if (enabled) next.securityPatch[key] = {mode:'automatic'};
+          else if (current.mode === 'automatic') next.securityPatch[key] = {mode:'device_default'};
+        });
+      }, enabled ? 'Auto Security Patch enabled' : 'Auto Security Patch disabled');
+    };
+  }
+
+  panel.querySelectorAll('[data-open-tab]').forEach(button => {
+    button.onclick = () => global.switchTab && global.switchTab(button.dataset.openTab);
+  });
+}
+
+function defaultPatch() {
+  return {
+    automaticThresholdMonths:6,
+    system:{mode:'device_default'},
+    vendor:{mode:'device_default'},
+    boot:{mode:'device_default'}
+  };
+}
+
+function isAutoPatch() {
+  if (!policyState || !policyState.securityPatch) return false;
+  return PATCH_COMPONENTS.every(([key]) => policyState.securityPatch[key] && policyState.securityPatch[key].mode === 'automatic');
+}
+
+async function setLegacyToggle(setting, enabled) {
+  const source = document.getElementById(setting);
+  if (source && typeof global.toggle === 'function') {
+    source.checked = enabled;
+    await global.toggle(setting, source);
+    await loadLegacyConfig();
+    renderFeatureCenters();
+    hideLegacySurfaces();
+    return;
+  }
+  try {
+    const body = new URLSearchParams();
+    body.set('setting', setting);
+    body.set('value', String(Boolean(enabled)));
+    await request('/api/toggle', {method:'POST', body});
+    await loadLegacyConfig();
+    renderFeatureCenters();
+  } catch (error) {
+    notify(error.message || 'Could not update setting', 'error');
+  }
+}
+
+function installFeatureCenters() {
+  const dashboard = document.getElementById('dashboard');
+  const info = document.getElementById('info');
+  if (dashboard && !document.getElementById('ct_dashboard_controls')) {
+    const panel = document.createElement('div');
+    panel.id = 'ct_dashboard_controls';
+    panel.className = 'panel';
+    panel.innerHTML = '<h3>Feature Center</h3><div class="scope-note">Main controls are here. Parent features reveal only the settings that belong to them.</div><div class="ct-control-host"></div>';
+    const firstPanel = dashboard.querySelector('.panel');
+    if (firstPanel && firstPanel.nextSibling) dashboard.insertBefore(panel, firstPanel.nextSibling);
+    else dashboard.prepend(panel);
+  }
+  if (info && !document.getElementById('ct_resources_controls')) {
+    const panel = document.createElement('div');
+    panel.id = 'ct_resources_controls';
+    panel.className = 'panel';
+    panel.innerHTML = '<h3>Quick Controls</h3><div class="scope-note">The same primary switches from Dashboard are available here in Resources.</div><div class="ct-control-host"></div>';
+    info.prepend(panel);
+  }
+}
+
+function installIdentityBanner() {
+  const spoof = document.getElementById('spoof');
+  if (!spoof) return;
+  let banner = document.getElementById('ct_identity_disabled_banner');
+  if (!banner) {
+    banner = document.createElement('div');
+    banner.id = 'ct_identity_disabled_banner';
+    banner.className = 'ct-banner';
+    banner.innerHTML = 'Identity şu anda devre dışı bırakıldı. Dashboard’dan etkinleştirebilirsiniz. <button type="button" style="margin-left:8px;padding:8px 10px;min-height:38px">Dashboard</button>';
+    const button = banner.querySelector('button');
+    button.onclick = () => global.switchTab && global.switchTab('dashboard');
+    spoof.prepend(banner);
+  }
+  banner.hidden = identityEnabled();
+}
+
+function installAppsProfileCard() {
+  const apps = document.getElementById('apps');
+  if (!apps || document.getElementById('ct_apps_profiles_card')) return;
+  const panel = document.createElement('div');
+  panel.id = 'ct_apps_profiles_card';
+  panel.className = 'panel';
+  panel.innerHTML = `<h3>Advanced App Profiles</h3>
+    <div class="scope-note">Use Profiles v2 for app assignments, identity template, custom keybox, DRM identifier privacy, per-feature overrides and per-app Security Patch rules in one place.</div>
+    <button type="button" class="primary" style="width:100%">Open Profiles</button>`;
+  panel.querySelector('button').onclick = () => global.switchTab && global.switchTab('profiles');
+  apps.prepend(panel);
+}
+
+function staticPages() {
+  makeTab('patch','Security Patch','spoof');
+  makeTab('profiles','Profiles','patch');
+  makeTab('effective','Effective State','profiles');
+
+  const patch = makePage('patch','spoof');
+  patch.innerHTML = `<div class="panel">
+    <h3>Security Patch</h3>
+    <div class="row"><label for="ct_patch_master" style="flex:1;padding-right:12px"><strong style="color:#fff">Security Patch</strong><span class="res-desc">Independent from Identity. Child controls appear only while this feature is enabled.</span></label><input id="ct_patch_master" type="checkbox" class="toggle"></div>
+    <div id="ct_patch_children">
+      <div class="row"><label for="ct_patch_auto" style="flex:1;padding-right:12px"><strong style="color:#fff">Auto Security Patch</strong><span class="res-desc">Use automatic mode for System, Vendor and Boot.</span></label><input id="ct_patch_auto" type="checkbox" class="toggle"></div>
+      <div style="margin:12px 0"><label for="ct_patch_threshold">Stale ROM threshold (months)</label><input id="ct_patch_threshold" type="number" min="1" max="24" inputmode="numeric"></div>
+      <div id="ct_patch_components"></div>
+      <button id="ct_patch_save" class="primary" type="button" style="width:100%">Save Security Patch</button>
+    </div>
+  </div>
+  <div class="panel">
+    <h3>Resolve for an app</h3>
+    <div class="scope-note">Shows captured, configured and effective values from the runtime resolver.</div>
+    <input id="ct_patch_package" type="search" list="ct_package_list" placeholder="com.example.app" autocomplete="off">
+    <button id="ct_patch_inspect" type="button" style="width:100%;margin-top:10px">Resolve</button>
+    <div id="ct_patch_result" class="scope-note" style="margin-top:12px"></div>
+  </div>`;
+
+  const profilesPage = makePage('profiles','patch');
+  profilesPage.innerHTML = `<div class="panel">
+    <h3>Profiles v2</h3>
+    <div class="scope-note">App-centric configuration. Assign installed apps or wildcards, then choose privacy, identity, keybox and feature overrides.</div>
+    <div class="ct-toolbar"><button id="ct_profile_new" type="button" class="primary">New profile</button><button id="ct_profile_export" type="button">Export</button><button id="ct_profile_import" type="button">Import</button><input id="ct_profile_import_file" type="file" accept="application/json,.json" hidden></div>
+    <div id="ct_profile_list" style="margin-top:12px"></div>
+  </div>
+  <div class="panel" id="ct_profile_editor_panel" hidden>
+    <h3>Profile Editor</h3>
+    <div class="ct-choice-grid">
+      <div><label for="ct_profile_name">Name</label><input id="ct_profile_name" type="text" maxlength="64"></div>
+      <div><label for="ct_profile_privacy">DRM / privacy mode</label><select id="ct_profile_privacy"><option value="inherit">Inherit</option><option value="isolate">Isolate — app-scoped pseudonymous DRM ID</option><option value="redact">Redact</option></select></div>
+    </div>
+    <div style="margin-top:12px">
+      <label for="ct_profile_app_picker">Add installed app</label>
+      <div class="ct-toolbar"><input id="ct_profile_app_picker" type="search" list="ct_package_list" placeholder="com.example.app" autocomplete="off"><button id="ct_profile_add_app" type="button">Add app</button></div>
+      <label for="ct_profile_apps" style="display:block;margin-top:10px">Assignments (one package or wildcard per line)</label>
+      <textarea id="ct_profile_apps" rows="4" maxlength="16384" placeholder="com.example.app&#10;com.example.*"></textarea>
+      <div id="ct_profile_app_chips" class="ct-chip-wrap"></div>
+    </div>
+    <div class="ct-choice-grid" style="margin-top:12px">
+      <div><label for="ct_profile_template">Identity template</label><select id="ct_profile_template"><option value="">Inherit / none</option></select></div>
+      <div><label for="ct_profile_keybox">Keybox</label><select id="ct_profile_keybox"><option value="">Inherit / none</option></select></div>
+    </div>
+    <div class="section-header">Feature overrides</div>
+    <div id="ct_profile_features"></div>
+    <div class="section-header">Security Patch override</div>
+    <div class="row"><label for="ct_profile_patch_master" style="flex:1">Security Patch</label><select id="ct_profile_patch_master" style="max-width:180px"><option value="inherit">Inherit</option><option value="true">Enabled</option><option value="false">Disabled</option></select></div>
+    <div id="ct_profile_patch_children" hidden></div>
+    <div class="ct-toolbar" style="margin-top:16px"><button id="ct_profile_save" type="button" class="primary">Save profile</button><button id="ct_profile_clone" type="button">Clone</button><button id="ct_profile_delete" type="button" class="danger">Delete</button></div>
+  </div>`;
+
+  const effective = makePage('effective','profiles');
+  effective.innerHTML = `<div class="panel"><h3>Effective State</h3><div class="scope-note">Inspect the exact resolver output for an installed application without exposing private key material.</div><input id="ct_effective_package" type="search" list="ct_package_list" placeholder="com.example.app" autocomplete="off"><button id="ct_effective_load" class="primary" type="button" style="width:100%;margin-top:10px">Inspect</button></div><div class="panel"><h3>Resolved Configuration</h3><div id="ct_effective_result" class="scope-note">Select an app.</div></div>`;
+
+  if (!document.getElementById('ct_package_list')) {
+    const list = document.createElement('datalist');
+    list.id = 'ct_package_list';
+    document.body.appendChild(list);
+  }
+}
+
+function patchEditor(prefix, component, title, value, allowInherit) {
+  const options = (allowInherit ? [['inherit','Inherit']] : []).concat(PATCH_MODES);
+  const selected = value && value.mode ? value.mode : (allowInherit ? 'inherit' : 'device_default');
+  return `<div class="ct-patch-component">
+    <label for="${prefix}_${component}_mode"><strong style="color:#fff">${escapeHtml(title)}</strong></label>
+    <select id="${prefix}_${component}_mode">${options.map(([v,l]) => `<option value="${v}" ${v===selected?'selected':''}>${escapeHtml(l)}</option>`).join('')}</select>
+    <input id="${prefix}_${component}_value" type="text" maxlength="10" inputmode="numeric" placeholder="YYYY-MM-DD" value="${escapeHtml(value && value.value ? value.value : '')}" style="margin-top:8px;${selected==='manual'?'':'display:none'}">
+  </div>`;
+}
+
+function bindPatchEditor(prefix, component) {
+  const select = document.getElementById(`${prefix}_${component}_mode`);
+  const manual = document.getElementById(`${prefix}_${component}_value`);
+  if (!select || !manual) return;
+  select.onchange = () => { manual.style.display = select.value === 'manual' ? 'block' : 'none'; };
+}
+
+function readPatchEditor(prefix, component, allowInherit) {
+  const mode = document.getElementById(`${prefix}_${component}_mode`).value;
+  if (allowInherit && mode === 'inherit') return null;
+  const result = {mode};
+  if (mode === 'manual') {
+    const value = document.getElementById(`${prefix}_${component}_value`).value.trim();
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) throw new Error(`${component} manual date must be YYYY-MM-DD`);
+    result.value = value;
+  }
+  return result;
+}
+
+function renderPatchPage() {
+  if (!policyState) return;
+  const enabled = Boolean(policyState.features.securityPatch);
+  document.getElementById('ct_patch_master').checked = enabled;
+  const children = document.getElementById('ct_patch_children');
+  children.hidden = !enabled;
+  const auto = document.getElementById('ct_patch_auto');
+  auto.checked = isAutoPatch();
+  document.getElementById('ct_patch_threshold').value = String(policyState.securityPatch.automaticThresholdMonths || 6);
+  const host = document.getElementById('ct_patch_components');
+  host.innerHTML = PATCH_COMPONENTS.map(([key,title]) => patchEditor('ct_patch', key, title, policyState.securityPatch[key], false)).join('');
+  PATCH_COMPONENTS.forEach(([key]) => bindPatchEditor('ct_patch', key));
+
+  document.getElementById('ct_patch_master').onchange = event => savePolicy(next => {
+    next.features.securityPatch = event.target.checked;
+  }, event.target.checked ? 'Security Patch enabled' : 'Security Patch disabled');
+
+  auto.onchange = event => savePolicy(next => {
+    PATCH_COMPONENTS.forEach(([key]) => {
+      if (event.target.checked) next.securityPatch[key] = {mode:'automatic'};
+      else if ((next.securityPatch[key] || {}).mode === 'automatic') next.securityPatch[key] = {mode:'device_default'};
+    });
+  }, event.target.checked ? 'Auto Security Patch enabled' : 'Auto Security Patch disabled');
+
+  document.getElementById('ct_patch_save').onclick = () => savePolicy(next => {
+    next.securityPatch.automaticThresholdMonths = Number(document.getElementById('ct_patch_threshold').value) || 6;
+    PATCH_COMPONENTS.forEach(([key]) => { next.securityPatch[key] = readPatchEditor('ct_patch', key, false); });
+  }, 'Security Patch policy saved');
+
+  document.getElementById('ct_patch_inspect').onclick = inspectPatch;
+}
+
+async function inspectPatch() {
+  const input = document.getElementById('ct_patch_package');
+  const result = document.getElementById('ct_patch_result');
+  const pkg = input.value.trim();
+  if (!pkg) return;
+  try {
+    const data = await request(`/api/effective_state?package=${encodeURIComponent(pkg)}`);
+    const patch = data.securityPatch || {};
+    result.innerHTML = PATCH_COMPONENTS.map(([key,title]) => {
+      const item = patch[key] || {};
+      return `<div class="ct-patch-component"><strong>${escapeHtml(title)}</strong><div class="ct-inline-note">Captured: ${escapeHtml(String(item.captured ?? '—'))}<br>Configured: ${escapeHtml(String(item.configured ?? '—'))}<br>Effective: ${escapeHtml(String(item.effective ?? '—'))}</div></div>`;
+    }).join('');
+  } catch (error) {
+    result.textContent = error.message || 'Could not resolve patch state';
+  }
+}
+
+function renderProfiles() {
+  if (!policyState) return;
+  const list = document.getElementById('ct_profile_list');
+  const profiles = Array.isArray(policyState.profiles) ? policyState.profiles : [];
+  if (!profiles.length) list.innerHTML = '<div class="scope-note">No custom profiles yet.</div>';
+  else list.innerHTML = profiles.map((p,index) => `<div class="ct-profile-item"><div class="ct-profile-copy"><strong>${escapeHtml(p.name)}</strong><small>${escapeHtml((p.applications||[]).join(', ') || 'No app assignments')} · privacy=${escapeHtml(p.privacy || 'inherit')}</small></div><button type="button" data-edit-profile="${index}">Edit</button></div>`).join('');
+  list.querySelectorAll('[data-edit-profile]').forEach(button => button.onclick = () => openProfile(Number(button.dataset.editProfile)));
+
+  document.getElementById('ct_profile_new').onclick = () => openProfile(-1);
+  document.getElementById('ct_profile_export').onclick = exportProfiles;
+  document.getElementById('ct_profile_import').onclick = () => document.getElementById('ct_profile_import_file').click();
+  document.getElementById('ct_profile_import_file').onchange = importProfiles;
+}
+
+function emptyProfile() {
+  return {name:'',applications:[],template:null,keybox:null,privacy:'inherit',features:{},securityPatch:{},rkpPassthrough:null,drmPassthrough:null};
+}
+
+function openProfile(index) {
+  selectedProfileIndex = index;
+  const profile = normalizeProfile(index >= 0 ? policyState.profiles[index] : emptyProfile());
+  const panel = document.getElementById('ct_profile_editor_panel');
+  panel.hidden = false;
+  document.getElementById('ct_profile_name').value = profile.name;
+  document.getElementById('ct_profile_privacy').value = profile.privacy;
+  document.getElementById('ct_profile_apps').value = profile.applications.join('\n');
+  fillSelect(document.getElementById('ct_profile_template'), templates, profile.template || '', 'Inherit / none');
+  fillSelect(document.getElementById('ct_profile_keybox'), keyboxes, profile.keybox || '', 'Inherit / none');
+
+  const featuresHost = document.getElementById('ct_profile_features');
+  featuresHost.innerHTML = FEATURE_KEYS.map(([key,title,desc]) => {
+    const current = typeof profile.features[key] === 'boolean' ? String(profile.features[key]) : 'inherit';
+    return `<div class="row"><label for="ct_pf_${key}" style="flex:1;padding-right:10px"><strong style="color:#fff">${escapeHtml(title)}</strong><span class="res-desc">${escapeHtml(desc)}</span></label><select id="ct_pf_${key}" style="max-width:180px"><option value="inherit" ${current==='inherit'?'selected':''}>Inherit</option><option value="true" ${current==='true'?'selected':''}>Enabled</option><option value="false" ${current==='false'?'selected':''}>Disabled</option></select></div>`;
+  }).join('');
+
+  const patchMaster = document.getElementById('ct_profile_patch_master');
+  const patchOverride = typeof profile.features.securityPatch === 'boolean' ? String(profile.features.securityPatch) : 'inherit';
+  patchMaster.value = patchOverride;
+  const patchChildren = document.getElementById('ct_profile_patch_children');
+  patchChildren.innerHTML = PATCH_COMPONENTS.map(([key,title]) => patchEditor('ct_profile_patch', key, title, profile.securityPatch[key], true)).join('');
+  PATCH_COMPONENTS.forEach(([key]) => bindPatchEditor('ct_profile_patch',key));
+  const syncPatchChildren = () => { patchChildren.hidden = patchMaster.value !== 'true'; };
+  patchMaster.onchange = syncPatchChildren;
+  syncPatchChildren();
+
+  renderAppChips();
+  document.getElementById('ct_profile_add_app').onclick = addProfileApp;
+  document.getElementById('ct_profile_apps').oninput = renderAppChips;
+  document.getElementById('ct_profile_save').onclick = saveProfile;
+  document.getElementById('ct_profile_clone').onclick = cloneProfile;
+  document.getElementById('ct_profile_delete').onclick = deleteProfile;
+  document.getElementById('ct_profile_delete').hidden = index < 0;
+  panel.scrollIntoView({behavior:'smooth',block:'start'});
+}
+
+function fillSelect(select, values, selected, emptyLabel) {
+  select.replaceChildren();
+  const empty = document.createElement('option');
+  empty.value = '';
+  empty.textContent = emptyLabel;
+  select.appendChild(empty);
+  [...new Set(values)].sort().forEach(value => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = value;
+    select.appendChild(option);
+  });
+  select.value = selected;
+  if (selected && select.value !== selected) {
+    const option = document.createElement('option');
+    option.value = selected;
+    option.textContent = `${selected} (current)`;
+    select.appendChild(option);
+    select.value = selected;
+  }
+}
+
+function profileAppsFromEditor() {
+  return [...new Set(document.getElementById('ct_profile_apps').value.split(/\r?\n/).map(v => v.trim()).filter(Boolean))];
+}
+
+function addProfileApp() {
+  const picker = document.getElementById('ct_profile_app_picker');
+  const value = picker.value.trim();
+  if (!value) return;
+  const apps = profileAppsFromEditor();
+  if (!apps.includes(value)) apps.push(value);
+  document.getElementById('ct_profile_apps').value = apps.join('\n');
+  picker.value = '';
+  renderAppChips();
+}
+
+function renderAppChips() {
+  const host = document.getElementById('ct_profile_app_chips');
+  if (!host) return;
+  const apps = profileAppsFromEditor();
+  host.innerHTML = apps.slice(0,64).map((app,index) => `<span class="ct-chip">${escapeHtml(app)}<button type="button" data-remove-app="${index}" aria-label="Remove ${escapeHtml(app)}">×</button></span>`).join('');
+  host.querySelectorAll('[data-remove-app]').forEach(button => button.onclick = () => {
+    const next = profileAppsFromEditor();
+    next.splice(Number(button.dataset.removeApp),1);
+    document.getElementById('ct_profile_apps').value = next.join('\n');
+    renderAppChips();
+  });
+}
+
+function boolOrInherit(id) {
+  const value = document.getElementById(id).value;
+  return value === 'inherit' ? null : value === 'true';
+}
+
+function collectProfile() {
+  const existing = selectedProfileIndex >= 0 ? normalizeProfile(policyState.profiles[selectedProfileIndex]) : emptyProfile();
+  const name = document.getElementById('ct_profile_name').value.trim();
+  if (!/^[A-Za-z0-9][A-Za-z0-9 _.-]{0,63}$/.test(name)) throw new Error('Profile name is invalid');
+  const apps = profileAppsFromEditor();
+  const features = {};
+  FEATURE_KEYS.forEach(([key]) => {
+    const value = boolOrInherit(`ct_pf_${key}`);
+    if (value !== null) features[key] = value;
+  });
+  const patchMaster = boolOrInherit('ct_profile_patch_master');
+  if (patchMaster !== null) features.securityPatch = patchMaster;
+  const patch = {};
+  if (patchMaster === true) PATCH_COMPONENTS.forEach(([key]) => {
+    const value = readPatchEditor('ct_profile_patch',key,true);
+    if (value) patch[key] = value;
+  });
+  return {
+    name,
+    applications: apps,
+    template: document.getElementById('ct_profile_template').value || null,
+    keybox: document.getElementById('ct_profile_keybox').value || null,
+    privacy: document.getElementById('ct_profile_privacy').value,
+    features,
+    securityPatch: patch,
+    rkpPassthrough: existing.rkpPassthrough,
+    drmPassthrough: existing.drmPassthrough
+  };
+}
+
+function saveProfile() {
+  let profile;
+  try { profile = collectProfile(); } catch (error) { notify(error.message,'error'); return; }
+  const index = selectedProfileIndex;
+  savePolicy(next => {
+    const profiles = Array.isArray(next.profiles) ? next.profiles : (next.profiles = []);
+    const conflict = profiles.findIndex((p,i) => i !== index && String(p.name).toLowerCase() === profile.name.toLowerCase());
+    if (conflict >= 0) throw new Error('Profile name already exists');
+    if (index >= 0) {
+      const oldName = profiles[index].name;
+      profiles[index] = profile;
+      if (next.activeProfile && String(next.activeProfile).toLowerCase() === String(oldName).toLowerCase()) next.activeProfile = profile.name;
+    } else profiles.push(profile);
+  }, 'Profile saved');
+  selectedProfileIndex = -1;
+  document.getElementById('ct_profile_editor_panel').hidden = true;
+}
+
+function cloneProfile() {
+  let profile;
+  try { profile = collectProfile(); } catch (error) { notify(error.message,'error'); return; }
+  const base = profile.name || 'Profile';
+  let name = `${base} Copy`;
+  let n = 2;
+  const names = new Set((policyState.profiles || []).map(p => String(p.name).toLowerCase()));
+  while (names.has(name.toLowerCase())) name = `${base} Copy ${n++}`;
+  profile.name = name;
+  profile.applications = [];
+  savePolicy(next => { next.profiles.push(profile); }, 'Profile cloned');
+  selectedProfileIndex = -1;
+  document.getElementById('ct_profile_editor_panel').hidden = true;
+}
+
+function deleteProfile() {
+  if (selectedProfileIndex < 0) return;
+  const profile = policyState.profiles[selectedProfileIndex];
+  if (!global.confirm || global.confirm(`Delete profile "${profile.name}"?`)) {
+    const index = selectedProfileIndex;
+    savePolicy(next => {
+      const removed = next.profiles.splice(index,1)[0];
+      if (next.activeProfile && removed && String(next.activeProfile).toLowerCase() === String(removed.name).toLowerCase()) next.activeProfile = null;
+    }, 'Profile deleted');
+    selectedProfileIndex = -1;
+    document.getElementById('ct_profile_editor_panel').hidden = true;
+  }
+}
+
+function exportProfiles() {
+  const payload = JSON.stringify(stateForSave(policyState), null, 2);
+  try {
+    if (typeof bridge.exportBlob === 'function') {
+      bridge.exportBlob(new Blob([payload],{type:'application/json'}),'cleverestricky-profiles-v2.json');
+      return;
+    }
+  } catch (_) {}
+  navigator.clipboard && navigator.clipboard.writeText(payload);
+  notify('Profile policy copied/exported');
+}
+
+async function importProfiles(event) {
+  const file = event.target.files && event.target.files[0];
+  event.target.value = '';
+  if (!file) return;
+  try {
+    if (file.size > 512*1024) throw new Error('Policy file is too large');
+    const parsed = JSON.parse(await file.text());
+    const clean = stateForSave(parsed);
+    const body = new URLSearchParams();
+    body.set('data', JSON.stringify(clean));
+    policyState = await request('/api/policy_state',{method:'POST',body});
+    renderAll();
+    notify('Profile policy imported');
+  } catch (error) {
+    notify(error.message || 'Could not import profile policy','error');
+  }
+}
+
+async function inspectEffective() {
+  const pkg = document.getElementById('ct_effective_package').value.trim();
+  const host = document.getElementById('ct_effective_result');
+  if (!pkg) return;
+  try {
+    const data = await request(`/api/effective_state?package=${encodeURIComponent(pkg)}`);
+    const rows = [
+      ['Scope',data.scope],
+      ['Matched profile',data.matchedProfile],
+      ['Matched rule',data.matchedApplicationRule],
+      ['Identity template',data.identityTemplate],
+      ['Keybox',data.keyboxReference],
+      ['DRM privacy',data.privacy],
+      ['Build identity',data.buildIdentity],
+      ['Attestation identity',data.attestationIdentity],
+      ['Telephony identity',data.telephonyIdentity],
+      ['Region identity',data.regionIdentity],
+      ['Identity refresh',data.identityRefresh],
+      ['Security Patch',data.securityPatchOverride],
+      ['Keystore core',data.keystoreCore],
+      ['KeyMint',data.keyMint],
+      ['Reboot required',data.rebootRequired]
     ];
-    const patchModes = [
-        ['device_default', 'Device'],
-        ['prop', 'Property'],
-        ['manual', 'Manual'],
-        ['automatic', 'Automatic'],
-        ['no', 'Omit']
-    ];
-    const securityPatchDescription = 'Controls system, vendor and boot patch authorization resolution independently. Disabled preserves captured genuine patch authorizations.';
-    const profileFeatureKeys = featureKeys.map(item => item[0]).concat(['securityPatch']);
-    let infoCardSequence = 0;
-    let policyState = null;
-    let packages = [];
-    let selectedProfile = null;
+    host.innerHTML = rows.map(([key,value]) => `<div class="row"><span>${escapeHtml(key)}</span><span class="tag">${escapeHtml(String(value ?? '—'))}</span></div>`).join('');
+  } catch (error) {
+    host.textContent = error.message || 'Could not inspect effective state';
+  }
+}
 
-    async function request(path, options) {
-        const response = await bridge.fetch(path, options || {});
-        if (!response.ok) throw new Error((await response.text()) || `Request failed with ${response.status}`);
-        const type = response.headers.get('content-type') || '';
-        return type.includes('application/json') ? response.json() : response.text();
+function installAutoIdentityOverride() {
+  const spoof = document.getElementById('spoof');
+  if (!spoof) return;
+  const button = [...spoof.querySelectorAll('button')].find(btn => (btn.textContent || '').toUpperCase().includes('AUTO IDENTITY'));
+  if (!button || button.dataset.ctAutoIdentity === '1') return;
+  button.dataset.ctAutoIdentity = '1';
+  button.onclick = null;
+  button.removeAttribute('onclick');
+  button.addEventListener('click', async event => {
+    event.preventDefault();
+    if (button.disabled) return;
+    const original = button.textContent;
+    button.disabled = true;
+    button.textContent = 'RESOLVING PIXEL IDENTITY…';
+    notify('Resolving Pixel identity…','working');
+    try {
+      const data = await request('/api/auto_identity',{method:'POST',timeoutMs:18000});
+      if (typeof global.loadIdentity === 'function') await global.loadIdentity();
+      if (typeof global.loadConfig === 'function') await global.loadConfig();
+      notify(`Identity ready: ${data.model || data.device || 'Pixel'} · ${data.build_id || data.buildId || 'current build'}`);
+    } catch (error) {
+      const message = /unavailable|timeout|timed out|network/i.test(error.message || '')
+        ? 'Auto Identity source is temporarily unavailable. The request was stopped quickly; try again later or choose a local template.'
+        : (error.message || 'Auto Identity failed');
+      notify(message,'error');
+    } finally {
+      button.disabled = false;
+      button.textContent = original;
     }
+  });
+}
 
-    function notifyUser(message, type) {
-        if (typeof global.notify === 'function') global.notify(message, type || 'normal');
+function relocateCommunityCard() {
+  const card = document.getElementById('cleveresCommunityCard');
+  const dashboard = document.getElementById('dashboard');
+  if (!card || !dashboard) return false;
+  let slot = document.getElementById('ct_community_slot');
+  if (!slot) {
+    slot = document.createElement('div');
+    slot.id = 'ct_community_slot';
+    slot.className = 'ct-community-slot';
+    const configPanel = [...dashboard.querySelectorAll('.panel')].find(panel => /Configuration Management/i.test(panel.textContent || ''));
+    if (configPanel) dashboard.insertBefore(slot, configPanel);
+    else dashboard.appendChild(slot);
+  }
+  slot.appendChild(card);
+  const link = card.querySelector('a');
+  if (link) {
+    link.href = 'https://t.me/s/cleverestech';
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.textContent = 'Open Telegram Community';
+  }
+  return true;
+}
+
+function watchCommunityCardBriefly() {
+  if (relocateCommunityCard()) return;
+  const observer = new MutationObserver(() => {
+    if (relocateCommunityCard()) observer.disconnect();
+  });
+  observer.observe(document.body,{childList:true,subtree:true});
+  global.setTimeout(() => observer.disconnect(),15000);
+}
+
+function sanitizeErrors() {
+  const originalNotify = global.notify;
+  if (typeof originalNotify !== 'function' || originalNotify.ctWrapped) return;
+  function wrapped(message,type) {
+    let text = String(message || '');
+    if (type === 'error' && /^[a-f0-9]{24,128}$/i.test(text.trim())) {
+      text = 'The operation failed. Open Logs for details instead of exposing an internal error identifier.';
     }
+    return originalNotify(text,type);
+  }
+  wrapped.ctWrapped = true;
+  global.notify = wrapped;
+}
 
-    function makeTab(id, title, afterId) {
-        if (document.getElementById(`tab_${id}`)) return;
-        const tabs = document.querySelector('.tabs');
-        const after = document.getElementById(`tab_${afterId}`);
-        const tab = document.createElement('div');
-        tab.className = 'tab';
-        tab.id = `tab_${id}`;
-        tab.setAttribute('role', 'tab');
-        tab.setAttribute('tabindex', '-1');
-        tab.setAttribute('aria-selected', 'false');
-        tab.setAttribute('aria-controls', id);
-        tab.textContent = title;
-        tab.onclick = () => global.switchTab(id);
-        tab.onkeydown = event => global.handleTabNavigation(event, id);
-        if (after && after.nextSibling) tabs.insertBefore(tab, after.nextSibling);
-        else tabs.appendChild(tab);
-    }
+async function loadLegacyConfig() {
+  try { legacyConfig = await request('/api/config'); } catch (_) { legacyConfig = legacyConfig || {}; }
+}
 
-    function makePage(id, afterId) {
-        if (document.getElementById(id)) return document.getElementById(id);
-        const page = document.createElement('div');
-        page.id = id;
-        page.className = 'content';
-        page.setAttribute('role', 'tabpanel');
-        page.setAttribute('aria-labelledby', `tab_${id}`);
-        const after = document.getElementById(afterId);
-        if (after && after.nextSibling) after.parentNode.insertBefore(page, after.nextSibling);
-        else document.body.appendChild(page);
-        return page;
-    }
+async function loadReferenceData() {
+  const tasks = [];
+  if (typeof bridge.listPackages === 'function') tasks.push(Promise.resolve(bridge.listPackages()).then(value => { packages = Array.isArray(value) ? value : []; }).catch(()=>{}));
+  tasks.push(request('/api/keyboxes').then(value => { keyboxes = Array.isArray(value) ? value : []; }).catch(()=>{}));
+  tasks.push(request('/api/config').then(value => {
+    legacyConfig = value || {};
+    if (Array.isArray(value.templates)) templates = value.templates;
+  }).catch(()=>{}));
+  await Promise.all(tasks);
+  const list = document.getElementById('ct_package_list');
+  if (list) {
+    list.replaceChildren();
+    packages.slice(0,5000).forEach(pkg => {
+      const option = document.createElement('option');
+      option.value = typeof pkg === 'string' ? pkg : (pkg.packageName || pkg.name || '');
+      if (option.value) list.appendChild(option);
+    });
+  }
+}
 
-    function staticMarkup() {
-        makeTab('patch', 'Security Patch', 'spoof');
-        makeTab('profiles', 'Profiles', 'patch');
-        makeTab('effective', 'Effective State', 'profiles');
-        const patchPage = makePage('patch', 'spoof');
-        const profilesPage = makePage('profiles', 'patch');
-        const effectivePage = makePage('effective', 'profiles');
-        patchPage.innerHTML = `
-            <div class="panel">
-                <h3>Security Patch</h3>
-                <div class="row"><label for="policy_securityPatch"><strong style="color:#fff;">Security Patch Override</strong><span class="res-desc">Independent from Device / Build Identity. Disabled preserves genuine attestation patch authorizations.</span></label><input type="checkbox" class="toggle" id="policy_securityPatch"></div>
-                <div style="margin-bottom:16px;"><label for="policy_patch_threshold">Automatic age threshold in months</label><input type="number" id="policy_patch_threshold" min="1" max="24" inputmode="numeric"></div>
-                <div id="policy_patch_components"></div>
-                <button class="primary" id="policy_patch_save" style="width:100%;">Save Security Patch Policy</button>
-            </div>
-            <div class="panel">
-                <h3>Captured / Configured / Effective</h3>
-                <div class="scope-note">Captured is the genuine authorization value observed for a request. Configured is the selected policy. Effective is the value CleveresTricky resolves for the selected application.</div>
-                <label for="policy_patch_package">Application</label>
-                <input type="search" id="policy_patch_package" list="policy_package_list" placeholder="com.example.app" autocomplete="off" spellcheck="false">
-                <button id="policy_patch_inspect" style="width:100%; margin-top:10px;">Resolve Patch State</button>
-                <div id="policy_patch_resolution" style="margin-top:14px;"></div>
-            </div>`;
-        profilesPage.innerHTML = `
-            <div class="panel">
-                <h3>Profiles v2</h3>
-                <div class="scope-note">Profiles store configuration and validated references only. Private keybox material is never copied into a profile.</div>
-                <div style="display:flex; gap:10px; flex-wrap:wrap; margin-bottom:14px;"><button id="policy_profile_new">New Profile</button><button id="policy_profile_export">Export</button><button id="policy_profile_import">Import</button><input type="file" id="policy_profile_import_file" accept="application/json,.json" style="display:none"></div>
-                <div id="policy_profile_list"></div>
-            </div>
-            <div class="panel" id="policy_profile_editor_panel" style="display:none;">
-                <h3>Profile Editor</h3>
-                <div class="grid-2"><div><label for="policy_profile_name">Name</label><input type="text" id="policy_profile_name" maxlength="64"></div><div><label for="policy_profile_privacy">Privacy</label><select id="policy_profile_privacy"><option value="inherit">Inherit</option><option value="isolate">Isolate</option><option value="redact">Redact</option></select></div></div>
-                <div style="margin-top:12px;"><label for="policy_profile_apps">Application assignments</label><textarea id="policy_profile_apps" rows="3" maxlength="16384" placeholder="One package or wildcard per line"></textarea></div>
-                <div class="grid-2"><div><label for="policy_profile_template">Identity template</label><input type="text" id="policy_profile_template" maxlength="64" placeholder="Optional"></div><div><label for="policy_profile_keybox">Keybox reference</label><input type="text" id="policy_profile_keybox" maxlength="128" placeholder="Optional .xml or .cbox reference"></div></div>
-                <div class="section-header">Optional feature overrides</div><div id="policy_profile_features"></div>
-                <div class="section-header">Security Patch overrides</div><div id="policy_profile_patches"></div>
-                <div class="grid-2"><div><label for="policy_profile_rkp">RKP</label><select id="policy_profile_rkp"><option value="inherit">Inherit</option><option value="true">Genuine passthrough</option><option value="false">Compatibility path</option></select></div><div><label for="policy_profile_drm">DRM</label><select id="policy_profile_drm"><option value="inherit">Inherit</option><option value="true">Genuine passthrough</option><option value="false">Configured path</option></select></div></div>
-                <div style="display:flex; gap:10px; margin-top:16px; flex-wrap:wrap;"><button class="primary" id="policy_profile_save" style="flex:1;">Save Profile</button><button id="policy_profile_clone" style="flex:1;">Clone</button><button class="danger" id="policy_profile_delete" style="flex:1;">Delete</button></div>
-            </div>`;
-        effectivePage.innerHTML = `
-            <div class="panel">
-                <h3>Effective State / Resolution Inspector</h3>
-                <div class="scope-note">This view is produced by the same resolver used for runtime policy decisions and never exposes private key material.</div>
-                <label for="policy_effective_package">Installed application</label>
-                <input type="search" id="policy_effective_package" list="policy_package_list" placeholder="com.example.app" autocomplete="off" spellcheck="false">
-                <button id="policy_effective_load" class="primary" style="width:100%; margin-top:10px;">Inspect Effective State</button>
-            </div>
-            <div class="panel"><h3>Resolved Configuration</h3><div id="policy_effective_result" class="scope-note">Select an application.</div></div>`;
-        if (!document.getElementById('policy_package_list')) {
-            const list = document.createElement('datalist');
-            list.id = 'policy_package_list';
-            document.body.appendChild(list);
-        }
-        const securityPatchToggle = document.getElementById('policy_securityPatch');
-        securityPatchToggle.parentNode.insertBefore(makeFeatureInfo('Security Patch Override', securityPatchDescription), securityPatchToggle);
-        const oldControls = document.getElementById('spoof_enabled');
-        if (oldControls) oldControls.closest('.panel').style.display = 'none';
-        const identity = document.getElementById('spoof');
-        const featurePanel = document.createElement('div');
-        featurePanel.className = 'panel';
-        featurePanel.id = 'policy_feature_panel';
-        featurePanel.innerHTML = '<h3>Optional Feature Controls</h3><div class="scope-note">Enable only the optional identity paths you need. Core Keystore, genuine hardware key operations, root-of-trust handling and boot compatibility remain independent.</div><div id="policy_feature_controls"></div><button class="primary" id="policy_feature_save" style="width:100%;">Save Optional Features</button>';
-        identity.appendChild(featurePanel);
-        const dashboard = document.getElementById('dashboard');
-        const runtimePanel = document.createElement('div');
-        runtimePanel.className = 'panel';
-        runtimePanel.id = 'policy_runtime_panel';
-        runtimePanel.innerHTML = '<h3>Runtime Components</h3><div id="policy_runtime_state"></div>';
-        dashboard.appendChild(runtimePanel);
-    }
+function renderAll() {
+  if (!policyState) return;
+  renderFeatureCenters();
+  installIdentityBanner();
+  renderPatchPage();
+  renderProfiles();
+  document.getElementById('ct_effective_load').onclick = inspectEffective;
+  hideLegacySurfaces();
+}
 
-    function closeFeatureInfoCards(except) {
-        document.querySelectorAll('.policy-info-card').forEach(card => {
-            if (card === except) return;
-            card.hidden = true;
-            const button = card.parentElement.querySelector('.policy-info-button');
-            if (button) button.setAttribute('aria-expanded', 'false');
-        });
-    }
+function escapeHtml(value) {
+  return String(value == null ? '' : value).replace(/[&<>"']/g, char => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[char]));
+}
 
-    function makeFeatureInfo(title, description) {
-        const wrap = document.createElement('span');
-        wrap.style.position = 'relative';
-        wrap.style.flex = '0 0 auto';
-        const button = document.createElement('button');
-        button.type = 'button';
-        button.className = 'policy-info-button';
-        button.textContent = 'i';
-        button.setAttribute('aria-label', `${title} information`);
-        button.setAttribute('aria-expanded', 'false');
-        button.style.width = '30px';
-        button.style.height = '30px';
-        button.style.padding = '0';
-        button.style.borderRadius = '50%';
-        button.style.fontWeight = '700';
-        const card = document.createElement('span');
-        card.className = 'policy-info-card';
-        card.id = `policy_info_${++infoCardSequence}`;
-        card.hidden = true;
-        card.setAttribute('role', 'note');
-        card.style.position = 'absolute';
-        card.style.right = '0';
-        card.style.top = '36px';
-        card.style.width = 'min(300px, calc(100vw - 48px))';
-        card.style.padding = '12px';
-        card.style.border = '1px solid rgba(255,255,255,.16)';
-        card.style.borderRadius = '10px';
-        card.style.background = '#1d1f24';
-        card.style.boxShadow = '0 8px 28px rgba(0,0,0,.35)';
-        card.style.zIndex = '40';
-        const heading = document.createElement('strong');
-        heading.style.display = 'block';
-        heading.style.marginBottom = '6px';
-        heading.textContent = title;
-        const body = document.createElement('span');
-        body.className = 'res-desc';
-        body.style.display = 'block';
-        body.textContent = description;
-        card.append(heading, body);
-        button.setAttribute('aria-controls', card.id);
-        button.onclick = event => {
-            event.preventDefault();
-            event.stopPropagation();
-            const opening = card.hidden;
-            closeFeatureInfoCards(card);
-            card.hidden = !opening;
-            button.setAttribute('aria-expanded', String(opening));
-        };
-        card.onclick = event => event.stopPropagation();
-        wrap.append(button, card);
-        return wrap;
-    }
+async function initialize() {
+  injectStyles();
+  staticPages();
+  installFeatureCenters();
+  installAppsProfileCard();
+  hideLegacySurfaces();
+  markIdentityActionGroups();
+  installAutoIdentityOverride();
+  watchCommunityCardBriefly();
 
-    function renderFeatureControls() {
-        const container = document.getElementById('policy_feature_controls');
-        container.replaceChildren();
-        featureKeys.forEach(([key, title, description]) => {
-            const row = document.createElement('div');
-            row.className = 'row';
-            const label = document.createElement('label');
-            label.htmlFor = `policy_feature_${key}`;
-            const strong = document.createElement('strong');
-            strong.style.color = '#fff';
-            strong.textContent = title;
-            const desc = document.createElement('span');
-            desc.className = 'res-desc';
-            desc.textContent = description;
-            label.append(strong, desc);
-            const input = document.createElement('input');
-            input.type = 'checkbox';
-            input.className = 'toggle';
-            input.id = `policy_feature_${key}`;
-            input.checked = Boolean(policyState.features[key]);
-            row.append(label, makeFeatureInfo(title, description), input);
-            container.appendChild(row);
-        });
-    }
+  try {
+    policyState = await request('/api/policy_state');
+  } catch (error) {
+    notify(`Policy controls unavailable: ${error.message}`,'error');
+    return;
+  }
+  await loadReferenceData();
+  renderAll();
+  sanitizeErrors();
 
-    function componentEditor(component, title, policy, prefix) {
-        const wrap = document.createElement('div');
-        wrap.className = 'panel';
-        wrap.style.padding = '14px';
-        const heading = document.createElement('div');
-        heading.className = 'section-header';
-        heading.textContent = title;
-        const select = document.createElement('select');
-        select.id = `${prefix}_${component}_mode`;
-        patchModes.forEach(([value, label]) => {
-            const option = document.createElement('option');
-            option.value = value;
-            option.textContent = label;
-            select.appendChild(option);
-        });
-        select.value = policy && policy.mode ? policy.mode : 'device_default';
-        const manual = document.createElement('input');
-        manual.type = 'text';
-        manual.id = `${prefix}_${component}_manual`;
-        manual.placeholder = 'YYYY-MM-DD';
-        manual.maxLength = 10;
-        manual.inputMode = 'numeric';
-        manual.value = policy && policy.value ? policy.value : '';
-        manual.style.marginTop = '8px';
-        const sync = () => { manual.style.display = select.value === 'manual' ? 'block' : 'none'; };
-        select.onchange = sync;
-        sync();
-        wrap.append(heading, select, manual);
-        return wrap;
-    }
+  // Resources is rendered by legacy code when opened; sanitize once after each tab switch
+  // without a persistent observer or polling timer.
+  const originalSwitchTab = global.switchTab;
+  if (typeof originalSwitchTab === 'function' && !originalSwitchTab.ctWrapped) {
+    const wrapped = function(name) {
+      const result = originalSwitchTab.apply(this,arguments);
+      queueMicrotask(() => {
+        hideLegacySurfaces();
+        if (name === 'info') renderFeatureCenters();
+        if (name === 'spoof') { installIdentityBanner(); markIdentityActionGroups(); installAutoIdentityOverride(); }
+      });
+      return result;
+    };
+    wrapped.ctWrapped = true;
+    global.switchTab = wrapped;
+  }
+}
 
-    function renderPatchControls() {
-        document.getElementById('policy_securityPatch').checked = Boolean(policyState.features.securityPatch);
-        document.getElementById('policy_patch_threshold').value = String(policyState.securityPatch.automaticThresholdMonths || 6);
-        const container = document.getElementById('policy_patch_components');
-        container.replaceChildren();
-        [['system', 'System'], ['vendor', 'Vendor'], ['boot', 'Boot']].forEach(([key, title]) => {
-            container.appendChild(componentEditor(key, title, policyState.securityPatch[key], 'policy_patch'));
-        });
-    }
+onReady(initialize);
 
-    function renderRuntime() {
-        const container = document.getElementById('policy_runtime_state');
-        container.replaceChildren();
-        Object.entries(policyState.runtime || {}).forEach(([key, value]) => {
-            if (key === 'generation') return;
-            const row = document.createElement('div');
-            row.className = 'row';
-            const name = document.createElement('span');
-            name.textContent = key.replace(/([A-Z])/g, ' $1').replace(/^./, c => c.toUpperCase());
-            const state = document.createElement('span');
-            state.className = 'tag';
-            state.textContent = String(value).replace(/_/g, ' ');
-            row.append(name, state);
-            container.appendChild(row);
-        });
-    }
-
-    function readPatchPolicy(prefix, component, allowInherit) {
-        const select = document.getElementById(`${prefix}_${component}_mode`);
-        if (!select || (allowInherit && select.value === 'inherit')) return null;
-        const result = { mode: select.value };
-        if (select.value === 'manual') {
-            const value = document.getElementById(`${prefix}_${component}_manual`).value.trim();
-            if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) throw new Error(`${component} manual patch must use YYYY-MM-DD`);
-            result.value = value;
-        }
-        return result;
-    }
-
-    function stateForSave() {
-        const next = JSON.parse(JSON.stringify(policyState));
-        delete next.generation;
-        delete next.source;
-        delete next.recovery;
-        delete next.builtInProfiles;
-        delete next.runtime;
-        return next;
-    }
-
-    async function saveFeatures() {
-        const next = stateForSave();
-        featureKeys.forEach(([key]) => { next.features[key] = document.getElementById(`policy_feature_${key}`).checked; });
-        await saveState(next);
-    }
-
-    async function savePatch() {
-        const next = stateForSave();
-        next.features.securityPatch = document.getElementById('policy_securityPatch').checked;
-        next.securityPatch.automaticThresholdMonths = Number(document.getElementById('policy_patch_threshold').value);
-        ['system', 'vendor', 'boot'].forEach(component => { next.securityPatch[component] = readPatchPolicy('policy_patch', component, false); });
-        await saveState(next);
-    }
-
-    async function saveState(next) {
-        const body = new URLSearchParams();
-        body.set('data', JSON.stringify(next));
-        policyState = await request('/api/policy_state', { method: 'POST', body });
-        renderAll();
-        notifyUser('Policy state saved');
-    }
-
-    function profileFeatureSelect(key, value) {
-        const select = document.createElement('select');
-        select.id = `policy_profile_feature_${key}`;
-        [['inherit', 'Inherit'], ['true', 'Enabled'], ['false', 'Disabled']].forEach(([entry, label]) => {
-            const option = document.createElement('option');
-            option.value = entry;
-            option.textContent = label;
-            select.appendChild(option);
-        });
-        select.value = value === true ? 'true' : value === false ? 'false' : 'inherit';
-        return select;
-    }
-
-    function renderProfileEditor(profile) {
-        selectedProfile = profile || null;
-        const panel = document.getElementById('policy_profile_editor_panel');
-        panel.style.display = 'block';
-        document.getElementById('policy_profile_name').value = profile ? profile.name : '';
-        document.getElementById('policy_profile_privacy').value = profile ? profile.privacy || 'inherit' : 'inherit';
-        document.getElementById('policy_profile_apps').value = profile ? (profile.applications || []).join('\n') : '';
-        document.getElementById('policy_profile_template').value = profile && profile.template ? profile.template : '';
-        document.getElementById('policy_profile_keybox').value = profile && profile.keybox ? profile.keybox : '';
-        const features = document.getElementById('policy_profile_features');
-        features.replaceChildren();
-        profileFeatureKeys.forEach(key => {
-            const row = document.createElement('div');
-            row.className = 'row';
-            const metadata = key === 'securityPatch' ? ['securityPatch', 'Security Patch Override', securityPatchDescription] : featureKeys.find(item => item[0] === key);
-            const label = document.createElement('label');
-            label.textContent = metadata[1];
-            const info = makeFeatureInfo(metadata[1], `${metadata[2]} Inherit follows the base policy.`);
-            row.append(label, info, profileFeatureSelect(key, profile && profile.features ? profile.features[key] : undefined));
-            features.appendChild(row);
-        });
-        const patches = document.getElementById('policy_profile_patches');
-        patches.replaceChildren();
-        ['system', 'vendor', 'boot'].forEach(component => {
-            const current = profile && profile.securityPatch ? profile.securityPatch[component] : null;
-            const editor = componentEditor(component, component[0].toUpperCase() + component.slice(1), current || { mode: 'device_default' }, 'policy_profile_patch');
-            const select = editor.querySelector('select');
-            const inherit = document.createElement('option');
-            inherit.value = 'inherit';
-            inherit.textContent = 'Inherit';
-            select.insertBefore(inherit, select.firstChild);
-            select.value = current ? current.mode : 'inherit';
-            select.dispatchEvent(new Event('change'));
-            patches.appendChild(editor);
-        });
-        document.getElementById('policy_profile_rkp').value = profile && typeof profile.rkpPassthrough === 'boolean' ? String(profile.rkpPassthrough) : 'inherit';
-        document.getElementById('policy_profile_drm').value = profile && typeof profile.drmPassthrough === 'boolean' ? String(profile.drmPassthrough) : 'inherit';
-        document.getElementById('policy_profile_delete').disabled = !profile;
-        document.getElementById('policy_profile_clone').disabled = !profile;
-    }
-
-    function renderProfiles() {
-        const container = document.getElementById('policy_profile_list');
-        container.replaceChildren();
-        const profiles = Array.isArray(policyState.profiles) ? policyState.profiles : [];
-        if (!profiles.length) {
-            const empty = document.createElement('div');
-            empty.className = 'scope-note';
-            empty.textContent = 'No user-defined profiles yet.';
-            container.appendChild(empty);
-            return;
-        }
-        profiles.forEach(profile => {
-            const row = document.createElement('div');
-            row.className = 'server-item';
-            row.style.gap = '10px';
-            row.style.flexWrap = 'wrap';
-            const text = document.createElement('div');
-            const title = document.createElement('strong');
-            title.textContent = profile.name;
-            const detail = document.createElement('span');
-            detail.className = 'res-desc';
-            detail.textContent = `${(profile.applications || []).length} assignment(s)${policyState.activeProfile === profile.name ? ' · active' : ''}`;
-            text.append(title, detail);
-            const actions = document.createElement('div');
-            actions.style.display = 'flex';
-            actions.style.gap = '6px';
-            const edit = document.createElement('button');
-            edit.textContent = 'Edit';
-            edit.onclick = () => renderProfileEditor(profile);
-            const activate = document.createElement('button');
-            activate.textContent = policyState.activeProfile === profile.name ? 'Active' : 'Activate';
-            activate.disabled = policyState.activeProfile === profile.name;
-            activate.onclick = () => profileAction('activate', { name: profile.name });
-            actions.append(edit, activate);
-            row.append(text, actions);
-            container.appendChild(row);
-        });
-    }
-
-    function profilePayload() {
-        const features = {};
-        profileFeatureKeys.forEach(key => {
-            const value = document.getElementById(`policy_profile_feature_${key}`).value;
-            if (value !== 'inherit') features[key] = value === 'true';
-        });
-        const securityPatch = {};
-        ['system', 'vendor', 'boot'].forEach(component => {
-            const value = readPatchPolicy('policy_profile_patch', component, true);
-            if (value) securityPatch[component] = value;
-        });
-        const boolOrNull = id => {
-            const value = document.getElementById(id).value;
-            return value === 'inherit' ? null : value === 'true';
-        };
-        return {
-            name: document.getElementById('policy_profile_name').value.trim(),
-            applications: document.getElementById('policy_profile_apps').value.split(/\r?\n/).map(value => value.trim()).filter(Boolean),
-            template: document.getElementById('policy_profile_template').value.trim() || null,
-            keybox: document.getElementById('policy_profile_keybox').value.trim() || null,
-            privacy: document.getElementById('policy_profile_privacy').value,
-            features,
-            securityPatch,
-            rkpPassthrough: boolOrNull('policy_profile_rkp'),
-            drmPassthrough: boolOrNull('policy_profile_drm')
-        };
-    }
-
-    async function profileAction(action, data) {
-        const body = new URLSearchParams();
-        body.set('action', action);
-        body.set('data', JSON.stringify(data || {}));
-        policyState = await request('/api/profile_v2', { method: 'POST', body });
-        selectedProfile = null;
-        document.getElementById('policy_profile_editor_panel').style.display = 'none';
-        renderAll();
-        notifyUser('Profile updated');
-    }
-
-    async function saveProfile() {
-        const profile = profilePayload();
-        if (!profile.name) throw new Error('Profile name is required');
-        if (selectedProfile) await profileAction('edit', { name: selectedProfile.name, profile });
-        else await profileAction('create', { profile });
-    }
-
-    async function cloneProfile() {
-        if (!selectedProfile) return;
-        const name = global.prompt('New profile name', `${selectedProfile.name} Copy`);
-        if (!name) return;
-        await profileAction('duplicate', { name: selectedProfile.name, newName: name.trim() });
-    }
-
-    async function deleteProfile() {
-        if (!selectedProfile) return;
-        if (!global.confirm(`Delete profile ${selectedProfile.name}?`)) return;
-        await profileAction('delete', { name: selectedProfile.name });
-    }
-
-    async function exportProfiles() {
-        const safe = stateForSave();
-        const blob = new Blob([JSON.stringify(safe, null, 2)], { type: 'application/json' });
-        await bridge.exportBlob(blob, 'cleverestricky-profiles-v2.json');
-    }
-
-    async function importProfiles(file) {
-        if (!(file instanceof File) || file.size < 1 || file.size > 512 * 1024) throw new Error('Profile import file is outside the supported size');
-        const parsed = JSON.parse(await file.text());
-        await saveState(parsed);
-    }
-
-    function renderPatchResolution(state) {
-        const container = document.getElementById('policy_patch_resolution');
-        container.replaceChildren();
-        ['system', 'vendor', 'boot'].forEach(component => {
-            const value = state.securityPatch[component];
-            const panel = document.createElement('div');
-            panel.className = 'panel';
-            panel.style.padding = '12px';
-            const title = document.createElement('strong');
-            title.textContent = component[0].toUpperCase() + component.slice(1);
-            const captured = document.createElement('span');
-            captured.className = 'res-desc';
-            captured.textContent = `Captured: ${value.captured === null ? 'not captured yet' : value.captured}`;
-            const configured = document.createElement('span');
-            configured.className = 'res-desc';
-            configured.textContent = `Configured: ${value.configured}`;
-            const effective = document.createElement('span');
-            effective.className = 'res-desc';
-            effective.textContent = `Effective: ${value.effective}`;
-            panel.append(title, captured, configured, effective);
-            container.appendChild(panel);
-        });
-    }
-
-    async function inspectPatch() {
-        const packageName = document.getElementById('policy_patch_package').value.trim();
-        if (!packageName) throw new Error('Select an application');
-        const state = await request(`/api/effective_state?package=${encodeURIComponent(packageName)}`);
-        renderPatchResolution(state);
-    }
-
-    function renderEffective(state) {
-        const container = document.getElementById('policy_effective_result');
-        container.replaceChildren();
-        const ordered = [
-            ['matchedApplicationRule', 'Matched application rule'],
-            ['matchedProfile', 'Matched profile'],
-            ['scope', 'Scope'],
-            ['identityTemplate', 'Identity template'],
-            ['keyboxReference', 'Keybox reference'],
-            ['privacy', 'Privacy'],
-            ['buildIdentity', 'Device / Build Identity'],
-            ['attestationIdentity', 'Attestation Identity'],
-            ['telephonyIdentity', 'Telephony Identity'],
-            ['regionIdentity', 'Region Identity'],
-            ['identityRefresh', 'Identity Refresh'],
-            ['securityPatchOverride', 'Security Patch Override'],
-            ['rkp', 'RKP'],
-            ['drm', 'DRM'],
-            ['keyMint', 'KeyMint / StrongBox'],
-            ['keystoreCore', 'Core Keystore'],
-            ['providerCoexistence', 'Provider coexistence'],
-            ['rebootRequired', 'Reboot required']
-        ];
-        ordered.forEach(([key, label]) => {
-            const row = document.createElement('div');
-            row.className = 'row';
-            const name = document.createElement('span');
-            name.textContent = label;
-            const value = document.createElement('span');
-            value.className = 'tag';
-            value.textContent = state[key] === null ? 'none' : String(state[key]);
-            row.append(name, value);
-            container.appendChild(row);
-        });
-        const patchTitle = document.createElement('div');
-        patchTitle.className = 'section-header';
-        patchTitle.textContent = 'Security Patch';
-        container.appendChild(patchTitle);
-        ['system', 'vendor', 'boot'].forEach(component => {
-            const value = state.securityPatch[component];
-            const row = document.createElement('div');
-            row.className = 'row wrap';
-            const name = document.createElement('span');
-            name.textContent = component[0].toUpperCase() + component.slice(1);
-            const detail = document.createElement('span');
-            detail.className = 'res-desc';
-            detail.textContent = `Captured ${value.captured === null ? 'n/a' : value.captured} · Configured ${value.configured} · Effective ${value.effective}`;
-            row.append(name, detail);
-            container.appendChild(row);
-        });
-    }
-
-    async function inspectEffective() {
-        const packageName = document.getElementById('policy_effective_package').value.trim();
-        if (!packageName) throw new Error('Select an application');
-        renderEffective(await request(`/api/effective_state?package=${encodeURIComponent(packageName)}`));
-    }
-
-    function renderPackages() {
-        const list = document.getElementById('policy_package_list');
-        list.replaceChildren();
-        packages.forEach(packageName => {
-            const option = document.createElement('option');
-            option.value = packageName;
-            list.appendChild(option);
-        });
-    }
-
-    function renderAll() {
-        renderFeatureControls();
-        renderPatchControls();
-        renderProfiles();
-        renderRuntime();
-    }
-
-    function guard(action) {
-        return async () => {
-            try {
-                await action();
-            } catch (error) {
-                notifyUser(error && error.message ? error.message : String(error), 'error');
-            }
-        };
-    }
-
-    async function initialize() {
-        staticMarkup();
-        packages = bridge.listPackages();
-        renderPackages();
-        policyState = await request('/api/policy_state');
-        renderAll();
-        document.getElementById('policy_feature_save').onclick = guard(saveFeatures);
-        document.getElementById('policy_patch_save').onclick = guard(savePatch);
-        document.getElementById('policy_patch_inspect').onclick = guard(inspectPatch);
-        document.getElementById('policy_effective_load').onclick = guard(inspectEffective);
-        document.getElementById('policy_profile_new').onclick = () => renderProfileEditor(null);
-        document.getElementById('policy_profile_save').onclick = guard(saveProfile);
-        document.getElementById('policy_profile_clone').onclick = guard(cloneProfile);
-        document.getElementById('policy_profile_delete').onclick = guard(deleteProfile);
-        document.getElementById('policy_profile_export').onclick = guard(exportProfiles);
-        document.getElementById('policy_profile_import').onclick = () => document.getElementById('policy_profile_import_file').click();
-        document.addEventListener('click', () => closeFeatureInfoCards(null));
-        document.addEventListener('keydown', event => {
-            if (event.key === 'Escape') closeFeatureInfoCards(null);
-        });
-        document.getElementById('policy_profile_import_file').onchange = guard(async () => {
-            const input = document.getElementById('policy_profile_import_file');
-            const file = input.files && input.files[0];
-            if (file) await importProfiles(file);
-            input.value = '';
-        });
-    }
-
-    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', guard(initialize), { once: true });
-    else guard(initialize)();
 })(window);

--- a/module/template/webroot/policy.js
+++ b/module/template/webroot/policy.js
@@ -511,7 +511,7 @@ function staticPages() {
     <h3>Profile Editor</h3>
     <div class="ct-choice-grid">
       <div><label for="ct_profile_name">Name</label><input id="ct_profile_name" type="text" maxlength="64"></div>
-      <div><label for="ct_profile_privacy">DRM / privacy mode</label><select id="ct_profile_privacy"><option value="inherit">Inherit</option><option value="isolate">Isolate — app-scoped pseudonymous DRM ID</option><option value="redact">Redact</option></select></div>
+      <div><label for="ct_profile_privacy">DRM / privacy mode</label><select id="ct_profile_privacy"><option value="inherit">Inherit</option><option value="isolate">Isolate - app-scoped pseudonymous DRM ID</option><option value="redact">Redact</option></select></div>
     </div>
     <div style="margin-top:12px">
       <label for="ct_profile_app_picker">Add installed app</label>
@@ -613,7 +613,7 @@ async function inspectPatch() {
     const patch = data.securityPatch || {};
     result.innerHTML = PATCH_COMPONENTS.map(([key,title]) => {
       const item = patch[key] || {};
-      return `<div class="ct-patch-component"><strong>${escapeHtml(title)}</strong><div class="ct-inline-note">Captured: ${escapeHtml(String(item.captured ?? '—'))}<br>Configured: ${escapeHtml(String(item.configured ?? '—'))}<br>Effective: ${escapeHtml(String(item.effective ?? '—'))}</div></div>`;
+      return `<div class="ct-patch-component"><strong>${escapeHtml(title)}</strong><div class="ct-inline-note">Captured: ${escapeHtml(String(item.captured ?? '-'))}<br>Configured: ${escapeHtml(String(item.configured ?? '-'))}<br>Effective: ${escapeHtml(String(item.effective ?? '-'))}</div></div>`;
     }).join('');
   } catch (error) {
     result.textContent = error.message || 'Could not resolve patch state';
@@ -860,7 +860,7 @@ async function inspectEffective() {
       ['KeyMint',data.keyMint],
       ['Reboot required',data.rebootRequired]
     ];
-    host.innerHTML = rows.map(([key,value]) => `<div class="row"><span>${escapeHtml(key)}</span><span class="tag">${escapeHtml(String(value ?? '—'))}</span></div>`).join('');
+    host.innerHTML = rows.map(([key,value]) => `<div class="row"><span>${escapeHtml(key)}</span><span class="tag">${escapeHtml(String(value ?? '-'))}</span></div>`).join('');
   } catch (error) {
     host.textContent = error.message || 'Could not inspect effective state';
   }

--- a/service/src/main/java/cleveres/tricky/cleverestech/AutoIdentityManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/AutoIdentityManager.kt
@@ -13,8 +13,8 @@ import javax.net.ssl.HttpsURLConnection
 
 /**
  * Resolves a current Pixel beta/canary identity from Google's public Android
- * developer and Flash Tool metadata. This is an opt-in Custom ROM helper; it
- * never changes the always-on bootloader/TEE protection policy.
+ * developer and Flash Tool metadata. Production lookups are deadline-bounded
+ * and successful results are cached so repeated taps do not keep the WebUI busy.
  */
 object AutoIdentityManager {
     data class Result(
@@ -59,11 +59,22 @@ object AutoIdentityManager {
         ): String
     }
 
+    private data class CachedResult(
+        val value: Result,
+        val storedAtMs: Long,
+    )
+
     private const val ANDROID_DEVELOPERS = "https://developer.android.com"
     private const val FLASH_TOOL = "https://flash.android.com/"
     private const val FLASH_BUILDS = "https://content-flashstation-pa.googleapis.com/v1/builds"
     private const val PIXEL_BULLETIN = "https://source.android.com/docs/security/bulletin/pixel"
     private const val MAX_DOWNLOAD_BYTES = 3 * 1024 * 1024
+    private const val FETCH_BUDGET_MS = 14_000L
+    private const val CONNECT_TIMEOUT_MS = 2_500
+    private const val READ_TIMEOUT_MS = 3_500
+    private const val CACHE_TTL_MS = 6 * 60 * 60 * 1000L
+    private const val STALE_CACHE_FALLBACK_MS = 24 * 60 * 60 * 1000L
+
     private val allowedHosts =
         setOf(
             "developer.android.com",
@@ -72,7 +83,33 @@ object AutoIdentityManager {
             "source.android.com",
         )
 
-    fun fetchLatest(): Result = fetchLatest(NetworkFetcher)
+    @Volatile
+    private var cachedResult: CachedResult? = null
+
+    /**
+     * Production entry point. It is synchronized to collapse accidental
+     * double-taps into one bounded network lookup.
+     */
+    @Synchronized
+    fun fetchLatest(): Result {
+        val now = System.currentTimeMillis()
+        cachedResult?.takeIf { ageMs(now, it.storedAtMs) <= CACHE_TTL_MS }?.let { return it.value }
+
+        return try {
+            val deadlineNanos = System.nanoTime() + FETCH_BUDGET_MS * 1_000_000L
+            fetchLatest(NetworkFetcher(deadlineNanos)).also { resolved ->
+                cachedResult = CachedResult(resolved, System.currentTimeMillis())
+            }
+        } catch (error: IOException) {
+            val fallback = cachedResult?.takeIf { ageMs(now, it.storedAtMs) <= STALE_CACHE_FALLBACK_MS }
+            fallback?.value ?: throw error
+        }
+    }
+
+    private fun ageMs(
+        now: Long,
+        then: Long,
+    ): Long = if (now >= then) now - then else Long.MAX_VALUE
 
     internal fun fetchLatest(
         fetcher: Fetcher,
@@ -84,6 +121,7 @@ object AutoIdentityManager {
 
         val downloadLinks = extractDownloadLinks(versionHtml)
         if (downloadLinks.isEmpty()) throw IOException("Pixel beta download pages were not found")
+
         val candidatePages =
             downloadLinks.mapNotNull { link ->
                 runCatching {
@@ -124,7 +162,8 @@ object AutoIdentityManager {
             } else {
                 null
             }
-        val securityPatch = explicitPatch ?: bulletinPatch ?: estimateSecurityPatch(canary.optString("id")).also { estimated = true }
+        val securityPatch =
+            explicitPatch ?: bulletinPatch ?: estimateSecurityPatch(canary.optString("id")).also { estimated = true }
 
         return Result(
             model = candidate.model,
@@ -152,7 +191,7 @@ object AutoIdentityManager {
             .map { it.groupValues[1] }
             .filter { it.startsWith('/') || it.startsWith(ANDROID_DEVELOPERS) }
             .distinct()
-            .take(4)
+            .take(2)
             .toList()
 
     internal fun parseDeviceCandidates(html: String): List<DeviceCandidate> {
@@ -285,22 +324,25 @@ object AutoIdentityManager {
             .replace(Regex("""\s+"""), " ")
             .trim()
 
-    private object NetworkFetcher : Fetcher {
+    private class NetworkFetcher(
+        private val deadlineNanos: Long,
+    ) : Fetcher {
         override fun get(
             url: String,
             headers: Map<String, String>,
         ): String {
             var current = URI(url)
             repeat(4) {
+                ensureBudget()
                 validateRemoteUri(current)
                 val connection = current.toURL().openConnection() as HttpsURLConnection
                 try {
-                    connection.connectTimeout = 10_000
-                    connection.readTimeout = 10_000
+                    connection.connectTimeout = boundedTimeout(CONNECT_TIMEOUT_MS)
+                    connection.readTimeout = boundedTimeout(READ_TIMEOUT_MS)
                     connection.instanceFollowRedirects = false
                     connection.requestMethod = "GET"
                     connection.setRequestProperty("Accept-Encoding", "identity")
-                    connection.setRequestProperty("User-Agent", "CleveresTricky-AutoIdentity/1")
+                    connection.setRequestProperty("User-Agent", "CleveresTricky-AutoIdentity/2")
                     headers.forEach { (name, value) -> connection.setRequestProperty(name, value) }
                     val code = connection.responseCode
                     if (code in 300..399) {
@@ -314,6 +356,7 @@ object AutoIdentityManager {
                         val buffer = ByteArray(16 * 1024)
                         var total = 0
                         while (true) {
+                            ensureBudget()
                             val count = input.read(buffer)
                             if (count < 0) break
                             if (count == 0) continue
@@ -328,6 +371,16 @@ object AutoIdentityManager {
                 }
             }
             throw IOException("Too many identity-source redirects")
+        }
+
+        private fun boundedTimeout(maxMs: Int): Int {
+            val remainingMs = (deadlineNanos - System.nanoTime()) / 1_000_000L
+            if (remainingMs <= 0) throw IOException("Auto Identity lookup timed out")
+            return remainingMs.coerceAtMost(maxMs.toLong()).coerceAtLeast(250L).toInt()
+        }
+
+        private fun ensureBudget() {
+            if (System.nanoTime() >= deadlineNanos) throw IOException("Auto Identity lookup timed out")
         }
 
         private fun validateRemoteUri(uri: URI) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -7,16 +7,20 @@ import android.system.keystore2.KeyMetadata
 import cleveres.tricky.cleverestech.binder.BinderInterceptor
 import cleveres.tricky.cleverestech.keystore.CertHack
 import cleveres.tricky.cleverestech.keystore.Utils
-import java.util.concurrent.locks.LockSupport
 
 /**
  * Rewrites only the certificate chain returned by a successful, genuine
  * KeyMint key generation. The private key and every later cryptographic
  * operation remain owned by the platform security level.
+ *
+ * Targeted generateKey and getKeyEntry calls deliberately use the same
+ * certificate-compatibility path. The retired RKP passthrough switch must not
+ * split those two paths, otherwise the same alias can expose two different
+ * attestation leaves. No synthetic timing delay is added here; certificate
+ * caching in CertHack handles repeated reads without parking Keystore threads.
  */
 class SecurityLevelInterceptor : BinderInterceptor() {
     companion object {
-        private const val GENERATE_KEY_EQUALIZATION_NANOS = 2_000_000L
         private val generateKeyTransaction =
             getTransactCode(IKeystoreSecurityLevel.Stub::class.java, "generateKey")
 
@@ -33,14 +37,9 @@ class SecurityLevelInterceptor : BinderInterceptor() {
     ): Result {
         return if (
             code == generateKeyTransaction &&
-            !PolicyState.rkpPassthrough(callingUid) &&
             CertHack.canHack() &&
             Config.needHack(callingUid)
         ) {
-            // Keep attested and non-attested generateKey calls on the same small timing base.
-            // Certificate rewriting happens only for attested replies; without this common delay
-            // repeated samples expose that branch even though both operations otherwise succeed.
-            LockSupport.parkNanos(GENERATE_KEY_EQUALIZATION_NANOS)
             Continue
         } else {
             Skip
@@ -59,7 +58,6 @@ class SecurityLevelInterceptor : BinderInterceptor() {
     ): Result {
         if (
             code != generateKeyTransaction ||
-            PolicyState.rkpPassthrough(callingUid) ||
             reply == null ||
             resultCode != 0 ||
             !CertHack.canHack() ||


### PR DESCRIPTION
## What this fixes

- Reworks the WebUI policy surface for mobile: responsive action buttons, safe bottom spacing, parent/child feature controls, Dashboard + Resources quick controls, and clearer explanations for non-expert users.
- Keeps fresh-install defaults as requested: Global Mode ON, optional Identity OFF. Removes the old duplicate Identity Controls surface from the UI.
- Adds a first-class Security Patch page, independent from Identity. On a clean install, ROM patch levels older than six months bootstrap Security Patch + automatic patch resolution; otherwise the feature stays off. Auto Security Patch is only shown while Security Patch is enabled.
- Fixes the missing Profiles/Security Patch UI packaging regression: `customize.sh` now actually extracts `webroot/policy.js` despite `SKIPUNZIP=1`.
- Bounds Auto Identity network work, caches successful resolutions, collapses repeated taps, and gives the WebUI a finite timeout/friendly fallback instead of appearing frozen.
- Moves the CleveresTech Community card above the bottom navigation and replaces the unsupported Telegram intent path with a browser-compatible Telegram link.
- Expands Profiles v2/app customization with installed-app assignment, wildcard assignments, template/keybox selection, DRM identifier privacy, feature overrides, Security Patch overrides, clone/import/export/delete, plus effective-state inspection.
- Corrects the DRM description: Isolate only replaces DRM `deviceUniqueId` with a stable app-scoped pseudonymous identifier; licensing/provisioning/security-level paths remain genuine.
- Retires RKP Passthrough as a user-facing control. RKP infrastructure UIDs remain excluded by target protection, while targeted `generateKey` and `getKeyEntry` now use a coherent certificate-rewrite path so the same alias does not expose mismatched leaves.
- Removes the fixed synthetic generateKey sleep and avoids new permanent WebUI observers/pollers to reduce avoidable thread/CPU overhead.
- Mirrors `.xml`/`.cbox` files copied directly into `/data/adb/cleverestricky` into the managed keybox directory at service start so Stored Keyboxes can discover them safely.
- Shows an explicit Identity-disabled banner directing users back to Dashboard.

## Validation intent

This PR intentionally relies on the repository's full PR CI gate before merge: shellcheck, Kotlin formatting, Android lint, WebUI syntax/behavior tests, unit tests, module builds, archive validation, and native hardening checks.
