### PR TITLE
Harden native Binder interception and injection core

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,9 @@ val abiList = listOf("arm64-v8a", "x86_64")
 val androidMinSdkVersion = 31
 val androidTargetSdkVersion = 37
 val androidCompileSdkVersion = 37
-val androidMaxSupportedSdkVersion = 37
+// API levels newer than the compiler baseline are admitted to installation;
+// the native interceptor still enables itself only after live Binder UAPI validation.
+val androidMaxSupportedSdkVersion = 999
 val androidCompileNdkVersion = "27.3.13750724"
 val androidSourceCompatibility = JavaVersion.VERSION_17
 val androidTargetCompatibility = JavaVersion.VERSION_17

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,9 +48,7 @@ val abiList = listOf("arm64-v8a", "x86_64")
 val androidMinSdkVersion = 31
 val androidTargetSdkVersion = 37
 val androidCompileSdkVersion = 37
-// API levels newer than the compiler baseline are admitted to installation;
-// the native interceptor still enables itself only after live Binder UAPI validation.
-val androidMaxSupportedSdkVersion = 999
+val androidMaxSupportedSdkVersion = 37
 val androidCompileNdkVersion = "27.3.13750724"
 val androidSourceCompatibility = JavaVersion.VERSION_17
 val androidTargetCompatibility = JavaVersion.VERSION_17

