### PR TITLE
Fix Kotlin security update automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
-    allow:
-      - dependency-type: "direct"
     groups:
       bouncycastle-security:
         applies-to: security-updates

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ agp = "9.3.1"
 bcpkix-jdk18on = "1.85"
 bcprov-jdk18on = "1.85.2"
 bcutil-jdk18on = "1.85"
-kotlin = "2.4.10"
+kotlin = "2.4.20-RC"
 annotation = "1.10.0"
 junit = "4.13.2"
 compose-bom = "2026.06.01"
@@ -19,6 +19,9 @@ mockito = "5.23.0"
 
 [libraries]
 nanohttpd = { module = "org.nanohttpd:nanohttpd", version = "2.3.1" }
+# Keep KGP's Maven coordinate explicit so Dependabot can map security advisories
+# to the shared Kotlin plugin version instead of treating it as transitive only.
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 junit = { module = "junit:junit", version.ref = "junit" }
 annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 bcpkix-jdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bcpkix-jdk18on" }


### PR DESCRIPTION
## What changed

- upgrade the shared Kotlin and Compose plugin version from 2.4.10 to 2.4.20-RC
- declare `org.jetbrains.kotlin:kotlin-gradle-plugin` explicitly in the version catalog, tied to the same Kotlin version
- remove the Gradle `allow: dependency-type: direct` override that filtered the advisory target out of security update jobs

## Why

Dependabot update job #1524120911 exited successfully without opening a PR. Its final log says `Found no dependencies to update after filtering allowed updates`. The affected package is the Maven coordinate behind the Kotlin plugin, while the repository only exposed plugin IDs through the catalog. The first patched line is a Kotlin 2.4.20 pre-release, which Dependabot would not select while the project remained on stable 2.4.10.

Moving to the newer 2.4.20-RC immediately clears CVE-2026-53914 and keeps the project on the patched pre-release line. Making the Maven coordinate explicit and removing the restrictive allow override lets future security jobs target the shared catalog version instead of silently finishing with no candidate.

## Validation

- parsed `.github/dependabot.yml` and verified the Gradle update block has no restrictive `allow`
- parsed `gradle/libs.versions.toml` and verified the Kotlin version and Maven coordinate share one version reference
- `git diff --check`
- confirmed Kotlin 2.4.20-RC, Android plugin marker, and Compose plugin marker are published
- full Android/Gradle compilation is left to the repository Build and Security Regression workflows because this workspace cannot reach Google/Maven artifact endpoints