### PR TITLE
Add GPL-compatible attribution requirement

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,32 @@
+CleveresTricky Attribution Notice
+
+Copyright (c) 2024-2026 tryigit. All rights in original material are reserved
+except for the permissions granted under the applicable license.
+
+The repository contains upstream and third-party material. The following
+additional term applies only to material for which tryigit is a copyright
+holder, and only to the extent permitted by section 7(b) of the GNU General
+Public License version 3:
+
+When conveying that material, modified or unmodified, you must preserve this
+NOTICE and the following reasonable author attribution in the copyright or
+legal notices accompanying the source distribution:
+
+    CleveresTricky — original work and modifications by tryigit
+    https://github.com/tryigit/CleveresTricky
+
+If the conveyed work already provides an About, Credits, or Legal Notices view,
+the same attribution must also be included in that view. This requirement does
+not require advertising, endorsement, or placement in ordinary runtime UI where
+no legal-notices mechanism exists.
+
+This additional term does not apply to material for which tryigit is not a
+copyright holder, and it does not replace, remove, or narrow any license or
+notice applicable to upstream or third-party material.
+
+Commercial use is not prohibited for material governed by GPL-3.0-only. The
+GPL permits commercial use and does not permit a distributor to add a general
+non-commercial-use restriction to GPL-covered upstream material. A separate
+non-commercial license can therefore apply only to material that can legally be
+licensed that way by all relevant copyright holders and that is not required to
+remain under incompatible upstream terms.

--- a/rust/injector-core/Cargo.toml
+++ b/rust/injector-core/Cargo.toml
@@ -1,3 +1,4 @@
+# Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
 [package]
 name = "cleverestricky-injector-core"
 version = "0.1.0"

--- a/rust/native-core/Cargo.toml
+++ b/rust/native-core/Cargo.toml
@@ -1,3 +1,4 @@
+# Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
 [package]
 name = "cleverestricky-native-core"
 version = "0.2.0"

--- a/rust/webui-bridge/Cargo.toml
+++ b/rust/webui-bridge/Cargo.toml
@@ -1,3 +1,4 @@
+# Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
 [package]
 name = "cleverestricky-webui-bridge"
 version = "0.1.0"


### PR DESCRIPTION
## Summary
- add a repository-level `NOTICE` with a GNU GPLv3 section 7(b) attribution term
- require preservation of the CleveresTricky/tryigit attribution for material where tryigit is a copyright holder
- reference the notice from the Rust crate manifests that were added in this fork
- explicitly avoid imposing a non-commercial restriction on upstream GPL-covered material

## Rationale
GPLv3 permits reasonable author-attribution requirements under section 7(b), but a blanket non-commercial restriction would be a further restriction incompatible with GPL-covered upstream code. The repository is a fork and still contains upstream material, so this change strengthens attribution without claiming relicensing rights over third-party code.

## Verification
Documentation/metadata-only legal-notice change; no runtime behavior changed.