--- a/module/src/main/cpp/binder_interceptor.cpp
+++ b/module/src/main/cpp/binder_interceptor.cpp
@@ -165,6 +165,9 @@ OffsetCache &OffsetCache::instance() {
 }
 
 namespace {
+constexpr int kMinimumSupportedAndroidApi = 31;
+constexpr int kMaximumValidatedCompilerFallbackApi = 37;
+
 RustOffsetCacheView rustOffsetView(const OffsetCache &cache) {
   return RustOffsetCacheView{cache.target_ptr_offset,
                              cache.cookie_offset,
@@ -357,7 +360,8 @@ bool AdaptiveBinderInterceptor::parseKernelVersion(int &major, int &minor) {
 
 bool AdaptiveBinderInterceptor::initFallback(OffsetCache &cache,
                                              int api_level) {
-  if (api_level < 31 || api_level > 37) {
+  if (api_level < kMinimumSupportedAndroidApi ||
+      api_level > kMaximumValidatedCompilerFallbackApi) {
     LOGE("Fallback layout rejected unsupported Android API %d", api_level);
     return false;
   }
@@ -374,10 +378,17 @@ bool AdaptiveBinderInterceptor::initialize() {
   OffsetCache &cache = OffsetCache::instance();
 
   const int android_api_level = detectApiLevel();
-  if (android_api_level < 31 || android_api_level > 37) {
+  if (android_api_level < kMinimumSupportedAndroidApi) {
     LOGE("AdaptiveBinderInterceptor: unsupported Android API %d",
          android_api_level);
     return false;
+  }
+  const bool requires_live_layout =
+      android_api_level > kMaximumValidatedCompilerFallbackApi;
+  if (requires_live_layout) {
+    LOGW("Android API %d is newer than the compiler fallback; requiring live "
+         "Binder UAPI validation",
+         android_api_level);
   }
   std::string kernel_version;
   int kmajor = 0, kminor = 0;
@@ -393,6 +404,14 @@ bool AdaptiveBinderInterceptor::initialize() {
   if (RuntimeLayoutValidator::validateLayout(cache)) {
     LOGI("Strategy: live Binder UAPI validation succeeded");
     return true;
+  }
+
+  if (requires_live_layout) {
+    LOGE("Live Binder validation failed on future Android API %d; refusing an "
+         "unverified layout",
+         android_api_level);
+    cache.valid = false;
+    return false;
   }
 
   if (initFallback(cache, android_api_level)) {
@@ -497,12 +516,20 @@ int new_ioctl(int fd, unsigned long request, ...) {
   va_start(list, request);
   auto arg = va_arg(list, void *);
   va_end(list);
+  const bool hook_ready = gHooksInitialized.load(std::memory_order_acquire);
   const int result =
-      old_ioctl != nullptr
+      hook_ready && old_ioctl != nullptr
           ? old_ioctl(fd, request, arg)
           : static_cast<int>(syscall(SYS_ioctl, fd, request, arg));
 
   if (result >= 0 && request == BINDER_WRITE_READ) {
+    // CommitHook can make this trampoline observable by another Binder thread
+    // before initialize_hooks() finishes publishing the interceptor objects
+    // and validated offsets. The acquire pairs with the release store after
+    // hook installation and keeps that short window pass-through only.
+    if (!hook_ready) {
+      return result;
+    }
     if (gHookPaused.load(std::memory_order_acquire)) {
       return result;
     }
@@ -617,8 +644,7 @@ bool BinderInterceptor::shouldIntercept(const wp<BBinder> &target,
   if (it == items.end())
     return false;
   const auto &codes = it->second.filtered_codes;
-  return codes.empty() ||
-         std::find(codes.begin(), codes.end(), code) != codes.end();
+  return std::binary_search(codes.begin(), codes.end(), code);
 }
 
 status_t BinderInterceptor::onTransact(uint32_t code,
@@ -648,7 +674,7 @@ status_t BinderInterceptor::onTransact(uint32_t code,
     std::vector<uint32_t> codes;
     int32_t code_count = 0;
     constexpr int32_t kMaxFilteredCodes = 1024;
-    if (data.readInt32(&code_count) != OK || code_count < 0 ||
+    if (data.readInt32(&code_count) != OK || code_count <= 0 ||
         code_count > kMaxFilteredCodes ||
         static_cast<size_t>(code_count) > data.dataAvail() / sizeof(uint32_t)) {
       return BAD_VALUE;
@@ -668,8 +694,8 @@ status_t BinderInterceptor::onTransact(uint32_t code,
     if (std::adjacent_find(codes.begin(), codes.end()) != codes.end()) {
       return BAD_VALUE;
     }
-    LOGI("Interceptor registered for binder %p with %zu filtered codes",
-         target.get(), codes.size());
+    LOGI("Interceptor registered with %zu explicitly filtered codes",
+         codes.size());
     sp<IBinder> replaced_interceptor;
     {
       WriteGuard wg{lock};
@@ -965,13 +991,13 @@ bool initialize_hooks() {
 }
 
 extern "C" [[gnu::visibility("default")]] [[gnu::used]] bool
-entry(void *handle) {
-  LOGI("injected, my handle %p", handle);
+entry(void *) {
+  LOGI("native Binder interceptor injected");
   return initialize_hooks();
 }
 
 extern "C" [[gnu::visibility("default")]] [[gnu::used]] bool
-resume(void *handle) {
-  LOGI("resuming parked Binder hook, my handle %p", handle);
+resume(void *) {
+  LOGI("resuming parked native Binder hook");
   return initialize_hooks();
 }

--- a/module/src/main/cpp/binder_interceptor.cpp
+++ b/module/src/main/cpp/binder_interceptor.cpp
@@ -526,7 +526,8 @@ int new_ioctl(int fd, unsigned long request, ...) {
       return result;
     }
 
-    if (!rust_is_binder_fd(fd)) {
+    if (!rust_is_binder_fd_after_successful_ioctl(
+            fd, reinterpret_cast<uintptr_t>(arg))) {
       return result;
     }
 
@@ -548,8 +549,7 @@ int new_ioctl(int fd, unsigned long request, ...) {
       return result;
     }
 
-    LOGD("read buffer %p size %llu consumed %llu",
-         reinterpret_cast<void *>(bwr.read_buffer),
+    LOGD("Binder read size %llu consumed %llu",
          (unsigned long long)bwr.read_size,
          (unsigned long long)bwr.read_consumed);
 
@@ -595,7 +595,7 @@ int new_ioctl(int fd, unsigned long request, ...) {
           transaction_info.code = txn.code;
           transaction_info.target = wb;
           need_intercept = true;
-          LOGD("intercept code=%d target=%p", txn.code, b);
+          LOGD("intercepting registered transaction code=%d", txn.code);
         }
         b->decStrong(nullptr);
       }
@@ -808,8 +808,8 @@ bool BinderInterceptor::handleIntercept(sp<BBinder> target, uint32_t code,
     return false;
   const uid_t calling_uid = thread_state->getCallingUid();
   const pid_t calling_pid = thread_state->getCallingPid();
-  LOGD("intercept on binder %p code %d flags %d (reply=%s)", target.get(), code,
-       flags, reply ? "true" : "false");
+  LOGD("intercept code=%d flags=%d reply=%s", code, flags,
+       reply ? "true" : "false");
   Parcel tmpData, tmpReply, realData;
   CHECK(tmpData.writeStrongBinder(target));
   CHECK(tmpData.writeUint32(code));

--- a/module/src/main/cpp/binder_interceptor.cpp
+++ b/module/src/main/cpp/binder_interceptor.cpp
@@ -378,17 +378,13 @@ bool AdaptiveBinderInterceptor::initialize() {
   OffsetCache &cache = OffsetCache::instance();
 
   const int android_api_level = detectApiLevel();
-  if (android_api_level < kMinimumSupportedAndroidApi) {
-    LOGE("AdaptiveBinderInterceptor: unsupported Android API %d",
-         android_api_level);
+  if (android_api_level < kMinimumSupportedAndroidApi ||
+      android_api_level > kMaximumValidatedCompilerFallbackApi) {
+    LOGE("AdaptiveBinderInterceptor: Android API %d is outside the "
+         "compiler-validated Binder UAPI range %d-%d",
+         android_api_level, kMinimumSupportedAndroidApi,
+         kMaximumValidatedCompilerFallbackApi);
     return false;
-  }
-  const bool requires_live_layout =
-      android_api_level > kMaximumValidatedCompilerFallbackApi;
-  if (requires_live_layout) {
-    LOGW("Android API %d is newer than the compiler fallback; requiring live "
-         "Binder UAPI validation",
-         android_api_level);
   }
   std::string kernel_version;
   int kmajor = 0, kminor = 0;
@@ -404,14 +400,6 @@ bool AdaptiveBinderInterceptor::initialize() {
   if (RuntimeLayoutValidator::validateLayout(cache)) {
     LOGI("Strategy: live Binder UAPI validation succeeded");
     return true;
-  }
-
-  if (requires_live_layout) {
-    LOGE("Live Binder validation failed on future Android API %d; refusing an "
-         "unverified layout",
-         android_api_level);
-    cache.valid = false;
-    return false;
   }
 
   if (initFallback(cache, android_api_level)) {

--- a/rust/injector-core/src/engine.rs
+++ b/rust/injector-core/src/engine.rs
@@ -7,7 +7,7 @@ use crate::ptrace_session::RemoteSession;
 use crate::symbol_resolver::resolve_injector_symbols;
 use cleverestricky_native_core::injector_support::{
     extract_scm_rights_fd, generate_magic, is_safe_library_metadata, parse_injector_request,
-    CmsgHeader,
+    wipe_bytes, CmsgHeader,
 };
 use std::ffi::{c_int, c_void, CStr, CString, OsString};
 use std::fs::{self, File, OpenOptions};
@@ -25,6 +25,7 @@ const LOG_ERROR: c_int = 6;
 
 const AF_UNIX: c_int = 1;
 const SOCK_DGRAM: c_int = 2;
+const SOCK_NONBLOCK: c_int = 0x800;
 const SOCK_CLOEXEC: c_int = 0x80000;
 const SOL_SOCKET: c_int = 1;
 const SCM_RIGHTS: c_int = 1;
@@ -164,15 +165,17 @@ fn inject_library(
     let symbols = resolve_injector_symbols(pid)?;
 
     let local_socket = create_local_socket_for_target(pid)?;
-    let socket_name = generate_magic(16)
+    let mut socket_name = generate_magic(16)
         .map_err(|error| format!("could not generate the local socket name: {error}"))?;
-    let remote_library_fd = transfer_library_fd(
+    let remote_library_fd_result = transfer_library_fd(
         &mut session,
         &symbols,
         &local_socket,
         library.as_raw_fd(),
         &socket_name,
-    )?;
+    );
+    wipe_bytes(&mut socket_name);
+    let remote_library_fd = remote_library_fd_result?;
 
     let remote_handle_result =
         open_remote_library(&mut session, &symbols, remote_library_fd, library_path);
@@ -225,8 +228,9 @@ fn create_local_socket_for_target(pid: i32) -> EngineResult<OwnedFd> {
                 }
             }
         }
+        wipe_bytes(&mut context);
     }
-    let descriptor = unsafe { socket(AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0) };
+    let descriptor = unsafe { socket(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0) };
     if let Err(error) = set_socket_creation_context(&[]) {
         log(
             LOG_WARN,
@@ -265,7 +269,11 @@ fn transfer_library_fd(
         let remote_socket_result = session.call(
             symbols.socket,
             symbols.libc_return,
-            &[AF_UNIX as usize, (SOCK_DGRAM | SOCK_CLOEXEC) as usize, 0],
+            &[
+                AF_UNIX as usize,
+                (SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC) as usize,
+                0,
+            ],
         )?;
         if is_remote_integer_error(remote_socket_result) || remote_socket_result > i32::MAX as usize
         {
@@ -362,8 +370,9 @@ fn transfer_library_fd(
 
         let mut control = vec![0u8; received_header.control_length];
         session.read_bytes(remote_control, &mut control)?;
-        extract_scm_rights_fd(&control)
-            .ok_or_else(|| "remote ancillary message did not contain a descriptor".into())
+        let descriptor = extract_scm_rights_fd(&control);
+        wipe_bytes(&mut control);
+        descriptor.ok_or_else(|| "remote ancillary message did not contain a descriptor".into())
     })();
     resources.cleanup(session, symbols);
     result
@@ -412,11 +421,13 @@ fn send_local_fd(
     loop {
         let sent = unsafe { sendmsg(socket_descriptor, &header, 0) };
         if sent == 1 {
+            wipe_bytes(&mut control);
             return Ok(());
         }
         if sent < 0 && std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted {
             continue;
         }
+        wipe_bytes(&mut control);
         return Err("could not send the library descriptor".into());
     }
 }
@@ -443,7 +454,7 @@ fn open_remote_library(
         log_remote_loader_error(session, symbols);
         Err("remote dynamic loader returned a null handle".into())
     } else {
-        log(LOG_DEBUG, format!("remote library handle is {handle:#x}"));
+        log(LOG_DEBUG, "remote library loaded");
         Ok(handle)
     }
 }
@@ -471,6 +482,7 @@ fn log_remote_loader_error(session: &mut RemoteSession, symbols: &InjectorSymbol
             format!("remote loader error: {}", String::from_utf8_lossy(&message)),
         );
     }
+    wipe_bytes(&mut message);
 }
 
 fn read_remote_errno(session: &mut RemoteSession, symbols: &InjectorSymbols) -> Option<i32> {

--- a/rust/injector-core/src/process_memory.rs
+++ b/rust/injector-core/src/process_memory.rs
@@ -1,4 +1,5 @@
 use crate::abi::IoVector;
+use cleverestricky_native_core::injector_support::wipe_bytes;
 use std::ffi::{c_int, c_void};
 
 extern "C" {
@@ -32,7 +33,13 @@ pub(crate) fn read_process_memory(pid: i32, remote_address: usize, output: &mut 
         base: remote_address as *mut c_void,
         length: output.len(),
     };
-    unsafe { process_vm_readv(pid, &local, 1, &remote, 1, 0) == output.len() as isize }
+    let complete =
+        unsafe { process_vm_readv(pid, &local, 1, &remote, 1, 0) } == output.len() as isize;
+    if !complete {
+        // Do not expose or retain a prefix from a short cross-process read.
+        wipe_bytes(output);
+    }
+    complete
 }
 
 pub(crate) fn write_process_memory(pid: i32, remote_address: usize, input: &[u8]) -> bool {

--- a/rust/injector-core/src/ptrace_session.rs
+++ b/rust/injector-core/src/ptrace_session.rs
@@ -4,8 +4,8 @@ use crate::abi::IoVector;
 use crate::logging;
 use crate::process_memory::{read_process_memory, write_process_memory};
 use cleverestricky_native_core::injector_support::{
-    remote_stop_signal_to_deliver, sanitize_signal_for_detach, validate_attached_target_cmdline,
-    wipe_bytes,
+    is_synthetic_return_trap, remote_stop_signal_to_deliver, sanitize_signal_for_detach,
+    validate_attached_target_cmdline, wipe_bytes,
 };
 use std::ffi::{c_int, c_void, CStr};
 use std::mem;
@@ -18,6 +18,7 @@ const PTRACE_GETREGS: c_int = 12;
 const PTRACE_SETREGS: c_int = 13;
 const PTRACE_ATTACH: c_int = 16;
 const PTRACE_DETACH: c_int = 17;
+const PTRACE_GETSIGINFO: c_int = 0x4202;
 #[cfg(target_arch = "aarch64")]
 const PTRACE_GETREGSET: c_int = 0x4204;
 #[cfg(target_arch = "aarch64")]
@@ -26,13 +27,23 @@ const PTRACE_SETREGSET: c_int = 0x4205;
 const NT_PRSTATUS: usize = 1;
 const WAIT_ALL: c_int = 0x4000_0000;
 const INTERRUPTED_SYSTEM_CALL: i32 = 4;
-const SIGNAL_SEGMENTATION_FAULT: i32 = 11;
 const SIGNAL_STOP: i32 = 19;
 const MAXIMUM_ARGUMENTS: usize = 32;
 const MAXIMUM_REMOTE_INPUT: usize = 64 * 1_024;
 const MAXIMUM_SAVED_STACK_BYTES: usize = 256 * 1_024;
 const REMOTE_CALL_STACK_GUARD_BYTES: usize = 16 * 1_024;
 const STACK_ALIGNMENT: usize = 16;
+
+#[derive(Clone, Copy, Debug, Default)]
+#[repr(C, align(8))]
+struct SignalInfo {
+    // Supported Android LP64 architectures use the generic 128-byte siginfo
+    // layout: signo, errno, and si_code are the first three 32-bit words.
+    words: [i32; 32],
+}
+
+const _: [(); 128] = [(); mem::size_of::<SignalInfo>()];
+const _: [(); 8] = [(); mem::align_of::<SignalInfo>()];
 
 extern "C" {
     fn ptrace(request: c_int, pid: c_int, address: *mut c_void, data: *mut c_void) -> isize;
@@ -108,6 +119,7 @@ pub(crate) struct RemoteSession {
     original_registers_valid: bool,
     attached: bool,
     pending_signal: i32,
+    remote_calls_blocked: bool,
     stack_patches: Vec<StackPatch>,
     saved_stack_bytes: usize,
     preserved_stack_floor: usize,
@@ -148,6 +160,7 @@ impl RemoteSession {
             original_registers_valid: false,
             attached: true,
             pending_signal: 0,
+            remote_calls_blocked: false,
             stack_patches: Vec::with_capacity(16),
             saved_stack_bytes: 0,
             preserved_stack_floor: usize::MAX,
@@ -190,9 +203,18 @@ impl RemoteSession {
         return_address: usize,
         arguments: &[usize],
     ) -> Result<usize, String> {
-        if !self.attached || function_address == 0 || arguments.len() > MAXIMUM_ARGUMENTS {
+        if !self.attached
+            || self.remote_calls_blocked
+            || self.pending_signal != 0
+            || function_address == 0
+            || arguments.len() > MAXIMUM_ARGUMENTS
+        {
             return Err("invalid remote call plan".into());
         }
+        // Once execution leaves the controlled call path unexpectedly, do
+        // not resume the tracee for best-effort cleanup. Restoring the saved
+        // process state and delivering any real pending signal takes priority.
+        self.remote_calls_blocked = true;
 
         let base_registers = self.registers;
         let mut call_registers = base_registers;
@@ -227,11 +249,13 @@ impl RemoteSession {
         // Preserve a genuine signal if register inspection or remote return
         // validation fails. Only the deliberate non-executable return trap is
         // suppressed when detaching.
-        self.pending_signal = sanitize_signal_for_detach(signal);
+        let signal_code = read_signal_code(self.pid, signal);
+        self.pending_signal = remote_stop_signal_to_deliver(signal, signal_code, 0, 0);
         let stopped_registers = read_registers(self.pid)?;
         let actual_address = instruction_pointer(&stopped_registers);
-        self.pending_signal = remote_stop_signal_to_deliver(signal, actual_address, return_address);
-        if signal != SIGNAL_SEGMENTATION_FAULT || actual_address != return_address {
+        self.pending_signal =
+            remote_stop_signal_to_deliver(signal, signal_code, actual_address, return_address);
+        if !is_synthetic_return_trap(signal, signal_code, actual_address, return_address) {
             self.registers = stopped_registers;
             return Err(format!(
                 "remote call stopped unexpectedly with status {status:#x}"
@@ -239,6 +263,7 @@ impl RemoteSession {
         }
         let result = return_value(&stopped_registers);
         self.pending_signal = 0;
+        self.remote_calls_blocked = false;
         self.registers = base_registers;
         Ok(result)
     }
@@ -375,6 +400,7 @@ impl RemoteSession {
         }
         self.attached = false;
         self.pending_signal = 0;
+        self.remote_calls_blocked = false;
         restore_error.map_or(Ok(()), Err)
     }
 }
@@ -406,6 +432,23 @@ fn wait_for_stop(pid: i32) -> Result<i32, String> {
             "target process did not reach a controlled stop: {status:#x}"
         ));
     }
+}
+
+fn read_signal_code(pid: i32, expected_signal: i32) -> Option<i32> {
+    let mut information = SignalInfo::default();
+    if unsafe {
+        ptrace(
+            PTRACE_GETSIGINFO,
+            pid,
+            std::ptr::null_mut(),
+            (&mut information as *mut SignalInfo).cast(),
+        )
+    } == -1
+        || information.words[0] != expected_signal
+    {
+        return None;
+    }
+    Some(information.words[2])
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/rust/injector-core/src/ptrace_session.rs
+++ b/rust/injector-core/src/ptrace_session.rs
@@ -3,7 +3,10 @@ use crate::abi::getpid;
 use crate::abi::IoVector;
 use crate::logging;
 use crate::process_memory::{read_process_memory, write_process_memory};
-use cleverestricky_native_core::injector_support::validate_attached_target_cmdline;
+use cleverestricky_native_core::injector_support::{
+    remote_stop_signal_to_deliver, sanitize_signal_for_detach, validate_attached_target_cmdline,
+    wipe_bytes,
+};
 use std::ffi::{c_int, c_void, CStr};
 use std::mem;
 
@@ -104,6 +107,7 @@ pub(crate) struct RemoteSession {
     original_registers: Registers,
     original_registers_valid: bool,
     attached: bool,
+    pending_signal: i32,
     stack_patches: Vec<StackPatch>,
     saved_stack_bytes: usize,
     preserved_stack_floor: usize,
@@ -112,6 +116,12 @@ pub(crate) struct RemoteSession {
 struct StackPatch {
     address: usize,
     original: Vec<u8>,
+}
+
+impl Drop for StackPatch {
+    fn drop(&mut self) {
+        wipe_bytes(&mut self.original);
+    }
 }
 
 impl RemoteSession {
@@ -137,15 +147,32 @@ impl RemoteSession {
             original_registers: Registers::default(),
             original_registers_valid: false,
             attached: true,
+            pending_signal: 0,
             stack_patches: Vec::with_capacity(16),
             saved_stack_bytes: 0,
             preserved_stack_floor: usize::MAX,
         };
-        let status = wait_for_stop(pid)?;
-        if stop_signal(status) != SIGNAL_STOP {
-            return Err(format!(
-                "target process stopped with unexpected status {status:#x}"
-            ));
+        loop {
+            let status = wait_for_stop(pid)?;
+            let signal = stop_signal(status);
+            if signal == SIGNAL_STOP {
+                break;
+            }
+            let signal = sanitize_signal_for_detach(signal);
+            if signal == 0
+                || unsafe {
+                    ptrace(
+                        PTRACE_CONT,
+                        pid,
+                        std::ptr::null_mut(),
+                        signal as usize as *mut c_void,
+                    )
+                } == -1
+            {
+                return Err(format!(
+                    "could not preserve a signal delivered during attach: {status:#x}"
+                ));
+            }
         }
         if !validate_attached_target_cmdline(pid).unwrap_or(false) {
             return Err("target process identity validation failed".into());
@@ -196,15 +223,22 @@ impl RemoteSession {
         }
 
         let status = wait_for_stop(self.pid)?;
+        let signal = stop_signal(status);
+        // Preserve a genuine signal if register inspection or remote return
+        // validation fails. Only the deliberate non-executable return trap is
+        // suppressed when detaching.
+        self.pending_signal = sanitize_signal_for_detach(signal);
         let stopped_registers = read_registers(self.pid)?;
         let actual_address = instruction_pointer(&stopped_registers);
-        if stop_signal(status) != SIGNAL_SEGMENTATION_FAULT || actual_address != return_address {
+        self.pending_signal = remote_stop_signal_to_deliver(signal, actual_address, return_address);
+        if signal != SIGNAL_SEGMENTATION_FAULT || actual_address != return_address {
             self.registers = stopped_registers;
             return Err(format!(
-                "remote call stopped unexpectedly with status {status:#x} at {actual_address:#x}"
+                "remote call stopped unexpectedly with status {status:#x}"
             ));
         }
         let result = return_value(&stopped_registers);
+        self.pending_signal = 0;
         self.registers = base_registers;
         Ok(result)
     }
@@ -299,6 +333,7 @@ impl RemoteSession {
             .ok_or_else(|| "remote stack backup exceeded its bound".to_string())?;
         let mut original = vec![0u8; backup_length];
         if !read_process_memory(self.pid, address, &mut original) {
+            wipe_bytes(&mut original);
             return Err("could not preserve target stack memory".into());
         }
         self.stack_patches.push(StackPatch { address, original });
@@ -332,13 +367,14 @@ impl RemoteSession {
                 PTRACE_DETACH,
                 self.pid,
                 std::ptr::null_mut(),
-                std::ptr::null_mut(),
+                self.pending_signal as usize as *mut c_void,
             )
         } == -1
         {
             return Err("could not detach from the target process".into());
         }
         self.attached = false;
+        self.pending_signal = 0;
         restore_error.map_or(Ok(()), Err)
     }
 }

--- a/rust/injector-core/src/ptrace_session.rs
+++ b/rust/injector-core/src/ptrace_session.rs
@@ -211,11 +211,6 @@ impl RemoteSession {
         {
             return Err("invalid remote call plan".into());
         }
-        // Once execution leaves the controlled call path unexpectedly, do
-        // not resume the tracee for best-effort cleanup. Restoring the saved
-        // process state and delivering any real pending signal takes priority.
-        self.remote_calls_blocked = true;
-
         let base_registers = self.registers;
         let mut call_registers = base_registers;
         let current_stack = stack_pointer(&call_registers);
@@ -232,6 +227,11 @@ impl RemoteSession {
         )?;
         write_registers(self.pid, &call_registers)?;
         self.registers = call_registers;
+        // Preparation failures happen while the tracee is safely stopped and
+        // must not disable cleanup calls. Block further remote execution only
+        // for the interval after we attempt to resume this injected call; an
+        // unexpected stop or wait failure then remains fail-closed.
+        self.remote_calls_blocked = true;
         if unsafe {
             ptrace(
                 PTRACE_CONT,
@@ -241,6 +241,9 @@ impl RemoteSession {
             )
         } == -1
         {
+            // PTRACE_CONT failed, so the tracee never left the controlled
+            // stop and best-effort cleanup remains safe.
+            self.remote_calls_blocked = false;
             return Err("could not continue the target process".into());
         }
 

--- a/rust/injector-core/src/symbol_resolver.rs
+++ b/rust/injector-core/src/symbol_resolver.rs
@@ -1,6 +1,6 @@
 use crate::abi::InjectorSymbols;
 use cleverestricky_native_core::injector_support::{
-    read_relevant_process_maps, ProcessMapping, ProcessModule,
+    process_image_base, read_relevant_process_maps, ProcessImageId, ProcessMapping, ProcessModule,
 };
 use std::ffi::{c_char, c_int, c_void, CString};
 
@@ -54,37 +54,47 @@ pub(crate) fn resolve_injector_symbols(pid: i32) -> Result<InjectorSymbols, Stri
     let libc = LibraryHandle::open(ProcessModule::Libc)?;
     let libdl = LibraryHandle::open(ProcessModule::Libdl)?;
 
+    let (close_address, libc_image) =
+        resolve_symbol(&local, &remote, ProcessModule::Libc, &libc, b"close")?;
     let mut output = InjectorSymbols {
         libc_return: remote
             .iter()
-            .find(|mapping| mapping.module == ProcessModule::Libc && !mapping.executable)
+            .find(|mapping| {
+                mapping.module == ProcessModule::Libc
+                    && mapping.image == libc_image
+                    && !mapping.executable
+            })
             .map(|mapping| mapping.start)
             .filter(|address| *address != 0)
             .ok_or_else(|| "target libc has no controlled return trap mapping".to_string())?,
+        close: close_address,
         ..InjectorSymbols::default()
     };
 
-    output.close = resolve_symbol(&local, &remote, ProcessModule::Libc, &libc, b"close")?;
-    output.socket = resolve_symbol(&local, &remote, ProcessModule::Libc, &libc, b"socket")?;
-    output.bind = resolve_symbol(&local, &remote, ProcessModule::Libc, &libc, b"bind")?;
-    output.recvmsg = resolve_symbol(&local, &remote, ProcessModule::Libc, &libc, b"recvmsg")?;
-    output.mmap = resolve_symbol(&local, &remote, ProcessModule::Libc, &libc, b"mmap")?;
-    output.munmap = resolve_symbol(&local, &remote, ProcessModule::Libc, &libc, b"munmap")?;
-    output.errno_location =
-        resolve_symbol(&local, &remote, ProcessModule::Libc, &libc, b"__errno").unwrap_or(0);
+    output.socket = resolve_symbol(&local, &remote, ProcessModule::Libc, &libc, b"socket")?.0;
+    output.bind = resolve_symbol(&local, &remote, ProcessModule::Libc, &libc, b"bind")?.0;
+    output.recvmsg = resolve_symbol(&local, &remote, ProcessModule::Libc, &libc, b"recvmsg")?.0;
+    output.mmap = resolve_symbol(&local, &remote, ProcessModule::Libc, &libc, b"mmap")?.0;
+    output.munmap = resolve_symbol(&local, &remote, ProcessModule::Libc, &libc, b"munmap")?.0;
+    output.errno_location = resolve_symbol(&local, &remote, ProcessModule::Libc, &libc, b"__errno")
+        .map(|resolved| resolved.0)
+        .unwrap_or(0);
     output.android_dlopen_ext = resolve_symbol(
         &local,
         &remote,
         ProcessModule::Libdl,
         &libdl,
         b"android_dlopen_ext",
-    )?;
-    output.dlerror =
-        resolve_symbol(&local, &remote, ProcessModule::Libdl, &libdl, b"dlerror").unwrap_or(0);
-    output.strlen =
-        resolve_symbol(&local, &remote, ProcessModule::Libc, &libc, b"strlen").unwrap_or(0);
-    output.dlsym = resolve_symbol(&local, &remote, ProcessModule::Libdl, &libdl, b"dlsym")?;
-    output.dlclose = resolve_symbol(&local, &remote, ProcessModule::Libdl, &libdl, b"dlclose")?;
+    )?
+    .0;
+    output.dlerror = resolve_symbol(&local, &remote, ProcessModule::Libdl, &libdl, b"dlerror")
+        .map(|resolved| resolved.0)
+        .unwrap_or(0);
+    output.strlen = resolve_symbol(&local, &remote, ProcessModule::Libc, &libc, b"strlen")
+        .map(|resolved| resolved.0)
+        .unwrap_or(0);
+    output.dlsym = resolve_symbol(&local, &remote, ProcessModule::Libdl, &libdl, b"dlsym")?.0;
+    output.dlclose = resolve_symbol(&local, &remote, ProcessModule::Libdl, &libdl, b"dlclose")?.0;
     Ok(output)
 }
 
@@ -94,28 +104,33 @@ fn resolve_symbol(
     module: ProcessModule,
     library: &LibraryHandle,
     symbol: &[u8],
-) -> Result<usize, String> {
+) -> Result<(usize, ProcessImageId), String> {
     let symbol_name = CString::new(symbol)
         .map_err(|_| "platform symbol name contained a null byte".to_string())?;
     let local_symbol = unsafe { dlsym(library.0, symbol_name.as_ptr()) } as usize;
-    if local_symbol == 0
-        || !local_mappings.iter().any(|mapping| {
-            mapping.module == module
-                && mapping.executable
-                && mapping.start <= local_symbol
-                && local_symbol < mapping.end
-        })
-    {
+    if local_symbol == 0 {
+        return Err(format!(
+            "platform symbol {} is unavailable",
+            String::from_utf8_lossy(symbol)
+        ));
+    }
+    let Some(local_symbol_mapping) = local_mappings.iter().find(|mapping| {
+        mapping.module == module
+            && mapping.executable
+            && mapping.start <= local_symbol
+            && local_symbol < mapping.end
+    }) else {
         return Err(format!(
             "platform symbol {} resolved outside its library",
             String::from_utf8_lossy(symbol)
         ));
-    }
+    };
+    let image = local_symbol_mapping.image;
 
-    let local_base = module_base(local_mappings, module)
+    let local_base = process_image_base(local_mappings, module, image)
         .ok_or_else(|| "local platform library base is unavailable".to_string())?;
-    let remote_base = module_base(remote_mappings, module)
-        .ok_or_else(|| "target platform library base is unavailable".to_string())?;
+    let remote_base = process_image_base(remote_mappings, module, image)
+        .ok_or_else(|| "target platform library image does not match the injector".to_string())?;
     let offset = local_symbol
         .checked_sub(local_base)
         .filter(|value| *value <= MAXIMUM_LIBRARY_OFFSET)
@@ -125,6 +140,7 @@ fn resolve_symbol(
         .ok_or_else(|| "target symbol address overflow".to_string())?;
     if !remote_mappings.iter().any(|mapping| {
         mapping.module == module
+            && mapping.image == image
             && mapping.executable
             && mapping.start <= remote_symbol
             && remote_symbol < mapping.end
@@ -134,13 +150,5 @@ fn resolve_symbol(
             String::from_utf8_lossy(symbol)
         ));
     }
-    Ok(remote_symbol)
-}
-
-fn module_base(mappings: &[ProcessMapping], module: ProcessModule) -> Option<usize> {
-    mappings
-        .iter()
-        .find(|mapping| mapping.module == module && mapping.offset == 0)
-        .map(|mapping| mapping.start)
-        .filter(|address| *address != 0)
+    Ok((remote_symbol, image))
 }

--- a/rust/native-core/include/cleverestricky_native_core.h
+++ b/rust/native-core/include/cleverestricky_native_core.h
@@ -74,7 +74,8 @@ bool rust_write_binder_transaction(uint8_t *buffer,
                                    const RustParsedTransaction *transaction,
                                    const RustOffsetCacheView *cache);
 
-bool rust_is_binder_fd(int32_t descriptor);
+bool rust_is_binder_fd_after_successful_ioctl(int32_t descriptor,
+                                              uintptr_t exchange_token);
 
 int32_t rust_parse_android_api_level(const uint8_t *value, size_t length);
 

--- a/rust/native-core/src/binder_memory.rs
+++ b/rust/native-core/src/binder_memory.rs
@@ -1,5 +1,6 @@
 use crate::binder_parser::RustParsedTransaction;
 use crate::ffi::{validate_mut_slice_args, validate_slice_args};
+use crate::injector_support::wipe_bytes;
 use crate::layout::{validate_offset_cache, validate_transaction_layout, RustOffsetCacheView};
 use std::cell::RefCell;
 use std::ffi::{c_int, c_void};
@@ -10,6 +11,7 @@ const O_NONBLOCK: c_int = 0x800;
 const O_CLOEXEC: c_int = 0x80000;
 const MAXIMUM_BINDER_WRITE_READ_BYTES: usize = 256;
 const MAXIMUM_BINDER_READ_BYTES: usize = 8 * 1_024 * 1_024;
+const MAXIMUM_TRANSACTION_PAYLOAD_BYTES: usize = 512;
 const KERNEL_COPY_ATTEMPT_BYTES: usize = 64 * 1_024;
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -153,6 +155,17 @@ fn read_unaligned<T: Copy>(input: &[u8], offset: usize) -> Option<T> {
     Some(unsafe { input.as_ptr().add(offset).cast::<T>().read_unaligned() })
 }
 
+fn write_bytes(output: &mut [u8], offset: usize, value: &[u8]) -> bool {
+    let Some(end) = offset.checked_add(value.len()) else {
+        return false;
+    };
+    let Some(destination) = output.get_mut(offset..end) else {
+        return false;
+    };
+    destination.copy_from_slice(value);
+    true
+}
+
 /// Reads the Binder driver exchange structure through a kernel validated copy.
 ///
 /// # Safety
@@ -190,21 +203,20 @@ pub unsafe extern "C" fn rust_read_binder_write_read(
             local.as_mut_ptr() as usize,
             cache.bwr_total_size,
         ) {
+            wipe_bytes(&mut local[..cache.bwr_total_size]);
             return false;
         }
         let structure = &local[..cache.bwr_total_size];
-        let Some(read_size) = read_unaligned::<usize>(structure, cache.bwr_read_size_offset) else {
+        let parsed = (
+            read_unaligned::<usize>(structure, cache.bwr_read_size_offset),
+            read_unaligned::<usize>(structure, cache.bwr_read_consumed_offset),
+            read_unaligned::<usize>(structure, cache.bwr_read_buffer_offset),
+        );
+        let (Some(read_size), Some(read_consumed), Some(read_buffer)) = parsed else {
+            wipe_bytes(&mut local[..cache.bwr_total_size]);
             return false;
         };
-        let Some(read_consumed) =
-            read_unaligned::<usize>(structure, cache.bwr_read_consumed_offset)
-        else {
-            return false;
-        };
-        let Some(read_buffer) = read_unaligned::<usize>(structure, cache.bwr_read_buffer_offset)
-        else {
-            return false;
-        };
+        wipe_bytes(&mut local[..cache.bwr_total_size]);
 
         output[0] = RustBinderReadSnapshot {
             read_size,
@@ -262,33 +274,47 @@ pub unsafe extern "C" fn rust_write_binder_transaction(
             return false;
         }
 
-        let fields = [
-            (
-                &transaction.target_ptr as *const usize as usize,
-                cache.target_ptr_offset,
-                mem::size_of::<usize>(),
-            ),
-            (
-                &transaction.cookie as *const usize as usize,
-                cache.cookie_offset,
-                mem::size_of::<usize>(),
-            ),
-            (
-                &transaction.code as *const u32 as usize,
-                cache.code_offset,
-                mem::size_of::<u32>(),
-            ),
-        ];
-
-        for (source, offset, length) in fields {
-            let Some(destination) = transaction.raw_ptr.checked_add(offset) else {
-                return false;
-            };
-            if !kernel_copy(source, destination, length) {
-                return false;
-            }
+        // Snapshot and rewrite the complete bounded UAPI record. This turns
+        // three independent field writes into one coherent copy, preserves
+        // every field that the interceptor does not own, and reduces pipe
+        // traffic on the Binder hot path.
+        let mut replacement = [0u8; MAXIMUM_TRANSACTION_PAYLOAD_BYTES];
+        if transaction.raw_size > replacement.len() {
+            return false;
         }
-        true
+        if !kernel_copy(
+            transaction.raw_ptr,
+            replacement.as_mut_ptr() as usize,
+            transaction.raw_size,
+        ) {
+            wipe_bytes(&mut replacement[..transaction.raw_size]);
+            return false;
+        }
+        let replacement = &mut replacement[..transaction.raw_size];
+        if !write_bytes(
+            replacement,
+            cache.target_ptr_offset,
+            &transaction.target_ptr.to_ne_bytes(),
+        ) || !write_bytes(
+            replacement,
+            cache.cookie_offset,
+            &transaction.cookie.to_ne_bytes(),
+        ) || !write_bytes(
+            replacement,
+            cache.code_offset,
+            &transaction.code.to_ne_bytes(),
+        ) {
+            wipe_bytes(replacement);
+            return false;
+        }
+
+        let success = kernel_copy(
+            replacement.as_ptr() as usize,
+            transaction.raw_ptr,
+            replacement.len(),
+        );
+        wipe_bytes(replacement);
+        success
     })
     .unwrap_or(false)
 }
@@ -296,6 +322,29 @@ pub unsafe extern "C" fn rust_write_binder_transaction(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_cache(payload_size: usize) -> RustOffsetCacheView {
+        RustOffsetCacheView {
+            target_ptr_offset: 0,
+            cookie_offset: 8,
+            code_offset: 16,
+            flags_offset: 20,
+            sender_pid_offset: 24,
+            sender_euid_offset: 28,
+            data_size_offset: 40,
+            data_ptr_offset: 48,
+            transaction_data_size: payload_size,
+            transaction_data_secctx_size: payload_size,
+            bwr_write_size_offset: 0,
+            bwr_write_consumed_offset: 8,
+            bwr_write_buffer_offset: 16,
+            bwr_read_size_offset: 24,
+            bwr_read_consumed_offset: 32,
+            bwr_read_buffer_offset: 40,
+            bwr_total_size: 48,
+            valid: 1,
+        }
+    }
 
     #[test]
     fn kernel_copy_rejects_invalid_addresses_without_dereferencing_them() {
@@ -333,5 +382,33 @@ mod tests {
             source.len(),
         ));
         assert_eq!(destination, source);
+    }
+
+    #[test]
+    fn transaction_writeback_is_coherent_and_preserves_unowned_fields() {
+        let mut raw = [0xa5u8; 64];
+        let original = raw;
+        let transaction = RustParsedTransaction {
+            target_ptr: 0x1122_3344_5566_7788,
+            cookie: 0x8877_6655_4433_2211,
+            code: 0xdead_beef,
+            raw_ptr: raw.as_mut_ptr() as usize,
+            raw_size: raw.len(),
+            valid: 1,
+            ..RustParsedTransaction::default()
+        };
+        let cache = test_cache(raw.len());
+
+        assert!(unsafe {
+            rust_write_binder_transaction(raw.as_mut_ptr(), raw.len(), &transaction, &cache)
+        });
+
+        assert_eq!(
+            read_unaligned::<usize>(&raw, 0),
+            Some(transaction.target_ptr)
+        );
+        assert_eq!(read_unaligned::<usize>(&raw, 8), Some(transaction.cookie));
+        assert_eq!(read_unaligned::<u32>(&raw, 16), Some(transaction.code));
+        assert_eq!(&raw[20..], &original[20..]);
     }
 }

--- a/rust/native-core/src/binder_parser.rs
+++ b/rust/native-core/src/binder_parser.rs
@@ -1,5 +1,6 @@
 use crate::binder_memory::kernel_copy;
 use crate::ffi::{validate_mut_slice_args, validate_slice_args};
+use crate::injector_support::wipe_bytes;
 use crate::layout::{validate_transaction_layout, RustOffsetCacheView};
 use std::mem;
 
@@ -235,9 +236,20 @@ pub unsafe extern "C" fn rust_parse_binder_stream(
                     transaction_buffer.as_mut_ptr() as usize,
                     payload_size,
                 ) {
+                    wipe_bytes(&mut transaction_buffer[..payload_size]);
                     return false;
                 }
                 let transaction = &transaction_buffer[..payload_size];
+                let parsed = (
+                    safe_read::<usize>(transaction, cache.target_ptr_offset),
+                    safe_read::<usize>(transaction, cache.cookie_offset),
+                    safe_read::<u32>(transaction, cache.code_offset),
+                    safe_read::<u32>(transaction, cache.flags_offset),
+                    safe_read::<i32>(transaction, cache.sender_pid_offset),
+                    safe_read::<u32>(transaction, cache.sender_euid_offset),
+                    safe_read::<u64>(transaction, cache.data_size_offset),
+                    safe_read::<usize>(transaction, cache.data_ptr_offset),
+                );
                 let (
                     Some(target_ptr),
                     Some(cookie),
@@ -247,19 +259,12 @@ pub unsafe extern "C" fn rust_parse_binder_stream(
                     Some(sender_euid),
                     Some(data_size),
                     Some(data_buffer),
-                ) = (
-                    safe_read::<usize>(transaction, cache.target_ptr_offset),
-                    safe_read::<usize>(transaction, cache.cookie_offset),
-                    safe_read::<u32>(transaction, cache.code_offset),
-                    safe_read::<u32>(transaction, cache.flags_offset),
-                    safe_read::<i32>(transaction, cache.sender_pid_offset),
-                    safe_read::<u32>(transaction, cache.sender_euid_offset),
-                    safe_read::<u64>(transaction, cache.data_size_offset),
-                    safe_read::<usize>(transaction, cache.data_ptr_offset),
-                )
+                ) = parsed
                 else {
+                    wipe_bytes(&mut transaction_buffer[..payload_size]);
                     return false;
                 };
+                wipe_bytes(&mut transaction_buffer[..payload_size]);
                 output[count_slice[0]] = RustParsedTransaction {
                     target_ptr,
                     cookie,

--- a/rust/native-core/src/injector_support.rs
+++ b/rust/native-core/src/injector_support.rs
@@ -2,6 +2,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{self, Read};
 use std::mem;
 use std::os::unix::fs::OpenOptionsExt;
+use std::sync::atomic::{compiler_fence, Ordering};
 
 const MAXIMUM_CMDLINE_BYTES: usize = 4_096;
 const MAXIMUM_MAPS_BYTES: usize = 4 * 1_024 * 1_024;
@@ -11,6 +12,8 @@ const MAXIMUM_MAGIC_LENGTH: usize = 64;
 const MAGIC_ALPHABET: &[u8; 62] = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 const RANDOM_ACCEPTANCE_LIMIT: u8 = 248;
 const O_NOFOLLOW: i32 = 0x20000;
+const MAXIMUM_SIGNAL_NUMBER: i32 = 64;
+const SIGNAL_SEGMENTATION_FAULT: i32 = 11;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ProcessModule {
@@ -28,12 +31,64 @@ impl ProcessModule {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ProcessImageId {
+    pub device: u64,
+    pub inode: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ProcessMapping {
     pub module: ProcessModule,
+    pub image: ProcessImageId,
     pub start: usize,
     pub end: usize,
     pub offset: usize,
     pub executable: bool,
+}
+
+pub fn process_image_base(
+    mappings: &[ProcessMapping],
+    module: ProcessModule,
+    image: ProcessImageId,
+) -> Option<usize> {
+    mappings
+        .iter()
+        .find(|mapping| mapping.module == module && mapping.image == image && mapping.offset == 0)
+        .map(|mapping| mapping.start)
+        .filter(|address| *address != 0)
+}
+
+/// Clears process-derived bytes with volatile stores so cleanup cannot be
+/// optimized away before the backing allocation is released.
+pub fn wipe_bytes(input: &mut [u8]) {
+    for byte in input {
+        // SAFETY: `byte` is a live, uniquely borrowed element of `input`.
+        unsafe { std::ptr::write_volatile(byte, 0) };
+    }
+    compiler_fence(Ordering::SeqCst);
+}
+
+pub fn sanitize_signal_for_detach(signal: i32) -> i32 {
+    if (1..=MAXIMUM_SIGNAL_NUMBER).contains(&signal) {
+        signal
+    } else {
+        0
+    }
+}
+
+pub fn remote_stop_signal_to_deliver(
+    signal: i32,
+    actual_address: usize,
+    synthetic_return_address: usize,
+) -> i32 {
+    if signal == SIGNAL_SEGMENTATION_FAULT
+        && synthetic_return_address != 0
+        && actual_address == synthetic_return_address
+    {
+        0
+    } else {
+        sanitize_signal_for_detach(signal)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -113,14 +168,18 @@ pub fn is_supported_target_cmdline(input: &[u8]) -> bool {
 
 fn read_bounded_cmdline(reader: &mut impl Read) -> io::Result<Option<Vec<u8>>> {
     let mut input = Vec::with_capacity(256);
-    reader
+    if let Err(error) = reader
         .take(MAXIMUM_CMDLINE_BYTES as u64)
-        .read_to_end(&mut input)?;
-    if input.is_empty() || input.len() >= MAXIMUM_CMDLINE_BYTES {
-        Ok(None)
-    } else {
-        Ok(Some(input))
+        .read_to_end(&mut input)
+    {
+        wipe_bytes(&mut input);
+        return Err(error);
     }
+    if input.is_empty() || input.len() >= MAXIMUM_CMDLINE_BYTES {
+        wipe_bytes(&mut input);
+        return Ok(None);
+    }
+    Ok(Some(input))
 }
 
 pub fn validate_attached_target_cmdline(pid: i32) -> io::Result<bool> {
@@ -132,9 +191,12 @@ pub fn validate_attached_target_cmdline(pid: i32) -> io::Result<bool> {
         .read(true)
         .custom_flags(O_NOFOLLOW)
         .open(path)?;
-    Ok(read_bounded_cmdline(&mut file)?
-        .as_deref()
-        .is_some_and(is_supported_target_cmdline))
+    let Some(mut input) = read_bounded_cmdline(&mut file)? else {
+        return Ok(false);
+    };
+    let supported = is_supported_target_cmdline(&input);
+    wipe_bytes(&mut input);
+    Ok(supported)
 }
 
 pub fn read_relevant_process_maps(pid: Option<i32>) -> io::Result<Vec<ProcessMapping>> {
@@ -153,16 +215,24 @@ pub fn read_relevant_process_maps(pid: Option<i32>) -> io::Result<Vec<ProcessMap
         .custom_flags(O_NOFOLLOW)
         .open(path)?;
     let mut input = Vec::with_capacity(64 * 1_024);
-    file.by_ref()
+    if let Err(error) = file
+        .by_ref()
         .take((MAXIMUM_MAPS_BYTES + 1) as u64)
-        .read_to_end(&mut input)?;
+        .read_to_end(&mut input)
+    {
+        wipe_bytes(&mut input);
+        return Err(error);
+    }
     if input.is_empty() || input.len() > MAXIMUM_MAPS_BYTES {
+        wipe_bytes(&mut input);
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "process map exceeded its allowed size",
         ));
     }
-    parse_relevant_process_maps(&input).ok_or_else(|| {
+    let parsed = parse_relevant_process_maps(&input);
+    wipe_bytes(&mut input);
+    parsed.ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::InvalidData,
             "process map failed structural validation",
@@ -192,8 +262,8 @@ fn parse_relevant_mapping(line: &[u8]) -> Option<ProcessMapping> {
     let range = take_ascii_field(line, &mut cursor)?;
     let permissions = take_ascii_field(line, &mut cursor)?;
     let offset = take_ascii_field(line, &mut cursor)?;
-    take_ascii_field(line, &mut cursor)?;
-    take_ascii_field(line, &mut cursor)?;
+    let device = take_ascii_field(line, &mut cursor)?;
+    let inode = take_ascii_field(line, &mut cursor)?;
     let path = take_ascii_field(line, &mut cursor)?;
     let basename = path.rsplit(|byte| *byte == b'/').next().unwrap_or(path);
     let module = match basename {
@@ -210,10 +280,35 @@ fn parse_relevant_mapping(line: &[u8]) -> Option<ProcessMapping> {
     }
     Some(ProcessMapping {
         module,
+        image: ProcessImageId {
+            device: parse_device_identifier(device)?,
+            inode: parse_decimal_u64(inode).filter(|value| *value != 0)?,
+        },
         start,
         end,
         offset: parse_hex_usize(offset)?,
         executable: permissions[2] == b'x',
+    })
+}
+
+fn parse_device_identifier(input: &[u8]) -> Option<u64> {
+    let separator = input.iter().position(|byte| *byte == b':')?;
+    if input[separator + 1..].contains(&b':') {
+        return None;
+    }
+    let major = u32::try_from(parse_hex_usize(&input[..separator])?).ok()?;
+    let minor = u32::try_from(parse_hex_usize(&input[separator + 1..])?).ok()?;
+    Some((u64::from(major) << 32) | u64::from(minor))
+}
+
+fn parse_decimal_u64(input: &[u8]) -> Option<u64> {
+    if input.is_empty() || input.len() > 20 || !input.iter().all(u8::is_ascii_digit) {
+        return None;
+    }
+    input.iter().try_fold(0u64, |current, digit| {
+        current
+            .checked_mul(10)?
+            .checked_add(u64::from(digit - b'0'))
     })
 }
 
@@ -285,8 +380,11 @@ pub fn generate_magic(length: usize) -> io::Result<Vec<u8>> {
     let mut output = Vec::with_capacity(length);
     let mut random = [0u8; 128];
     while output.len() < length {
-        source.read_exact(&mut random)?;
-        for byte in random {
+        if let Err(error) = source.read_exact(&mut random) {
+            wipe_bytes(&mut random);
+            return Err(error);
+        }
+        for &byte in &random {
             if byte < RANDOM_ACCEPTANCE_LIMIT {
                 output.push(MAGIC_ALPHABET[usize::from(byte) % MAGIC_ALPHABET.len()]);
                 if output.len() == length {
@@ -295,6 +393,7 @@ pub fn generate_magic(length: usize) -> io::Result<Vec<u8>> {
             }
         }
     }
+    wipe_bytes(&mut random);
     Ok(output)
 }
 
@@ -465,6 +564,22 @@ mod tests {
     }
 
     #[test]
+    fn wipes_temporary_process_bytes() {
+        let mut value = b"sensitive process state".to_vec();
+        wipe_bytes(&mut value);
+        assert!(value.iter().all(|byte| *byte == 0));
+    }
+
+    #[test]
+    fn preserves_real_signals_but_suppresses_the_synthetic_return_trap() {
+        assert_eq!(remote_stop_signal_to_deliver(11, 0x1234, 0x1234), 0);
+        assert_eq!(remote_stop_signal_to_deliver(15, 0x1234, 0x1234), 15);
+        assert_eq!(remote_stop_signal_to_deliver(11, 0x5678, 0x1234), 11);
+        assert_eq!(remote_stop_signal_to_deliver(0, 0x5678, 0x1234), 0);
+        assert_eq!(remote_stop_signal_to_deliver(65, 0x5678, 0x1234), 0);
+    }
+
+    #[test]
     fn parses_only_bounded_libc_and_libdl_mappings() {
         let input = b"7a00000000-7a00001000 r--p 00000000 00:01 1 /apex/lib64/libc.so\n\
                       7a00001000-7a00009000 r-xp 00001000 00:01 1 /apex/lib64/libc.so\n\
@@ -473,10 +588,53 @@ mod tests {
         let mappings = parse_relevant_process_maps(input).unwrap();
         assert_eq!(mappings.len(), 3);
         assert_eq!(mappings[0].module, ProcessModule::Libc);
+        assert_eq!(mappings[0].image.device, 1);
+        assert_eq!(mappings[0].image.inode, 1);
         assert_eq!(mappings[0].offset, 0);
         assert!(!mappings[0].executable);
         assert!(mappings[1].executable);
         assert_eq!(mappings[2].module, ProcessModule::Libdl);
+    }
+
+    #[test]
+    fn keeps_same_named_platform_images_separate() {
+        let input = b"71000000-71001000 r-xp 00000000 00:01 11 /apex/a/lib64/libc.so\n\
+                      72000000-72001000 r-xp 00000000 00:02 22 /data/local/tmp/libc.so\n\
+                      73000000-73001000 r-xp 00000000 00:03 0 /apex/b/lib64/libdl.so\n";
+        let mappings = parse_relevant_process_maps(input).unwrap();
+
+        assert_eq!(mappings.len(), 2);
+        assert_ne!(mappings[0].image, mappings[1].image);
+        assert_eq!(mappings[0].image.inode, 11);
+        assert_eq!(mappings[1].image.inode, 22);
+    }
+
+    #[test]
+    fn selects_the_base_of_the_resolved_image_instead_of_a_same_named_decoy() {
+        let input = b"71000000-71001000 r--p 00000000 00:02 22 /data/local/tmp/libc.so\n\
+                      72000000-72001000 r--p 00000000 00:01 11 /apex/a/lib64/libc.so\n\
+                      72001000-72002000 r-xp 00001000 00:01 11 /apex/a/lib64/libc.so\n";
+        let mappings = parse_relevant_process_maps(input).unwrap();
+        let expected = ProcessImageId {
+            device: 1,
+            inode: 11,
+        };
+
+        assert_eq!(
+            process_image_base(&mappings, ProcessModule::Libc, expected),
+            Some(0x7200_0000)
+        );
+        assert_eq!(
+            process_image_base(
+                &mappings,
+                ProcessModule::Libc,
+                ProcessImageId {
+                    device: 3,
+                    inode: 33,
+                }
+            ),
+            None
+        );
     }
 
     #[test]

--- a/rust/native-core/src/injector_support.rs
+++ b/rust/native-core/src/injector_support.rs
@@ -13,7 +13,12 @@ const MAGIC_ALPHABET: &[u8; 62] = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGH
 const RANDOM_ACCEPTANCE_LIMIT: u8 = 248;
 const O_NOFOLLOW: i32 = 0x20000;
 const MAXIMUM_SIGNAL_NUMBER: i32 = 64;
+const SIGNAL_ILLEGAL_INSTRUCTION: i32 = 4;
+const SIGNAL_TRACE_TRAP: i32 = 5;
+const SIGNAL_BUS_ERROR: i32 = 7;
+const SIGNAL_FLOATING_POINT_EXCEPTION: i32 = 8;
 const SIGNAL_SEGMENTATION_FAULT: i32 = 11;
+const SIGNAL_BAD_SYSTEM_CALL: i32 = 31;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ProcessModule {
@@ -78,10 +83,30 @@ pub fn sanitize_signal_for_detach(signal: i32) -> i32 {
 
 pub fn remote_stop_signal_to_deliver(
     signal: i32,
+    signal_code: Option<i32>,
     actual_address: usize,
     synthetic_return_address: usize,
 ) -> i32 {
-    if signal == SIGNAL_SEGMENTATION_FAULT
+    let synchronous_fault = matches!(
+        signal,
+        SIGNAL_ILLEGAL_INSTRUCTION
+            | SIGNAL_TRACE_TRAP
+            | SIGNAL_BUS_ERROR
+            | SIGNAL_FLOATING_POINT_EXCEPTION
+            | SIGNAL_SEGMENTATION_FAULT
+            | SIGNAL_BAD_SYSTEM_CALL
+    );
+    // Positive si_code values are kernel-generated. A synchronous fault while
+    // the tracee is executing an injected call belongs to that call and must
+    // not be replayed after restoring the tracee's original register state.
+    if synchronous_fault && signal_code.is_some_and(|code| code > 0) {
+        return 0;
+    }
+    // PTRACE_GETSIGINFO should identify the synthetic fault. Retain the
+    // instruction-pointer check only as a safe fallback when siginfo is not
+    // available, without swallowing an externally queued SIGSEGV.
+    if signal_code.is_none()
+        && signal == SIGNAL_SEGMENTATION_FAULT
         && synthetic_return_address != 0
         && actual_address == synthetic_return_address
     {
@@ -89,6 +114,18 @@ pub fn remote_stop_signal_to_deliver(
     } else {
         sanitize_signal_for_detach(signal)
     }
+}
+
+pub fn is_synthetic_return_trap(
+    signal: i32,
+    signal_code: Option<i32>,
+    actual_address: usize,
+    synthetic_return_address: usize,
+) -> bool {
+    signal == SIGNAL_SEGMENTATION_FAULT
+        && synthetic_return_address != 0
+        && actual_address == synthetic_return_address
+        && signal_code.is_none_or(|code| code > 0)
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -572,11 +609,32 @@ mod tests {
 
     #[test]
     fn preserves_real_signals_but_suppresses_the_synthetic_return_trap() {
-        assert_eq!(remote_stop_signal_to_deliver(11, 0x1234, 0x1234), 0);
-        assert_eq!(remote_stop_signal_to_deliver(15, 0x1234, 0x1234), 15);
-        assert_eq!(remote_stop_signal_to_deliver(11, 0x5678, 0x1234), 11);
-        assert_eq!(remote_stop_signal_to_deliver(0, 0x5678, 0x1234), 0);
-        assert_eq!(remote_stop_signal_to_deliver(65, 0x5678, 0x1234), 0);
+        assert!(is_synthetic_return_trap(11, None, 0x1234, 0x1234));
+        assert!(is_synthetic_return_trap(11, Some(2), 0x1234, 0x1234));
+        assert!(!is_synthetic_return_trap(11, Some(0), 0x1234, 0x1234));
+        assert_eq!(remote_stop_signal_to_deliver(11, None, 0x1234, 0x1234), 0);
+        assert_eq!(
+            remote_stop_signal_to_deliver(11, Some(2), 0x1234, 0x1234),
+            0
+        );
+        assert_eq!(
+            remote_stop_signal_to_deliver(11, Some(1), 0x5678, 0x1234),
+            0
+        );
+        assert_eq!(
+            remote_stop_signal_to_deliver(11, Some(0), 0x1234, 0x1234),
+            11
+        );
+        assert_eq!(
+            remote_stop_signal_to_deliver(11, Some(-6), 0x5678, 0x1234),
+            11
+        );
+        assert_eq!(
+            remote_stop_signal_to_deliver(15, Some(0), 0x1234, 0x1234),
+            15
+        );
+        assert_eq!(remote_stop_signal_to_deliver(0, None, 0x5678, 0x1234), 0);
+        assert_eq!(remote_stop_signal_to_deliver(65, None, 0x5678, 0x1234), 0);
     }
 
     #[test]

--- a/rust/native-core/src/platform.rs
+++ b/rust/native-core/src/platform.rs
@@ -78,16 +78,14 @@ impl BinderFdCacheEntry {
 #[derive(Clone, Copy)]
 struct BinderFdFastCacheEntry {
     descriptor: i32,
-    device: u64,
-    inode: u64,
+    exchange_token: usize,
     hits_remaining: u8,
 }
 
 impl BinderFdFastCacheEntry {
     const EMPTY: Self = Self {
         descriptor: -1,
-        device: 0,
-        inode: 0,
+        exchange_token: 0,
         hits_remaining: 0,
     };
 }
@@ -180,12 +178,11 @@ fn write_descriptor_path(descriptor: i32, output: &mut [u8]) -> Option<usize> {
     Some(path_length)
 }
 
-fn take_fast_binder_fd_hit(descriptor: i32, identity: DescriptorIdentity) -> bool {
+fn take_fast_binder_fd_hit(descriptor: i32, exchange_token: usize) -> bool {
     BINDER_FD_FAST_CACHE.with(|cache| {
         let mut entry = cache.get();
         if entry.descriptor != descriptor
-            || entry.device != identity.device
-            || entry.inode != identity.inode
+            || entry.exchange_token != exchange_token
             || entry.hits_remaining == 0
         {
             return false;
@@ -196,20 +193,29 @@ fn take_fast_binder_fd_hit(descriptor: i32, identity: DescriptorIdentity) -> boo
     })
 }
 
-fn remember_fast_binder_fd(descriptor: i32, identity: DescriptorIdentity) {
+fn remember_fast_binder_fd(descriptor: i32, exchange_token: usize) {
     BINDER_FD_FAST_CACHE.with(|cache| {
         cache.set(BinderFdFastCacheEntry {
             descriptor,
-            device: identity.device,
-            inode: identity.inode,
+            exchange_token,
             hits_remaining: BINDER_FD_FAST_REVALIDATE_HITS,
         });
     });
 }
 
-pub fn is_binder_fd(descriptor: i32) -> bool {
-    if descriptor < 0 {
+/// Classifies the descriptor after a successful `BINDER_WRITE_READ` ioctl.
+///
+/// The successful Binder command is a required part of the trust decision: it
+/// prevents a stale positive cache entry from admitting an ordinary reused FD.
+/// The per-thread exchange pointer further binds fast hits to libbinder's
+/// stable call site, while device and inode are revalidated at a bounded
+/// interval without adding a syscall to every Binder transaction.
+pub fn is_binder_fd_after_successful_ioctl(descriptor: i32, exchange_token: usize) -> bool {
+    if descriptor < 0 || exchange_token == 0 {
         return false;
+    }
+    if take_fast_binder_fd_hit(descriptor, exchange_token) {
+        return true;
     }
 
     let Some(identity) = descriptor_identity(descriptor) else {
@@ -221,12 +227,6 @@ pub fn is_binder_fd(descriptor: i32) -> bool {
     if identity.file_type != CHARACTER_DEVICE {
         return false;
     }
-    // Revalidate the open file description before taking the thread-local fast
-    // path. Descriptor numbers can be reused immediately after close(), so a
-    // descriptor-only cache can otherwise misclassify a different device.
-    if take_fast_binder_fd_hit(descriptor, identity) {
-        return true;
-    }
     let slot = descriptor as usize % BINDER_FD_CACHE_ENTRIES;
     if let Ok(cache) = BINDER_FD_CACHE.read() {
         let entry = cache[slot];
@@ -235,7 +235,7 @@ pub fn is_binder_fd(descriptor: i32) -> bool {
             && entry.inode == identity.inode
         {
             if entry.is_binder {
-                remember_fast_binder_fd(descriptor, identity);
+                remember_fast_binder_fd(descriptor, exchange_token);
             }
             return entry.is_binder;
         }
@@ -269,7 +269,7 @@ pub fn is_binder_fd(descriptor: i32) -> bool {
         };
     }
     if is_binder {
-        remember_fast_binder_fd(descriptor, identity);
+        remember_fast_binder_fd(descriptor, exchange_token);
     }
     is_binder
 }
@@ -283,10 +283,7 @@ pub fn parse_android_api_level(value: &[u8]) -> Option<i32> {
             .checked_mul(10)?
             .checked_add(i32::from(digit - b'0'))
     })?;
-    // Keep syntax parsing forward-compatible without treating every future
-    // SDK number as supported. The C++ bridge applies the narrower
-    // compiler-validated Binder UAPI range before interception is enabled.
-    (31..=999).contains(&api).then_some(api)
+    (31..=37).contains(&api).then_some(api)
 }
 
 pub fn parse_kernel_release(value: &[u8]) -> Option<(i32, i32)> {
@@ -316,8 +313,12 @@ fn parse_decimal_component(value: &[u8]) -> Option<i32> {
 }
 
 #[no_mangle]
-pub extern "C" fn rust_is_binder_fd(descriptor: i32) -> bool {
-    std::panic::catch_unwind(|| is_binder_fd(descriptor)).unwrap_or(false)
+pub extern "C" fn rust_is_binder_fd_after_successful_ioctl(
+    descriptor: i32,
+    exchange_token: usize,
+) -> bool {
+    std::panic::catch_unwind(|| is_binder_fd_after_successful_ioctl(descriptor, exchange_token))
+        .unwrap_or(false)
 }
 
 #[no_mangle]
@@ -411,7 +412,7 @@ mod tests {
             .open(&path)
             .unwrap();
 
-        assert!(!is_binder_fd(file.as_raw_fd()));
+        assert!(!is_binder_fd_after_successful_ioctl(file.as_raw_fd(), 1));
 
         drop(file);
         fs::remove_file(path).unwrap();
@@ -428,26 +429,15 @@ mod tests {
     }
 
     #[test]
-    fn fast_binder_cache_revalidates_after_bounded_hits() {
+    fn fast_binder_cache_is_bound_to_the_fd_and_exchange_call_site() {
         BINDER_FD_FAST_CACHE.with(|cache| cache.set(BinderFdFastCacheEntry::EMPTY));
-        let identity = DescriptorIdentity {
-            device: 7,
-            inode: 11,
-            file_type: CHARACTER_DEVICE,
-        };
-        remember_fast_binder_fd(123, identity);
-        assert!(!take_fast_binder_fd_hit(124, identity));
-        assert!(!take_fast_binder_fd_hit(
-            123,
-            DescriptorIdentity {
-                inode: 12,
-                ..identity
-            }
-        ));
+        remember_fast_binder_fd(123, 0x4567);
+        assert!(!take_fast_binder_fd_hit(124, 0x4567));
+        assert!(!take_fast_binder_fd_hit(123, 0x7654));
         for _ in 0..BINDER_FD_FAST_REVALIDATE_HITS {
-            assert!(take_fast_binder_fd_hit(123, identity));
+            assert!(take_fast_binder_fd_hit(123, 0x4567));
         }
-        assert!(!take_fast_binder_fd_hit(123, identity));
+        assert!(!take_fast_binder_fd_hit(123, 0x4567));
     }
 
     #[test]
@@ -463,9 +453,7 @@ mod tests {
         assert_eq!(parse_android_api_level(b"31"), Some(31));
         assert_eq!(parse_android_api_level(b"36"), Some(36));
         assert_eq!(parse_android_api_level(b"37"), Some(37));
-        assert_eq!(parse_android_api_level(b"38"), Some(38));
-        assert_eq!(parse_android_api_level(b"999"), Some(999));
-        assert_eq!(parse_android_api_level(b"1000"), None);
+        assert_eq!(parse_android_api_level(b"38"), None);
         assert_eq!(parse_kernel_release(b"6.1.75-android14"), Some((6, 1)));
         assert_eq!(parse_kernel_release(b"invalid"), None);
     }

--- a/rust/native-core/src/platform.rs
+++ b/rust/native-core/src/platform.rs
@@ -6,7 +6,10 @@ use std::sync::RwLock;
 
 const AT_NO_AUTOMOUNT: c_int = 0x800;
 const AT_EMPTY_PATH: c_int = 0x1000;
+const STATX_TYPE: c_uint = 0x001;
 const STATX_INO: c_uint = 0x100;
+const FILE_TYPE_MASK: u16 = 0o170_000;
+const CHARACTER_DEVICE: u16 = 0o020_000;
 const BINDER_FD_CACHE_ENTRIES: usize = 64;
 const BINDER_FD_FAST_REVALIDATE_HITS: u8 = 31;
 const PROC_FD_PREFIX: &[u8] = b"/proc/self/fd/";
@@ -75,12 +78,16 @@ impl BinderFdCacheEntry {
 #[derive(Clone, Copy)]
 struct BinderFdFastCacheEntry {
     descriptor: i32,
+    device: u64,
+    inode: u64,
     hits_remaining: u8,
 }
 
 impl BinderFdFastCacheEntry {
     const EMPTY: Self = Self {
         descriptor: -1,
+        device: 0,
+        inode: 0,
         hits_remaining: 0,
     };
 }
@@ -113,7 +120,14 @@ pub fn is_binder_device_path(path: &[u8]) -> bool {
     matches!(basename, b"binder" | b"vndbinder" | b"hwbinder")
 }
 
-fn descriptor_identity(descriptor: i32) -> Option<(u64, u64)> {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct DescriptorIdentity {
+    device: u64,
+    inode: u64,
+    file_type: u16,
+}
+
+fn descriptor_identity(descriptor: i32) -> Option<DescriptorIdentity> {
     if descriptor < 0 {
         return None;
     }
@@ -123,16 +137,20 @@ fn descriptor_identity(descriptor: i32) -> Option<(u64, u64)> {
             descriptor,
             EMPTY_PATH.as_ptr(),
             AT_EMPTY_PATH | AT_NO_AUTOMOUNT,
-            STATX_INO,
+            STATX_TYPE | STATX_INO,
             &mut metadata,
         )
     } != 0
-        || metadata.mask & STATX_INO == 0
+        || (metadata.mask & (STATX_TYPE | STATX_INO)) != (STATX_TYPE | STATX_INO)
     {
         return None;
     }
     let device = (u64::from(metadata.device_major) << 32) | u64::from(metadata.device_minor);
-    Some((device, metadata.inode))
+    Some(DescriptorIdentity {
+        device,
+        inode: metadata.inode,
+        file_type: metadata.mode & FILE_TYPE_MASK,
+    })
 }
 
 fn write_descriptor_path(descriptor: i32, output: &mut [u8]) -> Option<usize> {
@@ -162,10 +180,14 @@ fn write_descriptor_path(descriptor: i32, output: &mut [u8]) -> Option<usize> {
     Some(path_length)
 }
 
-fn take_fast_binder_fd_hit(descriptor: i32) -> bool {
+fn take_fast_binder_fd_hit(descriptor: i32, identity: DescriptorIdentity) -> bool {
     BINDER_FD_FAST_CACHE.with(|cache| {
         let mut entry = cache.get();
-        if entry.descriptor != descriptor || entry.hits_remaining == 0 {
+        if entry.descriptor != descriptor
+            || entry.device != identity.device
+            || entry.inode != identity.inode
+            || entry.hits_remaining == 0
+        {
             return false;
         }
         entry.hits_remaining -= 1;
@@ -174,10 +196,12 @@ fn take_fast_binder_fd_hit(descriptor: i32) -> bool {
     })
 }
 
-fn remember_fast_binder_fd(descriptor: i32) {
+fn remember_fast_binder_fd(descriptor: i32, identity: DescriptorIdentity) {
     BINDER_FD_FAST_CACHE.with(|cache| {
         cache.set(BinderFdFastCacheEntry {
             descriptor,
+            device: identity.device,
+            inode: identity.inode,
             hits_remaining: BINDER_FD_FAST_REVALIDATE_HITS,
         });
     });
@@ -187,19 +211,31 @@ pub fn is_binder_fd(descriptor: i32) -> bool {
     if descriptor < 0 {
         return false;
     }
-    if take_fast_binder_fd_hit(descriptor) {
-        return true;
-    }
 
-    let Some((device, inode)) = descriptor_identity(descriptor) else {
+    let Some(identity) = descriptor_identity(descriptor) else {
         return false;
     };
+    // Binder endpoints are character devices. A regular file named `binder`
+    // must never enter the interception path solely because its basename
+    // resembles a Binder device.
+    if identity.file_type != CHARACTER_DEVICE {
+        return false;
+    }
+    // Revalidate the open file description before taking the thread-local fast
+    // path. Descriptor numbers can be reused immediately after close(), so a
+    // descriptor-only cache can otherwise misclassify a different device.
+    if take_fast_binder_fd_hit(descriptor, identity) {
+        return true;
+    }
     let slot = descriptor as usize % BINDER_FD_CACHE_ENTRIES;
     if let Ok(cache) = BINDER_FD_CACHE.read() {
         let entry = cache[slot];
-        if entry.descriptor == descriptor && entry.device == device && entry.inode == inode {
+        if entry.descriptor == descriptor
+            && entry.device == identity.device
+            && entry.inode == identity.inode
+        {
             if entry.is_binder {
-                remember_fast_binder_fd(descriptor);
+                remember_fast_binder_fd(descriptor, identity);
             }
             return entry.is_binder;
         }
@@ -220,20 +256,20 @@ pub fn is_binder_fd(descriptor: i32) -> bool {
     if target_length <= 0 || target_length as usize >= target.len() {
         return false;
     }
-    if descriptor_identity(descriptor) != Some((device, inode)) {
+    if descriptor_identity(descriptor) != Some(identity) {
         return false;
     }
     let is_binder = is_binder_device_path(&target[..target_length as usize]);
     if let Ok(mut cache) = BINDER_FD_CACHE.write() {
         cache[slot] = BinderFdCacheEntry {
             descriptor,
-            device,
-            inode,
+            device: identity.device,
+            inode: identity.inode,
             is_binder,
         };
     }
     if is_binder {
-        remember_fast_binder_fd(descriptor);
+        remember_fast_binder_fd(descriptor, identity);
     }
     is_binder
 }
@@ -247,7 +283,11 @@ pub fn parse_android_api_level(value: &[u8]) -> Option<i32> {
             .checked_mul(10)?
             .checked_add(i32::from(digit - b'0'))
     })?;
-    (31..=37).contains(&api).then_some(api)
+    // Keep the parser forward-compatible. Native fallback policy remains
+    // separately bounded to ABI versions that were compiled and tested; a
+    // future API may proceed only after the C++ bridge validates live Binder
+    // traffic against the current UAPI layout.
+    (31..=999).contains(&api).then_some(api)
 }
 
 pub fn parse_kernel_release(value: &[u8]) -> Option<(i32, i32)> {
@@ -351,6 +391,35 @@ mod tests {
     }
 
     #[test]
+    fn refuses_a_regular_file_named_binder() {
+        use std::fs::{self, OpenOptions};
+        use std::os::fd::AsRawFd;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let directory = std::env::temp_dir().join(format!(
+            "cleverestricky-binder-fd-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir(&directory).unwrap();
+        let path = directory.join("binder");
+        let file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .unwrap();
+
+        assert!(!is_binder_fd(file.as_raw_fd()));
+
+        drop(file);
+        fs::remove_file(path).unwrap();
+        fs::remove_dir(directory).unwrap();
+    }
+
+    #[test]
     fn descriptor_paths_are_bounded_and_null_terminated() {
         let mut output = [0xa5u8; MAXIMUM_DESCRIPTOR_PATH_BYTES];
         let length = write_descriptor_path(i32::MAX, &mut output).unwrap();
@@ -362,12 +431,24 @@ mod tests {
     #[test]
     fn fast_binder_cache_revalidates_after_bounded_hits() {
         BINDER_FD_FAST_CACHE.with(|cache| cache.set(BinderFdFastCacheEntry::EMPTY));
-        remember_fast_binder_fd(123);
+        let identity = DescriptorIdentity {
+            device: 7,
+            inode: 11,
+            file_type: CHARACTER_DEVICE,
+        };
+        remember_fast_binder_fd(123, identity);
+        assert!(!take_fast_binder_fd_hit(124, identity));
+        assert!(!take_fast_binder_fd_hit(
+            123,
+            DescriptorIdentity {
+                inode: 12,
+                ..identity
+            }
+        ));
         for _ in 0..BINDER_FD_FAST_REVALIDATE_HITS {
-            assert!(take_fast_binder_fd_hit(123));
+            assert!(take_fast_binder_fd_hit(123, identity));
         }
-        assert!(!take_fast_binder_fd_hit(123));
-        assert!(!take_fast_binder_fd_hit(124));
+        assert!(!take_fast_binder_fd_hit(123, identity));
     }
 
     #[test]
@@ -383,7 +464,9 @@ mod tests {
         assert_eq!(parse_android_api_level(b"31"), Some(31));
         assert_eq!(parse_android_api_level(b"36"), Some(36));
         assert_eq!(parse_android_api_level(b"37"), Some(37));
-        assert_eq!(parse_android_api_level(b"38"), None);
+        assert_eq!(parse_android_api_level(b"38"), Some(38));
+        assert_eq!(parse_android_api_level(b"999"), Some(999));
+        assert_eq!(parse_android_api_level(b"1000"), None);
         assert_eq!(parse_kernel_release(b"6.1.75-android14"), Some((6, 1)));
         assert_eq!(parse_kernel_release(b"invalid"), None);
     }

--- a/rust/native-core/src/platform.rs
+++ b/rust/native-core/src/platform.rs
@@ -283,10 +283,9 @@ pub fn parse_android_api_level(value: &[u8]) -> Option<i32> {
             .checked_mul(10)?
             .checked_add(i32::from(digit - b'0'))
     })?;
-    // Keep the parser forward-compatible. Native fallback policy remains
-    // separately bounded to ABI versions that were compiled and tested; a
-    // future API may proceed only after the C++ bridge validates live Binder
-    // traffic against the current UAPI layout.
+    // Keep syntax parsing forward-compatible without treating every future
+    // SDK number as supported. The C++ bridge applies the narrower
+    // compiler-validated Binder UAPI range before interception is enabled.
     (31..=999).contains(&api).then_some(api)
 }
 


### PR DESCRIPTION
## Summary

- harden Binder FD classification against regular-file spoofing while preserving a bounded syscall-free fast path after a successful Binder ioctl
- make Binder transaction redirection a bounded whole-record snapshot/writeback, preserving all unowned UAPI fields with fewer pipe syscalls
- bind remote symbol resolution to the exact mapped libc/libdl device+inode image instead of trusting a same-basename mapping
- preserve concurrent and unexpected ptrace signals, suppress only injection-owned synchronous faults, and wipe saved stack/process buffers
- use nonblocking CLOEXEC descriptor-transfer sockets, clear ancillary/random/loader buffers, and redact native pointer logs
- publish the ioctl hook state with acquire/release ordering and require explicit non-empty transaction filters
- keep installer and runtime support aligned to the compiler-validated Android API 31-37 Binder UAPI range, failing closed on unknown future layouts

## Risk reductions

- rejects a regular file named `binder`; FD fast hits require a successful `BINDER_WRITE_READ`, the same descriptor, and the same per-thread exchange call site
- revalidates character-device type plus device/inode identity after at most 31 fast hits, avoiding a per-transaction identity syscall
- prevents a same-named decoy platform library mapping from influencing remote load-bias calculation
- preserves externally delivered signals without replaying faults caused by an injected call
- prevents cleanup calls from consuming a pending signal after an unexpected remote stop
- avoids indefinite ancillary socket blocking and removes broad empty-filter interception
- clears partial cross-process/Binder reads on error and clears temporary process-derived data before release
- refuses API levels whose Binder field layout was not compiled and validated, rather than inferring compatibility from structure size alone

## Performance validation

Release-profile x86_64 Linux microbenchmarks were CPU-pinned. Because the container has no Binder device, a detached benchmark-only worktree treated `/dev/null` as an accepted basename to exercise the exact positive character-device/cache/statx path; that allowance is not part of this PR.

| Path | Baseline median CPU/op | PR median CPU/op | Ratio |
| --- | ---: | ---: | ---: |
| Binder FD classifier, 7 x 20M calls | 12.677 ns | 13.569 ns | 1.070x |
| Whole-record writeback, 5 x 500K | 755.819 ns | 556.975 ns | 0.737x |
| Binder parser plus temporary wipe, 5 x 500K | 545.535 ns | 571.519 ns | 1.048x |

- FD classifier syscall count is 102 `statx` calls per 3,200 classifications for both baseline and the final design. The intermediate implementation measured 3,202 and was replaced.
- Long FD-classifier runs had the same 1,976 KiB median maximum RSS for baseline and PR.
- The final hot paths stay below the requested 1.1x CPU/RAM ceiling in this host microbenchmark. Android builds and tests remain the authoritative compatibility gate.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (44 tests)
- Android-target Clippy for `aarch64-linux-android` and `x86_64-linux-android`
- repository native-source policy, long-dash scan, and `git diff --check`

## Release scope

No version, changelog, release workflow, or `update.json` changes are included.