### PR TITLE
chore: publish V2.5.8 update metadata

### DIFF
--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
-    "version": "V2.5.7 (2525-7dd81852-release)",
-    "versionCode": 2525,
-    "zipUrl": "https://github.com/tryigit/CleveresTricky/releases/download/V2.5.7/CleveresTricky-V2.5.7-2525-7dd81852-release.zip",
+    "version": "V2.5.8 (2531-74c25526-release)",
+    "versionCode": 2531,
+    "zipUrl": "https://github.com/tryigit/CleveresTricky/releases/download/V2.5.8/CleveresTricky-V2.5.8-2531-74c25526-release.zip",
     "changelog": "https://raw.githubusercontent.com/tryigit/CleveresTricky/refs/heads/master/CHANGELOG.md"
 }


### PR DESCRIPTION
Updates `update.json` to the published V2.5.8 release using only the actual release asset metadata.

Verified release asset:
- `CleveresTricky-V2.5.8-2531-74c25526-release.zip`
- versionCode `2531`
- SHA-256 `777373a1bd165e449339cb12f4c6c02111f0af0cfc219c50f367c91ea45df3ab`

The existing update schema does not contain a checksum field, so no unsupported field was invented.