### PR TITLE
Polish WebUI, harden upgrades, and reduce TEE timing overhead

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,7 +301,7 @@ jobs:
         run: |
           set -euo pipefail
           errors=0
-          for f in module.prop customize.sh verify.sh service.sh post-fs-data.sh sepolicy.rule webroot/index.html webroot/bridge.js; do
+          for f in module.prop customize.sh verify.sh service.sh post-fs-data.sh sepolicy.rule webroot/index.html webroot/bridge.js webroot/policy.js webroot/ux.js; do
             if [ ! -f "module/template/$f" ]; then
               echo "::error::Missing required module file: module/template/$f"
               errors=$((errors + 1))
@@ -326,6 +326,7 @@ jobs:
           set -euo pipefail
           node --check module/template/webroot/bridge.js
           node --check module/template/webroot/policy.js
+          node --check module/template/webroot/ux.js
           node <<'NODE'
           const fs = require('fs')
           const html = fs.readFileSync('module/template/webroot/index.html', 'utf8')
@@ -386,7 +387,6 @@ jobs:
       - name: Build Android Artifacts
         run: |
           ./gradlew zipRelease --warning-mode=fail --console=plain
-          ./gradlew zipDebug --warning-mode=fail --console=plain
           ./gradlew :encryptor-app:assembleRelease --warning-mode=fail --console=plain
 
       - name: Verify module archive layout and checksums
@@ -397,74 +397,73 @@ jobs:
           work=$(mktemp -d)
           trap 'rm -rf "$work"' EXIT
 
-          for variant in release debug; do
-            archives=(module/release/*-"$variant".zip)
-            if [ "${#archives[@]}" -ne 1 ]; then
-              echo "::error::Expected exactly one $variant module zip, found ${#archives[@]}"
+          variant=release
+          archives=(module/release/*-"$variant".zip)
+          if [ "${#archives[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one $variant module zip, found ${#archives[@]}"
+            exit 1
+          fi
+          archive="${archives[0]}"
+          unzip -tq "$archive" >/dev/null
+          entries=$(unzip -Z1 "$archive")
+          duplicates=$(printf '%s\n' "$entries" | sort | uniq -d)
+          if [ -n "$duplicates" ]; then
+            echo "::error file=$archive::Duplicate ZIP entries are not allowed"
+            printf '%s\n' "$duplicates"
+            exit 1
+          fi
+          while IFS= read -r entry; do
+            case "$entry" in
+              /*|../*|*/../*|*/..|*\\*)
+                echo "::error file=$archive::Unsafe ZIP entry: $entry"
+                exit 1
+                ;;
+            esac
+          done <<<"$entries"
+          for required in module.prop customize.sh verify.sh service.sh post-fs-data.sh sepolicy.rule; do
+            if ! grep -Fx "$required" <<<"$entries" >/dev/null; then
+              echo "::error file=$archive::Missing required root entry: $required"
               exit 1
             fi
-            archive="${archives[0]}"
-            unzip -tq "$archive" >/dev/null
-            entries=$(unzip -Z1 "$archive")
-            duplicates=$(printf '%s\n' "$entries" | sort | uniq -d)
-            if [ -n "$duplicates" ]; then
-              echo "::error file=$archive::Duplicate ZIP entries are not allowed"
-              printf '%s\n' "$duplicates"
-              exit 1
-            fi
-            while IFS= read -r entry; do
-              case "$entry" in
-                /*|../*|*/../*|*/..|*\\*)
-                  echo "::error file=$archive::Unsafe ZIP entry: $entry"
-                  exit 1
-                  ;;
-              esac
-            done <<<"$entries"
-            for required in module.prop customize.sh verify.sh service.sh post-fs-data.sh sepolicy.rule; do
-              if ! grep -Fx "$required" <<<"$entries" >/dev/null; then
-                echo "::error file=$archive::Missing required root entry: $required"
-                exit 1
-              fi
-            done
-
-            target="$work/$variant"
-            mkdir -p "$target"
-            unzip -q "$archive" -d "$target"
-            while IFS= read -r -d '' payload; do
-              case "$payload" in
-                *.sha256) continue ;;
-              esac
-              checksum="$payload.sha256"
-              if [ ! -f "$checksum" ]; then
-                echo "::error file=$archive::Missing checksum for ${payload#"$target/"}"
-                exit 1
-              fi
-              expected=$(tr -d '[:space:]' < "$checksum")
-              case "$expected" in
-                ''|*[!0-9A-Fa-f]*)
-                  echo "::error file=$archive::Malformed checksum for ${payload#"$target/"}"
-                  exit 1
-                  ;;
-              esac
-              if [ "${#expected}" -ne 64 ]; then
-                echo "::error file=$archive::Invalid checksum length for ${payload#"$target/"}"
-                exit 1
-              fi
-              actual=$(sha256sum "$payload" | awk '{print $1}')
-              if [ "${expected,,}" != "$actual" ]; then
-                echo "::error file=$archive::Checksum mismatch for ${payload#"$target/"}"
-                exit 1
-              fi
-            done < <(find "$target" -type f -print0)
-
-            while IFS= read -r -d '' checksum; do
-              payload=${checksum%.sha256}
-              if [ ! -f "$payload" ]; then
-                echo "::error file=$archive::Orphan checksum ${checksum#"$target/"}"
-                exit 1
-              fi
-            done < <(find "$target" -type f -name '*.sha256' -print0)
           done
+
+          target="$work/$variant"
+          mkdir -p "$target"
+          unzip -q "$archive" -d "$target"
+          while IFS= read -r -d '' payload; do
+            case "$payload" in
+              *.sha256) continue ;;
+            esac
+            checksum="$payload.sha256"
+            if [ ! -f "$checksum" ]; then
+              echo "::error file=$archive::Missing checksum for ${payload#"$target/"}"
+              exit 1
+            fi
+            expected=$(tr -d '[:space:]' < "$checksum")
+            case "$expected" in
+              ''|*[!0-9A-Fa-f]*)
+                echo "::error file=$archive::Malformed checksum for ${payload#"$target/"}"
+                exit 1
+                ;;
+            esac
+            if [ "${#expected}" -ne 64 ]; then
+              echo "::error file=$archive::Invalid checksum length for ${payload#"$target/"}"
+              exit 1
+            fi
+            actual=$(sha256sum "$payload" | awk '{print $1}')
+            if [ "${expected,,}" != "$actual" ]; then
+              echo "::error file=$archive::Checksum mismatch for ${payload#"$target/"}"
+              exit 1
+            fi
+          done < <(find "$target" -type f -print0)
+
+          while IFS= read -r -d '' checksum; do
+            payload=${checksum%.sha256}
+            if [ ! -f "$payload" ]; then
+              echo "::error file=$archive::Orphan checksum ${checksum#"$target/"}"
+              exit 1
+            fi
+          done < <(find "$target" -type f -name '*.sha256' -print0)
 
       - name: Verify native artifact hardening
         shell: bash
@@ -523,13 +522,6 @@ jobs:
           if-no-files-found: error
           archive: false
 
-      - name: Upload debug module zip
-        uses: actions/upload-artifact@v7
-        with:
-          path: "module/release/*-debug.zip"
-          if-no-files-found: error
-          archive: false
-
       - name: Upload Encryptor App
         uses: actions/upload-artifact@v7
         with:
@@ -562,14 +554,6 @@ jobs:
           merge-multiple: true
           skip-decompress: true
 
-      - name: Download debug module zip
-        uses: actions/download-artifact@v8
-        with:
-          pattern: "CleveresTricky-*-debug.zip"
-          path: release-assets
-          merge-multiple: true
-          skip-decompress: true
-
       - name: Download Encryptor App
         uses: actions/download-artifact@v8
         with:
@@ -582,16 +566,13 @@ jobs:
           set -euo pipefail
           shopt -s nullglob
           release_zips=(release-assets/*-release.zip)
-          debug_zips=(release-assets/*-debug.zip)
           apks=(release-assets/*.apk)
           [ "${#release_zips[@]}" -eq 1 ] || { echo "::error::Expected one release module zip"; exit 1; }
-          [ "${#debug_zips[@]}" -eq 1 ] || { echo "::error::Expected one debug module zip"; exit 1; }
           [ "${#apks[@]}" -ge 1 ] || { echo "::error::Encryptor APK is missing"; exit 1; }
           unzip -tq "${release_zips[0]}" >/dev/null
-          unzip -tq "${debug_zips[0]}" >/dev/null
           (
             cd release-assets
-            sha256sum -- *-release.zip *-debug.zip *.apk | LC_ALL=C sort -k2 > SHA256SUMS
+            sha256sum -- *-release.zip *.apk | LC_ALL=C sort -k2 > SHA256SUMS
             sha256sum -c SHA256SUMS
           )
 

--- a/module/template/customize.sh
+++ b/module/template/customize.sh
@@ -88,10 +88,12 @@ fi
 extract "$ZIPFILE" 'webroot/index.html' "$MODPATH"
 extract "$ZIPFILE" 'webroot/bridge.js'  "$MODPATH"
 extract "$ZIPFILE" 'webroot/policy.js'  "$MODPATH"
+extract "$ZIPFILE" 'webroot/ux.js'      "$MODPATH"
 if [ -L "$MODPATH/webroot" ] || [ ! -d "$MODPATH/webroot" ] || \
   [ -L "$MODPATH/webroot/index.html" ] || [ ! -f "$MODPATH/webroot/index.html" ] || \
   [ -L "$MODPATH/webroot/bridge.js" ] || [ ! -f "$MODPATH/webroot/bridge.js" ] || \
-  [ -L "$MODPATH/webroot/policy.js" ] || [ ! -f "$MODPATH/webroot/policy.js" ]; then
+  [ -L "$MODPATH/webroot/policy.js" ] || [ ! -f "$MODPATH/webroot/policy.js" ] || \
+  [ -L "$MODPATH/webroot/ux.js" ] || [ ! -f "$MODPATH/webroot/ux.js" ]; then
   abort "! Native WebUI files are unsafe"
 fi
 rm -f "$MODPATH/action.sh" "$MODPATH/action.sh.sha256" || abort "! Could not remove legacy WebUI launcher"
@@ -141,7 +143,8 @@ for config_file in spoof_build_vars security_patch.txt target.txt drm_packages.t
   spoof_enabled spoof_switch_initialized spoof_build_identity global_mode tee_broken_mode \
   auto_keybox_check random_on_boot rkp_passthrough drm_passthrough hide_sensitive_props \
   spoof_region_cn telephony privacy_seed boot_key boot_hash app_config templates.json custom_templates module_hash \
-  servers.json keybox.xml lang.json spoof_build_vars.next apply_profile; do
+  servers.json keybox.xml lang.json spoof_build_vars.next apply_profile policy_state_v2.json \
+  policy_state_v2.last_good.json debug_logging settings_schema_v3; do
   config_path="$CONFIG_DIR/$config_file"
   if [ -e "$config_path" ] || [ -L "$config_path" ]; then
     if [ -L "$config_path" ] || [ ! -f "$config_path" ]; then
@@ -158,6 +161,29 @@ if [ -e "$CONFIG_DIR/keyboxes" ] || [ -L "$CONFIG_DIR/keyboxes" ]; then
   fi
   chmod 700 "$CONFIG_DIR/keyboxes" || abort "! Could not secure keybox directory"
   chown 0:0 "$CONFIG_DIR/keyboxes" || abort "! Could not set keybox directory ownership"
+fi
+
+# Schema v3 retires the historical RKP user switch. RKP infrastructure UIDs are
+# protected by the runtime unconditionally, so retaining this file only creates
+# conflicting Dashboard/Resources state. CBOX device caches are disposable and
+# are regenerated after an upgrade to avoid carrying stale serialization state.
+if [ ! -e "$CONFIG_DIR/settings_schema_v3" ]; then
+  ui_print "- Migrating persisted settings to schema v3"
+  if [ -e "$CONFIG_DIR/rkp_passthrough" ]; then
+    rm -f "$CONFIG_DIR/rkp_passthrough" || abort "! Could not retire the old RKP setting"
+  fi
+  if [ -d "$CONFIG_DIR/keyboxes" ]; then
+    for stale_cache in "$CONFIG_DIR"/keyboxes/*.cbox.cache; do
+      [ -e "$stale_cache" ] || continue
+      if [ -L "$stale_cache" ] || [ ! -f "$stale_cache" ]; then
+        abort "! Refusing unsafe CBOX cache during migration"
+      fi
+      rm -f "$stale_cache" || abort "! Could not invalidate stale CBOX cache"
+    done
+  fi
+  : > "$CONFIG_DIR/settings_schema_v3" || abort "! Could not write settings migration marker"
+  chmod 600 "$CONFIG_DIR/settings_schema_v3" || abort "! Could not secure settings migration marker"
+  chown 0:0 "$CONFIG_DIR/settings_schema_v3" || abort "! Could not set settings migration marker ownership"
 fi
 
 # Fresh installs start with the core protection path enabled globally. Identity
@@ -217,7 +243,7 @@ if [ ! -f "$CONFIG_DIR/boot_props_mode" ]; then
 fi
 chmod 600 "$CONFIG_DIR/boot_props_mode" || abort "! Could not secure boot_props_mode"
 
-for optional_flag in auto_keybox_check rkp_passthrough drm_passthrough hide_sensitive_props; do
+for optional_flag in auto_keybox_check drm_passthrough hide_sensitive_props debug_logging; do
   [ ! -e "$CONFIG_DIR/$optional_flag" ] || chmod 600 "$CONFIG_DIR/$optional_flag" \
     || abort "! Could not secure $optional_flag"
 done
@@ -233,6 +259,6 @@ chown 0:0 "$CONFIG_DIR/spoof_build_vars" "$CONFIG_DIR/security_patch.txt" \
 [ ! -e "$CONFIG_DIR/spoof_enabled" ] || chown 0:0 "$CONFIG_DIR/spoof_enabled" \
   || abort "! Could not set identity Spoof Engine switch ownership"
 [ ! -e "$CONFIG_DIR/spoof_build_identity" ] || chown 0:0 "$CONFIG_DIR/spoof_build_identity"
-[ ! -e "$CONFIG_DIR/rkp_passthrough" ] || chown 0:0 "$CONFIG_DIR/rkp_passthrough"
 [ ! -e "$CONFIG_DIR/drm_passthrough" ] || chown 0:0 "$CONFIG_DIR/drm_passthrough"
 [ ! -e "$CONFIG_DIR/hide_sensitive_props" ] || chown 0:0 "$CONFIG_DIR/hide_sensitive_props"
+[ ! -e "$CONFIG_DIR/debug_logging" ] || chown 0:0 "$CONFIG_DIR/debug_logging"

--- a/module/template/webroot/bridge.js
+++ b/module/template/webroot/bridge.js
@@ -13,6 +13,7 @@
     const maxEnvelopeChars = 1024 * 1024;
     const responseFields = new Set(['version', 'status', 'statusText', 'mimeType', 'size', 'body', 'downloadId']);
     const communityUrl = 'https://t.me/cleverestech';
+    const debugFlag = '/data/adb/cleverestricky/debug_logging';
     let callbackCounter = 0;
 
     function encodeBytes(bytes) {
@@ -84,9 +85,6 @@
 
     function normalizeExecResult(values, expectEnvelope = false) {
         if (expectEnvelope) {
-            // Some WebUI hosts report a non-zero callback code while still returning the
-            // completed bridge response on stdout/stderr. Only recover an exact, bounded
-            // protocol envelope; normal command failures continue down the errno path.
             for (const value of [values[1], values[0], values[2]]) {
                 const envelope = extractResponseEnvelope(value);
                 if (envelope) return { errno: 0, stdout: envelope, stderr: '' };
@@ -121,9 +119,6 @@
                 stdout = parsed.stdout ?? parsed.out ?? '';
                 stderr = parsed.stderr ?? parsed.err ?? '';
             } else {
-                // Newer/alternate WebUI hosts may deliver stdout as the only callback argument.
-                // Commands are fixed and their outputs are validated by the caller, so preserve
-                // that output instead of treating it as an errno value.
                 errno = 0;
                 stdout = raw;
                 stderr = '';
@@ -136,6 +131,38 @@
             stdout: String(stdout ?? '').trim(),
             stderr: String(stderr ?? '').trim()
         };
+    }
+
+    function execHostCommand(command, timeoutMs = 10000) {
+        if (!nativeApi || typeof nativeApi.exec !== 'function') return Promise.reject(new Error('Open this page from the KernelSU or APatch WebUI button'));
+        const boundedTimeout = Math.min(Math.max(Number(timeoutMs) || 10000, 1000), 30000);
+        return new Promise((resolve, reject) => {
+            const callbackName = `ct_host_${Date.now()}_${callbackCounter++}`;
+            let settled = false;
+            const timer = setTimeout(() => {
+                if (settled) return;
+                settled = true;
+                delete global[callbackName];
+                reject(new Error('Host command timed out'));
+            }, boundedTimeout + 2000);
+            global[callbackName] = (...values) => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timer);
+                delete global[callbackName];
+                const result = normalizeExecResult(values, false);
+                if (result.errno === 0) resolve(result.stdout);
+                else reject(new Error(result.stderr || result.stdout || `Host command failed with code ${result.errno}`));
+            };
+            try {
+                nativeApi.exec(command, '{}', callbackName);
+            } catch (error) {
+                settled = true;
+                clearTimeout(timer);
+                delete global[callbackName];
+                reject(error);
+            }
+        });
     }
 
     function execNative(args, timeoutMs, expectEnvelope = false) {
@@ -174,6 +201,25 @@
                 reject(error);
             }
         });
+    }
+
+    async function openCommunity() {
+        const command = `/system/bin/am start --user current -W -a android.intent.action.VIEW -c android.intent.category.BROWSABLE -d '${communityUrl}' -p com.android.chrome >/dev/null 2>&1 || /system/bin/am start --user current -W -a android.intent.action.VIEW -c android.intent.category.BROWSABLE -d '${communityUrl}' >/dev/null 2>&1`;
+        await execHostCommand(command, 12000);
+        return true;
+    }
+
+    async function getDebugLogging() {
+        const output = await execHostCommand(`[ -f '${debugFlag}' ] && [ ! -L '${debugFlag}' ] && printf on || printf off`, 5000);
+        return output === 'on';
+    }
+
+    async function setDebugLogging(enabled) {
+        const command = enabled
+            ? `umask 077; [ ! -L '${debugFlag}' ] || exit 2; : > '${debugFlag}'; chmod 0600 '${debugFlag}'`
+            : `[ ! -L '${debugFlag}' ] || exit 2; rm -f '${debugFlag}'`;
+        await execHostCommand(command, 5000);
+        return Boolean(enabled);
     }
 
     async function createStage(kind, timeoutMs) {
@@ -359,7 +405,6 @@
         }
         validateResponseEnvelope(envelope);
         const hasBody = typeof envelope.body === 'string';
-        const hasDownload = typeof envelope.downloadId === 'string';
         const response = new NativeResponse(envelope, timeoutMs);
         if (hasBody) {
             const decoded = decodeBytes(envelope.body);
@@ -467,6 +512,16 @@
         }
     }
 
+    function loadUxEnhancements() {
+        const document = global.document;
+        if (!document || !document.head || !document.createElement || document.getElementById('ct_ux_script')) return;
+        const script = document.createElement('script');
+        script.id = 'ct_ux_script';
+        script.src = 'ux.js?revision=1';
+        script.defer = true;
+        document.head.appendChild(script);
+    }
+
     try {
         if (nativeApi && typeof nativeApi.enableEdgeToEdge === 'function') nativeApi.enableEdgeToEdge(true);
     } catch (_) {
@@ -477,5 +532,15 @@
     }
 
     scheduleCommunityCard();
-    global.CleveresBridge = Object.freeze({ revision: 4, fetch: nativeFetch, exportBlob, exportResponse, listPackages });
+    global.CleveresBridge = Object.freeze({
+        revision: 5,
+        fetch: nativeFetch,
+        exportBlob,
+        exportResponse,
+        listPackages,
+        openCommunity,
+        getDebugLogging,
+        setDebugLogging
+    });
+    loadUxEnhancements();
 })(window);

--- a/module/template/webroot/ux.js
+++ b/module/template/webroot/ux.js
@@ -357,7 +357,7 @@
                 ensureFooterOrder();
             });
         }
-        dashboard.appendChild(panel);
+        if (panel.parentElement !== dashboard) dashboard.appendChild(panel);
         panel.querySelector('select').value = locale;
     }
 
@@ -365,10 +365,12 @@
         const dashboard = document.getElementById('dashboard');
         if (!dashboard) return;
         const language = document.getElementById('ct_language_panel');
-        if (language) dashboard.appendChild(language);
         const card = document.getElementById('cleveresCommunityCard');
+        if (language && language.parentElement !== dashboard) dashboard.appendChild(language);
         if (card) {
-            dashboard.appendChild(card);
+            if (card.parentElement !== dashboard) dashboard.appendChild(card);
+            if (language && language.nextElementSibling !== card) dashboard.insertBefore(language, card);
+            if (card.nextElementSibling) dashboard.appendChild(card);
             const link = card.querySelector('a');
             if (link) {
                 link.href = 'https://t.me/cleverestech';
@@ -522,7 +524,9 @@
     function renderGuide() {
         const guide = document.getElementById('guide');
         if (!guide) return;
+        if (guide.dataset.ctGuideLocale === locale && guide.querySelector('#ct_full_guide')) return;
         const sections = GUIDE[locale] || GUIDE.en;
+        guide.dataset.ctGuideLocale = locale;
         guide.innerHTML = `<div class="panel" id="ct_full_guide"><h3>${escapeHtml(tr('Guide'))}</h3><div class="scope-note">${escapeHtml(locale === 'tr' ? 'Tüm temel özellikler ve çalışma yolları tek yerde.' : locale === 'zh-CN' ? '所有主要功能和运行路径集中说明。' : locale === 'es' ? 'Todas las funciones principales y rutas de ejecución en un solo lugar.' : locale === 'de' ? 'Alle wichtigen Funktionen und Laufzeitpfade an einem Ort.' : locale === 'ru' ? 'Все основные функции и пути выполнения в одном месте.' : 'All major features and runtime paths in one place.')}</div>${sections.map(([title,body]) => `<section class="ct-guide-section"><h4>${escapeHtml(title)}</h4><p>${escapeHtml(body)}</p></section>`).join('')}</div>`;
     }
 
@@ -581,11 +585,6 @@
             wrapLegacyToggle();
             wrapTabSwitch();
         }, delay));
-        if (typeof MutationObserver === 'function') {
-            const observer = new MutationObserver(() => applyEnhancements());
-            observer.observe(document.body,{childList:true,subtree:true});
-            global.setTimeout(() => observer.disconnect(),10000);
-        }
     }
 
     if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', start, { once:true });

--- a/module/template/webroot/ux.js
+++ b/module/template/webroot/ux.js
@@ -1,0 +1,593 @@
+(function (global) {
+    'use strict';
+
+    const bridge = global.CleveresBridge;
+    if (!bridge || typeof document === 'undefined') return;
+
+    const STORAGE_KEY = 'cleverestricky.language.v1';
+    const SUPPORTED = [
+        ['en', 'English'],
+        ['tr', 'Türkçe'],
+        ['zh-CN', '简体中文'],
+        ['es', 'Español'],
+        ['de', 'Deutsch'],
+        ['ru', 'Русский']
+    ];
+
+    const TRANSLATIONS = {
+        tr: {
+            'Dashboard': 'Gösterge Paneli', 'Identity': 'Kimlik', 'Apps': 'Uygulamalar', 'Keyboxes': 'Keyboxlar',
+            'Info & Resources': 'Bilgi ve Kaynaklar', 'Guide': 'Kılavuz', 'Logs': 'Günlükler', 'Editor': 'Düzenleyici',
+            'Donate': 'Bağış', 'Profiles': 'Profiller', 'Security Patch': 'Güvenlik Yaması',
+            'Core Protection': 'Temel Koruma', 'Global Mode': 'Global Mod', 'Auto Keybox Check': 'Otomatik Keybox Kontrolü',
+            'DRM Passthrough': 'DRM Geçiş Modu', 'Configuration Management': 'Yapılandırma Yönetimi',
+            'Reload Config': 'Yapılandırmayı Yenile', 'Identity Manager': 'Kimlik Yöneticisi', 'No attestation template': 'Attestation şablonu yok',
+            'Randomize All Identifiers': 'Tüm Kimlikleri Rastgeleleştir', 'Auto Identity (Pixel Beta)': 'Otomatik Kimlik (Pixel Beta)',
+            'Apply Identity': 'Kimliği Uygula', 'Application Privacy Shield': 'Uygulama Gizlilik Kalkanı', 'New Rule': 'Yeni Kural',
+            'Package Name': 'Paket Adı', 'Attestation Identity Profile': 'Attestation Kimlik Profili', 'Custom Keybox': 'Özel Keybox',
+            'Privacy Policy': 'Gizlilik Politikası', 'Add Rule': 'Kural Ekle', 'Active Rules': 'Etkin Kurallar',
+            'Runtime Health': 'Çalışma Durumu', 'Resource Monitor': 'Kaynak İzleyici', 'Module Logs': 'Modül Günlükleri',
+            'Refresh Logs': 'Günlükleri Yenile', 'Download Logs': 'Günlükleri İndir', 'Copy Logs': 'Günlükleri Kopyala',
+            'Language': 'Dil', 'Debug Logging': 'Hata Ayıklama Günlükleri', 'Effective State': 'Etkin Durum',
+            'Resolved Configuration': 'Çözümlenen Yapılandırma', 'Inspect': 'İncele', 'Select an app.': 'Bir uygulama seçin.',
+            'Identity is currently disabled. You can enable it from Dashboard.': 'Kimlik şu anda devre dışı. Gösterge Paneli üzerinden etkinleştirebilirsiniz.',
+            'Open Telegram Community': 'Telegram Topluluğunu Aç', 'Join Telegram Community': 'Telegram Topluluğuna Katıl',
+            'Save profile': 'Profili kaydet', 'Clone': 'Klonla', 'Delete': 'Sil', 'Profile saved': 'Profil kaydedildi',
+            'System / preinstalled packages are included in this search.': 'Sistem / ön yüklü paketler de bu aramaya dahildir.'
+        },
+        'zh-CN': {
+            'Dashboard': '仪表盘', 'Identity': '身份', 'Apps': '应用', 'Keyboxes': '密钥盒', 'Info & Resources': '信息与资源',
+            'Guide': '指南', 'Logs': '日志', 'Editor': '编辑器', 'Donate': '捐赠', 'Profiles': '配置档案',
+            'Security Patch': '安全补丁', 'Core Protection': '核心保护', 'Global Mode': '全局模式',
+            'Auto Keybox Check': '自动密钥盒检查', 'DRM Passthrough': 'DRM 直通', 'Configuration Management': '配置管理',
+            'Reload Config': '重新加载配置', 'Identity Manager': '身份管理器', 'No attestation template': '无认证模板',
+            'Randomize All Identifiers': '随机化所有标识符', 'Auto Identity (Pixel Beta)': '自动身份（Pixel Beta）',
+            'Apply Identity': '应用身份', 'Application Privacy Shield': '应用隐私保护', 'New Rule': '新规则',
+            'Package Name': '包名', 'Attestation Identity Profile': '认证身份配置', 'Custom Keybox': '自定义密钥盒',
+            'Privacy Policy': '隐私策略', 'Add Rule': '添加规则', 'Active Rules': '活动规则', 'Runtime Health': '运行状态',
+            'Resource Monitor': '资源监视器', 'Module Logs': '模块日志', 'Refresh Logs': '刷新日志',
+            'Download Logs': '下载日志', 'Copy Logs': '复制日志', 'Language': '语言', 'Debug Logging': '调试日志',
+            'Effective State': '有效状态', 'Resolved Configuration': '解析后的配置', 'Inspect': '检查', 'Select an app.': '请选择应用。',
+            'Identity is currently disabled. You can enable it from Dashboard.': '身份功能当前已关闭。可在仪表盘中启用。',
+            'Open Telegram Community': '打开 Telegram 社区', 'Join Telegram Community': '加入 Telegram 社区',
+            'Save profile': '保存配置', 'Clone': '克隆', 'Delete': '删除',
+            'System / preinstalled packages are included in this search.': '此搜索也包含系统 / 预装应用。'
+        },
+        es: {
+            'Dashboard': 'Panel', 'Identity': 'Identidad', 'Apps': 'Apps', 'Keyboxes': 'Keyboxes', 'Info & Resources': 'Info y recursos',
+            'Guide': 'Guía', 'Logs': 'Registros', 'Editor': 'Editor', 'Donate': 'Donar', 'Profiles': 'Perfiles',
+            'Security Patch': 'Parche de seguridad', 'Core Protection': 'Protección principal', 'Global Mode': 'Modo global',
+            'Auto Keybox Check': 'Comprobación automática de keybox', 'DRM Passthrough': 'Paso directo DRM',
+            'Configuration Management': 'Gestión de configuración', 'Reload Config': 'Recargar configuración',
+            'Identity Manager': 'Gestor de identidad', 'No attestation template': 'Sin plantilla de atestación',
+            'Randomize All Identifiers': 'Aleatorizar identificadores', 'Auto Identity (Pixel Beta)': 'Identidad automática (Pixel Beta)',
+            'Apply Identity': 'Aplicar identidad', 'Application Privacy Shield': 'Protección de privacidad por app', 'New Rule': 'Nueva regla',
+            'Package Name': 'Nombre del paquete', 'Attestation Identity Profile': 'Perfil de identidad de atestación',
+            'Custom Keybox': 'Keybox personalizado', 'Privacy Policy': 'Política de privacidad', 'Add Rule': 'Añadir regla',
+            'Active Rules': 'Reglas activas', 'Runtime Health': 'Estado de ejecución', 'Resource Monitor': 'Monitor de recursos',
+            'Module Logs': 'Registros del módulo', 'Refresh Logs': 'Actualizar registros', 'Download Logs': 'Descargar registros',
+            'Copy Logs': 'Copiar registros', 'Language': 'Idioma', 'Debug Logging': 'Registro de depuración',
+            'Effective State': 'Estado efectivo', 'Resolved Configuration': 'Configuración resuelta', 'Inspect': 'Inspeccionar',
+            'Select an app.': 'Selecciona una app.',
+            'Identity is currently disabled. You can enable it from Dashboard.': 'La identidad está desactivada. Puedes activarla desde el Panel.',
+            'Open Telegram Community': 'Abrir comunidad de Telegram', 'Join Telegram Community': 'Unirse a la comunidad de Telegram',
+            'Save profile': 'Guardar perfil', 'Clone': 'Clonar', 'Delete': 'Eliminar',
+            'System / preinstalled packages are included in this search.': 'La búsqueda incluye paquetes del sistema y preinstalados.'
+        },
+        de: {
+            'Dashboard': 'Übersicht', 'Identity': 'Identität', 'Apps': 'Apps', 'Keyboxes': 'Keyboxen', 'Info & Resources': 'Info & Ressourcen',
+            'Guide': 'Anleitung', 'Logs': 'Protokolle', 'Editor': 'Editor', 'Donate': 'Spenden', 'Profiles': 'Profile',
+            'Security Patch': 'Sicherheitspatch', 'Core Protection': 'Kernschutz', 'Global Mode': 'Globaler Modus',
+            'Auto Keybox Check': 'Automatische Keybox-Prüfung', 'DRM Passthrough': 'DRM-Durchleitung',
+            'Configuration Management': 'Konfigurationsverwaltung', 'Reload Config': 'Konfiguration neu laden',
+            'Identity Manager': 'Identitätsverwaltung', 'No attestation template': 'Keine Attestierungs-Vorlage',
+            'Randomize All Identifiers': 'Alle Kennungen randomisieren', 'Auto Identity (Pixel Beta)': 'Auto-Identität (Pixel Beta)',
+            'Apply Identity': 'Identität anwenden', 'Application Privacy Shield': 'App-Datenschutz', 'New Rule': 'Neue Regel',
+            'Package Name': 'Paketname', 'Attestation Identity Profile': 'Attestierungsprofil', 'Custom Keybox': 'Eigene Keybox',
+            'Privacy Policy': 'Datenschutzrichtlinie', 'Add Rule': 'Regel hinzufügen', 'Active Rules': 'Aktive Regeln',
+            'Runtime Health': 'Laufzeitstatus', 'Resource Monitor': 'Ressourcenmonitor', 'Module Logs': 'Modulprotokolle',
+            'Refresh Logs': 'Protokolle aktualisieren', 'Download Logs': 'Protokolle herunterladen', 'Copy Logs': 'Protokolle kopieren',
+            'Language': 'Sprache', 'Debug Logging': 'Debug-Protokollierung', 'Effective State': 'Effektiver Zustand',
+            'Resolved Configuration': 'Aufgelöste Konfiguration', 'Inspect': 'Prüfen', 'Select an app.': 'App auswählen.',
+            'Identity is currently disabled. You can enable it from Dashboard.': 'Identität ist derzeit deaktiviert. Sie kann in der Übersicht aktiviert werden.',
+            'Open Telegram Community': 'Telegram-Community öffnen', 'Join Telegram Community': 'Telegram-Community beitreten',
+            'Save profile': 'Profil speichern', 'Clone': 'Klonen', 'Delete': 'Löschen',
+            'System / preinstalled packages are included in this search.': 'System- und vorinstallierte Pakete sind in dieser Suche enthalten.'
+        },
+        ru: {
+            'Dashboard': 'Панель', 'Identity': 'Идентичность', 'Apps': 'Приложения', 'Keyboxes': 'Keybox', 'Info & Resources': 'Инфо и ресурсы',
+            'Guide': 'Руководство', 'Logs': 'Логи', 'Editor': 'Редактор', 'Donate': 'Поддержать', 'Profiles': 'Профили',
+            'Security Patch': 'Патч безопасности', 'Core Protection': 'Основная защита', 'Global Mode': 'Глобальный режим',
+            'Auto Keybox Check': 'Автопроверка keybox', 'DRM Passthrough': 'DRM passthrough', 'Configuration Management': 'Управление конфигурацией',
+            'Reload Config': 'Перезагрузить конфигурацию', 'Identity Manager': 'Менеджер идентичности', 'No attestation template': 'Без шаблона аттестации',
+            'Randomize All Identifiers': 'Случайные идентификаторы', 'Auto Identity (Pixel Beta)': 'Авто-идентичность (Pixel Beta)',
+            'Apply Identity': 'Применить идентичность', 'Application Privacy Shield': 'Защита приложений', 'New Rule': 'Новое правило',
+            'Package Name': 'Имя пакета', 'Attestation Identity Profile': 'Профиль аттестации', 'Custom Keybox': 'Свой keybox',
+            'Privacy Policy': 'Политика приватности', 'Add Rule': 'Добавить правило', 'Active Rules': 'Активные правила',
+            'Runtime Health': 'Состояние среды', 'Resource Monitor': 'Монитор ресурсов', 'Module Logs': 'Логи модуля',
+            'Refresh Logs': 'Обновить логи', 'Download Logs': 'Скачать логи', 'Copy Logs': 'Копировать логи',
+            'Language': 'Язык', 'Debug Logging': 'Отладочное логирование', 'Effective State': 'Эффективное состояние',
+            'Resolved Configuration': 'Итоговая конфигурация', 'Inspect': 'Проверить', 'Select an app.': 'Выберите приложение.',
+            'Identity is currently disabled. You can enable it from Dashboard.': 'Идентичность отключена. Её можно включить на Панели.',
+            'Open Telegram Community': 'Открыть Telegram-сообщество', 'Join Telegram Community': 'Вступить в Telegram-сообщество',
+            'Save profile': 'Сохранить профиль', 'Clone': 'Клонировать', 'Delete': 'Удалить',
+            'System / preinstalled packages are included in this search.': 'Поиск включает системные и предустановленные пакеты.'
+        }
+    };
+
+    const GUIDE = {
+        en: [
+            ['Dashboard and core protection', 'Dashboard is the single source of truth for Global Mode, DRM compatibility, Identity, Security Patch and keybox health. Core Keystore/TEE and verified-boot compatibility stay independent from optional Identity controls.'],
+            ['Identity and Auto Identity', 'Identity changes only configured app-visible build, attestation and telephony fields. Auto Identity first tries bounded Google Pixel metadata and falls back to a local verified Pixel template when the remote source is unavailable.'],
+            ['KeyMint and TEE', 'KeyMint keeps private-key operations on the genuine platform security level. CleveresTricky only rewrites the returned attestation certificate chain for eligible application UIDs; hardware root-of-trust state is not physically changed.'],
+            ['Keyboxes', 'Use only authorized XML or CBOX material. Keyboxes are validated before activation, mirrored into the managed keybox directory, checked against revocation information and selected per profile when configured.'],
+            ['Profiles', 'Profiles group app assignments, an identity template, a keybox, privacy behavior and feature overrides. Exact package rules take priority over wildcard rules.'],
+            ['Apps and Effective State', 'Use Apps to add or remove package rules. Effective State is embedded below the app controls so you can inspect the exact resolved profile, keybox, KeyMint and patch policy for one package.'],
+            ['Security Patch', 'Security Patch is independent from Identity. Device-default preserves captured values, automatic resolves calendar-based policy, and manual mode accepts an explicit date.'],
+            ['DRM', 'DRM Passthrough keeps configured playback or DRM packages on the genuine Keystore path. Per-app identifier isolation affects only supported privacy identifiers and does not fake a DRM security level.'],
+            ['RKP', 'RKP is no longer a user-facing switch. Remote-provisioning infrastructure UIDs are always protected, while generated-key and stored-key certificate paths stay coherent.'],
+            ['Runtime health and upgrades', 'Runtime Health reports the live interceptor and verified-keybox state. Upgrade migration repairs stale profile references, retires obsolete switches and keeps a recoverable copy instead of requiring a full settings reset.'],
+            ['Logs and debug mode', 'Normal releases keep extra debug logging off. Enable Debug Logging temporarily from Logs when diagnosing a problem, reproduce it, collect the logs, then turn it off again.'],
+            ['Performance', 'Global Mode uses bounded caches and avoids permanent WebUI polling. Certificate rewrite caches are deliberately small, and timing-sensitive work is kept off repeated reads whenever possible.']
+        ],
+        tr: [
+            ['Gösterge Paneli ve temel koruma', 'Gösterge Paneli; Global Mod, DRM uyumluluğu, Kimlik, Güvenlik Yaması ve keybox sağlığı için tek doğruluk kaynağıdır. Temel Keystore/TEE ve verified-boot uyumluluğu isteğe bağlı Kimlik kontrollerinden bağımsızdır.'],
+            ['Kimlik ve Otomatik Kimlik', 'Kimlik yalnızca yapılandırılmış uygulamalara görünen build, attestation ve telefon alanlarını değiştirir. Otomatik Kimlik önce süre sınırlandırılmış Google Pixel verisini dener; kaynak yoksa yerel doğrulanmış Pixel şablonuna döner.'],
+            ['KeyMint ve TEE', 'KeyMint özel anahtar işlemlerini gerçek platform güvenlik seviyesinde tutar. CleveresTricky yalnızca uygun uygulama UID’lerine dönen attestation sertifika zincirini yeniden yazar; donanımsal root-of-trust fiziksel olarak değişmez.'],
+            ['Keyboxlar', 'Yalnızca yetkili XML veya CBOX materyali kullanın. Keyboxlar etkinleşmeden önce doğrulanır, yönetilen dizine eşlenir, iptal bilgisine göre kontrol edilir ve gerektiğinde profile göre seçilir.'],
+            ['Profiller', 'Profiller uygulama atamalarını, kimlik şablonunu, keyboxı, gizlilik davranışını ve özellik geçersiz kılmalarını bir arada tutar. Tam paket kuralları wildcard kurallarından önceliklidir.'],
+            ['Uygulamalar ve Etkin Durum', 'Paket kurallarını Uygulamalar bölümünden yönetin. Etkin Durum aynı sayfada çözülmüş profil, keybox, KeyMint ve yama politikasını gösterir.'],
+            ['Güvenlik Yaması', 'Güvenlik Yaması Kimlikten bağımsızdır. Device-default yakalanan değerleri korur, otomatik mod takvime göre çözer, manuel mod açık bir tarih kabul eder.'],
+            ['DRM', 'DRM Geçiş Modu yapılandırılmış oynatma/DRM paketlerini gerçek Keystore yolunda bırakır. Uygulama bazlı kimlik izolasyonu yalnızca desteklenen gizlilik kimliklerini etkiler; DRM güvenlik seviyesini taklit etmez.'],
+            ['RKP', 'RKP artık kullanıcıya açık bir anahtar değildir. Remote provisioning altyapı UID’leri daima korunur ve üretilen/saklanan anahtar sertifika yolları tutarlı kalır.'],
+            ['Çalışma durumu ve yükseltmeler', 'Çalışma Durumu canlı interceptor ve doğrulanmış keybox durumunu gösterir. Yükseltme geçişi eski profil referanslarını onarır, kullanımdan kalkmış anahtarları temizler ve tam sıfırlama yerine kurtarılabilir ayarları korur.'],
+            ['Günlükler ve debug modu', 'Normal sürümde ekstra debug logları kapalıdır. Sorun incelerken Logs bölümünden geçici olarak açın, sorunu tekrar üretin, logları alın ve sonra kapatın.'],
+            ['Performans', 'Global Mod sınırlı önbellekler kullanır ve kalıcı WebUI polling yapmaz. Sertifika yeniden-yazım cache’i küçük tutulur; timing hassas işler tekrarlanan okumaların dışına alınır.']
+        ],
+        'zh-CN': [
+            ['仪表盘与核心保护', '仪表盘统一管理全局模式、DRM 兼容、身份、安全补丁与密钥盒状态。核心 Keystore/TEE 与 verified-boot 兼容逻辑独立于可选身份功能。'],
+            ['身份与自动身份', '身份功能仅修改配置应用可见的 build、认证和电话字段。自动身份优先使用有严格超时的 Google Pixel 元数据，远端不可用时回退到本地已验证 Pixel 模板。'],
+            ['KeyMint 与 TEE', 'KeyMint 的私钥运算仍在真实平台安全级别执行。CleveresTricky 只针对符合条件的应用 UID 重写返回的认证证书链，不会物理改变硬件 root-of-trust。'],
+            ['密钥盒', '仅使用获得授权的 XML 或 CBOX。启用前会验证密钥盒，将其同步到受管目录，执行吊销检查，并可按配置档案选择。'],
+            ['配置档案', '配置档案可组合应用分配、身份模板、密钥盒、隐私行为与功能覆盖。精确包名优先于通配规则。'],
+            ['应用与有效状态', '在“应用”中管理包规则。有效状态已放在同一页面，可查看某个包最终解析到的配置档案、密钥盒、KeyMint 与补丁策略。'],
+            ['安全补丁', '安全补丁独立于身份功能。设备默认值保留捕获值；自动模式按日期策略解析；手动模式使用明确日期。'],
+            ['DRM', 'DRM 直通让指定播放/DRM 包继续使用真实 Keystore 路径。应用级标识符隔离只影响支持的隐私标识符，不伪造 DRM 安全级别。'],
+            ['RKP', 'RKP 不再提供用户开关。远程配置基础设施 UID 始终受保护，生成密钥与已存密钥的证书路径保持一致。'],
+            ['运行状态与升级', '运行状态显示实时拦截器与已验证密钥盒状态。升级迁移会修复过期引用、移除废弃开关并尽量保留可恢复配置。'],
+            ['日志与调试模式', '正式版本默认关闭额外调试日志。排查时可在“日志”中临时开启，复现问题并收集日志后再关闭。'],
+            ['性能', '全局模式使用有界缓存，不进行永久 WebUI 轮询。证书重写缓存保持较小，并尽量减少计时敏感的重复工作。']
+        ],
+        es: [
+            ['Panel y protección principal', 'El Panel centraliza Modo global, compatibilidad DRM, Identidad, Parche de seguridad y salud de keyboxes. Keystore/TEE y verified boot siguen independientes de Identidad.'],
+            ['Identidad e Identidad automática', 'Solo se modifican campos visibles para las apps configuradas. Auto Identity usa primero metadatos Pixel con límites estrictos y recurre a una plantilla Pixel local verificada si la fuente remota falla.'],
+            ['KeyMint y TEE', 'Las operaciones de clave privada permanecen en el nivel de seguridad real de la plataforma. Solo se reescribe la cadena de certificados de atestación devuelta a UIDs de apps elegibles.'],
+            ['Keyboxes', 'Usa únicamente XML o CBOX autorizados. Se validan antes de activarse, se sincronizan con el directorio administrado y pueden seleccionarse por perfil.'],
+            ['Perfiles', 'Los perfiles agrupan apps, plantilla de identidad, keybox, privacidad y ajustes de funciones. Las reglas exactas tienen prioridad sobre comodines.'],
+            ['Apps y Estado efectivo', 'Gestiona reglas desde Apps. El Estado efectivo está integrado allí para mostrar perfil, keybox, KeyMint y política de parches resueltos.'],
+            ['Parche de seguridad', 'Es independiente de Identidad. El valor del dispositivo conserva lo capturado, Automático resuelve por calendario y Manual acepta una fecha explícita.'],
+            ['DRM', 'DRM Passthrough mantiene los paquetes configurados en la ruta Keystore genuina. El aislamiento de identificadores no falsifica el nivel de seguridad DRM.'],
+            ['RKP', 'RKP ya no es un interruptor de usuario. Los UIDs de aprovisionamiento remoto siempre están protegidos y las rutas de certificados permanecen coherentes.'],
+            ['Estado y actualizaciones', 'Runtime Health muestra el estado real. La migración corrige referencias obsoletas y retira opciones antiguas sin exigir un reinicio total de ajustes.'],
+            ['Logs y depuración', 'Las versiones normales desactivan el log extra. Actívalo temporalmente desde Logs para diagnosticar y vuelve a desactivarlo al terminar.'],
+            ['Rendimiento', 'Modo global usa cachés acotadas y evita sondeo WebUI permanente. La caché de certificados se mantiene pequeña para controlar RAM.']
+        ],
+        de: [
+            ['Übersicht und Kernschutz', 'Die Übersicht ist die zentrale Quelle für Globalen Modus, DRM, Identität, Sicherheitspatches und Keybox-Status. Keystore/TEE bleibt von optionalen Identitätsfunktionen unabhängig.'],
+            ['Identität und Auto-Identität', 'Nur für konfigurierte Apps sichtbare Build-, Attestierungs- und Telefoniefelder werden geändert. Bei Ausfall der begrenzten Pixel-Onlinequelle wird eine lokale geprüfte Pixel-Vorlage verwendet.'],
+            ['KeyMint und TEE', 'Private Schlüsseloperationen bleiben auf der echten Plattform-Sicherheitsstufe. Nur die zurückgegebene Attestierungs-Zertifikatskette für geeignete App-UIDs wird angepasst.'],
+            ['Keyboxen', 'Nur autorisiertes XML/CBOX verwenden. Keyboxen werden vor Aktivierung geprüft, in das verwaltete Verzeichnis gespiegelt und können pro Profil gewählt werden.'],
+            ['Profile', 'Profile bündeln App-Zuordnung, Identitätsvorlage, Keybox, Datenschutz und Funktions-Overrides. Exakte Paketregeln haben Vorrang vor Wildcards.'],
+            ['Apps und effektiver Zustand', 'Paketregeln werden unter Apps verwaltet. Der effektive Zustand zeigt dort das tatsächlich aufgelöste Profil, Keybox, KeyMint und Patch-Regeln.'],
+            ['Sicherheitspatch', 'Unabhängig von Identität. Device Default bewahrt erfasste Werte, Automatisch löst kalenderbasiert auf, Manuell nutzt ein festes Datum.'],
+            ['DRM', 'DRM-Durchleitung hält konfigurierte Wiedergabe-/DRM-Pakete auf dem echten Keystore-Pfad. Die Kennungsisolierung fälscht keine DRM-Sicherheitsstufe.'],
+            ['RKP', 'RKP ist kein Benutzer-Schalter mehr. Remote-Provisioning-UIDs bleiben immer geschützt und Zertifikatspfade konsistent.'],
+            ['Laufzeit und Upgrades', 'Runtime Health zeigt den Live-Zustand. Die Migration repariert veraltete Referenzen und entfernt alte Schalter, ohne pauschal alle Einstellungen zu löschen.'],
+            ['Logs und Debug', 'Zusätzliche Debug-Logs sind in normalen Releases aus. Nur zur Diagnose unter Logs temporär einschalten und danach wieder deaktivieren.'],
+            ['Leistung', 'Globaler Modus nutzt begrenzte Caches ohne dauerhaftes WebUI-Polling. Der Zertifikat-Cache bleibt bewusst klein.']
+        ],
+        ru: [
+            ['Панель и основная защита', 'Панель является единым источником настроек Global Mode, DRM, Identity, Security Patch и состояния keybox. Основной Keystore/TEE работает независимо от Identity.'],
+            ['Identity и Auto Identity', 'Меняются только видимые настроенным приложениям поля build, аттестации и телефонии. При недоступности ограниченного по времени источника Pixel используется локальный проверенный шаблон Pixel.'],
+            ['KeyMint и TEE', 'Операции закрытого ключа остаются на реальном уровне безопасности платформы. Для подходящих UID приложений меняется только возвращаемая цепочка сертификатов аттестации.'],
+            ['Keybox', 'Используйте только разрешённые XML/CBOX. Они проверяются до активации, синхронизируются с управляемым каталогом и могут назначаться профилям.'],
+            ['Профили', 'Профиль объединяет приложения, шаблон Identity, keybox, приватность и переопределения функций. Точные правила пакетов важнее wildcard.'],
+            ['Приложения и эффективное состояние', 'Правила пакетов управляются в Apps. Там же показывается итоговый профиль, keybox, KeyMint и политика патчей.'],
+            ['Security Patch', 'Не зависит от Identity. Device Default сохраняет полученные значения, Automatic выбирает по календарю, Manual использует указанную дату.'],
+            ['DRM', 'DRM Passthrough оставляет указанные DRM/медиа-пакеты на настоящем пути Keystore. Изоляция идентификаторов не подделывает уровень безопасности DRM.'],
+            ['RKP', 'RKP больше не имеет пользовательского переключателя. UID инфраструктуры remote provisioning всегда защищены, а пути сертификатов согласованы.'],
+            ['Состояние и обновления', 'Runtime Health показывает реальное состояние. Миграция исправляет устаревшие ссылки и удаляет старые переключатели без полного сброса настроек.'],
+            ['Логи и debug', 'Дополнительные debug-логи в обычном релизе выключены. Включайте их временно в Logs только для диагностики.'],
+            ['Производительность', 'Global Mode использует ограниченные кеши и не запускает постоянный WebUI polling. Кеш переписанных сертификатов намеренно небольшой.']
+        ]
+    };
+
+    let locale = readLocale();
+    const originalText = new WeakMap();
+    const originalAttrs = new WeakMap();
+    let compatibilityConfig = null;
+
+    function readLocale() {
+        try {
+            const saved = global.localStorage && global.localStorage.getItem(STORAGE_KEY);
+            if (SUPPORTED.some(([id]) => id === saved)) return saved;
+        } catch (_) {}
+        return 'en';
+    }
+
+    function saveLocale(value) {
+        locale = SUPPORTED.some(([id]) => id === value) ? value : 'en';
+        try { if (global.localStorage) global.localStorage.setItem(STORAGE_KEY, locale); } catch (_) {}
+    }
+
+    function tr(value) {
+        if (locale === 'en') return value;
+        return (TRANSLATIONS[locale] && TRANSLATIONS[locale][value]) || value;
+    }
+
+    function escapeHtml(value) {
+        return String(value == null ? '' : value).replace(/[&<>"']/g, char => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[char]));
+    }
+
+    function injectStyles() {
+        if (document.getElementById('ct_ux_styles')) return;
+        const style = document.createElement('style');
+        style.id = 'ct_ux_styles';
+        style.textContent = `
+            :root { --ct-soft-border: color-mix(in srgb, var(--border) 62%, transparent); }
+            .panel { border-color: var(--ct-soft-border) !important; box-shadow: 0 2px 10px rgba(0,0,0,.12) !important; }
+            .row, .row > *, .panel, .panel > *, .ct-feature-card, .ct-feature-card > *, td, td > *, .tag { min-width: 0; }
+            .row label, .res-desc, .scope-note, .tag, td, th, code, #runtimeHealthText, .ct-inline-note { overflow-wrap: anywhere; word-break: break-word; }
+            input[type="checkbox"].toggle {
+                appearance: none !important; -webkit-appearance: none !important; width: 48px !important; height: 28px !important;
+                box-sizing: border-box !important; flex: 0 0 48px !important; margin: 0 !important; padding: 0 !important;
+                border: 1px solid #4b4b4f !important; border-radius: 999px !important; background: #25262a !important;
+                background-clip: border-box !important; position: relative !important; transition: background .18s ease,border-color .18s ease !important;
+                box-shadow: inset 0 1px 2px rgba(0,0,0,.35) !important;
+            }
+            input[type="checkbox"].toggle::after {
+                content: '' !important; position: absolute !important; width: 22px !important; height: 22px !important;
+                top: 2px !important; left: 2px !important; border-radius: 50% !important; background: #f5f5f5 !important;
+                box-shadow: 0 1px 3px rgba(0,0,0,.45) !important; transform: translateX(0) !important; transition: transform .18s ease !important;
+            }
+            input[type="checkbox"].toggle:checked { background: var(--accent) !important; border-color: var(--accent) !important; }
+            input[type="checkbox"].toggle:checked::after { transform: translateX(20px) !important; background: #0b0b0c !important; }
+            input[type="checkbox"].toggle:focus-visible { outline: 2px solid var(--accent) !important; outline-offset: 3px !important; }
+            #apps .search-container, #apps .grid-2 > div { min-width: 0; }
+            .autocomplete-items { z-index: 1200 !important; max-height: min(42dvh,320px) !important; overflow-x: hidden !important; }
+            .autocomplete-items div { white-space: normal !important; overflow-wrap: anywhere !important; line-height: 1.25 !important; }
+            #ct_package_search_note { margin-top: -3px; margin-bottom: 12px; }
+            #ct_language_panel select { max-width: 260px; }
+            #ct_debug_panel .row, #ct_drm_dashboard_panel .row { margin-bottom: 0; }
+            #ct_effective_apps_host > .panel { margin-top: 0; }
+            #ct_effective_apps_host { margin-top: 20px; }
+            #cleveresCommunityCard { box-sizing: border-box; margin: 20px 0 max(18px, env(safe-area-inset-bottom)) !important; width: 100%; }
+            #dashboard { padding-bottom: max(116px, calc(84px + env(safe-area-inset-bottom))) !important; }
+            #ct_full_guide .ct-guide-section { padding: 14px 0; border-bottom: 1px solid var(--ct-soft-border); }
+            #ct_full_guide .ct-guide-section:last-child { border-bottom: 0; padding-bottom: 0; }
+            #ct_full_guide h4 { margin: 0 0 6px; color: var(--accent); font-size: 1em; }
+            #ct_full_guide p { margin: 0; color: #aaa; line-height: 1.55; }
+            .ct-compat-note { color:#999; font-size:.82em; line-height:1.45; margin-top:8px; }
+            @media (max-width: 520px) {
+                .row { gap: 12px; align-items: flex-start; }
+                .row > input[type="checkbox"].toggle { margin-top: 2px !important; }
+                #ct_language_panel .row, #ct_debug_panel .row, #ct_drm_dashboard_panel .row { align-items:center; }
+            }
+        `;
+        document.head.appendChild(style);
+    }
+
+    function canonicalizePolicyText() {
+        document.querySelectorAll('h1,h2,h3,h4,label,button,.tab,.scope-note,.res-desc,p,small,option').forEach(element => {
+            if (element.childElementCount > 0) return;
+            const text = (element.textContent || '').trim();
+            if (/^Profiles\s+v2$/i.test(text) || /^Profiles\s+V2$/i.test(text) || /^Advanced App Profiles$/i.test(text)) element.textContent = 'Profiles';
+            else if (/Use Profiles\s+v2/i.test(text)) element.textContent = text.replace(/Profiles\s+v2/ig, 'Profiles');
+        });
+        const banner = document.getElementById('ct_identity_disabled_banner');
+        if (banner) {
+            banner.childNodes.forEach(node => {
+                if (node.nodeType === 3 && /Identity şu anda|Identity is currently/i.test(node.nodeValue || '')) {
+                    node.nodeValue = 'Identity is currently disabled. You can enable it from Dashboard. ';
+                }
+            });
+            const button = banner.querySelector('button');
+            if (button) button.textContent = 'Dashboard';
+        }
+    }
+
+    function translateNode(node) {
+        if (node.nodeType !== 3) return;
+        const current = node.nodeValue || '';
+        if (!originalText.has(node)) originalText.set(node, current);
+        const original = originalText.get(node) || '';
+        const trimmed = original.trim();
+        if (!trimmed) return;
+        const translated = tr(trimmed);
+        if (translated === trimmed && locale !== 'en') return;
+        const leading = original.match(/^\s*/)[0];
+        const trailing = original.match(/\s*$/)[0];
+        node.nodeValue = leading + translated + trailing;
+    }
+
+    function translateElement(element) {
+        if (!element || element.id === 'ct_full_guide') return;
+        const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+        let node;
+        while ((node = walker.nextNode())) translateNode(node);
+        ['placeholder','title','aria-label'].forEach(name => {
+            if (!element.hasAttribute || !element.hasAttribute(name)) return;
+            let stored = originalAttrs.get(element);
+            if (!stored) { stored = Object.create(null); originalAttrs.set(element, stored); }
+            if (!(name in stored)) stored[name] = element.getAttribute(name);
+            element.setAttribute(name, tr(stored[name]));
+        });
+        if (element.querySelectorAll) element.querySelectorAll('[placeholder],[title],[aria-label]').forEach(child => {
+            ['placeholder','title','aria-label'].forEach(name => {
+                if (!child.hasAttribute(name)) return;
+                let stored = originalAttrs.get(child);
+                if (!stored) { stored = Object.create(null); originalAttrs.set(child, stored); }
+                if (!(name in stored)) stored[name] = child.getAttribute(name);
+                child.setAttribute(name, tr(stored[name]));
+            });
+        });
+    }
+
+    function applyTranslations() {
+        document.documentElement.lang = locale;
+        canonicalizePolicyText();
+        translateElement(document.body);
+        renderGuide();
+        const selector = document.getElementById('ct_language_selector');
+        if (selector) selector.value = locale;
+    }
+
+    function installLanguagePanel() {
+        const dashboard = document.getElementById('dashboard');
+        if (!dashboard) return;
+        let panel = document.getElementById('ct_language_panel');
+        if (!panel) {
+            panel = document.createElement('div');
+            panel.id = 'ct_language_panel';
+            panel.className = 'panel';
+            panel.innerHTML = `<h3>Language</h3><div class="row"><label for="ct_language_selector" style="flex:1">Language</label><select id="ct_language_selector" aria-label="Language">${SUPPORTED.map(([id,name]) => `<option value="${escapeHtml(id)}">${escapeHtml(name)}</option>`).join('')}</select></div><div class="ct-compat-note">Built-in translations are local and require no network connection. English is the default unless you choose another language here.</div>`;
+            panel.querySelector('select').addEventListener('change', event => {
+                saveLocale(event.target.value);
+                applyTranslations();
+                ensureFooterOrder();
+            });
+        }
+        dashboard.appendChild(panel);
+        panel.querySelector('select').value = locale;
+    }
+
+    function ensureFooterOrder() {
+        const dashboard = document.getElementById('dashboard');
+        if (!dashboard) return;
+        const language = document.getElementById('ct_language_panel');
+        if (language) dashboard.appendChild(language);
+        const card = document.getElementById('cleveresCommunityCard');
+        if (card) {
+            dashboard.appendChild(card);
+            const link = card.querySelector('a');
+            if (link) {
+                link.href = 'https://t.me/cleverestech';
+                link.target = '_blank';
+                link.rel = 'noopener noreferrer';
+                link.textContent = tr('Open Telegram Community');
+                if (!link.dataset.ctNativeOpen) {
+                    link.dataset.ctNativeOpen = '1';
+                    link.addEventListener('click', async event => {
+                        event.preventDefault();
+                        try {
+                            await bridge.openCommunity();
+                        } catch (_) {
+                            try { global.open('https://t.me/cleverestech', '_blank', 'noopener,noreferrer'); } catch (_) {}
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    function moveEffectiveStateIntoApps() {
+        const apps = document.getElementById('apps');
+        const effective = document.getElementById('effective');
+        const effectiveTab = document.getElementById('tab_effective');
+        if (effectiveTab) effectiveTab.hidden = true;
+        if (!apps || !effective) return;
+        let host = document.getElementById('ct_effective_apps_host');
+        if (!host) {
+            host = document.createElement('div');
+            host.id = 'ct_effective_apps_host';
+            apps.appendChild(host);
+        }
+        while (effective.firstChild) host.appendChild(effective.firstChild);
+        effective.hidden = true;
+    }
+
+    function installPackageSearchNote() {
+        const input = document.getElementById('appPkg');
+        if (!input || document.getElementById('ct_package_search_note')) return;
+        input.setAttribute('type','search');
+        const note = document.createElement('div');
+        note.id = 'ct_package_search_note';
+        note.className = 'scope-note';
+        note.textContent = tr('System / preinstalled packages are included in this search.');
+        const wrapper = input.closest('.search-container');
+        if (wrapper && wrapper.parentElement) wrapper.parentElement.insertBefore(note, wrapper.nextSibling);
+    }
+
+    async function requestConfig() {
+        const response = await bridge.fetch('/api/config');
+        if (!response.ok) throw new Error(await response.text());
+        compatibilityConfig = await response.json();
+        return compatibilityConfig;
+    }
+
+    function syncCompatibilityToggles(data) {
+        if (!data) return;
+        const drm = Boolean(data.drm_passthrough);
+        ['drm_passthrough','res_toggle_drm_passthrough','ct_drm_passthrough_toggle'].forEach(id => {
+            const checkbox = document.getElementById(id);
+            if (checkbox) checkbox.checked = drm;
+        });
+        ['rkp_passthrough','res_toggle_rkp_passthrough'].forEach(id => {
+            const checkbox = document.getElementById(id);
+            if (checkbox) checkbox.checked = false;
+        });
+    }
+
+    async function setSetting(name, enabled) {
+        const body = new URLSearchParams();
+        body.set('setting', name);
+        body.set('enabled', enabled ? 'true' : 'false');
+        const response = await bridge.fetch('/api/toggle', { method:'POST', body });
+        if (!response.ok) throw new Error(await response.text());
+        const data = await requestConfig();
+        syncCompatibilityToggles(data);
+    }
+
+    function hideRetiredRkpUi() {
+        document.querySelectorAll('#rkp_passthrough,#res_toggle_rkp_passthrough,#status_rkp').forEach(element => {
+            const row = element.closest('.row');
+            const card = element.parentElement && element.parentElement.parentElement;
+            if (row) row.hidden = true;
+            else if (card && /RKP/i.test(card.textContent || '')) card.hidden = true;
+            else element.hidden = true;
+        });
+        document.querySelectorAll('#resourceBody tr').forEach(row => {
+            if (/RKP Passthrough/i.test(row.textContent || '')) row.hidden = true;
+        });
+    }
+
+    async function retireRkpSetting() {
+        try {
+            const data = compatibilityConfig || await requestConfig();
+            if (data.rkp_passthrough) await setSetting('rkp_passthrough', false);
+        } catch (_) {}
+        hideRetiredRkpUi();
+    }
+
+    function installDrmPanel() {
+        const dashboard = document.getElementById('dashboard');
+        if (!dashboard || document.getElementById('ct_drm_dashboard_panel')) return;
+        const panel = document.createElement('div');
+        panel.id = 'ct_drm_dashboard_panel';
+        panel.className = 'panel';
+        panel.innerHTML = `<h3>DRM Passthrough</h3><div class="row"><label for="ct_drm_passthrough_toggle" style="flex:1;padding-right:14px"><strong style="color:#fff">DRM Passthrough</strong><span class="res-desc">Keep packages listed in drm_packages.txt on Android's genuine Keystore path. This does not fake a DRM security level.</span></label><input id="ct_drm_passthrough_toggle" class="toggle" type="checkbox"></div>`;
+        const configPanel = [...dashboard.querySelectorAll('.panel')].find(item => /Configuration Management/i.test(item.textContent || ''));
+        if (configPanel) dashboard.insertBefore(panel, configPanel);
+        else dashboard.appendChild(panel);
+        panel.querySelector('input').addEventListener('change', async event => {
+            const checkbox = event.target;
+            checkbox.disabled = true;
+            try {
+                await setSetting('drm_passthrough', checkbox.checked);
+                if (typeof global.notify === 'function') global.notify(checkbox.checked ? 'DRM passthrough enabled' : 'DRM passthrough disabled');
+            } catch (error) {
+                checkbox.checked = !checkbox.checked;
+                if (typeof global.notify === 'function') global.notify(error.message || 'Could not update DRM setting','error');
+            } finally {
+                checkbox.disabled = false;
+            }
+        });
+        requestConfig().then(syncCompatibilityToggles).catch(()=>{});
+    }
+
+    function installDebugPanel() {
+        const log = document.getElementById('log');
+        if (!log || document.getElementById('ct_debug_panel')) return;
+        const panel = document.createElement('div');
+        panel.id = 'ct_debug_panel';
+        panel.className = 'panel';
+        panel.innerHTML = `<h3>Debug Logging</h3><div class="row"><label for="ct_debug_logging_toggle" style="flex:1;padding-right:14px"><strong style="color:#fff">Debug Logging</strong><span class="res-desc">Enable additional runtime diagnostics without installing a debug build. Turn it off after collecting logs.</span></label><input id="ct_debug_logging_toggle" class="toggle" type="checkbox"></div>`;
+        log.insertBefore(panel, log.firstChild);
+        const checkbox = panel.querySelector('input');
+        bridge.getDebugLogging().then(enabled => { checkbox.checked = Boolean(enabled); }).catch(()=>{});
+        checkbox.addEventListener('change', async () => {
+            checkbox.disabled = true;
+            try {
+                await bridge.setDebugLogging(checkbox.checked);
+                if (typeof global.notify === 'function') global.notify(checkbox.checked ? 'Debug logging enabled' : 'Debug logging disabled');
+            } catch (error) {
+                checkbox.checked = !checkbox.checked;
+                if (typeof global.notify === 'function') global.notify(error.message || 'Could not update debug logging','error');
+            } finally {
+                checkbox.disabled = false;
+            }
+        });
+    }
+
+    function renderGuide() {
+        const guide = document.getElementById('guide');
+        if (!guide) return;
+        const sections = GUIDE[locale] || GUIDE.en;
+        guide.innerHTML = `<div class="panel" id="ct_full_guide"><h3>${escapeHtml(tr('Guide'))}</h3><div class="scope-note">${escapeHtml(locale === 'tr' ? 'Tüm temel özellikler ve çalışma yolları tek yerde.' : locale === 'zh-CN' ? '所有主要功能和运行路径集中说明。' : locale === 'es' ? 'Todas las funciones principales y rutas de ejecución en un solo lugar.' : locale === 'de' ? 'Alle wichtigen Funktionen und Laufzeitpfade an einem Ort.' : locale === 'ru' ? 'Все основные функции и пути выполнения в одном месте.' : 'All major features and runtime paths in one place.')}</div>${sections.map(([title,body]) => `<section class="ct-guide-section"><h4>${escapeHtml(title)}</h4><p>${escapeHtml(body)}</p></section>`).join('')}</div>`;
+    }
+
+    function wrapLegacyToggle() {
+        const original = global.toggle;
+        if (typeof original !== 'function' || original.ctUxWrapped) return;
+        const wrapped = function(setting, checkbox) {
+            if (setting === 'rkp_passthrough') {
+                if (checkbox) checkbox.checked = false;
+                retireRkpSetting();
+                return Promise.resolve();
+            }
+            const result = original.apply(this, arguments);
+            if (setting === 'drm_passthrough') Promise.resolve(result).finally(() => requestConfig().then(syncCompatibilityToggles).catch(()=>{}));
+            return result;
+        };
+        wrapped.ctUxWrapped = true;
+        global.toggle = wrapped;
+    }
+
+    function wrapTabSwitch() {
+        const original = global.switchTab;
+        if (typeof original !== 'function' || original.ctUxWrapped) return;
+        const wrapped = function(name) {
+            const result = original.apply(this, arguments);
+            queueMicrotask(() => {
+                applyEnhancements();
+                if (name === 'info') requestConfig().then(syncCompatibilityToggles).catch(()=>{});
+            });
+            return result;
+        };
+        wrapped.ctUxWrapped = true;
+        global.switchTab = wrapped;
+    }
+
+    function applyEnhancements() {
+        canonicalizePolicyText();
+        installLanguagePanel();
+        moveEffectiveStateIntoApps();
+        installPackageSearchNote();
+        installDrmPanel();
+        installDebugPanel();
+        hideRetiredRkpUi();
+        ensureFooterOrder();
+        applyTranslations();
+    }
+
+    function start() {
+        injectStyles();
+        applyEnhancements();
+        wrapLegacyToggle();
+        wrapTabSwitch();
+        retireRkpSetting();
+        [200,700,1500,3000,6000].forEach(delay => global.setTimeout(() => {
+            applyEnhancements();
+            wrapLegacyToggle();
+            wrapTabSwitch();
+        }, delay));
+        if (typeof MutationObserver === 'function') {
+            const observer = new MutationObserver(() => applyEnhancements());
+            observer.observe(document.body,{childList:true,subtree:true});
+            global.setTimeout(() => observer.disconnect(),10000);
+        }
+    }
+
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', start, { once:true });
+    else start();
+})(window);

--- a/service/src/main/java/cleveres/tricky/cleverestech/AutoIdentityManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/AutoIdentityManager.kt
@@ -15,6 +15,8 @@ import javax.net.ssl.HttpsURLConnection
  * Resolves a current Pixel beta/canary identity from Google's public Android
  * developer and Flash Tool metadata. Production lookups are deadline-bounded
  * and successful results are cached so repeated taps do not keep the WebUI busy.
+ * If the public metadata changes or is temporarily unreachable, a verified local
+ * Pixel template is returned instead of leaving the WebUI action unusable.
  */
 object AutoIdentityManager {
     data class Result(
@@ -102,8 +104,41 @@ object AutoIdentityManager {
             }
         } catch (error: IOException) {
             val fallback = cachedResult?.takeIf { ageMs(now, it.storedAtMs) <= STALE_CACHE_FALLBACK_MS }
-            fallback?.value ?: throw error
+            if (fallback != null) return fallback.value
+            localPixelFallback()?.also { resolved ->
+                Logger.w("Auto Identity remote source is unavailable; using a verified local Pixel template")
+                cachedResult = CachedResult(resolved, System.currentTimeMillis())
+                return resolved
+            }
+            throw error
         }
+    }
+
+    private fun localPixelFallback(): Result? {
+        val selected =
+            DeviceTemplateManager.listTemplates()
+                .asSequence()
+                .filter { template ->
+                    template.manufacturer.equals("Google", ignoreCase = true) ||
+                        template.brand.equals("google", ignoreCase = true)
+                }
+                .sortedWith(
+                    compareByDescending<DeviceTemplate> { template ->
+                        runCatching { LocalDate.parse(template.securityPatch) }.getOrDefault(LocalDate.MIN)
+                    }.thenByDescending { it.id },
+                ).firstOrNull()
+                ?: return null
+        return Result(
+            model = selected.model,
+            product = selected.product,
+            device = selected.device,
+            fingerprint = selected.fingerprint,
+            buildId = selected.buildId,
+            incremental = selected.incremental,
+            release = selected.release,
+            securityPatch = selected.securityPatch,
+            securityPatchEstimated = false,
+        )
     }
 
     private fun ageMs(

--- a/service/src/main/java/cleveres/tricky/cleverestech/Logger.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Logger.kt
@@ -1,9 +1,20 @@
 package cleveres.tricky.cleverestech
 
 import android.util.Log
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.LinkOption
 
 object Logger {
     const val TAG = "cleverestricky"
+    private const val DEBUG_FLAG_REFRESH_NANOS = 2_000_000_000L
+    private val runtimeDebugFlag = File("/data/adb/cleverestricky/debug_logging")
+
+    @Volatile
+    private var cachedRuntimeDebug = false
+
+    @Volatile
+    private var lastRuntimeDebugCheckNanos = Long.MIN_VALUE
 
     interface LogImpl {
         fun d(
@@ -85,7 +96,7 @@ object Logger {
 
     @JvmStatic
     fun d(msg: String) {
-        impl.d(TAG, msg)
+        if (isDebugEnabled()) impl.d(TAG, msg)
     }
 
     @JvmStatic
@@ -93,7 +104,7 @@ object Logger {
         tag: String,
         msg: String,
     ) {
-        impl.d(tag, msg)
+        if (isDebugEnabled()) impl.d(tag, msg)
     }
 
     @JvmStatic
@@ -168,6 +179,25 @@ object Logger {
 
     @JvmStatic
     fun isDebugEnabled(): Boolean {
-        return BuildConfig.DEBUG || Log.isLoggable(TAG, Log.DEBUG)
+        if (BuildConfig.DEBUG || Log.isLoggable(TAG, Log.DEBUG)) return true
+        val now = System.nanoTime()
+        val last = lastRuntimeDebugCheckNanos
+        if (last != Long.MIN_VALUE && now >= last && now - last < DEBUG_FLAG_REFRESH_NANOS) {
+            return cachedRuntimeDebug
+        }
+        return synchronized(this) {
+            val secondLast = lastRuntimeDebugCheckNanos
+            if (secondLast != Long.MIN_VALUE && now >= secondLast && now - secondLast < DEBUG_FLAG_REFRESH_NANOS) {
+                cachedRuntimeDebug
+            } else {
+                val path = runtimeDebugFlag.toPath()
+                cachedRuntimeDebug =
+                    runCatching {
+                        Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS) && !Files.isSymbolicLink(path)
+                    }.getOrDefault(false)
+                lastRuntimeDebugCheckNanos = now
+                cachedRuntimeDebug
+            }
+        }
     }
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
@@ -42,6 +42,10 @@ fun main(args: Array<String>) {
 
         try {
             Config.initialize()
+            if (PolicyMigration.sanitize(configDir)) {
+                PolicyState.reload().getOrThrow()
+                Logger.i("Recovered stale persisted policy references after upgrade")
+            }
             BootLogic.run()
             CertificatePolicyWatcher.start(configDir)
         } catch (e: Exception) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/PolicyMigration.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/PolicyMigration.kt
@@ -1,0 +1,98 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.util.SecureFile
+import org.json.JSONObject
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.LinkOption
+
+/**
+ * Performs narrowly-scoped, loss-minimizing repairs for persisted policy state
+ * after upgrades. The policy parser still owns schema validation; this helper
+ * only removes references that are known to become stale when keybox files or
+ * retired compatibility controls change between releases.
+ */
+object PolicyMigration {
+    private const val STATE_FILE = "policy_state_v2.json"
+    private const val LAST_GOOD_FILE = "policy_state_v2.last_good.json"
+    private const val SCHEMA_VERSION = 2
+    private const val MAX_STATE_BYTES = 512L * 1024
+    private val keyboxPattern = Regex("[A-Za-z0-9_.-]{5,128}")
+
+    fun sanitize(configRoot: File): Boolean {
+        var changed = false
+        changed = sanitizeFile(configRoot, File(configRoot, STATE_FILE)) || changed
+        changed = sanitizeFile(configRoot, File(configRoot, LAST_GOOD_FILE)) || changed
+        return changed
+    }
+
+    private fun sanitizeFile(
+        configRoot: File,
+        stateFile: File,
+    ): Boolean {
+        val path = stateFile.toPath()
+        if (!Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS) || stateFile.length() !in 1..MAX_STATE_BYTES) {
+            return false
+        }
+
+        val json =
+            runCatching { JSONObject(stateFile.readText(Charsets.UTF_8)) }
+                .getOrElse { return false }
+        if (json.optInt("version", -1) != SCHEMA_VERSION) return false
+
+        var changed = false
+        val profiles = json.optJSONArray("profiles")
+        val profileNames = HashSet<String>()
+        if (profiles != null) {
+            for (index in 0 until profiles.length()) {
+                val profile = profiles.optJSONObject(index) ?: continue
+                profile.optString("name").trim().takeIf(String::isNotEmpty)?.let(profileNames::add)
+
+                if (profile.has("rkpPassthrough")) {
+                    profile.remove("rkpPassthrough")
+                    changed = true
+                }
+
+                if (!profile.isNull("keybox")) {
+                    val keybox = profile.optString("keybox").trim()
+                    if (keybox.isNotEmpty() && !isAvailableKeybox(configRoot, keybox)) {
+                        profile.put("keybox", JSONObject.NULL)
+                        changed = true
+                        Logger.w("Removed stale profile keybox reference during policy migration")
+                    }
+                }
+            }
+        }
+
+        if (!json.isNull("activeProfile")) {
+            val active = json.optString("activeProfile").trim()
+            if (active.isNotEmpty() && active !in profileNames) {
+                json.put("activeProfile", JSONObject.NULL)
+                changed = true
+                Logger.w("Removed stale active profile reference during policy migration")
+            }
+        }
+
+        if (!changed) return false
+        SecureFile.writeText(stateFile, json.toString())
+        return true
+    }
+
+    private fun isAvailableKeybox(
+        configRoot: File,
+        filename: String,
+    ): Boolean {
+        if (!keyboxPattern.matches(filename) || filename.startsWith('.')) return false
+        val lower = filename.lowercase()
+        if (!lower.endsWith(".xml") && !lower.endsWith(".cbox")) return false
+        val candidates =
+            arrayOf(
+                File(configRoot, filename),
+                File(File(configRoot, "keyboxes"), filename),
+            )
+        return candidates.any { candidate ->
+            val path = candidate.toPath()
+            Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS) && !Files.isSymbolicLink(path)
+        }
+    }
+}

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -740,7 +740,7 @@ public final class CertHack {
                         verifiedBootHash = usableBootDigest(getByteArrayFromAsn1(r.getObjectAt(3)));
                     }
                 } catch (Throwable t) {
-                    Logger.d("Original root-of-trust fields were not needed or could not be reused")
+                    Logger.d("Original root-of-trust fields were not needed or could not be reused");
                 }
             }
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -15,6 +15,7 @@ import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.DERTaggedObject;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
@@ -46,6 +47,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -64,7 +66,7 @@ public final class CertHack {
     private static final int MAX_KEYS_PER_KEYBOX = 4;
     private static final int MAX_CERTIFICATES_PER_CHAIN = 16;
     private static final int MAX_PEM_CHARS = 256 * 1024;
-    private static final int MAX_CERTIFICATE_CACHE_ENTRIES = 128;
+    private static final int MAX_CERTIFICATE_CACHE_ENTRIES = 64;
     private static final int MAX_LEAF_CERTIFICATE_BYTES = 64 * 1024;
     private static final int MAX_ATTESTATION_EXTENSION_BYTES = 64 * 1024;
     private static final String[] ATTESTATION_ID_NAMES =
@@ -95,17 +97,48 @@ public final class CertHack {
                     }
                 }
             };
+    private static final ThreadLocal<JcaX509CertificateConverter> CERTIFICATE_CONVERTER =
+            ThreadLocal.withInitial(JcaX509CertificateConverter::new);
+    private static final ThreadLocal<JcaContentSignerBuilder> EC_SIGNER_BUILDER =
+            ThreadLocal.withInitial(() -> new JcaContentSignerBuilder("SHA256withECDSA"));
+    private static final ThreadLocal<JcaContentSignerBuilder> RSA_SIGNER_BUILDER =
+            ThreadLocal.withInitial(() -> new JcaContentSignerBuilder("SHA256withRSA"));
+
+    private static final class PreparedKeyBox {
+        final X500Name issuer;
+        final String signatureAlgorithm;
+
+        PreparedKeyBox(KeyBox keybox) throws Exception {
+            if (keybox.certificates.isEmpty()) throw new IOException("Keybox has no certificates");
+            this.issuer = new X509CertificateHolder(keybox.certificates.get(0).getEncoded()).getSubject();
+            this.signatureAlgorithm = signatureAlgorithmForKeybox(keybox);
+            if (this.signatureAlgorithm == null) throw new IOException("Unsupported keybox algorithm");
+        }
+    }
 
     private static class State {
         final Map<String, List<KeyBox>> keyboxes;
         final Map<String, List<KeyBox>> keyboxFiles;
+        final Map<KeyBox, PreparedKeyBox> preparedKeyboxes;
         final Map<CacheKey, Certificate[]> certificateCache;
 
         State(Map<String, List<KeyBox>> keyboxes, Map<String, List<KeyBox>> keyboxFiles) {
             this.keyboxes = immutableLists(keyboxes);
             this.keyboxFiles = immutableLists(keyboxFiles);
+            IdentityHashMap<KeyBox, PreparedKeyBox> prepared = new IdentityHashMap<>();
+            for (List<KeyBox> list : this.keyboxes.values()) {
+                for (KeyBox keybox : list) {
+                    if (prepared.containsKey(keybox)) continue;
+                    try {
+                        prepared.put(keybox, new PreparedKeyBox(keybox));
+                    } catch (Exception error) {
+                        Logger.e("Could not prepare keybox metadata", error);
+                    }
+                }
+            }
+            this.preparedKeyboxes = Collections.unmodifiableMap(prepared);
             this.certificateCache = Collections.synchronizedMap(
-                    new LinkedHashMap<CacheKey, Certificate[]>(64, 0.75f, true) {
+                    new LinkedHashMap<CacheKey, Certificate[]>(32, 0.75f, true) {
                         @Override
                         protected boolean removeEldestEntry(Map.Entry<CacheKey, Certificate[]> eldest) {
                             return size() > MAX_CERTIFICATE_CACHE_ENTRIES;
@@ -292,11 +325,31 @@ public final class CertHack {
         return filterKeyboxesByAlgorithm(candidates, KeyProperties.KEY_ALGORITHM_RSA);
     }
 
+    private static List<KeyBox> selectGlobalKeyboxPool(State currentState, String preferredAlgorithm) {
+        if (preferredAlgorithm != null) {
+            List<KeyBox> preferred = currentState.keyboxes.get(preferredAlgorithm);
+            if (preferred != null && !preferred.isEmpty()) return preferred;
+        }
+        String fallbackAlgorithm = KeyProperties.KEY_ALGORITHM_EC.equals(preferredAlgorithm)
+                ? KeyProperties.KEY_ALGORITHM_RSA
+                : KeyProperties.KEY_ALGORITHM_EC;
+        List<KeyBox> fallback = currentState.keyboxes.get(fallbackAlgorithm);
+        if (fallback != null && !fallback.isEmpty()) return fallback;
+        List<KeyBox> rsa = currentState.keyboxes.get(KeyProperties.KEY_ALGORITHM_RSA);
+        return rsa == null ? Collections.emptyList() : rsa;
+    }
+
     private static String signatureAlgorithmForKeybox(KeyBox keybox) {
         String algorithm = normalizeAlgorithm(keybox.keyPair.getPrivate().getAlgorithm());
         if (KeyProperties.KEY_ALGORITHM_EC.equals(algorithm)) return "SHA256withECDSA";
         if (KeyProperties.KEY_ALGORITHM_RSA.equals(algorithm)) return "SHA256withRSA";
         return null;
+    }
+
+    private static JcaContentSignerBuilder signerBuilder(String signatureAlgorithm) {
+        if ("SHA256withECDSA".equals(signatureAlgorithm)) return EC_SIGNER_BUILDER.get();
+        if ("SHA256withRSA".equals(signatureAlgorithm)) return RSA_SIGNER_BUILDER.get();
+        throw new IllegalArgumentException("Unsupported keybox signature algorithm");
     }
 
     public static List<KeyBox> parseKeyboxXml(Reader reader) {
@@ -473,18 +526,18 @@ public final class CertHack {
         setKeyboxes(parseKeyboxXml(reader));
     }
 
-    public static synchronized void clearCertificateCache() {
+    public static void clearCertificateCache() {
         State currentState = state;
         synchronized (currentState.certificateCache) {
             currentState.certificateCache.clear();
         }
     }
 
-    public static synchronized boolean hasCachedCertificateChains() {
+    public static boolean hasCachedCertificateChains() {
         return !state.certificateCache.isEmpty();
     }
 
-    public static synchronized Certificate[] getCachedCertificateChain(Certificate[] caList) {
+    public static Certificate[] getCachedCertificateChain(Certificate[] caList) {
         if (caList == null || caList.length == 0 || caList[0] == null) return null;
         try {
             byte[] leafEncoded = caList[0].getEncoded();
@@ -501,8 +554,10 @@ public final class CertHack {
      * Rewrites one key's attestation chain exactly once per active policy snapshot. The cache is
      * keyed by the genuine leaf identity, not the reader UID: a granted alias must return the same
      * certificate chain from generateKey and every later getKeyEntry path, including isolated UIDs.
+     * Expensive preparation is intentionally outside a global monitor so concurrent KeyMint callers
+     * do not amplify the timing signal that an attestation rewrite occurred.
      */
-    public static synchronized Certificate[] hackCertificateChain(Certificate[] caList, int uid) {
+    public static Certificate[] hackCertificateChain(Certificate[] caList, int uid) {
         if (caList == null || caList.length == 0 || caList[0] == null) {
             throw new UnsupportedOperationException("Certificate chain is empty");
         }
@@ -569,14 +624,14 @@ public final class CertHack {
             Config.AttestationPatchLevels patchLevels = PolicyState.INSTANCE.resolveAttestationPatchLevels(
                     uid, capturedSystem, capturedVendor, capturedBoot);
 
-            List<ASN1TaggedObject> teeTags = new ArrayList<>();
-            List<ASN1TaggedObject> softwareTags = new ArrayList<>();
+            List<ASN1TaggedObject> teeTags = new ArrayList<>(teeEnforced.size() + 8);
+            List<ASN1TaggedObject> softwareTags = new ArrayList<>(softwareEnforced.size() + 4);
             ASN1Encodable rootOfTrust = null;
             byte[] moduleHash = Config.INSTANCE.getModuleHash();
             ASN1TaggedObject originalModuleHash = null;
 
-            Map<Integer, byte[]> configuredIdAttestationTags = new HashMap<>();
-            List<Integer> originalOverriddenIdTags = new ArrayList<>();
+            Map<Integer, byte[]> configuredIdAttestationTags = new HashMap<>(ATTESTATION_ID_NAMES.length);
+            List<Integer> originalOverriddenIdTags = new ArrayList<>(ATTESTATION_ID_NAMES.length);
             for (int i = 0; i < ATTESTATION_ID_NAMES.length; i++) {
                 byte[] val = Config.INSTANCE.getAttestationId(ATTESTATION_ID_NAMES[i], uid);
                 if (val != null) {
@@ -644,69 +699,53 @@ public final class CertHack {
                 }
             }
 
-            LinkedList<Certificate> certificates;
-            X509v3CertificateBuilder builder;
-            ContentSigner signer;
-
             String preferredSignerAlgorithm = signingKeyAlgorithm(leaf.getSigAlgName());
-
-            List<KeyBox> candidates = new ArrayList<>();
             var appConfig = Config.INSTANCE.getAppConfig(uid);
+            List<KeyBox> list;
             if (appConfig != null && appConfig.getKeyboxFilename() != null) {
-                List<KeyBox> requested = currentState.keyboxFiles.get(appConfig.getKeyboxFilename());
-                if (requested != null) candidates.addAll(requested);
+                list = selectKeyboxPool(currentState.keyboxFiles.get(appConfig.getKeyboxFilename()), preferredSignerAlgorithm);
             } else {
-                candidates.addAll(currentState.keyboxes.getOrDefault(
-                        KeyProperties.KEY_ALGORITHM_EC, Collections.emptyList()));
-                candidates.addAll(currentState.keyboxes.getOrDefault(
-                        KeyProperties.KEY_ALGORITHM_RSA, Collections.emptyList()));
+                list = selectGlobalKeyboxPool(currentState, preferredSignerAlgorithm);
             }
-
-            List<KeyBox> list = selectKeyboxPool(candidates, preferredSignerAlgorithm);
             if (list.isEmpty()) throw new UnsupportedOperationException("No compatible keybox is available");
 
             int idx = cacheKey.indexForPool(list.size());
-            var k = list.get(idx);
-            String signatureAlgorithm = signatureAlgorithmForKeybox(k);
-            if (signatureAlgorithm == null) throw new UnsupportedOperationException("Unsupported keybox algorithm");
+            KeyBox k = list.get(idx);
+            PreparedKeyBox prepared = currentState.preparedKeyboxes.get(k);
+            if (prepared == null) throw new UnsupportedOperationException("Keybox metadata is unavailable");
 
-            certificates = new LinkedList<>(k.certificates);
-            if (certificates.isEmpty()) {
-                throw new UnsupportedOperationException("Keybox has no certificates");
-            }
-            builder = new X509v3CertificateBuilder(
-                    new X509CertificateHolder(
-                            certificates.get(0).getEncoded()
-                    ).getSubject(),
+            LinkedList<Certificate> certificates = new LinkedList<>(k.certificates);
+            X509v3CertificateBuilder builder = new X509v3CertificateBuilder(
+                    prepared.issuer,
                     leafHolder.getSerialNumber(),
                     leafHolder.getNotBefore(),
                     leafHolder.getNotAfter(),
                     leafHolder.getSubject(),
                     leafHolder.getSubjectPublicKeyInfo()
             );
-            signer = new JcaContentSignerBuilder(signatureAlgorithm)
-                    .build(k.keyPair.getPrivate());
+            ContentSigner signer = signerBuilder(prepared.signatureAlgorithm).build(k.keyPair.getPrivate());
 
             byte[] verifiedBootKey = usableBootDigest(UtilKt.getBootKey());
-            byte[] verifiedBootHash = null;
-            try {
-                if (rootOfTrust == null || !(rootOfTrust instanceof ASN1Sequence r)) {
-                    throw new CertificateParsingException("Expected sequence for root of trust, found "
-                            + (rootOfTrust == null ? "null" : rootOfTrust.getClass().getName()));
+            byte[] verifiedBootHash = usableBootDigest(UtilKt.getBootHash());
+            if (verifiedBootKey == null || verifiedBootHash == null) {
+                try {
+                    if (rootOfTrust == null || !(rootOfTrust instanceof ASN1Sequence r)) {
+                        throw new CertificateParsingException("Expected sequence for root of trust, found "
+                                + (rootOfTrust == null ? "null" : rootOfTrust.getClass().getName()));
+                    }
+                    if (verifiedBootKey == null) {
+                        verifiedBootKey = usableBootDigest(getByteArrayFromAsn1(r.getObjectAt(0)));
+                    }
+                    if (verifiedBootHash == null) {
+                        verifiedBootHash = usableBootDigest(getByteArrayFromAsn1(r.getObjectAt(3)));
+                    }
+                } catch (Throwable t) {
+                    Logger.d("Original root-of-trust fields were not needed or could not be reused")
                 }
-                if (verifiedBootKey == null) {
-                    verifiedBootKey = usableBootDigest(getByteArrayFromAsn1(r.getObjectAt(0)));
-                }
-                verifiedBootHash = usableBootDigest(getByteArrayFromAsn1(r.getObjectAt(3)));
-            } catch (Throwable t) {
-                Logger.e("Failed to read the original root-of-trust fields", t);
             }
 
             if (verifiedBootKey == null) {
                 verifiedBootKey = usableBootDigest(UtilKt.getPersistentBootKey());
-            }
-            if (verifiedBootHash == null) {
-                verifiedBootHash = usableBootDigest(UtilKt.getBootHash());
             }
             if (verifiedBootHash == null) {
                 verifiedBootHash = usableBootDigest(UtilKt.getPersistentBootHash());
@@ -748,10 +787,12 @@ public final class CertHack {
                     builder.addExtension(leafHolder.getExtension(extensionOID));
                 }
             }
-            certificates.addFirst(new JcaX509CertificateConverter().getCertificate(builder.build(signer)));
+            certificates.addFirst(CERTIFICATE_CONVERTER.get().getCertificate(builder.build(signer)));
 
             Certificate[] result = certificates.toArray(new Certificate[0]);
             synchronized (cache) {
+                Certificate[] raced = cache.get(cacheKey);
+                if (raced != null) return raced.clone();
                 cache.put(cacheKey, result.clone());
             }
             return result;

--- a/service/src/test/java/cleveres/tricky/cleverestech/PolicyMigrationTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/PolicyMigrationTest.kt
@@ -1,0 +1,110 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.util.SecureFile
+import cleveres.tricky.cleverestech.util.SecureFileOperations
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+
+class PolicyMigrationTest {
+    private lateinit var tempDir: File
+    private lateinit var originalSecureFileImpl: SecureFileOperations
+
+    @Before
+    fun setup() {
+        tempDir = Files.createTempDirectory("cleverestricky-policy-migration").toFile()
+        originalSecureFileImpl = SecureFile.impl
+        SecureFile.impl =
+            object : SecureFileOperations {
+                override fun writeText(
+                    file: File,
+                    content: String,
+                ) {
+                    file.parentFile?.mkdirs()
+                    file.writeText(content)
+                }
+
+                override fun mkdirs(
+                    file: File,
+                    mode: Int,
+                ) {
+                    file.mkdirs()
+                }
+
+                override fun touch(
+                    file: File,
+                    mode: Int,
+                ) {
+                    file.parentFile?.mkdirs()
+                    file.createNewFile()
+                }
+            }
+    }
+
+    @After
+    fun tearDown() {
+        SecureFile.impl = originalSecureFileImpl
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun staleKeyboxAndRetiredRkpFieldsAreRepairedWithoutResettingProfiles() {
+        val state =
+            JSONObject(
+                """
+                {
+                  "version": 2,
+                  "profiles": [
+                    {
+                      "name": "Daily",
+                      "keybox": "missing.xml",
+                      "rkpPassthrough": true
+                    }
+                  ],
+                  "activeProfile": "Daily"
+                }
+                """.trimIndent(),
+            )
+        val stateFile = File(tempDir, "policy_state_v2.json")
+        stateFile.writeText(state.toString())
+
+        assertTrue(PolicyMigration.sanitize(tempDir))
+
+        val repaired = JSONObject(stateFile.readText())
+        val profile = repaired.getJSONArray("profiles").getJSONObject(0)
+        assertTrue(profile.isNull("keybox"))
+        assertFalse(profile.has("rkpPassthrough"))
+        assertTrue(repaired.optString("activeProfile") == "Daily")
+    }
+
+    @Test
+    fun validManagedKeyboxReferenceIsPreserved() {
+        val keyboxDir = File(tempDir, "keyboxes")
+        keyboxDir.mkdirs()
+        File(keyboxDir, "valid.xml").writeText("placeholder")
+        val stateFile = File(tempDir, "policy_state_v2.json")
+        stateFile.writeText(
+            """
+            {
+              "version": 2,
+              "profiles": [
+                {
+                  "name": "Daily",
+                  "keybox": "valid.xml"
+                }
+              ],
+              "activeProfile": "Daily"
+            }
+            """.trimIndent(),
+        )
+
+        assertFalse(PolicyMigration.sanitize(tempDir))
+        val preserved = JSONObject(stateFile.readText())
+        assertTrue(preserved.getJSONArray("profiles").getJSONObject(0).getString("keybox") == "valid.xml")
+    }
+}


### PR DESCRIPTION
## Summary

This follow-up finishes the remaining WebUI, upgrade-compatibility, runtime-health, performance, and timing work after #909.

### WebUI and usability

- opens the CleveresTech Telegram community through a fixed Android `ACTION_VIEW` browser intent from KernelSU/APatch WebUI, preferring Chrome and falling back to the system browser; the visible link remains a normal fixed HTTPS URL and no `tg:` custom scheme is used
- keeps English as the default Identity-disabled message and adds built-in Turkish, Simplified Chinese, Spanish, German, and Russian UI support with a language selector at the bottom of Dashboard
- keeps the Community card as the last Dashboard item with safe bottom-nav/safe-area spacing
- normalizes `Profiles v2`/`Advanced App Profiles` wording to `Profiles`
- moves Effective State into Apps and hides its redundant top-level tab
- redesigns toggles and softens panel borders; adds generic long-value wrapping and mobile overflow protection
- improves the package selector/autocomplete for system and preinstalled package searches
- expands Guide into a broad feature/runtime reference covering Dashboard, Identity, Auto Identity, KeyMint/TEE, Keyboxes, Profiles, Apps/Effective State, Security Patch, DRM, RKP, upgrades, debug logging, and performance
- adds a first-class Dashboard DRM Passthrough switch synchronized with the same backend setting used elsewhere
- retires the obsolete user-facing RKP toggle from Dashboard/Resources so there is one consistent RKP policy surface

### Auto Identity and runtime debug

- keeps Auto Identity network work bounded, but now falls back to the newest verified local Google/Pixel template when public Pixel metadata is unavailable or changes unexpectedly
- adds a release-runtime Debug Logging switch under Logs; ordinary release builds keep verbose logs gated off unless the user explicitly enables the root-only debug flag
- stops producing and publishing a separate debug module ZIP in CI; tests/lint can still use debug Gradle variants internally

### Upgrade and keybox recovery

- adds a settings schema migration in `customize.sh` that retires the stale RKP flag, invalidates disposable CBOX caches, secures new policy/debug files, and packages the complete WebUI
- adds a runtime policy migration before interceptor activation that repairs stale profile keybox references and stale active-profile references instead of forcing users to reset every setting
- adds regression coverage for stale-keybox migration and preservation of valid managed keybox references

### TEE timing / RAM / hot path

- removes the broad synchronized monitor from attestation-chain rewriting and keeps locking limited to the small certificate cache
- halves the rewrite LRU bound from 128 to 64 entries
- precomputes immutable keybox issuer/signature metadata
- reuses per-thread certificate converters and signer builders
- avoids rebuilding global keybox candidate lists on every Global Mode attestation
- pre-sizes hot-path collections and avoids parsing original root-of-trust fields when the verified boot key/hash are already available
- preserves genuine KeyMint private-key operations and does not add synthetic sleeps or timing padding; the goal is to reduce the real attested/non-attested latency difference rather than mask it

## Validation

This PR is intended to pass the full existing PR gate: shellcheck, Kotlin formatting, Android lint, WebUI syntax/behavior checks, JVM tests, release module build/archive checksum validation, Rust checks/audit where applicable, and native hardening checks.

`update.json` is intentionally unchanged.