### PR TITLE
perf: reduce attestation timing delta and align defaults

### DIFF
--- a/module/template/customize.sh
+++ b/module/template/customize.sh
@@ -186,18 +186,31 @@ if [ ! -e "$CONFIG_DIR/settings_schema_v3" ]; then
   chown 0:0 "$CONFIG_DIR/settings_schema_v3" || abort "! Could not set settings migration marker ownership"
 fi
 
-# Fresh installs start with the core protection path enabled globally. Identity
-# spoofing stays opt-in; upgrading users keep their existing switch files.
+# Fresh installs use the recommended minimal default: global core coverage and
+# automatic keybox checking are enabled; identity/privacy extras stay off. The
+# v2 patch policy follows the device's captured/property patch level and only
+# advances stale values through Automatic mode.
 if [ ! -e "$CONFIG_DIR/spoof_switch_initialized" ]; then
-  ui_print "- Enabling Global Mode (identity spoofing remains off by default)"
+  ui_print "- Applying recommended default settings"
   [ -e "$CONFIG_DIR/global_mode" ] || : > "$CONFIG_DIR/global_mode" \
     || abort "! Could not enable Global Mode"
+  [ -e "$CONFIG_DIR/auto_keybox_check" ] || : > "$CONFIG_DIR/auto_keybox_check" \
+    || abort "! Could not enable automatic keybox checking"
+  if [ ! -e "$CONFIG_DIR/policy_state_v2.json" ]; then
+    extract "$ZIPFILE" 'policy_state_v2.json' "$TMPDIR"
+    mv "$TMPDIR/policy_state_v2.json" "$CONFIG_DIR/policy_state_v2.json" \
+      || abort "! Could not install the default policy state"
+  fi
   : > "$CONFIG_DIR/spoof_switch_initialized" \
     || abort "! Could not write the default-settings migration marker"
 fi
 chmod 600 "$CONFIG_DIR/spoof_switch_initialized" || abort "! Could not secure migration marker"
 [ ! -e "$CONFIG_DIR/global_mode" ] || chmod 600 "$CONFIG_DIR/global_mode" \
   || abort "! Could not secure Global Mode switch"
+[ ! -e "$CONFIG_DIR/auto_keybox_check" ] || chmod 600 "$CONFIG_DIR/auto_keybox_check" \
+  || abort "! Could not secure automatic keybox checking"
+[ ! -e "$CONFIG_DIR/policy_state_v2.json" ] || chmod 600 "$CONFIG_DIR/policy_state_v2.json" \
+  || abort "! Could not secure default policy state"
 [ ! -e "$CONFIG_DIR/spoof_enabled" ] || chmod 600 "$CONFIG_DIR/spoof_enabled" \
   || abort "! Could not secure identity Spoof Engine switch"
 
@@ -256,6 +269,8 @@ chown 0:0 "$CONFIG_DIR/spoof_build_vars" "$CONFIG_DIR/security_patch.txt" \
   || abort "! Could not set Global Mode switch ownership"
 [ ! -e "$CONFIG_DIR/auto_keybox_check" ] || chown 0:0 "$CONFIG_DIR/auto_keybox_check" \
   || abort "! Could not set keybox revocation switch ownership"
+[ ! -e "$CONFIG_DIR/policy_state_v2.json" ] || chown 0:0 "$CONFIG_DIR/policy_state_v2.json" \
+  || abort "! Could not set policy state ownership"
 [ ! -e "$CONFIG_DIR/spoof_enabled" ] || chown 0:0 "$CONFIG_DIR/spoof_enabled" \
   || abort "! Could not set identity Spoof Engine switch ownership"
 [ ! -e "$CONFIG_DIR/spoof_build_identity" ] || chown 0:0 "$CONFIG_DIR/spoof_build_identity"

--- a/module/template/policy_state_v2.json
+++ b/module/template/policy_state_v2.json
@@ -1,0 +1,19 @@
+{
+  "version": 2,
+  "features": {
+    "buildIdentity": false,
+    "attestationIdentity": false,
+    "telephonyIdentity": false,
+    "regionIdentity": false,
+    "identityRefresh": false,
+    "securityPatch": true
+  },
+  "securityPatch": {
+    "automaticThresholdMonths": 6,
+    "system": { "mode": "automatic" },
+    "vendor": { "mode": "automatic" },
+    "boot": { "mode": "automatic" }
+  },
+  "profiles": [],
+  "activeProfile": null
+}

