### PR TITLE
perf: finish KeyMint hotpath audit and align defaults

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -1931,18 +1931,19 @@ object Config {
                 SecureFile.touch(File(root, DRM_PASSTHROUGH_FILE), 384)
             }
             "default" -> {
-                SecureFile.touch(File(root, SPOOF_ENABLED_FILE), 384)
+                SecureFile.touch(File(root, GLOBAL_MODE_FILE), 384)
+                SecureFile.touch(File(root, AUTO_KEYBOX_CHECK_FILE), 384)
                 removeConfigFiles(
+                    SPOOF_ENABLED_FILE,
                     BUILD_IDENTITY_FILE,
-                    GLOBAL_MODE_FILE,
                     TEE_BROKEN_MODE_FILE,
                     RANDOM_ON_BOOT_FILE,
                     BootLogic.FILE_HIDE_PROPS,
                     BootLogic.FILE_SPOOF_CN,
                     TELEPHONY_FILE,
+                    RKP_PASSTHROUGH_FILE,
+                    DRM_PASSTHROUGH_FILE,
                 )
-                SecureFile.touch(File(root, AUTO_KEYBOX_CHECK_FILE), 384)
-                SecureFile.touch(File(root, DRM_PASSTHROUGH_FILE), 384)
             }
         }
 
@@ -1955,7 +1956,11 @@ object Config {
         updateDrmPassthrough(File(root, DRM_PASSTHROUGH_FILE))
         updateBuildVars(File(root, SPOOF_BUILD_VARS_FILE))
         updateTargetPackages(File(root, TARGET_FILE))
-        PolicyState.synchronizeBuiltInProfile()
+        if (profile == "default") {
+            PolicyState.applyRecommendedDefaults()
+        } else {
+            PolicyState.synchronizeBuiltInProfile()
+        }
         updateRandomOnBoot(File(root, RANDOM_ON_BOOT_FILE))
         KeyboxAutoCleaner.setEnabled(isRegularFlagFile(File(root, AUTO_KEYBOX_CHECK_FILE)))
     }
@@ -2342,8 +2347,8 @@ object Config {
                 }
             if (isDrm) return false
         }
-        if (getAppConfig(callingUid) != null) return true
         if (isGlobalMode) return true
+        if (getAppConfig(callingUid) != null) return true
 
         val state = targetState
         val cached = getCachedDecision(state.hackCache, callingUid)

