### PR TITLE
fix: stabilize startup attestation and device-aware defaults

### DIFF
--- a/module/template/customize.sh
+++ b/module/template/customize.sh
@@ -201,6 +201,12 @@ if [ ! -e "$CONFIG_DIR/spoof_switch_initialized" ]; then
     mv "$TMPDIR/policy_state_v2.json" "$CONFIG_DIR/policy_state_v2.json" \
       || abort "! Could not install the default policy state"
   fi
+  : > "$CONFIG_DIR/recommended_defaults_pending" \
+    || abort "! Could not schedule device-aware default evaluation"
+  chmod 600 "$CONFIG_DIR/recommended_defaults_pending" \
+    || abort "! Could not secure device-aware default marker"
+  chown 0:0 "$CONFIG_DIR/recommended_defaults_pending" \
+    || abort "! Could not set device-aware default marker ownership"
   : > "$CONFIG_DIR/spoof_switch_initialized" \
     || abort "! Could not write the default-settings migration marker"
 fi

--- a/module/template/policy_state_v2.json
+++ b/module/template/policy_state_v2.json
@@ -6,7 +6,7 @@
     "telephonyIdentity": false,
     "regionIdentity": false,
     "identityRefresh": false,
-    "securityPatch": true
+    "securityPatch": false
   },
   "securityPatch": {
     "automaticThresholdMonths": 6,

--- a/module/webui-tests/default-settings.test.js
+++ b/module/webui-tests/default-settings.test.js
@@ -15,7 +15,7 @@ assert.deepStrictEqual(policy.features, {
   telephonyIdentity: false,
   regionIdentity: false,
   identityRefresh: false,
-  securityPatch: true
+  securityPatch: false
 });
 assert.strictEqual(policy.securityPatch.automaticThresholdMonths, 6);
 for (const component of ['system', 'vendor', 'boot']) {
@@ -32,6 +32,7 @@ const defaultsBlock = installer.slice(start, end);
 assert.match(defaultsBlock, /CONFIG_DIR\/global_mode/);
 assert.match(defaultsBlock, /CONFIG_DIR\/auto_keybox_check/);
 assert.match(defaultsBlock, /policy_state_v2\.json/);
+assert.match(defaultsBlock, /recommended_defaults_pending/);
 assert.doesNotMatch(defaultsBlock, /: > "\$CONFIG_DIR\/spoof_enabled"/);
 assert.doesNotMatch(defaultsBlock, /: > "\$CONFIG_DIR\/drm_passthrough"/);
 assert.doesNotMatch(defaultsBlock, /: > "\$CONFIG_DIR\/telephony"/);

--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -1743,6 +1743,7 @@ object Config {
     private const val RANDOM_ON_BOOT_FILE = "random_on_boot"
     private const val AUTO_KEYBOX_CHECK_FILE = "auto_keybox_check"
     private const val APPLY_PROFILE_FILE = "apply_profile"
+    private const val RECOMMENDED_DEFAULTS_PENDING_FILE = "recommended_defaults_pending"
     private const val MAX_DRM_PACKAGES_BYTES = 64L * 1024
     private const val MAX_DRM_PACKAGE_RULES = 256
     private const val MAX_TARGET_FILE_BYTES = 1024L * 1024
@@ -2118,6 +2119,7 @@ object Config {
         Logger.i("Config.initialize: starting (root=${root.absolutePath})")
         SecureFile.mkdirs(root, 448) // 0700
         SecureFile.mkdirs(keyboxDir, 448) // 0700
+        KeyboxVerifier.configureCacheRoot(root)
         DeviceKeyManager.initialize(root)
         CboxManager.initialize()
         ServerManager.initialize()
@@ -2137,6 +2139,7 @@ object Config {
         updateSecurityPatch(File(root, SECURITY_PATCH_FILE))
         updateAppConfigs(File(root, APP_CONFIG_FILE))
         PolicyState.initialize(root).getOrThrow()
+        applyPendingRecommendedDefaults()
         refreshPrivacySeed().getOrThrow()
 
         updateRandomOnBoot(File(root, RANDOM_ON_BOOT_FILE))
@@ -2158,6 +2161,20 @@ object Config {
 
         ConfigObserver.startWatching()
         KeyboxDirObserver.startWatching()
+    }
+
+    private fun applyPendingRecommendedDefaults() {
+        val marker = File(root, RECOMMENDED_DEFAULTS_PENDING_FILE)
+        val path = marker.toPath()
+        if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) return
+        if (!Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
+            Logger.e("Refusing unsafe recommended-defaults marker")
+            return
+        }
+        PolicyState.applyRecommendedDefaults()
+        if (!marker.delete()) {
+            Logger.w("Could not remove recommended-defaults marker; defaults may be re-evaluated on restart")
+        }
     }
 
     @Volatile

--- a/service/src/main/java/cleveres/tricky/cleverestech/PolicyState.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/PolicyState.kt
@@ -1129,14 +1129,24 @@ object PolicyState {
         )
     }
 
+    private fun recommendedSecurityPatchRequired(thresholdMonths: Long): Boolean {
+        val cutoff = currentDateSource().minusMonths(thresholdMonths)
+        return listOf("system", "vendor", "boot")
+            .asSequence()
+            .mapNotNull(::readPropertyDate)
+            .any { it.isBefore(cutoff) }
+    }
+
     @Synchronized
     fun applyRecommendedDefaults() {
+        val thresholdMonths = 6L
         val automatic = PatchPolicy(PatchMode.AUTOMATIC)
+        val securityPatchRequired = recommendedSecurityPatchRequired(thresholdMonths)
         persistAndPublish(
             Snapshot(
                 explicit = true,
-                features = FeatureSet(false, false, false, false, false, true),
-                patch = PatchSet(6, automatic, automatic, automatic),
+                features = FeatureSet(false, false, false, false, false, securityPatchRequired),
+                patch = PatchSet(thresholdMonths, automatic, automatic, automatic),
                 profiles = emptyMap(),
                 activeProfile = null,
                 assignments = emptyList(),

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -35,9 +35,13 @@ object KeyboxVerifier {
     private const val MAX_CRL_KEY_CHARS = 128
     private const val MAX_KEYBOX_XML_BYTES = 10L * 1024 * 1024
     private const val MAX_KEYBOX_FILES = 64
+    private const val PERSISTED_CRL_FILE = "attestation_status_cache.json"
 
     @Volatile
     private var crlUrl = DEFAULT_CRL_URL
+
+    @Volatile
+    private var cacheRoot = File("/data/adb/cleverestricky")
     private val HASH_LENGTHS = listOf(32, 40, 64)
     private val ZEROS = "0".repeat(64)
 
@@ -58,6 +62,47 @@ object KeyboxVerifier {
         cacheLock.lock()
         try {
             crlUrl = DEFAULT_CRL_URL
+            clearCacheLocked()
+        } finally {
+            cacheLock.unlock()
+        }
+    }
+
+    fun configureCacheRoot(configDir: File) {
+        cacheLock.lock()
+        try {
+            cacheRoot = configDir
+        } finally {
+            cacheLock.unlock()
+        }
+    }
+
+    @androidx.annotation.VisibleForTesting
+    fun setCacheRootForTesting(configDir: File) {
+        cacheLock.lock()
+        try {
+            cacheRoot = configDir
+            clearCacheLocked()
+        } finally {
+            cacheLock.unlock()
+        }
+    }
+
+    @androidx.annotation.VisibleForTesting
+    fun clearMemoryCacheForTesting() {
+        cacheLock.lock()
+        try {
+            clearCacheLocked()
+        } finally {
+            cacheLock.unlock()
+        }
+    }
+
+    @androidx.annotation.VisibleForTesting
+    fun resetCacheRootForTesting() {
+        cacheLock.lock()
+        try {
+            cacheRoot = File("/data/adb/cleverestricky")
             clearCacheLocked()
         } finally {
             cacheLock.unlock()
@@ -143,6 +188,13 @@ object KeyboxVerifier {
                 return cachedCrl
             }
 
+            loadPersistedCrlLocked(now)?.let { persisted ->
+                cachedCrl = persisted.first
+                lastFetchTime = persisted.second
+                Logger.i("Loaded fresh attestation revocation cache from disk")
+                return persisted.first
+            }
+
             val requestedUrl = crlUrl
             if (!isAllowedCrlUrl(requestedUrl, allowLoopbackHttp = requestedUrl != DEFAULT_CRL_URL)) {
                 Logger.e("Rejected unsafe CRL URL")
@@ -173,10 +225,15 @@ object KeyboxVerifier {
 
                 val declaredLength = connection.contentLengthLong
                 if (declaredLength > MAX_CRL_BYTES) throw IOException("CRL response is too large")
-                val newCrl = BoundedInputStream(connection.inputStream, MAX_CRL_BYTES).bufferedReader().use(::parseCrl)
+                val rawCrl =
+                    BoundedInputStream(connection.inputStream, MAX_CRL_BYTES)
+                        .bufferedReader(Charsets.UTF_8)
+                        .use { it.readText() }
+                val newCrl = parseCrl(rawCrl)
                 cachedCrl = newCrl
                 cachedEtag = connection.getHeaderField("ETag")?.take(512)
                 lastFetchTime = now
+                persistCrlLocked(rawCrl)
                 return newCrl
             } catch (e: Exception) {
                 Logger.e("Failed to fetch CRL", e)
@@ -206,6 +263,33 @@ object KeyboxVerifier {
         } catch (e: Exception) {
             false
         }
+
+    private fun loadPersistedCrlLocked(now: Long): Pair<Set<String>, Long>? {
+        val cacheFile = File(cacheRoot, PERSISTED_CRL_FILE)
+        val path = cacheFile.toPath()
+        if (!Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) return null
+        val size = cacheFile.length()
+        val modified = cacheFile.lastModified()
+        val age = now - modified
+        if (size !in 1..MAX_CRL_BYTES || modified <= 0L || age < 0L || age >= CACHE_TTL) return null
+        return runCatching {
+            val parsed =
+                BoundedInputStream(Files.newInputStream(path, LinkOption.NOFOLLOW_LINKS), MAX_CRL_BYTES)
+                    .bufferedReader(Charsets.UTF_8)
+                    .use(::parseCrl)
+            parsed to modified
+        }.onFailure {
+            Logger.w("Ignoring invalid persisted attestation revocation cache")
+        }.getOrNull()
+    }
+
+    private fun persistCrlLocked(rawCrl: String) {
+        runCatching {
+            SecureFile.writeText(File(cacheRoot, PERSISTED_CRL_FILE), rawCrl)
+        }.onFailure {
+            Logger.w("Could not persist attestation revocation cache")
+        }
+    }
 
     private fun clearCacheLocked() {
         cachedCrl = null

--- a/service/src/test/java/cleveres/tricky/cleverestech/PolicyStateHotPathTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/PolicyStateHotPathTest.kt
@@ -13,34 +13,34 @@ class PolicyStateHotPathTest {
         val root = Files.createTempDirectory("ct-defaults-current").toFile()
         val oldProperties = systemPropertiesGet
         try {
-  PolicyState.setRootForTesting(root)
-  PolicyState.currentDateSource = { LocalDate.of(2026, 8, 14) }
-  systemPropertiesGet = { name, default ->
-      when (name) {
-          "ro.build.version.security_patch" -> "2026-08-05"
-          "ro.vendor.build.security_patch" -> "2026-07-05"
-          "ro.bootimage.build.version.security_patch" -> "2026-07-05"
-          else -> default
-      }
-  }
-  PolicyState.applyRecommendedDefaults()
-  val state = PolicyState.stateJson()
-  val features = state.getJSONObject("features")
-  assertFalse(features.getBoolean("buildIdentity"))
-  assertFalse(features.getBoolean("attestationIdentity"))
-  assertFalse(features.getBoolean("telephonyIdentity"))
-  assertFalse(features.getBoolean("regionIdentity"))
-  assertFalse(features.getBoolean("identityRefresh"))
-  assertFalse(features.getBoolean("securityPatch"))
-  val patch = state.getJSONObject("securityPatch")
-  assertEquals(6L, patch.getLong("automaticThresholdMonths"))
-  listOf("system", "vendor", "boot").forEach { component ->
-      assertEquals("automatic", patch.getJSONObject(component).getString("mode"))
-  }
+            PolicyState.setRootForTesting(root)
+            PolicyState.currentDateSource = { LocalDate.of(2026, 8, 14) }
+            systemPropertiesGet = { name, default ->
+                when (name) {
+                    "ro.build.version.security_patch" -> "2026-08-05"
+                    "ro.vendor.build.security_patch" -> "2026-07-05"
+                    "ro.bootimage.build.version.security_patch" -> "2026-07-05"
+                    else -> default
+                }
+            }
+            PolicyState.applyRecommendedDefaults()
+            val state = PolicyState.stateJson()
+            val features = state.getJSONObject("features")
+            assertFalse(features.getBoolean("buildIdentity"))
+            assertFalse(features.getBoolean("attestationIdentity"))
+            assertFalse(features.getBoolean("telephonyIdentity"))
+            assertFalse(features.getBoolean("regionIdentity"))
+            assertFalse(features.getBoolean("identityRefresh"))
+            assertFalse(features.getBoolean("securityPatch"))
+            val patch = state.getJSONObject("securityPatch")
+            assertEquals(6L, patch.getLong("automaticThresholdMonths"))
+            listOf("system", "vendor", "boot").forEach { component ->
+                assertEquals("automatic", patch.getJSONObject(component).getString("mode"))
+            }
         } finally {
-  systemPropertiesGet = oldProperties
-  PolicyState.resetForTesting()
-  root.deleteRecursively()
+            systemPropertiesGet = oldProperties
+            PolicyState.resetForTesting()
+            root.deleteRecursively()
         }
     }
 
@@ -49,22 +49,22 @@ class PolicyStateHotPathTest {
         val root = Files.createTempDirectory("ct-defaults-stale").toFile()
         val oldProperties = systemPropertiesGet
         try {
-  PolicyState.setRootForTesting(root)
-  PolicyState.currentDateSource = { LocalDate.of(2026, 8, 14) }
-  systemPropertiesGet = { name, default ->
-      when (name) {
-          "ro.build.version.security_patch" -> "2025-12-05"
-          "ro.vendor.build.security_patch" -> "2025-12-05"
-          "ro.bootimage.build.version.security_patch" -> "2025-12-05"
-          else -> default
-      }
-  }
-  PolicyState.applyRecommendedDefaults()
-  assertTrue(PolicyState.stateJson().getJSONObject("features").getBoolean("securityPatch"))
+            PolicyState.setRootForTesting(root)
+            PolicyState.currentDateSource = { LocalDate.of(2026, 8, 14) }
+            systemPropertiesGet = { name, default ->
+                when (name) {
+                    "ro.build.version.security_patch" -> "2025-12-05"
+                    "ro.vendor.build.security_patch" -> "2025-12-05"
+                    "ro.bootimage.build.version.security_patch" -> "2025-12-05"
+                    else -> default
+                }
+            }
+            PolicyState.applyRecommendedDefaults()
+            assertTrue(PolicyState.stateJson().getJSONObject("features").getBoolean("securityPatch"))
         } finally {
-  systemPropertiesGet = oldProperties
-  PolicyState.resetForTesting()
-  root.deleteRecursively()
+            systemPropertiesGet = oldProperties
+            PolicyState.resetForTesting()
+            root.deleteRecursively()
         }
     }
 
@@ -73,15 +73,15 @@ class PolicyStateHotPathTest {
         val root = Files.createTempDirectory("ct-defaults-unknown").toFile()
         val oldProperties = systemPropertiesGet
         try {
-  PolicyState.setRootForTesting(root)
-  PolicyState.currentDateSource = { LocalDate.of(2026, 8, 14) }
-  systemPropertiesGet = { _, default -> default }
-  PolicyState.applyRecommendedDefaults()
-  assertFalse(PolicyState.stateJson().getJSONObject("features").getBoolean("securityPatch"))
+            PolicyState.setRootForTesting(root)
+            PolicyState.currentDateSource = { LocalDate.of(2026, 8, 14) }
+            systemPropertiesGet = { _, default -> default }
+            PolicyState.applyRecommendedDefaults()
+            assertFalse(PolicyState.stateJson().getJSONObject("features").getBoolean("securityPatch"))
         } finally {
-  systemPropertiesGet = oldProperties
-  PolicyState.resetForTesting()
-  root.deleteRecursively()
+            systemPropertiesGet = oldProperties
+            PolicyState.resetForTesting()
+            root.deleteRecursively()
         }
     }
 
@@ -90,47 +90,47 @@ class PolicyStateHotPathTest {
         val root = Files.createTempDirectory("ct-patch-hotpath").toFile()
         val oldProperties = systemPropertiesGet
         try {
-  Config.setRootForTesting(root)
-  Config.setPackagesForTesting(12345, arrayOf("com.example.test"))
-  PolicyState.installStateForTesting(
-      """
-      {
-        "version": 2,
-        "features": {
-          "buildIdentity": false,
-          "attestationIdentity": false,
-          "telephonyIdentity": false,
-          "regionIdentity": false,
-          "identityRefresh": false,
-          "securityPatch": true
-        },
-        "securityPatch": {
-          "automaticThresholdMonths": 6,
-          "system": {"mode": "automatic"},
-          "vendor": {"mode": "automatic"},
-          "boot": {"mode": "automatic"}
-        },
-        "profiles": [],
-        "activeProfile": null
-      }
-      """.trimIndent(),
-  )
-  PolicyState.currentDateSource = { LocalDate.of(2026, 8, 14) }
-  var reads = 0
-  systemPropertiesGet = { _, default ->
-      reads++
-      default
-  }
+            Config.setRootForTesting(root)
+            Config.setPackagesForTesting(12345, arrayOf("com.example.test"))
+            PolicyState.installStateForTesting(
+                """
+                {
+                  "version": 2,
+                  "features": {
+                    "buildIdentity": false,
+                    "attestationIdentity": false,
+                    "telephonyIdentity": false,
+                    "regionIdentity": false,
+                    "identityRefresh": false,
+                    "securityPatch": true
+                  },
+                  "securityPatch": {
+                    "automaticThresholdMonths": 6,
+                    "system": {"mode": "automatic"},
+                    "vendor": {"mode": "automatic"},
+                    "boot": {"mode": "automatic"}
+                  },
+                  "profiles": [],
+                  "activeProfile": null
+                }
+                """.trimIndent(),
+            )
+            PolicyState.currentDateSource = { LocalDate.of(2026, 8, 14) }
+            var reads = 0
+            systemPropertiesGet = { _, default ->
+                reads++
+                default
+            }
 
-  val levels = PolicyState.resolveAttestationPatchLevels(12345, 202608, 20260805, 20260805)
-  assertEquals(Config.PatchDisposition.KEEP, levels.system.disposition)
-  assertEquals(Config.PatchDisposition.KEEP, levels.vendor.disposition)
-  assertEquals(Config.PatchDisposition.KEEP, levels.boot.disposition)
-  assertEquals(0, reads)
+            val levels = PolicyState.resolveAttestationPatchLevels(12345, 202608, 20260805, 20260805)
+            assertEquals(Config.PatchDisposition.KEEP, levels.system.disposition)
+            assertEquals(Config.PatchDisposition.KEEP, levels.vendor.disposition)
+            assertEquals(Config.PatchDisposition.KEEP, levels.boot.disposition)
+            assertEquals(0, reads)
         } finally {
-  systemPropertiesGet = oldProperties
-  Config.reset()
-  root.deleteRecursively()
+            systemPropertiesGet = oldProperties
+            Config.reset()
+            root.deleteRecursively()
         }
     }
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/PolicyStateHotPathTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/PolicyStateHotPathTest.kt
@@ -9,27 +9,79 @@ import org.junit.Test
 
 class PolicyStateHotPathTest {
     @Test
-    fun recommendedDefaultsStayAligned() {
-        val root = Files.createTempDirectory("ct-defaults").toFile()
+    fun recommendedDefaultsKeepSecurityPatchOffForCurrentRom() {
+        val root = Files.createTempDirectory("ct-defaults-current").toFile()
+        val oldProperties = systemPropertiesGet
         try {
-            PolicyState.setRootForTesting(root)
-            PolicyState.applyRecommendedDefaults()
-            val state = PolicyState.stateJson()
-            val features = state.getJSONObject("features")
-            assertFalse(features.getBoolean("buildIdentity"))
-            assertFalse(features.getBoolean("attestationIdentity"))
-            assertFalse(features.getBoolean("telephonyIdentity"))
-            assertFalse(features.getBoolean("regionIdentity"))
-            assertFalse(features.getBoolean("identityRefresh"))
-            assertTrue(features.getBoolean("securityPatch"))
-            val patch = state.getJSONObject("securityPatch")
-            assertEquals(6L, patch.getLong("automaticThresholdMonths"))
-            listOf("system", "vendor", "boot").forEach { component ->
-                assertEquals("automatic", patch.getJSONObject(component).getString("mode"))
-            }
+  PolicyState.setRootForTesting(root)
+  PolicyState.currentDateSource = { LocalDate.of(2026, 8, 14) }
+  systemPropertiesGet = { name, default ->
+      when (name) {
+          "ro.build.version.security_patch" -> "2026-08-05"
+          "ro.vendor.build.security_patch" -> "2026-07-05"
+          "ro.bootimage.build.version.security_patch" -> "2026-07-05"
+          else -> default
+      }
+  }
+  PolicyState.applyRecommendedDefaults()
+  val state = PolicyState.stateJson()
+  val features = state.getJSONObject("features")
+  assertFalse(features.getBoolean("buildIdentity"))
+  assertFalse(features.getBoolean("attestationIdentity"))
+  assertFalse(features.getBoolean("telephonyIdentity"))
+  assertFalse(features.getBoolean("regionIdentity"))
+  assertFalse(features.getBoolean("identityRefresh"))
+  assertFalse(features.getBoolean("securityPatch"))
+  val patch = state.getJSONObject("securityPatch")
+  assertEquals(6L, patch.getLong("automaticThresholdMonths"))
+  listOf("system", "vendor", "boot").forEach { component ->
+      assertEquals("automatic", patch.getJSONObject(component).getString("mode"))
+  }
         } finally {
-            PolicyState.resetForTesting()
-            root.deleteRecursively()
+  systemPropertiesGet = oldProperties
+  PolicyState.resetForTesting()
+  root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun recommendedDefaultsEnableSecurityPatchForStaleRom() {
+        val root = Files.createTempDirectory("ct-defaults-stale").toFile()
+        val oldProperties = systemPropertiesGet
+        try {
+  PolicyState.setRootForTesting(root)
+  PolicyState.currentDateSource = { LocalDate.of(2026, 8, 14) }
+  systemPropertiesGet = { name, default ->
+      when (name) {
+          "ro.build.version.security_patch" -> "2025-12-05"
+          "ro.vendor.build.security_patch" -> "2025-12-05"
+          "ro.bootimage.build.version.security_patch" -> "2025-12-05"
+          else -> default
+      }
+  }
+  PolicyState.applyRecommendedDefaults()
+  assertTrue(PolicyState.stateJson().getJSONObject("features").getBoolean("securityPatch"))
+        } finally {
+  systemPropertiesGet = oldProperties
+  PolicyState.resetForTesting()
+  root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun recommendedDefaultsDoNotEnablePatchWhenPropertiesAreUnavailable() {
+        val root = Files.createTempDirectory("ct-defaults-unknown").toFile()
+        val oldProperties = systemPropertiesGet
+        try {
+  PolicyState.setRootForTesting(root)
+  PolicyState.currentDateSource = { LocalDate.of(2026, 8, 14) }
+  systemPropertiesGet = { _, default -> default }
+  PolicyState.applyRecommendedDefaults()
+  assertFalse(PolicyState.stateJson().getJSONObject("features").getBoolean("securityPatch"))
+        } finally {
+  systemPropertiesGet = oldProperties
+  PolicyState.resetForTesting()
+  root.deleteRecursively()
         }
     }
 
@@ -38,47 +90,47 @@ class PolicyStateHotPathTest {
         val root = Files.createTempDirectory("ct-patch-hotpath").toFile()
         val oldProperties = systemPropertiesGet
         try {
-            Config.setRootForTesting(root)
-            Config.setPackagesForTesting(12345, arrayOf("com.example.test"))
-            PolicyState.installStateForTesting(
-                """
-                {
-                  "version": 2,
-                  "features": {
-                    "buildIdentity": false,
-                    "attestationIdentity": false,
-                    "telephonyIdentity": false,
-                    "regionIdentity": false,
-                    "identityRefresh": false,
-                    "securityPatch": true
-                  },
-                  "securityPatch": {
-                    "automaticThresholdMonths": 6,
-                    "system": {"mode": "automatic"},
-                    "vendor": {"mode": "automatic"},
-                    "boot": {"mode": "automatic"}
-                  },
-                  "profiles": [],
-                  "activeProfile": null
-                }
-                """.trimIndent(),
-            )
-            PolicyState.currentDateSource = { LocalDate.of(2026, 8, 14) }
-            var reads = 0
-            systemPropertiesGet = { _, default ->
-                reads++
-                default
-            }
+  Config.setRootForTesting(root)
+  Config.setPackagesForTesting(12345, arrayOf("com.example.test"))
+  PolicyState.installStateForTesting(
+      """
+      {
+        "version": 2,
+        "features": {
+          "buildIdentity": false,
+          "attestationIdentity": false,
+          "telephonyIdentity": false,
+          "regionIdentity": false,
+          "identityRefresh": false,
+          "securityPatch": true
+        },
+        "securityPatch": {
+          "automaticThresholdMonths": 6,
+          "system": {"mode": "automatic"},
+          "vendor": {"mode": "automatic"},
+          "boot": {"mode": "automatic"}
+        },
+        "profiles": [],
+        "activeProfile": null
+      }
+      """.trimIndent(),
+  )
+  PolicyState.currentDateSource = { LocalDate.of(2026, 8, 14) }
+  var reads = 0
+  systemPropertiesGet = { _, default ->
+      reads++
+      default
+  }
 
-            val levels = PolicyState.resolveAttestationPatchLevels(12345, 202608, 20260805, 20260805)
-            assertEquals(Config.PatchDisposition.KEEP, levels.system.disposition)
-            assertEquals(Config.PatchDisposition.KEEP, levels.vendor.disposition)
-            assertEquals(Config.PatchDisposition.KEEP, levels.boot.disposition)
-            assertEquals(0, reads)
+  val levels = PolicyState.resolveAttestationPatchLevels(12345, 202608, 20260805, 20260805)
+  assertEquals(Config.PatchDisposition.KEEP, levels.system.disposition)
+  assertEquals(Config.PatchDisposition.KEEP, levels.vendor.disposition)
+  assertEquals(Config.PatchDisposition.KEEP, levels.boot.disposition)
+  assertEquals(0, reads)
         } finally {
-            systemPropertiesGet = oldProperties
-            Config.reset()
-            root.deleteRecursively()
+  systemPropertiesGet = oldProperties
+  Config.reset()
+  root.deleteRecursively()
         }
     }
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierPersistentCacheTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierPersistentCacheTest.kt
@@ -1,0 +1,60 @@
+package cleveres.tricky.cleverestech.util
+
+import java.net.ServerSocket
+import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class KeyboxVerifierPersistentCacheTest {
+    @Test
+    fun freshPersistedCrlSurvivesDaemonRestartWithoutNetwork() {
+        val root = Files.createTempDirectory("ct-crl-cache").toFile()
+        val requestCount = AtomicInteger(0)
+        val crlJson = """{"entries":{"12345":"REVOKED"}}"""
+        val server = ServerSocket(0)
+        val thread =
+  Thread {
+      try {
+          val client = server.accept()
+          requestCount.incrementAndGet()
+          val reader = client.inputStream.bufferedReader()
+              var line = reader.readLine()
+              while (line != null && line.isNotEmpty()) line = reader.readLine()
+          val writer = client.outputStream.bufferedWriter()
+              writer.write("HTTP/1.1 200 OK\r\n")
+              writer.write("Content-Type: application/json\r\n")
+              writer.write("Content-Length: ${crlJson.toByteArray().size}\r\n")
+              writer.write("\r\n")
+              writer.write(crlJson)
+          writer.flush()
+          client.close()
+      } catch (_: Exception) {
+      }
+  }
+        thread.start()
+
+        try {
+  KeyboxVerifier.setCacheRootForTesting(root)
+  KeyboxVerifier.setCrlUrlForTesting("http://localhost:${server.localPort}")
+  val first = KeyboxVerifier.fetchCrl()
+  assertNotNull(first)
+  assertEquals(1, requestCount.get())
+
+  thread.join(2_000)
+  server.close()
+  KeyboxVerifier.clearMemoryCacheForTesting()
+
+  val second = KeyboxVerifier.fetchCrl()
+  assertEquals(first, second)
+  assertEquals(1, requestCount.get())
+        } finally {
+  runCatching { server.close() }
+  thread.interrupt()
+  KeyboxVerifier.resetCrlUrlForTesting()
+  KeyboxVerifier.resetCacheRootForTesting()
+  root.deleteRecursively()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- fix the early-boot attestation inconsistency that could temporarily expose the genuine unlocked Root of Trust before the verified keybox pool recovered
- persist only a fresh, successfully parsed Google attestation revocation response for the existing 24-hour TTL, so daemon/reboot startup can reuse verified revocation state while networking is still coming up
- keep revocation handling fail-closed: missing, stale, corrupt, non-regular, oversized, or failed caches are ignored and never used to activate keyboxes
- make Restore Defaults and fresh-install Security Patch behavior device-aware: Global Mode and Automatic Keybox Check remain enabled, optional identity/privacy features remain disabled, while Security Patch is enabled only when a known system/vendor/boot patch level is older than the configured automatic threshold
- ship fresh policy with Security Patch disabled until the daemon performs the one-shot device-aware evaluation
- add regression tests for current/stale/unknown ROM patch defaults and for a fresh persisted revocation cache surviving an in-memory daemon restart without another network request

## Root cause
The service intentionally rejects all keyboxes when the revocation list is unavailable. The revocation cache was memory-only, so a reboot erased it. If networking was not ready during the first keybox scan, the active pool became empty and `CertHack.canHack()` was false. Early `generateKey` calls therefore passed through genuine hardware attestation unchanged; on an unlocked/rooted device that can legitimately report `deviceLocked=false`. `Main.kt` then retried keybox refresh at 5s/15s/45s/etc., explaining why the same device appeared to fix itself later in the boot.

This change does not fabricate a successful revocation check and does not use stale data beyond the existing TTL.

## Validation before PR
A branch-only staging run completed Kotlin formatting, `:service:testDebugUnitTest`, all WebUI regression tests, and `git diff --check` successfully. The staging workflow removed itself before the final commit; this PR contains one source commit and no temporary workflow.

Full Build and Security Regression workflows should gate device testing/merge.

No version, release, or update metadata changes are included.