--- a/module/webui-tests/default-settings.test.js
+++ b/module/webui-tests/default-settings.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const moduleRoot = path.resolve(__dirname, '..');
+const templateRoot = path.join(moduleRoot, 'template');
+
+const policy = JSON.parse(fs.readFileSync(path.join(templateRoot, 'policy_state_v2.json'), 'utf8'));
+assert.strictEqual(policy.version, 2);
+assert.deepStrictEqual(policy.features, {
+  buildIdentity: false,
+  attestationIdentity: false,
+  telephonyIdentity: false,
+  regionIdentity: false,
+  identityRefresh: false,
+  securityPatch: true
+});
+assert.strictEqual(policy.securityPatch.automaticThresholdMonths, 6);
+for (const component of ['system', 'vendor', 'boot']) {
+  assert.strictEqual(policy.securityPatch[component].mode, 'automatic');
+}
+assert.deepStrictEqual(policy.profiles, []);
+assert.strictEqual(policy.activeProfile, null);
+
+const installer = fs.readFileSync(path.join(templateRoot, 'customize.sh'), 'utf8');
+const start = installer.indexOf('# Fresh installs use the recommended minimal default:');
+const end = installer.indexOf('if [ ! -f "$CONFIG_DIR/spoof_build_vars" ]', start);
+assert.ok(start >= 0 && end > start, 'recommended default installer block must exist');
+const defaultsBlock = installer.slice(start, end);
+assert.match(defaultsBlock, /CONFIG_DIR\/global_mode/);
+assert.match(defaultsBlock, /CONFIG_DIR\/auto_keybox_check/);
+assert.match(defaultsBlock, /policy_state_v2\.json/);
+assert.doesNotMatch(defaultsBlock, /: > "\$CONFIG_DIR\/spoof_enabled"/);
+assert.doesNotMatch(defaultsBlock, /: > "\$CONFIG_DIR\/drm_passthrough"/);
+assert.doesNotMatch(defaultsBlock, /: > "\$CONFIG_DIR\/telephony"/);
+
+console.log('default-settings.test.js passed');

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -34,7 +34,6 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
-import java.security.MessageDigest;
 import java.security.PublicKey;
 import java.security.Security;
 import java.security.Signature;
@@ -86,33 +85,27 @@ public final class CertHack {
                     }
                 }
             };
-    private static final ThreadLocal<MessageDigest> SHA256_DIGEST =
-            new ThreadLocal<MessageDigest>() {
-                @Override
-                protected MessageDigest initialValue() {
-                    try {
-                        return MessageDigest.getInstance("SHA-256");
-                    } catch (Exception e) {
-                        throw new IllegalStateException("SHA-256 digest is unavailable", e);
-                    }
-                }
-            };
-    private static final ThreadLocal<JcaX509CertificateConverter> CERTIFICATE_CONVERTER =
-            ThreadLocal.withInitial(JcaX509CertificateConverter::new);
-    private static final ThreadLocal<JcaContentSignerBuilder> EC_SIGNER_BUILDER =
-            ThreadLocal.withInitial(() -> new JcaContentSignerBuilder("SHA256withECDSA"));
-    private static final ThreadLocal<JcaContentSignerBuilder> RSA_SIGNER_BUILDER =
-            ThreadLocal.withInitial(() -> new JcaContentSignerBuilder("SHA256withRSA"));
+    // Converter configuration is immutable after construction. Keeping one process-wide instance
+    // avoids paying ThreadLocal initialization on whichever Keystore Binder worker happens to see
+    // the first attested request.
+    private static final JcaX509CertificateConverter CERTIFICATE_CONVERTER =
+            new JcaX509CertificateConverter();
 
     private static final class PreparedKeyBox {
         final X500Name issuer;
         final String signatureAlgorithm;
+        final JcaContentSignerBuilder signerBuilder;
+        final Certificate[] issuerChain;
 
         PreparedKeyBox(KeyBox keybox) throws Exception {
             if (keybox.certificates.isEmpty()) throw new IOException("Keybox has no certificates");
             this.issuer = new X509CertificateHolder(keybox.certificates.get(0).getEncoded()).getSubject();
             this.signatureAlgorithm = signatureAlgorithmForKeybox(keybox);
             if (this.signatureAlgorithm == null) throw new IOException("Unsupported keybox algorithm");
+            this.signerBuilder = new JcaContentSignerBuilder(this.signatureAlgorithm);
+            this.issuerChain = keybox.certificates.toArray(new Certificate[0]);
+            // Force JCA/provider lookup while keyboxes are loaded, not on the first attestation.
+            this.signerBuilder.build(keybox.keyPair.getPrivate());
         }
     }
 
