### PR TITLE
Fix Encryptor release signing secret mapping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -489,13 +489,12 @@ jobs:
         if: github.event_name != 'pull_request'
         shell: bash
         env:
-          ENCRYPTOR_KEYSTORE_BASE64: ${{ secrets.ENCRYPTOR_KEYSTORE_BASE64 }}
-          ENCRYPTOR_KEYSTORE_PASSWORD: ${{ secrets.ENCRYPTOR_KEYSTORE_PASSWORD }}
-          ENCRYPTOR_KEY_ALIAS: ${{ secrets.ENCRYPTOR_KEY_ALIAS }}
-          ENCRYPTOR_KEY_PASSWORD: ${{ secrets.ENCRYPTOR_KEY_PASSWORD }}
+          RELEASE_KEYSTORE: ${{ secrets.RELEASE_KEYSTORE }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
         run: |
           set -euo pipefail
-          for name in ENCRYPTOR_KEYSTORE_BASE64 ENCRYPTOR_KEYSTORE_PASSWORD ENCRYPTOR_KEY_ALIAS ENCRYPTOR_KEY_PASSWORD; do
+          for name in RELEASE_KEYSTORE RELEASE_KEY_ALIAS RELEASE_KEY_PASSWORD; do
             if [ -z "${!name:-}" ]; then
               echo "::error::Missing GitHub Actions secret: $name"
               exit 1
@@ -503,19 +502,19 @@ jobs:
           done
 
           keystore="$RUNNER_TEMP/encryptor-release.jks"
-          printf '%s' "$ENCRYPTOR_KEYSTORE_BASE64" | base64 --decode > "$keystore"
+          printf '%s' "$RELEASE_KEYSTORE" | base64 --decode > "$keystore"
           chmod 600 "$keystore"
           test -s "$keystore"
           keytool -list \
             -keystore "$keystore" \
-            -storepass "$ENCRYPTOR_KEYSTORE_PASSWORD" \
-            -alias "$ENCRYPTOR_KEY_ALIAS" >/dev/null
+            -storepass "$RELEASE_KEY_PASSWORD" \
+            -alias "$RELEASE_KEY_ALIAS" >/dev/null
 
           {
             echo "ORG_GRADLE_PROJECT_ENCRYPTOR_RELEASE_KEYSTORE=$keystore"
-            echo "ORG_GRADLE_PROJECT_ENCRYPTOR_RELEASE_STORE_PASSWORD=$ENCRYPTOR_KEYSTORE_PASSWORD"
-            echo "ORG_GRADLE_PROJECT_ENCRYPTOR_RELEASE_KEY_ALIAS=$ENCRYPTOR_KEY_ALIAS"
-            echo "ORG_GRADLE_PROJECT_ENCRYPTOR_RELEASE_KEY_PASSWORD=$ENCRYPTOR_KEY_PASSWORD"
+            echo "ORG_GRADLE_PROJECT_ENCRYPTOR_RELEASE_STORE_PASSWORD=$RELEASE_KEY_PASSWORD"
+            echo "ORG_GRADLE_PROJECT_ENCRYPTOR_RELEASE_KEY_ALIAS=$RELEASE_KEY_ALIAS"
+            echo "ORG_GRADLE_PROJECT_ENCRYPTOR_RELEASE_KEY_PASSWORD=$RELEASE_KEY_PASSWORD"
           } >> "$GITHUB_ENV"
 
       - name: Build Encryptor App


### PR DESCRIPTION
## Root cause

The master Build run referenced four `ENCRYPTOR_*` repository secrets that do not exist, so the release stopped after the module ZIP had built successfully. The repository's configured stable-signing secrets are `RELEASE_KEYSTORE`, `RELEASE_KEY_ALIAS`, and `RELEASE_KEY_PASSWORD`.

## Fix

- map stable Encryptor signing directly to the existing `RELEASE_*` secret names
- decode `RELEASE_KEYSTORE` as the JKS payload
- use `RELEASE_KEY_PASSWORD` for both the keystore and key password, matching the available secret set
- keep `BETA_*` out of the stable master release path
- preserve the existing Gradle `ENCRYPTOR_RELEASE_*` property interface

No secret values are read, copied, or changed.

## Validation

- reproduced Build #2518 failure at `Prepare Encryptor release signing`
- exercised the complete signing-preparation shell path with a temporary JKS, including base64 decode, alias/password validation, and Gradle environment export
- parsed `.github/workflows/build.yml` as YAML
- `git diff --check`
- confirmed obsolete `ENCRYPTOR_*` repository-secret references are absent