--- a/service/src/main/java/cleveres/tricky/cleverestech/PolicyState.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/PolicyState.kt
@@ -233,6 +233,7 @@ object PolicyState {
     private const val MAX_AUTO_CACHE = 128
     private const val MAX_UID_RESOLUTIONS = 1024
     private const val CAPTURE_TTL_MS = 15 * 60 * 1000L
+    private const val CAPTURE_REFRESH_MS = 30 * 1000L
     private val profileNamePattern = Regex("[A-Za-z0-9][A-Za-z0-9 _.-]{0,63}")
     private val packagePattern = Regex("""(?:[A-Za-z_][A-Za-z0-9_]*|[*])(?:[.](?:[A-Za-z_][A-Za-z0-9_]*|[*]))*""")
     private val keyboxPattern = Regex("[A-Za-z0-9_.-]{5,128}")
@@ -718,10 +719,11 @@ object PolicyState {
         if (!current.explicit) return Config.getAttestationPatchLevels(uid)
         val selected = resolvedUid.selection.profile
         val basePatch = current.patch
+        val now = currentDateSource()
         return Config.AttestationPatchLevels(
-            system = resolvePatchComponent("system", selected?.systemPatch ?: basePatch.system, false, capturedSystem, basePatch.thresholdMonths),
-            vendor = resolvePatchComponent("vendor", selected?.vendorPatch ?: basePatch.vendor, true, capturedVendor, basePatch.thresholdMonths),
-            boot = resolvePatchComponent("boot", selected?.bootPatch ?: basePatch.boot, true, capturedBoot, basePatch.thresholdMonths),
+            system = resolvePatchComponent("system", selected?.systemPatch ?: basePatch.system, false, capturedSystem, basePatch.thresholdMonths, now),
+            vendor = resolvePatchComponent("vendor", selected?.vendorPatch ?: basePatch.vendor, true, capturedVendor, basePatch.thresholdMonths, now),
+            boot = resolvePatchComponent("boot", selected?.bootPatch ?: basePatch.boot, true, capturedBoot, basePatch.thresholdMonths, now),
         )
     }
 
@@ -738,6 +740,7 @@ object PolicyState {
         long: Boolean,
         captured: Int?,
         thresholdMonths: Long,
+        now: LocalDate? = null,
     ): Config.AttestationPatchComponent =
         when (policy.mode) {
             PatchMode.DEVICE_DEFAULT -> Config.AttestationPatchComponent(Config.PatchDisposition.KEEP)
@@ -755,7 +758,7 @@ object PolicyState {
                     Config.AttestationPatchComponent(Config.PatchDisposition.REPLACE, dateToPatch(propertyDate, long))
                 }
             }
-            PatchMode.AUTOMATIC -> resolveAutomatic(component, long, captured, thresholdMonths)
+            PatchMode.AUTOMATIC -> resolveAutomatic(component, long, captured, thresholdMonths, now ?: currentDateSource())
         }
 
     private fun resolveAutomatic(
@@ -763,12 +766,11 @@ object PolicyState {
         long: Boolean,
         captured: Int?,
         thresholdMonths: Long,
+        now: LocalDate,
     ): Config.AttestationPatchComponent {
         val capturedDate = captured?.let { patchToDate(it, long) }
-        val propertyDate = readPropertyDate(component)
-        val sourceDate = capturedDate ?: propertyDate
+        val sourceDate = capturedDate ?: readPropertyDate(component)
             ?: return Config.AttestationPatchComponent(Config.PatchDisposition.KEEP)
-        val now = currentDateSource()
         val cacheKey = AutoCacheKey(component, sourceDate, YearMonth.from(now), thresholdMonths, capturedDate != null)
         automaticCache[cacheKey]?.let { return it }
         val result =
@@ -822,9 +824,18 @@ object PolicyState {
         boot: Int?,
     ) {
         if (system == null && vendor == null && boot == null) return
-        if (capturedByPackage.size >= MAX_CAPTURED_PACKAGES) capturedByPackage.clear()
-        val record = CapturedPatch(system, vendor, boot, System.currentTimeMillis())
-        packages.asSequence().filter(packagePattern::matches).distinct().take(16).forEach { capturedByPackage[it] = record }
+        val now = System.currentTimeMillis()
+        var record: CapturedPatch? = null
+        packages.asSequence().filter(packagePattern::matches).distinct().take(16).forEach { packageName ->
+            val previous = capturedByPackage[packageName]
+            val age = previous?.let { now - it.timestamp }
+            if (previous != null && previous.system == system && previous.vendor == vendor && previous.boot == boot && age != null && age >= 0 && age < CAPTURE_REFRESH_MS) {
+                return@forEach
+            }
+            if (capturedByPackage.size >= MAX_CAPTURED_PACKAGES) capturedByPackage.clear()
+            val next = record ?: CapturedPatch(system, vendor, boot, now).also { record = it }
+            capturedByPackage[packageName] = next
+        }
     }
 
     private fun capturedForPackage(packageName: String): CapturedPatch? {
@@ -1115,6 +1126,23 @@ object PolicyState {
             assignments = assignments,
             generation = generationCounter.incrementAndGet(),
             recovery = "configured",
+        )
+    }
+
+    @Synchronized
+    fun applyRecommendedDefaults() {
+        val automatic = PatchPolicy(PatchMode.AUTOMATIC)
+        persistAndPublish(
+            Snapshot(
+                explicit = true,
+                features = FeatureSet(false, false, false, false, false, true),
+                patch = PatchSet(6, automatic, automatic, automatic),
+                profiles = emptyMap(),
+                activeProfile = null,
+                assignments = emptyList(),
+                generation = generationCounter.incrementAndGet(),
+                recovery = "default",
+            ),
         )
     }
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -211,7 +211,7 @@ public final class CertHack {
             // Certificates are public data and the cache is tiny/bounded, so a cryptographic digest
             // only adds provider work to every generateKey reply. Retain the exact DER bytes instead;
             // Arrays.equals protects correctness even if the ordinary hash collides.
-            this.leafEncoded = leafEncoded.clone();
+            this.leafEncoded = Objects.requireNonNull(leafEncoded, "leafEncoded");
             this.hashCode = Arrays.hashCode(this.leafEncoded);
         }
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/PolicyStateHotPathTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/PolicyStateHotPathTest.kt
@@ -12,24 +12,24 @@ class PolicyStateHotPathTest {
     fun recommendedDefaultsStayAligned() {
         val root = Files.createTempDirectory("ct-defaults").toFile()
         try {
-  PolicyState.setRootForTesting(root)
-  PolicyState.applyRecommendedDefaults()
-  val state = PolicyState.stateJson()
-  val features = state.getJSONObject("features")
-  assertFalse(features.getBoolean("buildIdentity"))
-  assertFalse(features.getBoolean("attestationIdentity"))
-  assertFalse(features.getBoolean("telephonyIdentity"))
-  assertFalse(features.getBoolean("regionIdentity"))
-  assertFalse(features.getBoolean("identityRefresh"))
-  assertTrue(features.getBoolean("securityPatch"))
-  val patch = state.getJSONObject("securityPatch")
-  assertEquals(6L, patch.getLong("automaticThresholdMonths"))
-  listOf("system", "vendor", "boot").forEach { component ->
-      assertEquals("automatic", patch.getJSONObject(component).getString("mode"))
-  }
+            PolicyState.setRootForTesting(root)
+            PolicyState.applyRecommendedDefaults()
+            val state = PolicyState.stateJson()
+            val features = state.getJSONObject("features")
+            assertFalse(features.getBoolean("buildIdentity"))
+            assertFalse(features.getBoolean("attestationIdentity"))
+            assertFalse(features.getBoolean("telephonyIdentity"))
+            assertFalse(features.getBoolean("regionIdentity"))
+            assertFalse(features.getBoolean("identityRefresh"))
+            assertTrue(features.getBoolean("securityPatch"))
+            val patch = state.getJSONObject("securityPatch")
+            assertEquals(6L, patch.getLong("automaticThresholdMonths"))
+            listOf("system", "vendor", "boot").forEach { component ->
+                assertEquals("automatic", patch.getJSONObject(component).getString("mode"))
+            }
         } finally {
-  PolicyState.resetForTesting()
-  root.deleteRecursively()
+            PolicyState.resetForTesting()
+            root.deleteRecursively()
         }
     }
 
@@ -38,21 +38,47 @@ class PolicyStateHotPathTest {
         val root = Files.createTempDirectory("ct-patch-hotpath").toFile()
         val oldProperties = systemPropertiesGet
         try {
-  Config.setRootForTesting(root)
-  Config.setPackagesForTesting(12345, arrayOf("com.example.test"))
-  PolicyState.installStateForTesting("""{"version":2,"features":{"buildIdentity":false,"attestationIdentity":false,"telephonyIdentity":false,"regionIdentity":false,"identityRefresh":false,"securityPatch":true},"securityPatch":{"automaticThresholdMonths":6,"system":{"mode":"automatic"},"vendor":{"mode":"automatic"},"boot":{"mode":"automatic"}},"profiles":[],"activeProfile":null}""")
-  PolicyState.currentDateSource = { LocalDate.of(2026, 8, 14) }
-  var reads = 0
-  systemPropertiesGet = { _, default -> reads++; default }
-  val levels = PolicyState.resolveAttestationPatchLevels(12345, 202608, 20260805, 20260805)
-  assertEquals(Config.PatchDisposition.KEEP, levels.system.disposition)
-  assertEquals(Config.PatchDisposition.KEEP, levels.vendor.disposition)
-  assertEquals(Config.PatchDisposition.KEEP, levels.boot.disposition)
-  assertEquals(0, reads)
+            Config.setRootForTesting(root)
+            Config.setPackagesForTesting(12345, arrayOf("com.example.test"))
+            PolicyState.installStateForTesting(
+                """
+                {
+                  "version": 2,
+                  "features": {
+                    "buildIdentity": false,
+                    "attestationIdentity": false,
+                    "telephonyIdentity": false,
+                    "regionIdentity": false,
+                    "identityRefresh": false,
+                    "securityPatch": true
+                  },
+                  "securityPatch": {
+                    "automaticThresholdMonths": 6,
+                    "system": {"mode": "automatic"},
+                    "vendor": {"mode": "automatic"},
+                    "boot": {"mode": "automatic"}
+                  },
+                  "profiles": [],
+                  "activeProfile": null
+                }
+                """.trimIndent(),
+            )
+            PolicyState.currentDateSource = { LocalDate.of(2026, 8, 14) }
+            var reads = 0
+            systemPropertiesGet = { _, default ->
+                reads++
+                default
+            }
+
+            val levels = PolicyState.resolveAttestationPatchLevels(12345, 202608, 20260805, 20260805)
+            assertEquals(Config.PatchDisposition.KEEP, levels.system.disposition)
+            assertEquals(Config.PatchDisposition.KEEP, levels.vendor.disposition)
+            assertEquals(Config.PatchDisposition.KEEP, levels.boot.disposition)
+            assertEquals(0, reads)
         } finally {
-  systemPropertiesGet = oldProperties
-  Config.reset()
-  root.deleteRecursively()
+            systemPropertiesGet = oldProperties
+            Config.reset()
+            root.deleteRecursively()
         }
     }
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/PolicyStateHotPathTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/PolicyStateHotPathTest.kt
@@ -1,0 +1,58 @@
+package cleveres.tricky.cleverestech
+
+import java.nio.file.Files
+import java.time.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PolicyStateHotPathTest {
+    @Test
+    fun recommendedDefaultsStayAligned() {
+        val root = Files.createTempDirectory("ct-defaults").toFile()
+        try {
+  PolicyState.setRootForTesting(root)
+  PolicyState.applyRecommendedDefaults()
+  val state = PolicyState.stateJson()
+  val features = state.getJSONObject("features")
+  assertFalse(features.getBoolean("buildIdentity"))
+  assertFalse(features.getBoolean("attestationIdentity"))
+  assertFalse(features.getBoolean("telephonyIdentity"))
+  assertFalse(features.getBoolean("regionIdentity"))
+  assertFalse(features.getBoolean("identityRefresh"))
+  assertTrue(features.getBoolean("securityPatch"))
+  val patch = state.getJSONObject("securityPatch")
+  assertEquals(6L, patch.getLong("automaticThresholdMonths"))
+  listOf("system", "vendor", "boot").forEach { component ->
+      assertEquals("automatic", patch.getJSONObject(component).getString("mode"))
+  }
+        } finally {
+  PolicyState.resetForTesting()
+  root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun capturedAutomaticPatchSkipsPropertyReads() {
+        val root = Files.createTempDirectory("ct-patch-hotpath").toFile()
+        val oldProperties = systemPropertiesGet
+        try {
+  Config.setRootForTesting(root)
+  Config.setPackagesForTesting(12345, arrayOf("com.example.test"))
+  PolicyState.installStateForTesting("""{"version":2,"features":{"buildIdentity":false,"attestationIdentity":false,"telephonyIdentity":false,"regionIdentity":false,"identityRefresh":false,"securityPatch":true},"securityPatch":{"automaticThresholdMonths":6,"system":{"mode":"automatic"},"vendor":{"mode":"automatic"},"boot":{"mode":"automatic"}},"profiles":[],"activeProfile":null}""")
+  PolicyState.currentDateSource = { LocalDate.of(2026, 8, 14) }
+  var reads = 0
+  systemPropertiesGet = { _, default -> reads++; default }
+  val levels = PolicyState.resolveAttestationPatchLevels(12345, 202608, 20260805, 20260805)
+  assertEquals(Config.PatchDisposition.KEEP, levels.system.disposition)
+  assertEquals(Config.PatchDisposition.KEEP, levels.vendor.disposition)
+  assertEquals(Config.PatchDisposition.KEEP, levels.boot.disposition)
+  assertEquals(0, reads)
+        } finally {
+  systemPropertiesGet = oldProperties
+  Config.reset()
+  root.deleteRecursively()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- short-circuit Global Mode before unnecessary per-app configuration resolution
- remove remaining avoidable work from automatic security-patch resolution on the attested generateKey path: reuse one current-date snapshot, avoid SystemProperties reads when KeyMint already supplied captured patch values, and throttle identical captured-patch telemetry writes
- remove a redundant DER byte-array clone from the bounded certificate cache key
- make WebUI Restore Defaults / built-in `default` profile exactly match fresh-install defaults: Global Mode + Automatic Keybox Check enabled; optional identity/privacy switches disabled; v2 security patch policy enabled in Automatic mode for system/vendor/boot
- add JVM regression coverage for the recommended default policy and the zero-property-read captured automatic patch fast path

## Audit notes
The final pass also rechecked SecurityLevelInterceptor, KeystoreInterceptor, PolicyState UID caching, issuer-chain handling, and the generateKey/getKeyEntry split. No additional high-confidence low-risk hot-path defect was found that should block this release.

## Validation
A focused Java 21 staging run completed `:service:testDebugUnitTest` plus all WebUI regression tests successfully before this PR was opened. Full Build and Security Regression workflows should gate merge.

No version or release metadata change is included.