### PR TITLE
Harden runtime retry and keybox refresh scheduling

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
@@ -69,9 +69,14 @@ fun main(args: Array<String>) {
             return@runBlocking
         }
 
+        runCatching { KeyboxDirectoryRefreshWatcher.start(Config.keyboxDirectory) }
+            .onFailure { Logger.e("Failed to install conflated keybox watcher; keeping legacy observer", it) }
+
         try {
             WebUiBridge(WebServer(0, configDir), configDir).start()
         } catch (e: Exception) {
+            KeyboxDirectoryRefreshWatcher.stop()
+            CertificatePolicyWatcher.stop()
             Logger.e("Failed to start native WebUI bridge", e)
             Logger.e("Main: Exiting so the module supervisor can restore native WebUI service")
             return@runBlocking
@@ -105,6 +110,7 @@ fun main(args: Array<String>) {
         var previousDrmEngineState: Boolean? = null
         var telephonyStopPending = false
         var drmStopPending = false
+        var runtimeRetryDelayMs = RUNTIME_RETRY_INITIAL_MS
         while (true) {
             val identityEngineEnabled = Config.isSpoofEnabled
             if (previousIdentityEngineState != identityEngineEnabled) {
@@ -197,17 +203,20 @@ fun main(args: Array<String>) {
             if (!telSuccess) Logger.d("Telephony interceptor not ready yet")
             if (!drmSuccess) Logger.d("DRM privacy interceptor not ready yet")
 
+            val runtimeHealthy =
+                ksSuccess && telSuccess && drmSuccess && !telephonyStopPending && !drmStopPending
+            val controllerWaitMs = if (runtimeHealthy) 30_000L else runtimeRetryDelayMs
             try {
-                Config.awaitRuntimeController(
-                    if (ksSuccess && telSuccess && drmSuccess && !telephonyStopPending && !drmStopPending) 30_000 else 1_000,
-                )
+                Config.awaitRuntimeController(controllerWaitMs)
             } catch (_: InterruptedException) {
                 Thread.currentThread().interrupt()
+                KeyboxDirectoryRefreshWatcher.stop()
                 CertificatePolicyWatcher.stop()
                 DrmInterceptor.stopDrmInterceptor()
                 Logger.i("Main: Runtime controller interrupted, shutting down")
                 return@runBlocking
             }
+            runtimeRetryDelayMs = nextRuntimeRetryDelayMs(runtimeRetryDelayMs, runtimeHealthy)
         }
     }
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/RuntimeWorkCoordinator.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/RuntimeWorkCoordinator.kt
@@ -1,0 +1,101 @@
+package cleveres.tricky.cleverestech
+
+import android.os.FileObserver
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.io.File
+
+internal const val RUNTIME_RETRY_INITIAL_MS = 1_000L
+internal const val RUNTIME_RETRY_MAX_MS = 30_000L
+private const val KEYBOX_REFRESH_DEBOUNCE_MS = 250L
+
+internal fun nextRuntimeRetryDelayMs(
+    currentDelayMs: Long,
+    healthy: Boolean,
+): Long {
+    if (healthy) return RUNTIME_RETRY_INITIAL_MS
+    val normalized = currentDelayMs.coerceAtLeast(RUNTIME_RETRY_INITIAL_MS)
+    return if (normalized >= RUNTIME_RETRY_MAX_MS / 2) {
+        RUNTIME_RETRY_MAX_MS
+    } else {
+        normalized * 2
+    }
+}
+
+/**
+ * Keeps one refresh active and at most one debounced follow-up queued.
+ * A burst of FileObserver events therefore cannot fan out into parallel scans.
+ */
+internal class ConflatedRefreshScheduler(
+    private val scope: CoroutineScope,
+    private val debounceMs: Long,
+    private val refresh: suspend () -> Unit,
+) {
+    private val executionMutex = Mutex()
+    private val stateLock = Any()
+    private var pendingJob: Job? = null
+
+    init {
+        require(debounceMs >= 0) { "debounceMs must not be negative" }
+    }
+
+    fun submit() {
+        synchronized(stateLock) {
+            pendingJob?.cancel()
+            pendingJob =
+                scope.launch {
+                    if (debounceMs > 0) delay(debounceMs)
+                    executionMutex.withLock { refresh() }
+                }
+        }
+    }
+
+    fun cancel() {
+        synchronized(stateLock) {
+            pendingJob?.cancel()
+            pendingJob = null
+        }
+    }
+}
+
+/** Replaces the legacy one-coroutine-per-event keybox observer with a conflated watcher. */
+internal object KeyboxDirectoryRefreshWatcher {
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val scheduler =
+        ConflatedRefreshScheduler(scope, KEYBOX_REFRESH_DEBOUNCE_MS) {
+            Config.updateKeyBoxesSync()
+        }
+    private var observer: FileObserver? = null
+
+    @Synchronized
+    fun start(directory: File) {
+        if (observer != null) return
+
+        // Config.initialize() starts the original observer after its initial synchronous scan.
+        // Stop it before installing the conflated replacement so both cannot react to one event.
+        Config.KeyboxDirObserver.stopWatching()
+        observer =
+            object : FileObserver(directory, CLOSE_WRITE or DELETE or MOVED_FROM or MOVED_TO) {
+                override fun onEvent(
+                    event: Int,
+                    path: String?,
+                ) {
+                    Logger.i("Keybox directory event: $path")
+                    scheduler.submit()
+                }
+            }.also(FileObserver::startWatching)
+    }
+
+    @Synchronized
+    fun stop() {
+        observer?.stopWatching()
+        observer = null
+        scheduler.cancel()
+    }
+}

--- a/service/src/main/java/cleveres/tricky/cleverestech/RuntimeWorkCoordinator.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/RuntimeWorkCoordinator.kt
@@ -77,10 +77,9 @@ internal object KeyboxDirectoryRefreshWatcher {
     fun start(directory: File) {
         if (observer != null) return
 
-        // Config.initialize() starts the original observer after its initial synchronous scan.
-        // Stop it before installing the conflated replacement so both cannot react to one event.
-        Config.KeyboxDirObserver.stopWatching()
-        observer =
+        // Config.initialize() already started the legacy observer. Start the replacement first so
+        // a failure leaves the original observer intact, then retire the old one after hand-off.
+        val replacement =
             object : FileObserver(directory, CLOSE_WRITE or DELETE or MOVED_FROM or MOVED_TO) {
                 override fun onEvent(
                     event: Int,
@@ -89,7 +88,10 @@ internal object KeyboxDirectoryRefreshWatcher {
                     Logger.i("Keybox directory event: $path")
                     scheduler.submit()
                 }
-            }.also(FileObserver::startWatching)
+            }
+        replacement.startWatching()
+        Config.KeyboxDirObserver.stopWatching()
+        observer = replacement
     }
 
     @Synchronized

--- a/service/src/test/java/cleveres/tricky/cleverestech/RuntimeWorkCoordinatorTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/RuntimeWorkCoordinatorTest.kt
@@ -1,0 +1,85 @@
+package cleveres.tricky.cleverestech
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class RuntimeWorkCoordinatorTest {
+    @Test
+    fun retryBackoffCapsAndResetsAfterRecovery() {
+        var delayMs = RUNTIME_RETRY_INITIAL_MS
+        val observed = ArrayList<Long>()
+        repeat(8) {
+            observed.add(delayMs)
+            delayMs = nextRuntimeRetryDelayMs(delayMs, healthy = false)
+        }
+
+        assertEquals(
+            listOf(1_000L, 2_000L, 4_000L, 8_000L, 16_000L, 30_000L, 30_000L, 30_000L),
+            observed,
+        )
+        assertEquals(RUNTIME_RETRY_INITIAL_MS, nextRuntimeRetryDelayMs(delayMs, healthy = true))
+    }
+
+    @Test
+    fun refreshSchedulerConflatesBurstIntoSingleRefresh() {
+        val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+        val refreshed = CountDownLatch(1)
+        val count = AtomicInteger(0)
+        val scheduler =
+            ConflatedRefreshScheduler(scope, debounceMs = 50L) {
+                count.incrementAndGet()
+                refreshed.countDown()
+            }
+
+        try {
+            repeat(32) { scheduler.submit() }
+            assertTrue("Debounced refresh did not run", refreshed.await(2, TimeUnit.SECONDS))
+            Thread.sleep(150)
+            assertEquals(1, count.get())
+        } finally {
+            scheduler.cancel()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun refreshSchedulerKeepsOnlyLatestFollowUpWhileRefreshIsActive() {
+        val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+        val firstStarted = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+        val secondFinished = CountDownLatch(1)
+        val count = AtomicInteger(0)
+        val scheduler =
+            ConflatedRefreshScheduler(scope, debounceMs = 10L) {
+                when (count.incrementAndGet()) {
+                    1 -> {
+                        firstStarted.countDown()
+                        releaseFirst.await(2, TimeUnit.SECONDS)
+                    }
+                    2 -> secondFinished.countDown()
+                }
+            }
+
+        try {
+            scheduler.submit()
+            assertTrue("Initial refresh did not start", firstStarted.await(2, TimeUnit.SECONDS))
+            repeat(32) { scheduler.submit() }
+            releaseFirst.countDown()
+            assertTrue("Conflated follow-up refresh did not run", secondFinished.await(2, TimeUnit.SECONDS))
+            Thread.sleep(100)
+            assertEquals(2, count.get())
+        } finally {
+            releaseFirst.countDown()
+            scheduler.cancel()
+            scope.cancel()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Non-urgent runtime hardening following a performance review.

- back off unhealthy interceptor controller retries from 1s up to 30s while preserving immediate wake-ups from runtime signals
- replace one-coroutine-per-KeyboxDirObserver-event refreshes with a debounced, conflated scheduler
- keep the legacy keybox observer alive until the replacement watcher starts successfully
- add regression coverage for retry reset/capping and keybox refresh burst coalescing

## Motivation

Healthy devices already use the normal low-overhead path. These changes target degraded/unsupported environments where repeated hook discovery or file-event bursts could otherwise create unnecessary procfs scans, log I/O, or duplicate keybox verification work.

## Test plan

- `RuntimeWorkCoordinatorTest.retryBackoffCapsAndResetsAfterRecovery`
- `RuntimeWorkCoordinatorTest.refreshSchedulerConflatesBurstIntoSingleRefresh`
- `RuntimeWorkCoordinatorTest.refreshSchedulerKeepsOnlyLatestFollowUpWhileRefreshIsActive`
- full repository PR CI before merge
