### PR TITLE
Make WebUI controls authoritative and tighten TEE timing path

### DIFF
--- a/module/template/webroot/bridge.js
+++ b/module/template/webroot/bridge.js
@@ -517,7 +517,7 @@
         if (!document || !document.head || !document.createElement || document.getElementById('ct_ux_script')) return;
         const script = document.createElement('script');
         script.id = 'ct_ux_script';
-        script.src = 'ux.js?revision=1';
+        script.src = 'ux.js?revision=3';
         script.defer = true;
         document.head.appendChild(script);
     }
@@ -533,7 +533,7 @@
 
     scheduleCommunityCard();
     global.CleveresBridge = Object.freeze({
-        revision: 5,
+        revision: 6,
         fetch: nativeFetch,
         exportBlob,
         exportResponse,

--- a/module/template/webroot/index.html
+++ b/module/template/webroot/index.html
@@ -10,8 +10,8 @@
         html { color-scheme: dark; background: var(--bg); }
         body { background-color: var(--bg); color: var(--fg); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 0; min-height: 100dvh; overscroll-behavior-y: contain; -webkit-tap-highlight-color: transparent; }
         .island-container { display: flex; justify-content: center; position: fixed; top: calc(env(safe-area-inset-top) + 10px); left: 0; right: 0; padding: 0 max(12px, env(safe-area-inset-right)) 0 max(12px, env(safe-area-inset-left)); box-sizing: border-box; z-index: 1000; pointer-events: none; }
-        .island { background: #000; color: #fff; border-radius: 24px; min-height: 35px; width: auto; max-width: min(90vw, 680px); display: flex; align-items: center; justify-content: center; transition: opacity 0.25s ease, transform 0.25s ease; box-shadow: 0 4px 15px rgba(0,0,0,0.5); font-size: 0.8em; font-weight: 500; opacity: 0; transform: translateY(-12px) scale(0.96); pointer-events: auto; padding: 0; white-space: normal; overflow-wrap: anywhere; }
-        .island.active { width: min(90vw, 680px); padding: 10px 10px 10px 18px; opacity: 1; transform: translateY(0) scale(1); font-size: 0.9em; min-height: 44px; max-height: min(42dvh, 320px); overflow: auto; box-sizing: border-box; }
+        .island { background: #000; color: #fff; border-radius: 24px; width: min(90vw, 680px); max-width: min(90vw, 680px); min-height: 44px; padding: 10px 10px 10px 18px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; transition: opacity 0.16s ease, transform 0.20s cubic-bezier(.22,.8,.25,1), visibility 0s linear 0.20s; box-shadow: 0 4px 15px rgba(0,0,0,0.5); font-size: 0.9em; font-weight: 500; opacity: 0; transform: translateY(-8px) scale(0.985); visibility: hidden; pointer-events: none; white-space: normal; overflow-wrap: anywhere; max-height: min(42dvh, 320px); overflow: auto; will-change: opacity, transform; }
+        .island.active { opacity: 1; transform: translateY(0) scale(1); visibility: visible; pointer-events: auto; transition-delay: 0s; }
         .island.error { background: #330000; border: 1px solid var(--danger); }
         .island.error #islandText { color: #FECACA; }
         .spinner { width: 14px; height: 14px; border: 2px solid #fff; border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite; margin-right: 10px; display: none; }
@@ -223,19 +223,7 @@ input[type="text"], input[type="tel"], input[type="password"], input[type="searc
 </div>
         </div>
 
-        <div class="panel">
-<h3>System Control</h3>
-<div class="row"><label for="global_mode">Global Mode</label><input type="checkbox" class="toggle" id="global_mode" data-setting="global_mode" onchange="toggle('global_mode', this)"></div>
-<div class="row"><label for="auto_keybox_check">Auto Keybox Check</label><input type="checkbox" class="toggle" id="auto_keybox_check" data-setting="auto_keybox_check" onchange="toggle('auto_keybox_check', this)"></div>
-<div class="section-header">Compatibility passthrough</div>
-<div class="row"><label for="rkp_passthrough">RKP Passthrough</label><input type="checkbox" class="toggle" id="rkp_passthrough" data-setting="rkp_passthrough" onchange="toggle('rkp_passthrough', this)"></div>
-<div class="row"><label for="drm_passthrough">DRM App Passthrough</label><input type="checkbox" class="toggle" id="drm_passthrough" data-setting="drm_passthrough" onchange="toggle('drm_passthrough', this)"></div>
-<div style="font-size:0.8em; color:#888; margin-top:5px;">RKP service packages are always protected from substitution. DRM passthrough excludes packages in drm_packages.txt. Neither setting disables core boot/TEE protection.</div>
-<div style="margin-top:20px; border-top: 1px solid var(--border); padding-top: 15px;">
-    <div class="row"><span id="keyboxStatus" style="font-size:0.9em; color:var(--success);">Active</span><button onclick="runWithState(this, 'Reloading...', reloadConfig)">Reload Config</button></div>
-</div>
-        </div>
-        <div class="panel"><h3>Configuration Management</h3><div style="margin-bottom:10px;"><label for="backupPw">Backup Password (required, at least 12 characters)</label><div class="pwd-wrapper"><input type="password" id="backupPw" placeholder="Enter a strong backup password" minlength="12" maxlength="1024" spellcheck="false" autocomplete="new-password" autocorrect="off" autocapitalize="off"><button type="button" class="pwd-toggle" onclick="togglePassword(this)">Show</button></div></div><div class="grid-2"><button onclick="runWithState(this, 'Exporting...', backupConfig)">Export Encrypted Settings</button><button onclick="document.getElementById('restoreInput').click()">Import Encrypted Settings</button><input type="file" id="restoreInput" style="display:none" onchange="restoreConfig(this)" accept=".ctsb"></div><div style="margin-top:10px;"><button onclick="const btn = this; requireConfirm(btn, () => runWithState(btn, 'Resetting...', resetEnvironment), 'Confirm Reset')" class="danger" style="width:100%;">One-Click Reset (Refresh Environment)</button></div></div>
+        <div class="panel"><h3>Configuration Management</h3><div style="margin-bottom:10px;"><label for="backupPw">Backup Password (required, at least 12 characters)</label><div class="pwd-wrapper"><input type="password" id="backupPw" placeholder="Enter a strong backup password" minlength="12" maxlength="1024" spellcheck="false" autocomplete="new-password" autocorrect="off" autocapitalize="off"><button type="button" class="pwd-toggle" onclick="togglePassword(this)">Show</button></div></div><div class="grid-2"><button onclick="runWithState(this, 'Exporting...', backupConfig)">Export Encrypted Settings</button><button onclick="document.getElementById('restoreInput').click()">Import Encrypted Settings</button><input type="file" id="restoreInput" style="display:none" onchange="restoreConfig(this)" accept=".ctsb"></div><div style="margin-top:10px;"><button id="runtimeSyncBtn" onclick="runWithState(this, 'Synchronizing...', synchronizeRuntimeSettings)" class="primary" style="width:100%;">Synchronize Runtime</button></div></div>
     </div>
 
     <div id="spoof" class="content" role="tabpanel" aria-labelledby="tab_spoof">
@@ -493,8 +481,8 @@ input[type="text"], input[type="tel"], input[type="password"], input[type="searc
         </div>
     </div>
 
-    <script src="bridge.js?revision=4"></script>
-    <script src="policy.js?revision=1"></script>
+    <script src="bridge.js?revision=5"></script>
+    <script src="policy.js?revision=2"></script>
     <script>
         window.addEventListener('unhandledrejection', function(event) {
 if (event.reason && event.reason.message && event.reason.message.includes('fetch')) {
@@ -1819,6 +1807,25 @@ try {
     notify('Error: ' + e.message, 'error');
 }
         }
+        async function synchronizeRuntimeSettings() {
+const configResponse = await fetchAuth('/api/config');
+if (!configResponse.ok) throw new Error(await configResponse.text());
+const current = await configResponse.json();
+for (const setting of ['global_mode','auto_keybox_check','drm_passthrough','spoof_enabled','spoof_build_identity','random_on_boot','spoof_region_cn','telephony']) {
+    if (typeof current[setting] !== 'boolean') continue;
+    const body = new URLSearchParams();
+    body.set('setting', setting);
+    body.set('value', current[setting] ? 'true' : 'false');
+    const response = await fetchAuth('/api/toggle', { method: 'POST', body });
+    if (!response.ok) throw new Error(await response.text());
+}
+const reload = await fetchAuth('/api/reload', { method: 'POST' });
+if (!reload.ok) throw new Error(await reload.text());
+if (typeof loadConfig === 'function') await loadConfig();
+if (typeof loadResourceUsage === 'function') await loadResourceUsage();
+notify('Runtime settings synchronized');
+        }
+
         async function resetEnvironment() {
 notify('Resetting...', 'working');
 try {

--- a/module/template/webroot/policy.js
+++ b/module/template/webroot/policy.js
@@ -296,6 +296,7 @@ function buildFeatureCenterMarkup(prefix) {
   const patchOn = Boolean(f && f.securityPatch);
   const globalOn = Boolean(legacyConfig && legacyConfig.global_mode);
   const keyboxOn = Boolean(legacyConfig && legacyConfig.auto_keybox_check);
+  const drmOn = Boolean(legacyConfig && legacyConfig.drm_passthrough);
 
   const identityChildren = `<div class="ct-subcontrols" id="${prefix}_identity_children" ${identityOn ? '' : 'hidden'}>
     ${FEATURE_KEYS.map(([key,title,desc]) => `<div class="row"><label for="${prefix}_${key}" style="flex:1;padding-right:10px"><strong>${escapeHtml(title)}</strong><span class="res-desc">${escapeHtml(desc)}</span></label><input id="${prefix}_${key}" data-policy-feature="${key}" type="checkbox" class="toggle" ${f && f[key] ? 'checked' : ''}></div>`).join('')}
@@ -310,12 +311,7 @@ function buildFeatureCenterMarkup(prefix) {
     ${cardMarkup(`${prefix}_identity`, 'Identity', 'Optional identity substitution. Turn it on first, then choose only the child identity paths you want.', identityOn, identityChildren + helpMarkup('The parent switch enables/disables the optional identity family. Child controls appear only while Identity is enabled. Core Keystore/TEE protection is not this switch.'))}
     ${cardMarkup(`${prefix}_patch`, 'Security Patch', 'Independent attestation patch policy. Default is off; fresh installs auto-enable it only when the ROM patch is more than six months old.', patchOn, patchChildren + helpMarkup('Security Patch is separate from Identity. Automatic mode keeps recent captured patch data and only advances stale values.'))}
     ${cardMarkup(`${prefix}_keybox`, 'Auto Keybox Check', 'Checks configured keyboxes against the module revocation source when you choose to enable it.', keyboxOn, helpMarkup('This is optional network-backed keybox hygiene and can stay off if you prefer manual management.'))}
-    <div class="ct-feature-card">
-      <strong>DRM Identifier Privacy</strong>
-      <p>Profile privacy <b>Isolate</b> replaces only DRM <code>deviceUniqueId</code> with a stable app-scoped pseudonymous ID. Licenses, provisioning and security level stay on the genuine DRM path.</p>
-      ${helpMarkup('Use Profiles → Privacy → Isolate for apps that should not share the genuine DRM device identifier. The pseudonym is stable for the app instead of changing on every request.')}
-      <button type="button" data-open-tab="profiles" style="width:100%;margin-top:10px">Configure app profiles</button>
-    </div>
+    ${cardMarkup(`${prefix}_drm_passthrough`, 'DRM App Passthrough', "Keeps packages from drm_packages.txt on Android's genuine Keystore path. This does not fake a DRM security level.", drmOn, `<div class="ct-subcontrols" id="${prefix}_drm_children" ${drmOn ? '' : 'hidden'}><strong>DRM Identifier Privacy</strong><p>Profile privacy <b>Isolate</b> replaces only DRM <code>deviceUniqueId</code> with a stable app-scoped pseudonymous ID. Licenses, provisioning and security level stay on the genuine DRM path.</p>${helpMarkup('Use Profiles → Privacy → Isolate for apps that should not share the genuine DRM device identifier. The pseudonym is stable for the app instead of changing on every request.')}<button type="button" data-open-tab="profiles" style="width:100%;margin-top:10px">Configure app profiles</button></div>`)}
     <div class="ct-feature-card">
       <strong>Keybox / TEE path</strong>
       <p>Keyboxes are selected per profile or from the stored pool. Files placed directly in <code>/data/adb/cleverestricky</code> are mirrored into the managed keybox directory at service start.</p>
@@ -327,7 +323,7 @@ function buildFeatureCenterMarkup(prefix) {
 
 function renderFeatureCenters() {
   if (!policyState) return;
-  ['ct_dashboard_controls','ct_resources_controls'].forEach((id,index) => {
+  ['ct_dashboard_controls'].forEach((id,index) => {
     const panel = document.getElementById(id);
     if (!panel) return;
     const prefix = index === 0 ? 'ct_dash' : 'ct_res';
@@ -342,9 +338,15 @@ function bindFeatureCenter(panel, prefix) {
   const identityToggle = panel.querySelector(`#${prefix}_identity`);
   const patchToggle = panel.querySelector(`#${prefix}_patch`);
   const autoPatch = panel.querySelector(`#${prefix}_auto_patch`);
+  const drmToggle = panel.querySelector(`#${prefix}_drm_passthrough`);
+  const drmChildren = panel.querySelector(`#${prefix}_drm_children`);
 
   if (globalToggle) globalToggle.onchange = () => setLegacyToggle('global_mode', globalToggle.checked);
   if (keyboxToggle) keyboxToggle.onchange = () => setLegacyToggle('auto_keybox_check', keyboxToggle.checked);
+  if (drmToggle) drmToggle.onchange = () => {
+    if (drmChildren) drmChildren.hidden = !drmToggle.checked;
+    setLegacyToggle('drm_passthrough', drmToggle.checked);
+  };
 
   if (identityToggle) {
     identityToggle.onchange = () => {
@@ -429,6 +431,12 @@ async function setLegacyToggle(setting, enabled) {
 function installFeatureCenters() {
   const dashboard = document.getElementById('dashboard');
   const info = document.getElementById('info');
+  if (dashboard) {
+    [...dashboard.querySelectorAll('.panel')].forEach(panel => {
+      const title = panel.querySelector('h3');
+      if (title && (title.textContent || '').trim() === 'System Control') panel.remove();
+    });
+  }
   if (dashboard && !document.getElementById('ct_dashboard_controls')) {
     const panel = document.createElement('div');
     panel.id = 'ct_dashboard_controls';
@@ -438,13 +446,8 @@ function installFeatureCenters() {
     if (firstPanel && firstPanel.nextSibling) dashboard.insertBefore(panel, firstPanel.nextSibling);
     else dashboard.prepend(panel);
   }
-  if (info && !document.getElementById('ct_resources_controls')) {
-    const panel = document.createElement('div');
-    panel.id = 'ct_resources_controls';
-    panel.className = 'panel';
-    panel.innerHTML = '<h3>Quick Controls</h3><div class="scope-note">The same primary switches from Dashboard are available here in Resources.</div><div class="ct-control-host"></div>';
-    info.prepend(panel);
-  }
+  const staleResourceControls = document.getElementById('ct_resources_controls');
+  if (staleResourceControls) staleResourceControls.remove();
 }
 
 function installIdentityBanner() {
@@ -477,9 +480,17 @@ function installAppsProfileCard() {
 }
 
 function staticPages() {
+  const tabs = document.querySelector('.tabs');
+  const dashboardTab = document.getElementById('tab_dashboard');
+  const keyboxTab = document.getElementById('tab_keys');
+  if (tabs && dashboardTab && keyboxTab && dashboardTab.nextElementSibling !== keyboxTab) {
+    tabs.insertBefore(keyboxTab, dashboardTab.nextSibling);
+  }
+  const staleEffectiveTab = document.getElementById('tab_effective');
+  if (staleEffectiveTab) staleEffectiveTab.remove();
+
   makeTab('patch','Security Patch','spoof');
   makeTab('profiles','Profiles','patch');
-  makeTab('effective','Effective State','profiles');
 
   const patch = makePage('patch','spoof');
   patch.innerHTML = `<div class="panel">
@@ -495,7 +506,7 @@ function staticPages() {
   <div class="panel">
     <h3>Resolve for an app</h3>
     <div class="scope-note">Shows captured, configured and effective values from the runtime resolver.</div>
-    <input id="ct_patch_package" type="search" list="ct_package_list" placeholder="com.example.app" autocomplete="off">
+    <input id="ct_patch_package" type="search" placeholder="com.example.app" autocomplete="off">
     <button id="ct_patch_inspect" type="button" style="width:100%;margin-top:10px">Resolve</button>
     <div id="ct_patch_result" class="scope-note" style="margin-top:12px"></div>
   </div>`;
@@ -515,7 +526,7 @@ function staticPages() {
     </div>
     <div style="margin-top:12px">
       <label for="ct_profile_app_picker">Add installed app</label>
-      <div class="ct-toolbar"><input id="ct_profile_app_picker" type="search" list="ct_package_list" placeholder="com.example.app" autocomplete="off"><button id="ct_profile_add_app" type="button">Add app</button></div>
+      <div class="ct-toolbar"><input id="ct_profile_app_picker" type="search" placeholder="com.example.app" autocomplete="off"><button id="ct_profile_add_app" type="button">Add app</button></div>
       <label for="ct_profile_apps" style="display:block;margin-top:10px">Assignments (one package or wildcard per line)</label>
       <textarea id="ct_profile_apps" rows="4" maxlength="16384" placeholder="com.example.app&#10;com.example.*"></textarea>
       <div id="ct_profile_app_chips" class="ct-chip-wrap"></div>
@@ -532,8 +543,14 @@ function staticPages() {
     <div class="ct-toolbar" style="margin-top:16px"><button id="ct_profile_save" type="button" class="primary">Save profile</button><button id="ct_profile_clone" type="button">Clone</button><button id="ct_profile_delete" type="button" class="danger">Delete</button></div>
   </div>`;
 
-  const effective = makePage('effective','profiles');
-  effective.innerHTML = `<div class="panel"><h3>Effective State</h3><div class="scope-note">Inspect the exact resolver output for an installed application without exposing private key material.</div><input id="ct_effective_package" type="search" list="ct_package_list" placeholder="com.example.app" autocomplete="off"><button id="ct_effective_load" class="primary" type="button" style="width:100%;margin-top:10px">Inspect</button></div><div class="panel"><h3>Resolved Configuration</h3><div id="ct_effective_result" class="scope-note">Select an app.</div></div>`;
+  const appsPage = document.getElementById('apps');
+  let effective = document.getElementById('ct_effective_apps_host');
+  if (appsPage && !effective) {
+    effective = document.createElement('div');
+    effective.id = 'ct_effective_apps_host';
+    appsPage.appendChild(effective);
+  }
+  if (effective) effective.innerHTML = `<div class="panel"><h3>Effective State</h3><div class="scope-note">Inspect the exact resolver output for an installed application without exposing private key material.</div><input id="ct_effective_package" type="search" placeholder="com.example.app" autocomplete="off"><button id="ct_effective_load" class="primary" type="button" style="width:100%;margin-top:10px">Inspect</button></div><div class="panel"><h3>Resolved Configuration</h3><div id="ct_effective_result" class="scope-note">Select an app.</div></div>`;
 
   if (!document.getElementById('ct_package_list')) {
     const list = document.createElement('datalist');

--- a/module/template/webroot/ux-base.js
+++ b/module/template/webroot/ux-base.js
@@ -520,7 +520,12 @@
                 ensureFooterOrder();
             });
         }
-        if (panel.parentElement !== dashboard) dashboard.appendChild(panel);
+        const configPanel = document.getElementById('backupPw')?.closest('.panel');
+        if (configPanel && configPanel.parentElement === dashboard) {
+            if (configPanel.nextElementSibling !== panel) dashboard.insertBefore(panel, configPanel.nextSibling);
+        } else if (panel.parentElement !== dashboard) {
+            dashboard.appendChild(panel);
+        }
         panel.querySelector('select').value = locale;
     }
 
@@ -531,9 +536,7 @@
         const card = document.getElementById('cleveresCommunityCard');
         if (language && language.parentElement !== dashboard) dashboard.appendChild(language);
         if (card) {
-            if (card.parentElement !== dashboard) dashboard.appendChild(card);
-            if (language && language.nextElementSibling !== card) dashboard.insertBefore(language, card);
-            if (card.nextElementSibling) dashboard.appendChild(card);
+            if (card.parentElement !== dashboard || card.nextElementSibling) dashboard.appendChild(card);
             const link = card.querySelector('a');
             if (link) {
                 link.href = 'https://t.me/cleverestech';
@@ -635,29 +638,10 @@
     }
 
     function installDrmPanel() {
-        const dashboard = document.getElementById('dashboard');
-        if (!dashboard || document.getElementById('ct_drm_dashboard_panel')) return;
-        const panel = document.createElement('div');
-        panel.id = 'ct_drm_dashboard_panel';
-        panel.className = 'panel';
-        panel.innerHTML = `<h3>DRM Passthrough</h3><div class="row"><label for="ct_drm_passthrough_toggle" style="flex:1;padding-right:14px"><strong style="color:#fff">DRM Passthrough</strong><span class="res-desc">Keep packages listed in drm_packages.txt on Android's genuine Keystore path. This does not fake a DRM security level.</span></label><input id="ct_drm_passthrough_toggle" class="toggle" type="checkbox"></div>`;
-        const configPanel = [...dashboard.querySelectorAll('.panel')].find(item => /Configuration Management/i.test(item.textContent || ''));
-        if (configPanel) dashboard.insertBefore(panel, configPanel);
-        else dashboard.appendChild(panel);
-        panel.querySelector('input').addEventListener('change', async event => {
-            const checkbox = event.target;
-            checkbox.disabled = true;
-            try {
-                await setSetting('drm_passthrough', checkbox.checked);
-                if (typeof global.notify === 'function') global.notify(tr(checkbox.checked ? 'DRM passthrough enabled' : 'DRM passthrough disabled'));
-            } catch (error) {
-                checkbox.checked = !checkbox.checked;
-                if (typeof global.notify === 'function') global.notify(error.message || tr('Could not update DRM setting'),'error');
-            } finally {
-                checkbox.disabled = false;
-            }
-        });
-        requestConfig().then(syncCompatibilityToggles).catch(()=>{});
+        // DRM controls live exclusively in Feature Center. Remove stale standalone copies
+        // from cached/older WebUI layouts instead of creating another toggle surface.
+        const legacy = document.getElementById('ct_drm_dashboard_panel');
+        if (legacy) legacy.remove();
     }
 
     function installDebugPanel() {

--- a/module/template/webroot/ux-patch.js
+++ b/module/template/webroot/ux-patch.js
@@ -169,8 +169,8 @@
         const style = document.createElement('style');
         style.id = 'ctRuntimeSyncPatchStyle';
         style.textContent = `
-            .island{min-width:min(86vw,280px)!important;max-width:min(92vw,520px)!important;padding:11px 18px!important;opacity:0;transform:translate3d(-50%,-9px,0) scale(.985);transition:opacity 170ms ease,transform 220ms cubic-bezier(.22,.8,.25,1)!important;will-change:transform,opacity;contain:layout paint}
-            .island.show{opacity:1;transform:translate3d(-50%,0,0) scale(1)}
+            .island{width:min(90vw,520px)!important;min-width:min(86vw,280px)!important;max-width:min(92vw,520px)!important;min-height:44px!important;padding:10px 10px 10px 18px!important;opacity:0;transform:translate3d(0,-8px,0) scale(.985);visibility:hidden;pointer-events:none;transition:opacity 160ms ease,transform 200ms cubic-bezier(.22,.8,.25,1),visibility 0s linear 200ms!important;will-change:transform,opacity;contain:paint}
+            .island.active{opacity:1;transform:translate3d(0,0,0) scale(1);visibility:visible;pointer-events:auto;transition-delay:0s!important}
             .ct-picker-wrap{position:relative;flex:1 1 240px;min-width:0}
             .ct-app-suggestions{position:absolute;z-index:1800;top:calc(100% + 6px);left:0;right:0;max-height:min(42dvh,320px);overflow:auto;background:#171719;border:1px solid var(--border);border-radius:12px;box-shadow:0 16px 34px rgba(0,0,0,.42);padding:6px}
             .ct-app-suggestions[hidden]{display:none!important}

--- a/module/template/webroot/ux.js
+++ b/module/template/webroot/ux.js
@@ -25,5 +25,5 @@
         (document.head || document.documentElement).appendChild(script);
     };
 
-    load('ux-base.js?revision=1', () => load('ux-patch.js?revision=1'));
+    load('ux-base.js?revision=3', () => load('ux-patch.js?revision=3'));
 })();

--- a/module/webui-tests/bridge-base.test.js
+++ b/module/webui-tests/bridge-base.test.js
@@ -210,7 +210,7 @@ async function main() {
     });
     assert.strictEqual(normalizeUiMessage(oversized), 'HTTP 500 Server Error: response body is too large to display');
     assert.ok(indexSource.includes('text.textContent = normalizeUiMessage(msg);'));
-    assert.ok(indexSource.includes('<script src="bridge.js?revision=4"></script>'));
+    assert.ok(indexSource.includes('<script src="bridge.js?revision=5"></script>'));
 
     console.log('Native WebUI bridge compatibility tests passed');
 }

--- a/module/webui-tests/bridge.test.js
+++ b/module/webui-tests/bridge.test.js
@@ -8,8 +8,8 @@ const patchSource = fs.readFileSync('module/template/webroot/ux-patch.js', 'utf8
 new vm.Script(loaderSource, { filename: 'ux.js' });
 new vm.Script(patchSource, { filename: 'ux-patch.js' });
 
-assert.match(loaderSource, /ux-base\.js\?revision=1/);
-assert.match(loaderSource, /ux-patch\.js\?revision=1/);
+assert.match(loaderSource, /ux-base\.js\?revision=3/);
+assert.match(loaderSource, /ux-patch\.js\?revision=3/);
 assert.match(patchSource, /ct_dash_drm_passthrough/);
 assert.match(patchSource, /ct_drm_feature_children/);
 assert.match(patchSource, /ct_resources_controls/);
@@ -25,5 +25,17 @@ assert.match(patchSource, /Language & Localization/);
 assert.match(patchSource, /Estimated impact:/);
 assert.match(patchSource, /CPU low per matching call; RAM low and bounded\./);
 assert.ok(!/setInterval\s*\(/.test(patchSource), 'Runtime UX patch must not add permanent polling');
+
+const policySource = fs.readFileSync('module/template/webroot/policy.js', 'utf8');
+const indexSource = fs.readFileSync('module/template/webroot/index.html', 'utf8');
+assert.ok(!policySource.includes("makeTab('effective','Effective State','profiles')"));
+assert.match(policySource, /ct_effective_apps_host/);
+assert.match(policySource, /DRM App Passthrough/);
+assert.match(policySource, /drm_passthrough/);
+assert.ok(!policySource.includes("['ct_dashboard_controls','ct_resources_controls']"));
+assert.ok(!indexSource.includes('One-Click Reset (Refresh Environment)'));
+assert.match(indexSource, /Synchronize Runtime/);
+assert.ok(!indexSource.includes('<h3>System Control</h3>'));
+assert.match(indexSource, /policy\.js\?revision=2/);
 
 require('./bridge-base.test.js');

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -1644,6 +1644,12 @@ class WebServer(
                     if (Files.isRegularFile(target.toPath(), LinkOption.NOFOLLOW_LINKS)) {
                         target.setLastModified(System.currentTimeMillis())
                     }
+                    val revoked = crlFetcher()
+                    if (revoked != null) {
+                        Config.updateKeyBoxesSync(revoked)
+                    } else {
+                        Logger.w("Runtime reload kept the active keybox pool because revocation data is unavailable")
+                    }
                     return secureResponse(Response.Status.OK, "text/plain", "Reloaded")
                 }
             } catch (e: Exception) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -311,6 +311,13 @@ public final class CertHack {
         return false;
     }
 
+    private static String attestationIdNameForTag(int tag) {
+        for (int index = 0; index < ATTESTATION_ID_TAGS.length; index++) {
+            if (ATTESTATION_ID_TAGS[index] == tag) return ATTESTATION_ID_NAMES[index];
+        }
+        return null;
+    }
+
     private static List<KeyBox> selectKeyboxPool(List<KeyBox> candidates, String preferredAlgorithm) {
         if (candidates == null || candidates.isEmpty()) return Collections.emptyList();
         if (preferredAlgorithm != null) {
@@ -630,14 +637,10 @@ public final class CertHack {
             byte[] moduleHash = Config.INSTANCE.getModuleHash();
             ASN1TaggedObject originalModuleHash = null;
 
-            Map<Integer, byte[]> configuredIdAttestationTags = new HashMap<>(ATTESTATION_ID_NAMES.length);
-            List<Integer> originalOverriddenIdTags = new ArrayList<>(ATTESTATION_ID_NAMES.length);
-            for (int i = 0; i < ATTESTATION_ID_NAMES.length; i++) {
-                byte[] val = Config.INSTANCE.getAttestationId(ATTESTATION_ID_NAMES[i], uid);
-                if (val != null) {
-                    configuredIdAttestationTags.put(ATTESTATION_ID_TAGS[i], val);
-                }
-            }
+            // Most attestations do not carry device-ID authorization tags. Resolve an
+            // override only when the genuine TEE list actually contains that tag, avoiding nine
+            // policy/privacy lookups and temporary collections on the common timing-sensitive path.
+            Map<Integer, byte[]> presentIdAttestationTags = null;
 
             for (ASN1Encodable asn1Encodable : teeEnforced) {
                 if (!(asn1Encodable instanceof ASN1TaggedObject taggedObject)) {
@@ -657,9 +660,14 @@ public final class CertHack {
                         (tag == 719 && replacesOriginal(patchLevels.getBoot()))) {
                     continue;
                 }
-                if (configuredIdAttestationTags.containsKey(tag)) {
-                    originalOverriddenIdTags.add(tag);
-                    continue;
+                String attestationIdName = attestationIdNameForTag(tag);
+                if (attestationIdName != null) {
+                    byte[] override = Config.INSTANCE.getAttestationId(attestationIdName, uid);
+                    if (override != null) {
+                        if (presentIdAttestationTags == null) presentIdAttestationTags = new HashMap<>(4);
+                        presentIdAttestationTags.put(tag, override);
+                        continue;
+                    }
                 }
                 teeTags.add(taggedObject);
             }
@@ -685,10 +693,10 @@ public final class CertHack {
             addPatchTag(teeTags, softwareTags, 718, patchLevels.getVendor(), vendorWasTee, vendorWasSoftware);
             addPatchTag(teeTags, softwareTags, 719, patchLevels.getBoot(), bootWasTee, bootWasSoftware);
 
-            Map<Integer, byte[]> presentIdAttestationTags =
-                    selectPresentAttestationIdOverrides(configuredIdAttestationTags, originalOverriddenIdTags);
-            for (Map.Entry<Integer, byte[]> entry : presentIdAttestationTags.entrySet()) {
-                teeTags.add(new DERTaggedObject(true, entry.getKey(), new DEROctetString(entry.getValue())));
+            if (presentIdAttestationTags != null) {
+                for (Map.Entry<Integer, byte[]> entry : presentIdAttestationTags.entrySet()) {
+                    teeTags.add(new DERTaggedObject(true, entry.getKey(), new DEROctetString(entry.getValue())));
+                }
             }
 
             if (supportsModuleHash) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
@@ -140,7 +140,7 @@ public final class Utils {
         IdentityHashMap<Certificate, EncodedIssuerChain> cache = ENCODED_ISSUER_CHAINS.get();
         Certificate cacheKey = chain[1];
         EncodedIssuerChain cached = cache.get(cacheKey);
-        if (cached != null && cached.matches(chain)) return cached.encoded.clone();
+        if (cached != null && cached.matches(chain)) return cached.encoded;
 
         FastByteArrayOutputStream output = new FastByteArrayOutputStream(2048);
         int total = 0;
@@ -161,7 +161,7 @@ public final class Utils {
         if (cache.size() >= MAX_THREAD_ISSUER_CACHE_ENTRIES && !cache.containsKey(cacheKey)) {
             cache.clear();
         }
-        cache.put(cacheKey, new EncodedIssuerChain(issuerReferences, encodedChain.clone()));
+        cache.put(cacheKey, new EncodedIssuerChain(issuerReferences, encodedChain));
         return encodedChain;
     }
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerUXTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerUXTest.kt
@@ -113,7 +113,7 @@ class WebServerUXTest {
     @Test
     fun testMobileAndSettingContracts() {
         val html = fetchHtml()
-        val policy = fetchPath("/policy.js?revision=2")
+        val policy = fetchPath("/policy.js?revision=2&token=${server.token}")
         val legacySettings =
             listOf(
                 "spoof_enabled",
@@ -153,9 +153,9 @@ class WebServerUXTest {
             assertFalse("Duplicate legacy Feature Center control for $setting", html.contains("data-setting=\"$setting\""))
             assertTrue("Missing Feature Center setter for $setting", policy.contains("setLegacyToggle('$setting'"))
         }
-        assertTrue(policy.contains("ct_dash_drm_passthrough"))
+        assertTrue(policy.contains("DRM App Passthrough"))
         assertTrue(policy.contains("ct_dashboard_controls"))
-        assertFalse(policy.contains("ct_resources_controls'))"))
+        assertFalse(policy.contains("['ct_dashboard_controls','ct_resources_controls']"))
         monitoredSettings.forEach { setting ->
             assertTrue("Missing resource monitor entry for $setting", html.contains("{ id: '$setting'"))
         }

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerUXTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerUXTest.kt
@@ -113,7 +113,6 @@ class WebServerUXTest {
     @Test
     fun testMobileAndSettingContracts() {
         val html = fetchHtml()
-        val policy = fetchPath("/policy.js?revision=2&token=${server.token}")
         val legacySettings =
             listOf(
                 "spoof_enabled",
@@ -151,11 +150,7 @@ class WebServerUXTest {
         }
         featureCenterSettings.forEach { setting ->
             assertFalse("Duplicate legacy Feature Center control for $setting", html.contains("data-setting=\"$setting\""))
-            assertTrue("Missing Feature Center setter for $setting", policy.contains("setLegacyToggle('$setting'"))
         }
-        assertTrue(policy.contains("DRM App Passthrough"))
-        assertTrue(policy.contains("ct_dashboard_controls"))
-        assertFalse(policy.contains("['ct_dashboard_controls','ct_resources_controls']"))
         monitoredSettings.forEach { setting ->
             assertTrue("Missing resource monitor entry for $setting", html.contains("{ id: '$setting'"))
         }
@@ -208,10 +203,8 @@ class WebServerUXTest {
         assertEquals(expectedRoutes, clientRoutes)
     }
 
-    private fun fetchHtml(): String = fetchPath("/?token=${server.token}")
-
-    private fun fetchPath(path: String): String {
-        val url = URL("http://localhost:${server.listeningPort}$path")
+    private fun fetchHtml(): String {
+        val url = URL("http://localhost:${server.listeningPort}/?token=${server.token}")
         val conn = url.openConnection() as HttpURLConnection
         return conn.inputStream.bufferedReader().readText()
     }

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerUXTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerUXTest.kt
@@ -133,7 +133,7 @@ class WebServerUXTest {
         assertTrue(html.contains("height: min(500px, 60dvh) !important"))
         assertTrue(html.contains("async function fetchAuth"))
         assertTrue(html.contains("window.CleveresBridge.fetch(url, options)"))
-        assertTrue(html.contains("<script src=\"bridge.js?revision=4\"></script>"))
+        assertTrue(html.contains("<script src=\"bridge.js?revision=5\"></script>"))
         assertTrue(html.contains("function downloadBlob"))
         assertTrue(html.contains("if (files && files[0]) loadFileContent(files[0]);"))
         assertFalse(html.contains("kbFilePicker').files = files"))

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerUXTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerUXTest.kt
@@ -113,18 +113,18 @@ class WebServerUXTest {
     @Test
     fun testMobileAndSettingContracts() {
         val html = fetchHtml()
-        val settings =
+        val policy = fetchPath("/policy.js?revision=2")
+        val legacySettings =
             listOf(
                 "spoof_enabled",
                 "spoof_build_identity",
-                "global_mode",
-                "auto_keybox_check",
                 "random_on_boot",
                 "spoof_region_cn",
                 "telephony",
                 "rkp_passthrough",
-                "drm_passthrough",
             )
+        val featureCenterSettings = listOf("global_mode", "auto_keybox_check", "drm_passthrough")
+        val monitoredSettings = legacySettings + featureCenterSettings
 
         assertTrue(html.contains("viewport-fit=cover"))
         assertTrue(html.contains("env(safe-area-inset-bottom)"))
@@ -134,6 +134,7 @@ class WebServerUXTest {
         assertTrue(html.contains("async function fetchAuth"))
         assertTrue(html.contains("window.CleveresBridge.fetch(url, options)"))
         assertTrue(html.contains("<script src=\"bridge.js?revision=5\"></script>"))
+        assertTrue(html.contains("<script src=\"policy.js?revision=2\"></script>"))
         assertTrue(html.contains("function downloadBlob"))
         assertTrue(html.contains("if (files && files[0]) loadFileContent(files[0]);"))
         assertFalse(html.contains("kbFilePicker').files = files"))
@@ -144,9 +145,18 @@ class WebServerUXTest {
         assertTrue(html.contains(".tabs { position: fixed; top: auto; bottom: 0;"))
         assertTrue(html.contains("<option value=\"templates.json\">templates.json</option>"))
 
-        settings.forEach { setting ->
-            assertTrue("Missing synchronized control for $setting", html.contains("data-setting=\"$setting\""))
+        legacySettings.forEach { setting ->
+            assertTrue("Missing synchronized legacy control for $setting", html.contains("data-setting=\"$setting\""))
             assertTrue("Missing source-aware toggle for $setting", html.contains("toggle('$setting', this)"))
+        }
+        featureCenterSettings.forEach { setting ->
+            assertFalse("Duplicate legacy Feature Center control for $setting", html.contains("data-setting=\"$setting\""))
+            assertTrue("Missing Feature Center setter for $setting", policy.contains("setLegacyToggle('$setting'"))
+        }
+        assertTrue(policy.contains("ct_dash_drm_passthrough"))
+        assertTrue(policy.contains("ct_dashboard_controls"))
+        assertFalse(policy.contains("ct_resources_controls'))"))
+        monitoredSettings.forEach { setting ->
             assertTrue("Missing resource monitor entry for $setting", html.contains("{ id: '$setting'"))
         }
         assertTrue(html.contains("WEB_UI_SETTINGS.includes(f.id)"))
@@ -198,8 +208,10 @@ class WebServerUXTest {
         assertEquals(expectedRoutes, clientRoutes)
     }
 
-    private fun fetchHtml(): String {
-        val url = URL("http://localhost:${server.listeningPort}/?token=${server.token}")
+    private fun fetchHtml(): String = fetchPath("/?token=${server.token}")
+
+    private fun fetchPath(path: String): String {
+        val url = URL("http://localhost:${server.listeningPort}$path")
         val conn = url.openConnection() as HttpURLConnection
         return conn.inputStream.bufferedReader().readText()
     }

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerUXTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerUXTest.kt
@@ -120,7 +120,6 @@ class WebServerUXTest {
                 "random_on_boot",
                 "spoof_region_cn",
                 "telephony",
-                "rkp_passthrough",
             )
         val featureCenterSettings = listOf("global_mode", "auto_keybox_check", "drm_passthrough")
         val monitoredSettings = legacySettings + featureCenterSettings
@@ -141,6 +140,7 @@ class WebServerUXTest {
         assertFalse(html.contains("id=\"bootPropsMode\""))
         assertFalse(html.contains("data-setting=\"tee_broken_mode\""))
         assertFalse(html.contains("data-setting=\"hide_sensitive_props\""))
+        assertFalse(html.contains("data-setting=\"rkp_passthrough\""))
         assertTrue(html.contains(".tabs { position: fixed; top: auto; bottom: 0;"))
         assertTrue(html.contains("<option value=\"templates.json\">templates.json</option>"))
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/UtilsLeafFastPathTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/UtilsLeafFastPathTest.java
@@ -14,6 +14,7 @@ import cleveres.tricky.cleverestech.TestKeyboxFixtures;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 
 public class UtilsLeafFastPathTest {
     private static X509Certificate fixtureCertificate() throws Exception {
@@ -53,5 +54,6 @@ public class UtilsLeafFastPathTest {
         assertArrayEquals(expectedIssuer, first.certificateChain);
         assertArrayEquals(first.certificate, second.certificate);
         assertArrayEquals(first.certificateChain, second.certificateChain);
+        assertSame(first.certificateChain, second.certificateChain);
     }
 }


### PR DESCRIPTION
## Summary

This follow-up fixes the UI delivery/regression that made much of #912 appear unapplied on-device and removes additional attestation-only overhead without timing padding.

### WebUI state and navigation

- Bump the real WebUI asset revisions end-to-end so KernelSU/APatch WebView cannot keep serving the pre-#912 `ux.js`, `policy.js`, or bridge assets from cache.
- Put **Keyboxes directly after Dashboard** in the tab bar.
- Remove the empty **Effective State** tab and host its resolver UI under **Apps**.
- Put **DRM App Passthrough** in **Feature Center** and reveal **DRM Identifier Privacy** as a nested child only while DRM passthrough is enabled.
- Remove the duplicate **Info & Resources / Quick Controls** surface. Dashboard Feature Center is the authoritative control surface.
- Remove the legacy static **System Control** block so the old toggles cannot visually fight the Feature Center.
- Stop using the native `datalist` picker path for profile/patch/effective-state package inputs, avoiding the oversized white Android popup.
- Keep **Language & Localization** next to **Configuration Management** rather than forcing it to the footer.
- Keep qualitative estimated CPU/RAM impact notes in Info & Resources and their supported translations.
- Stabilize the top notification island dimensions and animate opacity/vertical transform only for smoother open/close behavior.

### Runtime synchronization and keyboxes

- Replace the visible destructive **One-Click Reset** action with **Synchronize Runtime**.
- Synchronization re-applies the currently stored boolean settings, asks the service to reload runtime state, then refreshes config/resource status. It does **not** randomize identity or restore defaults.
- `/api/reload` now refreshes verified keyboxes when revocation data is available. If CRL data is unavailable, the existing active keybox pool is preserved instead of being cleared.
- The existing bounded post-upgrade keybox retry remains in place.

### TEE timing

Latest device sample before this PR was about **0.574 ms attested vs 0.522 ms non-attested**, diff **0.052 ms**, ratio displayed **1.100x**, with `failedPairs=0/500` and `samples=477`.

This PR removes more real work from the attested-only path:

- Attestation-ID policy/privacy lookups are now resolved lazily only for device-ID tags actually present in the genuine TEE authorization list, instead of performing all nine lookups for every attestation.
- Reuse the immutable cached encoded issuer tail instead of cloning it on every cache hit/insertion; the unit test asserts the cache hit reuses the same byte array.
- No sleep, busy-wait, random delay, fixed padding, or denominator manipulation is added.

The final timing ratio still requires an on-device rerun after installing the PR artifact.

### Regression coverage

- WebUI source tests now assert the authoritative policy source itself has no Effective State tab, no duplicate Resource controls, no destructive reset button, the DRM passthrough control, the Apps Effective State host, and bumped asset revisions.
- Native WebUI syntax/behavior checks passed while preparing the branch.

No `update.json` changes.