@@ -204,12 +197,15 @@ public final class CertHack {
     }
 
     private static final class CacheKey {
-        private final byte[] leafDigest;
+        private final byte[] leafEncoded;
         private final int hashCode;
 
         public CacheKey(byte[] leafEncoded) {
-            this.leafDigest = SHA256_DIGEST.get().digest(leafEncoded);
-            this.hashCode = Arrays.hashCode(leafDigest);
+            // Certificates are public data and the cache is tiny/bounded, so a cryptographic digest
+            // only adds provider work to every generateKey reply. Retain the exact DER bytes instead;
+            // Arrays.equals protects correctness even if the ordinary hash collides.
+            this.leafEncoded = leafEncoded.clone();
+            this.hashCode = Arrays.hashCode(this.leafEncoded);
         }
 
         int indexForPool(int size) {
@@ -222,7 +218,7 @@ public final class CertHack {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             CacheKey cacheKey = (CacheKey) o;
-            return MessageDigest.isEqual(leafDigest, cacheKey.leafDigest);
+            return Arrays.equals(leafEncoded, cacheKey.leafEncoded);
         }
 
         @Override
@@ -351,12 +347,6 @@ public final class CertHack {
         if (KeyProperties.KEY_ALGORITHM_EC.equals(algorithm)) return "SHA256withECDSA";
         if (KeyProperties.KEY_ALGORITHM_RSA.equals(algorithm)) return "SHA256withRSA";
         return null;
-    }
-
-    private static JcaContentSignerBuilder signerBuilder(String signatureAlgorithm) {
-        if ("SHA256withECDSA".equals(signatureAlgorithm)) return EC_SIGNER_BUILDER.get();
-        if ("SHA256withRSA".equals(signatureAlgorithm)) return RSA_SIGNER_BUILDER.get();
-        throw new IllegalArgumentException("Unsupported keybox signature algorithm");
     }
 
     public static List<KeyBox> parseKeyboxXml(Reader reader) {
@@ -591,20 +581,15 @@ public final class CertHack {
                         new ByteArrayInputStream(leafEncoded));
             }
 
-            byte[] bytes = leaf.getExtensionValue(OID.getId());
-            if (bytes == null) return caList;
-            if (bytes.length > MAX_ATTESTATION_EXTENSION_BYTES) {
+            X509CertificateHolder leafHolder = new X509CertificateHolder(leafEncoded);
+            Extension ext = leafHolder.getExtension(OID);
+            if (ext == null || ext.getExtnValue() == null) return caList;
+            byte[] extensionOctets = ext.getExtnValue().getOctets();
+            if (extensionOctets.length > MAX_ATTESTATION_EXTENSION_BYTES) {
                 Logger.e("Attestation extension exceeds the safety limit");
                 return caList;
             }
-
-            X509CertificateHolder leafHolder = new X509CertificateHolder(leafEncoded);
-            Extension ext = leafHolder.getExtension(OID);
-            if (ext == null || ext.getExtnValue() == null) {
-                Logger.e("Attestation extension present but holder returned null; skipping rewrite");
-                return caList;
-            }
-            ASN1Sequence sequence = ASN1Sequence.getInstance(ext.getExtnValue().getOctets());
+            ASN1Sequence sequence = ASN1Sequence.getInstance(extensionOctets);
             ASN1Encodable[] encodables = sequence.toArray();
             if (encodables.length <= 7 || !(encodables[6] instanceof ASN1Sequence) ||
                     !(encodables[7] instanceof ASN1Sequence)) {
@@ -636,10 +621,6 @@ public final class CertHack {
             ASN1Encodable rootOfTrust = null;
             byte[] moduleHash = Config.INSTANCE.getModuleHash();
             ASN1TaggedObject originalModuleHash = null;
-
-            // Most attestations do not carry device-ID authorization tags. Resolve an
-            // override only when the genuine TEE list actually contains that tag, avoiding nine
-            // policy/privacy lookups and temporary collections on the common timing-sensitive path.
             Map<Integer, byte[]> presentIdAttestationTags = null;
 
             for (ASN1Encodable asn1Encodable : teeEnforced) {
@@ -707,7 +688,10 @@ public final class CertHack {
                 }
             }
 
-            String preferredSignerAlgorithm = signingKeyAlgorithm(leaf.getSigAlgName());
+            // The subject key algorithm does not constrain the CA key algorithm. Prefer EC when
+            // available because signing the replacement leaf is the only unavoidable work unique to
+            // the attested path and EC signing is materially cheaper than RSA on mobile cores.
+            String preferredSignerAlgorithm = KeyProperties.KEY_ALGORITHM_EC;
             var appConfig = Config.INSTANCE.getAppConfig(uid);
             List<KeyBox> list;
             if (appConfig != null && appConfig.getKeyboxFilename() != null) {
@@ -722,7 +706,6 @@ public final class CertHack {
             PreparedKeyBox prepared = currentState.preparedKeyboxes.get(k);
             if (prepared == null) throw new UnsupportedOperationException("Keybox metadata is unavailable");
 
-            LinkedList<Certificate> certificates = new LinkedList<>(k.certificates);
             X509v3CertificateBuilder builder = new X509v3CertificateBuilder(
                     prepared.issuer,
                     leafHolder.getSerialNumber(),
@@ -731,7 +714,7 @@ public final class CertHack {
                     leafHolder.getSubject(),
                     leafHolder.getSubjectPublicKeyInfo()
             );
-            ContentSigner signer = signerBuilder(prepared.signatureAlgorithm).build(k.keyPair.getPrivate());
+            ContentSigner signer = prepared.signerBuilder.build(k.keyPair.getPrivate());
 
             byte[] verifiedBootKey = usableBootDigest(UtilKt.getBootKey());
             byte[] verifiedBootHash = usableBootDigest(UtilKt.getBootHash());
@@ -795,9 +778,10 @@ public final class CertHack {
                     builder.addExtension(leafHolder.getExtension(extensionOID));
                 }
             }
-            certificates.addFirst(CERTIFICATE_CONVERTER.get().getCertificate(builder.build(signer)));
-
-            Certificate[] result = certificates.toArray(new Certificate[0]);
+            Certificate rewrittenLeaf = CERTIFICATE_CONVERTER.getCertificate(builder.build(signer));
+            Certificate[] result = new Certificate[prepared.issuerChain.length + 1];
+            result[0] = rewrittenLeaf;
+            System.arraycopy(prepared.issuerChain, 0, result, 1, prepared.issuerChain.length);
             synchronized (cache) {
                 Certificate[] raced = cache.get(cacheKey);
                 if (raced != null) return raced.clone();

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -85,16 +85,16 @@ public final class CertHack {
                     }
                 }
             };
-    // Converter configuration is immutable after construction. Keeping one process-wide instance
-    // avoids paying ThreadLocal initialization on whichever Keystore Binder worker happens to see
-    // the first attested request.
-    private static final JcaX509CertificateConverter CERTIFICATE_CONVERTER =
-            new JcaX509CertificateConverter();
+    private static final ThreadLocal<JcaX509CertificateConverter> CERTIFICATE_CONVERTER =
+            ThreadLocal.withInitial(JcaX509CertificateConverter::new);
+    private static final ThreadLocal<JcaContentSignerBuilder> EC_SIGNER_BUILDER =
+            ThreadLocal.withInitial(() -> new JcaContentSignerBuilder("SHA256withECDSA"));
+    private static final ThreadLocal<JcaContentSignerBuilder> RSA_SIGNER_BUILDER =
+            ThreadLocal.withInitial(() -> new JcaContentSignerBuilder("SHA256withRSA"));
 
     private static final class PreparedKeyBox {
         final X500Name issuer;
         final String signatureAlgorithm;
-        final JcaContentSignerBuilder signerBuilder;
         final Certificate[] issuerChain;
 
         PreparedKeyBox(KeyBox keybox) throws Exception {
@@ -102,11 +102,18 @@ public final class CertHack {
             this.issuer = new X509CertificateHolder(keybox.certificates.get(0).getEncoded()).getSubject();
             this.signatureAlgorithm = signatureAlgorithmForKeybox(keybox);
             if (this.signatureAlgorithm == null) throw new IOException("Unsupported keybox algorithm");
-            this.signerBuilder = new JcaContentSignerBuilder(this.signatureAlgorithm);
             this.issuerChain = keybox.certificates.toArray(new Certificate[0]);
-            // Force JCA/provider lookup while keyboxes are loaded, not on the first attestation.
-            this.signerBuilder.build(keybox.keyPair.getPrivate());
+            // Resolve the provider and signing implementation while keyboxes are loaded. The
+            // per-Binder-worker builders below remain thread-confined for concurrency safety.
+            new JcaContentSignerBuilder(this.signatureAlgorithm).build(keybox.keyPair.getPrivate());
         }
+    }
+
+    private static final class AuthorizationSummary {
+        boolean hasRootOfTrust;
+        Integer systemPatch;
+        Integer vendorPatch;
+        Integer bootPatch;
     }
 
     private static class State {
@@ -231,21 +238,55 @@ public final class CertHack {
         return component.getDisposition() != Config.PatchDisposition.KEEP;
     }
 
+    private static int patchValue(ASN1TaggedObject taggedObject) throws CertificateParsingException {
+        try {
+            return ASN1Integer.getInstance(taggedObject.getBaseObject()).getValue().intValueExact();
+        } catch (Throwable error) {
+            throw new CertificateParsingException("Invalid security patch authorization", error);
+        }
+    }
+
+    private static Integer mergePatchValue(Integer current, int parsed)
+            throws CertificateParsingException {
+        if (current != null && current != parsed) {
+            throw new CertificateParsingException("Conflicting security patch authorizations");
+        }
+        return parsed;
+    }
+
+    private static AuthorizationSummary summarizeAuthorizationList(ASN1Sequence sequence)
+            throws CertificateParsingException {
+        AuthorizationSummary summary = new AuthorizationSummary();
+        for (ASN1Encodable value : sequence) {
+            if (!(value instanceof ASN1TaggedObject taggedObject)) {
+                throw new CertificateParsingException("Invalid authorization-list element");
+            }
+            switch (taggedObject.getTagNo()) {
+                case 704 -> summary.hasRootOfTrust = true;
+                case 706 -> summary.systemPatch = mergePatchValue(summary.systemPatch, patchValue(taggedObject));
+                case 718 -> summary.vendorPatch = mergePatchValue(summary.vendorPatch, patchValue(taggedObject));
+                case 719 -> summary.bootPatch = mergePatchValue(summary.bootPatch, patchValue(taggedObject));
+                default -> {
+                }
+            }
+        }
+        return summary;
+    }
+
+    private static Integer combineCapturedPatch(Integer teeValue, Integer softwareValue)
+            throws CertificateParsingException {
+        if (teeValue != null && softwareValue != null && !teeValue.equals(softwareValue)) {
+            throw new CertificateParsingException("Conflicting security patch authorization lists");
+        }
+        return teeValue != null ? teeValue : softwareValue;
+    }
+
     private static Integer readPatchTag(ASN1Sequence sequence, int targetTag)
             throws CertificateParsingException {
         Integer result = null;
         for (ASN1Encodable value : sequence) {
             if (!(value instanceof ASN1TaggedObject taggedObject) || taggedObject.getTagNo() != targetTag) continue;
-            int parsed;
-            try {
-                parsed = ASN1Integer.getInstance(taggedObject.getBaseObject()).getValue().intValueExact();
-            } catch (Throwable error) {
-                throw new CertificateParsingException("Invalid security patch authorization", error);
-            }
-            if (result != null && result != parsed) {
-                throw new CertificateParsingException("Conflicting security patch authorizations");
-            }
-            result = parsed;
+            result = mergePatchValue(result, patchValue(taggedObject));
         }
         return result;
     }
@@ -255,12 +296,7 @@ public final class CertHack {
             ASN1Sequence softwareEnforced,
             int tag
     ) throws CertificateParsingException {
-        Integer teeValue = readPatchTag(teeEnforced, tag);
-        Integer softwareValue = readPatchTag(softwareEnforced, tag);
-        if (teeValue != null && softwareValue != null && !teeValue.equals(softwareValue)) {
-            throw new CertificateParsingException("Conflicting security patch authorization lists");
-        }
-        return teeValue != null ? teeValue : softwareValue;
+        return combineCapturedPatch(readPatchTag(teeEnforced, tag), readPatchTag(softwareEnforced, tag));
     }
 
     private static void addPatchTag(
@@ -347,6 +383,12 @@ public final class CertHack {
         if (KeyProperties.KEY_ALGORITHM_EC.equals(algorithm)) return "SHA256withECDSA";
         if (KeyProperties.KEY_ALGORITHM_RSA.equals(algorithm)) return "SHA256withRSA";
         return null;
+    }
+
+    private static JcaContentSignerBuilder signerBuilder(String signatureAlgorithm) {
+        if ("SHA256withECDSA".equals(signatureAlgorithm)) return EC_SIGNER_BUILDER.get();
+        if ("SHA256withRSA".equals(signatureAlgorithm)) return RSA_SIGNER_BUILDER.get();
+        throw new IllegalArgumentException("Unsupported keybox signature algorithm");
     }
 
     public static List<KeyBox> parseKeyboxXml(Reader reader) {
@@ -596,23 +638,22 @@ public final class CertHack {
                 Logger.e("Attestation record is missing an authorization list");
                 return caList;
             }
-            int teeEnforcedIndex = containsTag((ASN1Sequence) encodables[6], 704) &&
-                    !containsTag((ASN1Sequence) encodables[7], 704) ? 6 : 7;
+            ASN1Sequence listSix = (ASN1Sequence) encodables[6];
+            ASN1Sequence listSeven = (ASN1Sequence) encodables[7];
+            AuthorizationSummary summarySix = summarizeAuthorizationList(listSix);
+            AuthorizationSummary summarySeven = summarizeAuthorizationList(listSeven);
+            int teeEnforcedIndex = summarySix.hasRootOfTrust && !summarySeven.hasRootOfTrust ? 6 : 7;
             int softwareEnforcedIndex = teeEnforcedIndex == 6 ? 7 : 6;
-            ASN1Sequence teeEnforced = (ASN1Sequence) encodables[teeEnforcedIndex];
-            ASN1Sequence softwareEnforced = (ASN1Sequence) encodables[softwareEnforcedIndex];
+            ASN1Sequence teeEnforced = teeEnforcedIndex == 6 ? listSix : listSeven;
+            ASN1Sequence softwareEnforced = teeEnforcedIndex == 6 ? listSeven : listSix;
+            AuthorizationSummary teeSummary = teeEnforcedIndex == 6 ? summarySix : summarySeven;
+            AuthorizationSummary softwareSummary = teeEnforcedIndex == 6 ? summarySeven : summarySix;
             int attestationVersion = ASN1Integer.getInstance(encodables[0]).getValue().intValueExact();
             int keyMintVersion = ASN1Integer.getInstance(encodables[2]).getValue().intValueExact();
             boolean supportsModuleHash = attestationVersion >= 400 && keyMintVersion >= 400;
-            boolean systemWasTee = containsTag(teeEnforced, 706);
-            boolean systemWasSoftware = containsTag(softwareEnforced, 706);
-            boolean vendorWasTee = containsTag(teeEnforced, 718);
-            boolean vendorWasSoftware = containsTag(softwareEnforced, 718);
-            boolean bootWasTee = containsTag(teeEnforced, 719);
-            boolean bootWasSoftware = containsTag(softwareEnforced, 719);
-            Integer capturedSystem = readCapturedPatch(teeEnforced, softwareEnforced, 706);
-            Integer capturedVendor = readCapturedPatch(teeEnforced, softwareEnforced, 718);
-            Integer capturedBoot = readCapturedPatch(teeEnforced, softwareEnforced, 719);
+            Integer capturedSystem = combineCapturedPatch(teeSummary.systemPatch, softwareSummary.systemPatch);
+            Integer capturedVendor = combineCapturedPatch(teeSummary.vendorPatch, softwareSummary.vendorPatch);
+            Integer capturedBoot = combineCapturedPatch(teeSummary.bootPatch, softwareSummary.bootPatch);
             Config.AttestationPatchLevels patchLevels = PolicyState.INSTANCE.resolveAttestationPatchLevels(
                     uid, capturedSystem, capturedVendor, capturedBoot);
 
@@ -670,9 +711,12 @@ public final class CertHack {
                 softwareTags.add(taggedObject);
             }
 
-            addPatchTag(teeTags, softwareTags, 706, patchLevels.getSystem(), systemWasTee, systemWasSoftware);
-            addPatchTag(teeTags, softwareTags, 718, patchLevels.getVendor(), vendorWasTee, vendorWasSoftware);
-            addPatchTag(teeTags, softwareTags, 719, patchLevels.getBoot(), bootWasTee, bootWasSoftware);
+            addPatchTag(teeTags, softwareTags, 706, patchLevels.getSystem(),
+                    teeSummary.systemPatch != null, softwareSummary.systemPatch != null);
+            addPatchTag(teeTags, softwareTags, 718, patchLevels.getVendor(),
+                    teeSummary.vendorPatch != null, softwareSummary.vendorPatch != null);
+            addPatchTag(teeTags, softwareTags, 719, patchLevels.getBoot(),
+                    teeSummary.bootPatch != null, softwareSummary.bootPatch != null);
 
             if (presentIdAttestationTags != null) {
                 for (Map.Entry<Integer, byte[]> entry : presentIdAttestationTags.entrySet()) {
@@ -714,7 +758,7 @@ public final class CertHack {
                     leafHolder.getSubject(),
                     leafHolder.getSubjectPublicKeyInfo()
             );
-            ContentSigner signer = prepared.signerBuilder.build(k.keyPair.getPrivate());
+            ContentSigner signer = signerBuilder(prepared.signatureAlgorithm).build(k.keyPair.getPrivate());
 
             byte[] verifiedBootKey = usableBootDigest(UtilKt.getBootKey());
             byte[] verifiedBootHash = usableBootDigest(UtilKt.getBootHash());
@@ -778,7 +822,7 @@ public final class CertHack {
                     builder.addExtension(leafHolder.getExtension(extensionOID));
                 }
             }
-            Certificate rewrittenLeaf = CERTIFICATE_CONVERTER.getCertificate(builder.build(signer));
+            Certificate rewrittenLeaf = CERTIFICATE_CONVERTER.get().getCertificate(builder.build(signer));
             Certificate[] result = new Certificate[prepared.issuerChain.length + 1];
             result[0] = rewrittenLeaf;
             System.arraycopy(prepared.issuerChain, 0, result, 1, prepared.issuerChain.length);


### PR DESCRIPTION
## Summary
- reduce avoidable work on the attested generateKey rewrite path by moving provider/signer preparation to keybox load time, removing per-request SHA-256 cache-key work, avoiding duplicate extension extraction, reusing prepared issuer chains, and preferring EC signing when an EC keybox is available
- add a v2 recommended default policy with identity extras disabled and Automatic security-patch handling enabled for system/vendor/boot
- fresh installs enable Global Mode and Automatic Keybox Check while keeping the rest of the optional identity/privacy feature switches off
- add a regression test that locks the intended fresh-install defaults

## Rationale
The timing probe repeatedly lands just above its 1.1x threshold. Android's own KeyMint attestation is inherently extra work, so this change does not fake parity with delays; it removes module-only provider/cache/certificate preparation from the timing-sensitive path and uses the cheaper valid issuer algorithm where possible.

## Validation
Build and Security Regression workflows are expected to gate merge. No release/version bump is included.