### PR TITLE
Document open-source licensing model

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,34 @@
+# Licensing
+
+CleveresTricky is distributed as **open-source software** under the GNU General Public License version 3 only (`GPL-3.0-only`), subject to the repository's `LICENSE` file and applicable third-party notices.
+
+## Commercial use
+
+The GPL is an Open Source Initiative-compatible open-source license and permits commercial use. Anyone who complies with the GPL may use, modify, convey, and sell GPL-covered copies. CleveresTricky does not claim an exclusive commercial-use right for `tryigit` over GPL-covered material.
+
+A license that allowed commercial use only by `tryigit`, or prohibited commercial use by everyone else, would not qualify as Open Source under the Open Source Definition and would also be incompatible as an added restriction on GPL-covered upstream material in this fork.
+
+## Attribution for tryigit-owned material
+
+For material for which `tryigit` is a copyright holder, the additional attribution term in `NOTICE` applies to the extent permitted by GNU GPLv3 section 7(b). When that material is conveyed, the required legal notice and author attribution must be preserved as described there.
+
+This attribution requirement does not extend `tryigit`'s rights over upstream or third-party material and does not remove any existing copyright, license, or notice obligations.
+
+## Why not MIT?
+
+MIT is more permissive than GPL. It permits commercial use and proprietary redistribution provided its copyright and license notice are retained. It would therefore provide less copyleft protection than the current GPL model and would not achieve an exclusive-commercial-use goal.
+
+## If the project ever needs exclusive commercial licensing
+
+A future model such as a non-commercial source-available license plus a separate commercial license could reserve commercial licensing to the relevant copyright holder. That model must not be described as Open Source in the OSI sense, and it can only be applied to code for which the necessary relicensing rights exist.
+
+Because CleveresTricky is a fork and contains GPL-covered upstream and third-party material, a repository-wide move to such a model would first require removing/replacing incompatible upstream-derived material or obtaining permission from all relevant copyright holders.
+
+## Summary
+
+- Current model: `GPL-3.0-only`.
+- Status: Open Source.
+- Commercial use by compliant downstream users: permitted.
+- Copyleft: required where GPL applies.
+- Attribution for tryigit-owned material: required as described in `NOTICE`.
+- Exclusive commercial use by tryigit: not claimed under the current open-source distribution.


### PR DESCRIPTION
## Summary
- add `LICENSING.md` documenting the repository's current GPL-3.0-only open-source model
- clarify that OSI open source necessarily permits commercial use
- explain why MIT would be less protective for this project
- preserve the GPLv3 section 7(b) attribution requirement for tryigit-owned material
- document the future path to an exclusive-commercial source-available model if upstream GPL-derived material is ever removed or relicensing permission is obtained

## Verification
Documentation-only change; no runtime behavior changed.