### PR TITLE
feat: improve diagnostics, installer safety, and docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -380,17 +380,13 @@ jobs:
         run: |
           set -euo pipefail
           errors=0
-          for f in module.prop customize.sh verify.sh service.sh post-fs-data.sh sepolicy.rule webroot/index.html webroot/bridge.js webroot/policy.js webroot/ux.js; do
+          for f in module.prop customize.sh verify.sh service.sh post-fs-data.sh action.sh sepolicy.rule webroot/index.html webroot/bridge.js webroot/policy.js webroot/ux.js; do
             if [ ! -f "module/template/$f" ]; then
               echo "::error::Missing required module file: module/template/$f"
               errors=$((errors + 1))
             fi
           done
-          if [ -e module/template/action.sh ]; then
-            echo "::error::Legacy external WebUI launcher must not be packaged"
-            errors=$((errors + 1))
-          fi
-          for script in module/template/customize.sh module/template/verify.sh module/template/service.sh module/template/post-fs-data.sh; do
+          for script in module/template/customize.sh module/template/verify.sh module/template/service.sh module/template/post-fs-data.sh module/template/action.sh; do
             if [ -f "$script" ] && ! bash -n "$script"; then
               echo "::error file=$script::Shell syntax error"
               errors=$((errors + 1))
@@ -616,7 +612,7 @@ jobs:
                 ;;
             esac
           done <<<"$entries"
-          for required in module.prop customize.sh verify.sh service.sh post-fs-data.sh sepolicy.rule; do
+          for required in module.prop customize.sh verify.sh service.sh post-fs-data.sh action.sh sepolicy.rule; do
             if ! grep -Fx "$required" <<<"$entries" >/dev/null; then
               echo "::error file=$archive::Missing required root entry: $required"
               exit 1

--- a/README.ar.md
+++ b/README.ar.md
@@ -6,7 +6,7 @@
 ![Android](https://img.shields.io/badge/Android-12--17-3DDC84?logo=android&logoColor=white)
 ![Module](https://img.shields.io/badge/Module-KernelSU%20%7C%20APatch-6f42c1)
 
-CleveresTricky هو موديول لـ KernelSU وAPatch على Android 12–17. يجمع توافق Android Keystore وattestation، وإدارة Keybox/CBOX، وتحديد التطبيقات، وخيارات الهوية الاختيارية، ومستويات التصحيح، وأدوات الخصوصية داخل WebUI واحد مناسب للهاتف.
+CleveresTricky هو موديول لـ KernelSU وAPatch على Android 12-17. يجمع توافق Android Keystore وattestation، وإدارة Keybox/CBOX، وتحديد التطبيقات، وخيارات الهوية الاختيارية، ومستويات التصحيح، وأدوات الخصوصية داخل WebUI واحد مناسب للهاتف.
 
 ابدأ بالإعدادات الافتراضية وفعّل فقط الميزات التي تحتاجها فعلاً.
 
@@ -30,7 +30,7 @@ CleveresTricky هو موديول لـ KernelSU وAPatch على Android 12–17. 
 
 ## البيئة المدعومة
 
-- Android **12–17** / API **31–37**
+- Android **12-17** / API **31-37**
 - **ARM64** و **x86-64**
 - **KernelSU** و **APatch**
 
@@ -46,12 +46,12 @@ Magisk والتثبيت من recovery غير مدعومين.
 
 ## المزيد من المعلومات
 
-- [Keybox Manager](docs/KeyboxManager.md) — تحميل Keybox/CBOX والتحقق منها واختيارها وفحص الإلغاء.
-- [Application Scope](docs/ApplicationScope.md) و [Application Rules](docs/ApplicationRules.md) — تحديد التطبيقات التي تنطبق عليها الميزات.
-- [Build Identity](docs/BuildIdentity.md) و [Telephony Identity](docs/TelephonyIdentity.md) و [Patch Levels](docs/PatchLevels.md) — خيارات الهوية الاختيارية.
-- [RKP Protection](docs/RkpProtection.md) و [DRM Privacy](docs/DrmPassthrough.md) — توافق المنصة وسلوك الخصوصية.
-- [Backup and Restore](docs/BackupRestore.md) — نسخ الإعدادات المشفّر واستعادته.
-- [Security Model](docs/SecurityModel.md) و [Installer](docs/Installer.md) — حدود الثقة وتفاصيل التثبيت.
+- [Keybox Manager](docs/KeyboxManager.md) - تحميل Keybox/CBOX والتحقق منها واختيارها وفحص الإلغاء.
+- [Application Scope](docs/ApplicationScope.md) و [Application Rules](docs/ApplicationRules.md) - تحديد التطبيقات التي تنطبق عليها الميزات.
+- [Build Identity](docs/BuildIdentity.md) و [Telephony Identity](docs/TelephonyIdentity.md) و [Patch Levels](docs/PatchLevels.md) - خيارات الهوية الاختيارية.
+- [RKP Protection](docs/RkpProtection.md) و [DRM Privacy](docs/DrmPassthrough.md) - توافق المنصة وسلوك الخصوصية.
+- [Backup and Restore](docs/BackupRestore.md) - نسخ الإعدادات المشفّر واستعادته.
+- [Security Model](docs/SecurityModel.md) و [Installer](docs/Installer.md) - حدود الثقة وتفاصيل التثبيت.
 
 ## تحتاج مساعدة؟
 

--- a/README.ar.md
+++ b/README.ar.md
@@ -1,147 +1,64 @@
-<div dir="rtl">
-
 # CleveresTricky
 
 **اللغة:** [English](README.md) | [Türkçe](README.tr.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Русский](README.ru.md) | [Bahasa Indonesia](README.id.md) | [हिन्दी](README.hi.md) | **العربية**
 
 [![Release](https://img.shields.io/github/v/release/tryigit/CleveresTricky?display_name=tag&sort=semver&label=Release)](https://github.com/tryigit/CleveresTricky/releases/latest)
-[![Localization](https://img.shields.io/badge/Localization-9%20Languages-teal?logo=googletranslate)](LANGUAGES.md)
-[![Channel](https://img.shields.io/badge/Follow-Telegram-blue.svg?logo=telegram)](https://t.me/cleverestech)
-[![License: GPL-3.0-only](https://img.shields.io/badge/License-GPL--3.0--only-orange.svg?logo=gnu)](LICENSING.md)
 ![Android](https://img.shields.io/badge/Android-12--17-3DDC84?logo=android&logoColor=white)
 ![Module](https://img.shields.io/badge/Module-KernelSU%20%7C%20APatch-6f42c1)
-![Architecture](https://img.shields.io/badge/Arch-ARM64%20%7C%20x86--64-0969DA)
 
-CleveresTricky هو موديول لـ KernelSU وAPatch مخصص لـ Android Keystore وattestation والهوية وتوافق التطبيقات. يجمع بين runtime أصلي مضبوط وWebUI موجه للهاتف، بحيث يمكن إدارة نطاق التطبيقات ومواد المفاتيح والهوية ومستويات التحديث وحماية Remote Key Provisioning وتوافق DRM من مكان واحد.
+CleveresTricky هو موديول لـ KernelSU وAPatch على Android 12–17. يجمع توافق Android Keystore وattestation، وإدارة Keybox/CBOX، وتحديد التطبيقات، وخيارات الهوية الاختيارية، ومستويات التصحيح، وأدوات الخصوصية داخل WebUI واحد مناسب للهاتف.
 
-> هذه نسخة مترجمة من توثيق المستخدم. عند وجود اختلاف تقني تكون الوثائق الإنجليزية هي المرجع الأساسي.
+ابدأ بالإعدادات الافتراضية وفعّل فقط الميزات التي تحتاجها فعلاً.
 
-## القدرات الرئيسية
+## ماذا يمكنك أن تفعل؟
 
-### التحكم في runtime
-
-[Spoof Engine](docs/i18n/ar.md#spoof-engine) يتحكم في استبدال الهوية الاختياري. تبقى حماية Keystore وTEE وboot properties الأساسية فعالة بشكل مستقل ما دامت خدمة الموديول سليمة.
-
-[Application Scope](docs/i18n/ar.md#application-scope) يشرح Targeted Mode وGlobal Mode وقواعد الحزم وAndroid UID المشترك وتحديثات الكاش الحية.
-
-[Application Rules](docs/i18n/ar.md#application-rules) يشرح القوالب الخاصة بالتطبيق واختيار keybox والهويات الخصوصية المستقرة.
-
-[Profiles](docs/i18n/ar.md#profiles) يشرح Daily Compatibility وDefault وMaximum Compatibility وMinimal.
-
-### Attestation والهوية
-
-[Attestation](docs/i18n/ar.md#attestation) يشرح استبدال سلسلة الشهادات وعمليات KeyMint الحقيقية وStrongBox وحدود التوافق البرمجي.
-
-[Certificate Safe Mode](docs/i18n/ar.md#certificate-safe-mode) يوثق مفهوم الإعداد القديم. الاستهداف الأساسي الحالي لم يعد يعتمد على ذلك المفتاح القديم.
-
-[Keybox Manager](docs/i18n/ar.md#keybox-manager) يغطي تحميل keybox والتحقق والاختيار والتدوير وفحص الإلغاء والمراقبة.
-
-[Automatic Keybox Check](docs/i18n/ar.md#automatic-keybox-check) يشرح عامل الصيانة المحدود ودورة حياته.
-
-[Remote Sources](docs/i18n/ar.md#remote-sources) يشرح الجلب الموثق والتحقق من التوقيع وسياسة التحديث وسلوك الفشل.
-
-[Encrypted Storage](docs/i18n/ar.md#encrypted-storage) يشرح حاويات CBOX والكاش المحلي المحمي والتعامل الآمن مع مواد المفاتيح.
-
-[Patch Levels](docs/i18n/ar.md#patch-levels) يشرح حقول تحديث System وVendor وBoot والقواعد العامة والخاصة بالتطبيق.
-
-[Build Identity](docs/i18n/ar.md#build-identity) يشرح قوالب الجهاز وfingerprint وحقول Build التي تراها التطبيقات والتفعيل المبكر المتزامن ومساعد Pixel beta Auto Identity لمستخدمي Custom ROM.
-
-[Identity Refresh](docs/i18n/ar.md#identity-refresh) يشرح تجهيز الهوية للإقلاع التالي واتساق snapshot.
-
-[Telephony Identity](docs/i18n/ar.md#telephony-identity) يشرح قيم شريحتي SIM والحفاظ على قرارات صلاحيات Android وواجهات API المدعومة وحدود مشغل الشبكة.
-
-### توافق المنصة
-
-[Boot Properties](docs/i18n/ar.md#boot-properties) يشرح عرض userspace الأساسي لخصائص الإقلاع وسياسة توافق الهوية المنفصلة.
-
-[Region Properties](docs/i18n/ar.md#region-properties) يشرح عرض البلد ومنطقة العتاد الاختياري والمحدود.
-
-[Provider Coexistence](docs/i18n/ar.md#provider-coexistence) يشرح كيف يمنع automatic mode الكتابة فوق مزود fingerprint آخر.
-
-[RKP Protection](docs/i18n/ar.md#rkp-protection) يشرح بنية Android المحمية وgenerated-key passthrough الحقيقي.
-
-[DRM Passthrough and Privacy](docs/i18n/ar.md#drm-passthrough) يفصل بين وظيفتين. يمكن لتطبيقات الوسائط المختارة البقاء على مسار شهادات Keystore الحقيقي في Android، بينما يمكن لـ `privacy=isolate` استبدال `deviceUniqueId` المدعوم في DRM الحديث باسم مستعار ثابت خاص بالتطبيق.
-
-هذه ليست أداة لتجاوز Widevine أو DRM. لا يتم تغيير مستوى الأمان أو التراخيص أو provisioning أو مفاتيح المحتوى أو الجلسات أو HDCP أو خصائص النص.
-
-### الواجهة والتشغيل
-
-[Web Interface](docs/i18n/ar.md#web-interface) يشرح نقل أوامر مدير الموديول الأصلي والتنقل على الهاتف والحالة الحية والتحقق وإمكانية الوصول.
-
-اللغات المضمنة في WebUI هي **English** و**Türkçe** و**简体中文** و**Español** و**Deutsch** و**Русский** و**Bahasa Indonesia** و**हिन्दी** و**العربية**. كتالوجات الترجمة محلية ولا يحتاج تبديل اللغة إلى اتصال بالشبكة.
-
-[Backup and Restore](docs/i18n/ar.md#backup-restore) يشرح التصدير المشفر والاستيراد المحدود والاستعادة الآمنة.
-
-[Installer](docs/i18n/ar.md#installer) يشرح بنية حزمة KernelSU/APatch والتحقق من payload والأجهزة المدعومة ومسار التثبيت.
-
-[Diagnostics](docs/i18n/ar.md#diagnostics) يشرح السجلات وفحوص الحالة والأخطاء الشائعة وتسلسل استكشاف المشاكل المنضبط.
-
-### مراجع هندسية
-
-[Security Model](docs/i18n/ar.md#security-model) يوثق حدود الثقة والملفات المحمية والتحقق من الإدخال والقدرات التي لا يدعيها الموديول.
-
-[Performance](docs/i18n/ar.md#performance) يوثق دورة حياة hook والكاش المحدود والعمل الخلفي واستخدام CPU والذاكرة.
-
-[Building](docs/i18n/ar.md#building) يوثق toolchain ومهام التحقق والملفات الناتجة.
-
-[Native Architecture](docs/i18n/ar.md#native-architecture) يوثق Rust injector وRust native core وسياسة اللغات وحد Android C++ ABI الوحيد المطلوب.
+- إدارة ملفات **Keybox/CBOX** والتحقق منها واختيارها وتبديلها.
+- استخدام Global Mode أو تطبيق قواعد منفصلة على تطبيقات محددة.
+- ضبط عرض device/build وattestation والاتصالات والمنطقة وsecurity patch عند الحاجة.
+- حماية تدفقات Remote Key Provisioning وتقليل كشف معرّفات DRM المدعومة بدون الادعاء بتجاوز DRM.
+- نسخ الإعدادات احتياطياً، ومراجعة الحالة الفعلية، وجمع التشخيصات من WebUI أو Action الخاص بالموديول.
 
 ## البدء السريع
 
-1. نزّل ZIP الحالي من صفحة Releases الرسمية للمشروع.
-2. عند الحاجة للتحقق من مصدر البناء الرسمي افحص `SHA256SUMS` وGitHub build provenance.
-3. افتح KernelSU أو APatch أثناء تشغيل Android.
-4. ثبّت ZIP ثم أعد التشغيل.
-5. افتح CleveresTricky WebUI من مدير الموديول.
-6. يبدأ التثبيت الجديد مع Global Mode مفعلا وidentity spoofing الاختياري متوقفا.
-7. أضف فقط مواد مفاتيح تملكها أو لديك تصريح باختبارها.
-8. اضبط خيارات الهوية فقط عند الحاجة.
-9. أعد التشغيل بعد تغيير قيم Template Build Identity.
+1. نزّل أحدث ملف ZIP من صفحة [Releases](https://github.com/tryigit/CleveresTricky/releases/latest) الرسمية.
+2. ثبّت ملف ZIP من خلال KernelSU أو APatch أثناء تشغيل Android.
+3. افتح WebUI الخاص بـ CleveresTricky من مدير الموديولات.
+4. أضف فقط **Keybox أو CBOX** تملكه أو لديك تصريح لاختباره.
+5. استخدم الإعدادات الافتراضية أولاً، ثم فعّل خيارات الهوية أو قواعد التطبيقات أو الخصوصية فقط عند الحاجة.
 
-لا يحتوي المشروع أو حزمة release على keybox قابل للاستخدام أو مفتاح attestation خاص.
+لا يتضمن المشروع Keybox جاهزاً للاستخدام ولا مفتاح attestation خاصاً.
 
 ## البيئة المدعومة
 
-يدعم CleveresTricky Android 12 حتى Android 17، أي API 31 حتى 37، على ARM64 وx86 64. يتم التثبيت من KernelSU أو APatch أثناء تشغيل Android.
+- Android **12–17** / API **31–37**
+- **ARM64** و **x86-64**
+- **KernelSU** و **APatch**
 
-Magisk وrecovery غير مدعومين. يوقف Installer المسار غير المدعوم قبل ترك موديول ناقص.
+Magisk والتثبيت من recovery غير مدعومين.
 
-## حدود مهمة
+## أمور مهمة
 
-تعتمد النتائج على حالة الجهاز الحقيقية وfirmware والشهادات ومواد المفاتيح وGoogle Play services وسياسة الخدمة البعيدة. يحسن CleveresTricky مسار التوافق المحلي لكنه لا يضمن verdict بعيدا محددا.
+يحسّن CleveresTricky مسار التوافق المحلي، لكن النتيجة البعيدة تظل مرتبطة بالجهاز الحقيقي والـ firmware وحالة الاعتماد وGoogle Play services وسياسة الخادم والبيانات التي تضبطها. لا يمكنه ضمان نتيجة محددة لـ Play Integrity أو attestation.
 
-قيم Telephony تظهر فقط عبر APIs المدعومة للتطبيقات ولا تغير modem أوbaseband أوEFS أوSIM الفعلية أو الهوية التي يراها مشغل الشبكة.
+لا يعيد قفل bootloader فعلياً، ولا يعيد كتابة قياسات Verified Boot، ولا يغيّر hardware Root of Trust، ولا يعدّل modem/baseband، ولا يحوّل أدوات خصوصية DRM إلى DRM bypass.
 
-في Android الحديث يكون Android ID مقيدا بهوية توقيع التطبيق والمستخدم والجهاز داخل SettingsProvider. لا يقدم CleveresTricky تحكما عالميا مضللا في Android ID.
+استخدم فقط الإعدادات وبيانات الاعتماد التي لديك صلاحية لاستخدامها.
 
-إصدار kernel الحقيقي لا يتغير. عرض boot properties لا يعيد قفل bootloader فعليا ولا يصلح verified boot ولا يعيد كتابة vbmeta ولا يغير hardware root of trust.
+## المزيد من المعلومات
 
-فتح bootloader لا يعني تلقائيا أن كل DRM أصبح غير قابل للاستخدام. السلوك يعتمد على الجهاز وتنفيذ vendor وحالة provisioning ومستوى الأمان وfirmware وسياسة الخدمة. عمل DRM الحالي يركز على الخصوصية وليس bypass.
+- [Keybox Manager](docs/KeyboxManager.md) — تحميل Keybox/CBOX والتحقق منها واختيارها وفحص الإلغاء.
+- [Application Scope](docs/ApplicationScope.md) و [Application Rules](docs/ApplicationRules.md) — تحديد التطبيقات التي تنطبق عليها الميزات.
+- [Build Identity](docs/BuildIdentity.md) و [Telephony Identity](docs/TelephonyIdentity.md) و [Patch Levels](docs/PatchLevels.md) — خيارات الهوية الاختيارية.
+- [RKP Protection](docs/RkpProtection.md) و [DRM Privacy](docs/DrmPassthrough.md) — توافق المنصة وسلوك الخصوصية.
+- [Backup and Restore](docs/BackupRestore.md) — نسخ الإعدادات المشفّر واستعادته.
+- [Security Model](docs/SecurityModel.md) و [Installer](docs/Installer.md) — حدود الثقة وتفاصيل التثبيت.
 
-تكتشف سجلات SHA 256 الداخلية payload المفقود أو المعدل أو المضاف أو المرتبط أو غير المتوقع، وتدخل الخدمة في tamper lockdown عند فشل التحقق. أصالة release الرسمي تعتمد على digest منشور بشكل منفصل وGitHub signed build provenance.
+## تحتاج مساعدة؟
 
-## الإعداد الأول الموصى به
+استخدم صفحة **Logs** في WebUI أو **Action** الخاص بالموديول لإنشاء تقرير تشخيص طارئ. راجع الأرشيف قبل مشاركته لأن التشخيصات قد تحتوي على معلومات عن الجهاز والنظام.
 
-ابدأ بإعدادات التثبيت الجديد. يحدد Global Mode تطبيقات UID المناسبة بينما تبقى حماية boot وKeystore الأساسية فعالة. يبقى identity spoofing الاختياري متوقفا حتى تفعله من قسم Identity.
+راجع [Diagnostics](docs/Diagnostics.md) للمشاكل الشائعة وخطوات استكشاف الأخطاء.
 
-لمستخدمي Custom ROM يمكن لـ Auto Identity جلب Pixel beta أو canary Build Identity من بيانات Google العامة وحفظها محليا. فعّل Identity Spoof Engine وأعد التشغيل فقط عندما تريد إظهار هذه القيم فعليا.
+## المشروع
 
-لخصوصية DRM identifier أنشئ Application Rule لتطبيق الوسائط واضبط `privacy=isolate`. يمكن أن يبقى DRM Keystore Passthrough مفعلا لأن مسار شهادة Keystore الحقيقية ومسار DRM ID المستعار مستقلان.
-
-## المساعدة ومعلومات المشروع
-
-للتشخيص استخدم WebUI Logs أو Android logcat مع الوسم `CleveresTricky`. التفاصيل في [Diagnostics](docs/i18n/ar.md#diagnostics).
-
-تاريخ المشروع في [CHANGELOG](docs/i18n/ar.md#changelog)، والمساهمة في [Contributing](docs/i18n/ar.md#contributing)، واللغات في [Language Support](docs/i18n/ar.md#languages)، والثيم في [Theme](docs/i18n/ar.md#theme).
-
-تبقى [وثائق Android attestation الرسمية](https://source.android.com/docs/security/features/keystore/attestation) و[وثائق Play Integrity verdict](https://developer.android.com/google/play/integrity/verdicts) و[دليل موديولات KernelSU](https://kernelsu.org/guide/module.html) هي المراجع المعتمدة لمنصاتها.
-
-## تحكم اختياري دقيق بالهوية
-
-يعالج CleveresTricky بشكل مستقل Device and Build Identity وAttestation Identity وTelephony Identity وRegion Identity وIdentity Refresh وSecurity Patch. Security Patch مستقل عن Device and Build Identity.
-
-تبقى Keystore interception الأساسية وعمليات private key الحقيقية في KeyMint وStrongBox ومعالجة root of trust وأمان Binder وتوافق boot الضروري مستقلة عن هذه الخيارات. تفصل الواجهة بين الحالة الحقيقية الملتقطة والحالة المعدة والحالة الفعلية التي يراها التطبيق.
-
-يوفر Security Patch سياسات مستقلة لـ System وVendor وBoot. يمكن لـ Profiles تعيين إعدادات متناسقة للتطبيقات، ويعرض Effective State inspector النتيجة النهائية للـ resolver.
-
-</div>
+[سجل التغييرات](CHANGELOG.md) · [المساهمة](CONTRIBUTING.md) · [اللغات](LANGUAGES.md) · [الترخيص](LICENSING.md) · [Telegram](https://t.me/cleverestech)

--- a/README.de.md
+++ b/README.de.md
@@ -6,7 +6,7 @@
 ![Android](https://img.shields.io/badge/Android-12--17-3DDC84?logo=android&logoColor=white)
 ![Module](https://img.shields.io/badge/Module-KernelSU%20%7C%20APatch-6f42c1)
 
-CleveresTricky ist ein KernelSU- und APatch-Modul für Android 12–17. Es bündelt Android-Keystore- und Attestation-Kompatibilität, Keybox/CBOX-Verwaltung, App-Zielauswahl, optionale Identitätssteuerung, Patch-Level-Einstellungen und Datenschutzfunktionen in einer mobilen WebUI.
+CleveresTricky ist ein KernelSU- und APatch-Modul für Android 12-17. Es bündelt Android-Keystore- und Attestation-Kompatibilität, Keybox/CBOX-Verwaltung, App-Zielauswahl, optionale Identitätssteuerung, Patch-Level-Einstellungen und Datenschutzfunktionen in einer mobilen WebUI.
 
 Beginne mit den Standardwerten und aktiviere nur die Funktionen, die du wirklich brauchst.
 
@@ -30,7 +30,7 @@ Das Projekt enthält keine verwendbare Keybox und keinen privaten Attestation-Sc
 
 ## Unterstützte Umgebung
 
-- Android **12–17** / API **31–37**
+- Android **12-17** / API **31-37**
 - **ARM64** und **x86-64**
 - **KernelSU** und **APatch**
 
@@ -46,12 +46,12 @@ Verwende nur Konfigurationen und Zugangsdaten, für deren Nutzung du berechtigt 
 
 ## Mehr erfahren
 
-- [Keybox Manager](docs/KeyboxManager.md) — Laden, Prüfen, Auswählen und Revocation-Checks für Keybox/CBOX.
-- [Application Scope](docs/ApplicationScope.md) und [Application Rules](docs/ApplicationRules.md) — festlegen, für welche Apps Funktionen gelten.
-- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md) und [Patch Levels](docs/PatchLevels.md) — optionale Identitätssteuerung.
-- [RKP Protection](docs/RkpProtection.md) und [DRM Privacy](docs/DrmPassthrough.md) — Plattformkompatibilität und Datenschutz.
-- [Backup and Restore](docs/BackupRestore.md) — verschlüsselte Sicherung und Wiederherstellung der Konfiguration.
-- [Security Model](docs/SecurityModel.md) und [Installer](docs/Installer.md) — Vertrauensgrenzen und Installationsdetails.
+- [Keybox Manager](docs/KeyboxManager.md) - Laden, Prüfen, Auswählen und Revocation-Checks für Keybox/CBOX.
+- [Application Scope](docs/ApplicationScope.md) und [Application Rules](docs/ApplicationRules.md) - festlegen, für welche Apps Funktionen gelten.
+- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md) und [Patch Levels](docs/PatchLevels.md) - optionale Identitätssteuerung.
+- [RKP Protection](docs/RkpProtection.md) und [DRM Privacy](docs/DrmPassthrough.md) - Plattformkompatibilität und Datenschutz.
+- [Backup and Restore](docs/BackupRestore.md) - verschlüsselte Sicherung und Wiederherstellung der Konfiguration.
+- [Security Model](docs/SecurityModel.md) und [Installer](docs/Installer.md) - Vertrauensgrenzen und Installationsdetails.
 
 ## Hilfe benötigt?
 

--- a/README.de.md
+++ b/README.de.md
@@ -3,141 +3,62 @@
 **Sprache:** [English](README.md) | [Türkçe](README.tr.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md) | **Deutsch** | [Русский](README.ru.md) | [Bahasa Indonesia](README.id.md) | [हिन्दी](README.hi.md) | [العربية](README.ar.md)
 
 [![Release](https://img.shields.io/github/v/release/tryigit/CleveresTricky?display_name=tag&sort=semver&label=Release)](https://github.com/tryigit/CleveresTricky/releases/latest)
-[![Localization](https://img.shields.io/badge/Localization-9%20Languages-teal?logo=googletranslate)](LANGUAGES.md)
-[![Channel](https://img.shields.io/badge/Follow-Telegram-blue.svg?logo=telegram)](https://t.me/cleverestech)
-[![License: GPL-3.0-only](https://img.shields.io/badge/License-GPL--3.0--only-orange.svg?logo=gnu)](LICENSING.md)
 ![Android](https://img.shields.io/badge/Android-12--17-3DDC84?logo=android&logoColor=white)
 ![Module](https://img.shields.io/badge/Module-KernelSU%20%7C%20APatch-6f42c1)
-![Architecture](https://img.shields.io/badge/Arch-ARM64%20%7C%20x86--64-0969DA)
 
-CleveresTricky ist ein KernelSU- und APatch-Modul für Android Keystore, Attestation, Identität und App-Kompatibilität. Es verbindet eine kontrollierte native Laufzeit mit einer mobilen WebUI, sodass Anwendungsbereich, Schlüsselmaterial, Identität, Patch-Level, Remote-Key-Provisioning-Schutz und DRM-Kompatibilität zentral verwaltet werden können.
+CleveresTricky ist ein KernelSU- und APatch-Modul für Android 12–17. Es bündelt Android-Keystore- und Attestation-Kompatibilität, Keybox/CBOX-Verwaltung, App-Zielauswahl, optionale Identitätssteuerung, Patch-Level-Einstellungen und Datenschutzfunktionen in einer mobilen WebUI.
 
-> Diese Datei ist eine lokalisierte Benutzerdokumentation. Bei technischen Abweichungen ist die englische Dokumentation die kanonische Referenz.
+Beginne mit den Standardwerten und aktiviere nur die Funktionen, die du wirklich brauchst.
 
-## Hauptfunktionen
+## Was du damit machen kannst
 
-### Laufzeitsteuerung
-
-[Spoof Engine](docs/i18n/de.md#spoof-engine) steuert optionale Identitätsersetzung. Kernschutz für Keystore, TEE und Boot Properties bleibt unabhängig aktiv, solange der Moduldienst gesund ist.
-
-[Application Scope](docs/i18n/de.md#application-scope) beschreibt Targeted Mode, Global Mode, Paketregeln, gemeinsam genutzte Android UIDs und Live-Cache-Updates.
-
-[Application Rules](docs/i18n/de.md#application-rules) beschreibt app-spezifische Templates, Keybox-Auswahl und stabile Datenschutzidentitäten.
-
-[Profiles](docs/i18n/de.md#profiles) beschreibt Daily Compatibility, Default, Maximum Compatibility und Minimal.
-
-### Attestation und Identität
-
-[Attestation](docs/i18n/de.md#attestation) beschreibt Zertifikatskettenersetzung, echte KeyMint-Operationen, StrongBox und die Grenzen softwarebasierter Kompatibilität.
-
-[Certificate Safe Mode](docs/i18n/de.md#certificate-safe-mode) dokumentiert das ältere Konfigurationskonzept. Das aktuelle Kern-Targeting hängt nicht mehr davon ab.
-
-[Keybox Manager](docs/i18n/de.md#keybox-manager) behandelt Laden, Prüfung, Auswahl, Rotation, Widerrufsprüfung und automatische Überwachung von Keyboxes.
-
-[Automatic Keybox Check](docs/i18n/de.md#automatic-keybox-check) erklärt den begrenzten Wartungs-Worker und seinen Lebenszyklus.
-
-[Remote Sources](docs/i18n/de.md#remote-sources) beschreibt authentifizierten Abruf, Signaturprüfung, Refresh-Politik und Fehlerverhalten.
-
-[Encrypted Storage](docs/i18n/de.md#encrypted-storage) erklärt CBOX-Container, lokale geschützte Caches und sicheren Umgang mit Schlüsselmaterial.
-
-[Patch Levels](docs/i18n/de.md#patch-levels) erklärt System-, Vendor- und Boot-Patchfelder mit globalen und app-spezifischen Regeln.
-
-[Build Identity](docs/i18n/de.md#build-identity) erklärt Gerätetemplates, Fingerprint, app-sichtbare Build-Felder, synchronisierte Early-Boot-Aktivierung und den optionalen Pixel-beta-Auto-Identity-Helfer für Custom ROMs.
-
-[Identity Refresh](docs/i18n/de.md#identity-refresh) erklärt die Identität für den nächsten Boot und Snapshot-Konsistenz.
-
-[Telephony Identity](docs/i18n/de.md#telephony-identity) erklärt Dual-SIM-Werte, Erhalt von Berechtigungsentscheidungen, unterstützte Android-APIs und Netzbetreibergrenzen.
-
-### Plattformkompatibilität
-
-[Boot Properties](docs/i18n/de.md#boot-properties) erklärt die zentrale Userspace-Boot-Property-Ansicht und die getrennte Identitätskompatibilitätspolitik.
-
-[Region Properties](docs/i18n/de.md#region-properties) erklärt die optionale begrenzte Länder- und Hardware-Regionsansicht.
-
-[Provider Coexistence](docs/i18n/de.md#provider-coexistence) erklärt, wie Automatic Mode das Überschreiben eines anderen Fingerprint-Anbieters verhindert.
-
-[RKP Protection](docs/i18n/de.md#rkp-protection) erklärt geschützte Android-Infrastruktur und echten Generated-Key-Passthrough.
-
-[DRM Passthrough and Privacy](docs/i18n/de.md#drm-passthrough) trennt zwei Funktionen. Ausgewählte Medien-Apps können auf dem echten Android-Keystore-Zertifikatspfad bleiben, während `privacy=isolate` beim unterstützten modernen DRM-HAL-`deviceUniqueId` ein stabiles app-spezifisches Pseudonym liefern kann.
-
-Dies ist kein Widevine- oder DRM-Bypass. Sicherheitslevel, Lizenzen, Provisioning, Content Keys, Sitzungen, HDCP und String Properties werden nicht verändert.
-
-### Oberfläche und Betrieb
-
-[Web Interface](docs/i18n/de.md#web-interface) erklärt den nativen Modulmanager-Transport, mobile Navigation, Live-Status, Validierung und Barrierefreiheit.
-
-Integrierte WebUI-Sprachen sind **English**, **Türkçe**, **简体中文**, **Español**, **Deutsch**, **Русский**, **Bahasa Indonesia**, **हिन्दी** und **العربية**. Alle Kataloge liegen lokal im Modul, ein Sprachwechsel benötigt kein Netzwerk.
-
-[Backup and Restore](docs/i18n/de.md#backup-restore) erklärt verschlüsselte Exporte, begrenzte Importe und sichere Wiederherstellung.
-
-[Installer](docs/i18n/de.md#installer) erklärt KernelSU/APatch-Paketlayout, Payload-Prüfung, unterstützte Geräte und Installationsablauf.
-
-[Diagnostics](docs/i18n/de.md#diagnostics) behandelt Logs, Statusprüfungen, häufige Fehler und eine kontrollierte Fehlersuchreihenfolge.
-
-### Engineering-Referenzen
-
-[Security Model](docs/i18n/de.md#security-model) dokumentiert Vertrauensgrenzen, geschützte Dateien, Eingabevalidierung und Fähigkeiten, die das Modul ausdrücklich nicht behauptet.
-
-[Performance](docs/i18n/de.md#performance) dokumentiert Hook-Lebenszyklus, begrenzte Caches, Hintergrundarbeit, CPU und Speicher.
-
-[Building](docs/i18n/de.md#building) dokumentiert Toolchain, Validierungen und erzeugte Artefakte.
-
-[Native Architecture](docs/i18n/de.md#native-architecture) dokumentiert Rust-Injector, Rust Native Core, Sprachrichtlinie und die einzige notwendige Android-C++-ABI-Grenze.
+- **Keybox/CBOX**-Dateien verwalten, prüfen, auswählen und wechseln.
+- Global Mode verwenden oder einzelne Apps mit eigenen Regeln auswählen.
+- Geräte-/Build-, Attestation-, Telefonie-, Regions- und Security-Patch-Darstellung optional konfigurieren.
+- Remote-Key-Provisioning-Abläufe schützen und die unterstützte DRM-Identifier-Exposition reduzieren, ohne einen DRM-Bypass vorzutäuschen.
+- Einstellungen sichern, den effektiven Zustand prüfen und Diagnosen über WebUI oder die Modul-Action sammeln.
 
 ## Schnellstart
 
-1. Aktuelles Release-ZIP von der offiziellen Projekt-Release-Seite laden.
-2. Bei Bedarf `SHA256SUMS` und GitHub Build Provenance prüfen.
-3. KernelSU oder APatch bei laufendem Android öffnen.
-4. ZIP installieren und neu starten.
-5. CleveresTricky WebUI aus dem Modulmanager öffnen.
-6. Neue Installationen starten mit Global Mode an und optionalem Identity Spoofing aus.
-7. Nur eigenes oder autorisiert zu testendes Schlüsselmaterial hinzufügen.
-8. Identitätsoptionen nur bei Bedarf konfigurieren.
-9. Nach Änderungen an Template-Build-Identity-Werten neu starten.
+1. Lade die aktuelle ZIP von der offiziellen [Releases](https://github.com/tryigit/CleveresTricky/releases/latest)-Seite herunter.
+2. Installiere die ZIP über KernelSU oder APatch, während Android läuft.
+3. Öffne die CleveresTricky-WebUI über deinen Modulmanager.
+4. Füge nur eine **Keybox oder CBOX** hinzu, die dir gehört oder die du testen darfst.
+5. Verwende zuerst die Standardkonfiguration und aktiviere Identität, App-Regeln oder Datenschutzoptionen nur bei Bedarf.
 
-Das Projekt enthält keine nutzbare Keybox und keinen privaten Attestation-Schlüssel.
+Das Projekt enthält keine verwendbare Keybox und keinen privaten Attestation-Schlüssel.
 
 ## Unterstützte Umgebung
 
-Unterstützt werden Android 12 bis Android 17, API 31 bis 37, ARM64 und x86 64. Die Installation erfolgt bei laufendem Android über KernelSU oder APatch.
+- Android **12–17** / API **31–37**
+- **ARM64** und **x86-64**
+- **KernelSU** und **APatch**
 
-Magisk- und Recovery-Installationen werden nicht unterstützt. Der Installer stoppt solche Pfade, bevor ein unvollständiges Modul zurückbleibt.
+Magisk und Recovery-Installationen werden nicht unterstützt.
 
-## Wichtige Grenzen
+## Wichtig zu wissen
 
-Ergebnisse hängen vom realen Gerätezustand, Firmware, Zertifizierung, Schlüsselmaterial, Google Play services und Remote-Policy ab. CleveresTricky verbessert lokale Kompatibilität, garantiert aber keinen bestimmten Remote-Verdict.
+CleveresTricky verbessert den lokalen Kompatibilitätspfad. Remote-Ergebnisse hängen trotzdem vom echten Gerät, der Firmware, dem Zertifizierungsstatus, Google Play services, Serverrichtlinien und deiner Konfiguration ab. Ein bestimmtes Play-Integrity- oder Attestation-Ergebnis kann nicht garantiert werden.
 
-Telephony-Werte sind nur über unterstützte App-APIs sichtbar. Modem, Baseband, EFS, physische SIM und die beim Netzbetreiber sichtbare Identität bleiben unverändert.
+Das Modul sperrt den Bootloader nicht physisch wieder, schreibt Verified-Boot-Messwerte nicht um, verändert den Hardware Root of Trust nicht, ändert weder Modem noch Baseband und macht aus DRM-Datenschutzfunktionen keinen DRM-Bypass.
 
-Android ID ist auf modernem Android nach App-Signatur, Nutzer und Gerät in SettingsProvider begrenzt. CleveresTricky bietet keinen irreführenden globalen Android-ID-Schalter.
+Verwende nur Konfigurationen und Zugangsdaten, für deren Nutzung du berechtigt bist.
 
-Die reale Kernel-Version bleibt unverändert. Boot Properties sperren den Bootloader nicht physisch, reparieren Verified Boot nicht, schreiben vbmeta nicht neu und ändern keinen Hardware Root of Trust.
+## Mehr erfahren
 
-Ein entsperrter Bootloader bedeutet nicht automatisch, dass jedes DRM unbrauchbar ist. Verhalten hängt von Gerät, Vendor-Implementierung, Provisioning, Sicherheitslevel, Service-Policy und Firmware ab. Die aktuelle DRM-Arbeit ist datenschutzorientiert und kein Bypass.
+- [Keybox Manager](docs/KeyboxManager.md) — Laden, Prüfen, Auswählen und Revocation-Checks für Keybox/CBOX.
+- [Application Scope](docs/ApplicationScope.md) und [Application Rules](docs/ApplicationRules.md) — festlegen, für welche Apps Funktionen gelten.
+- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md) und [Patch Levels](docs/PatchLevels.md) — optionale Identitätssteuerung.
+- [RKP Protection](docs/RkpProtection.md) und [DRM Privacy](docs/DrmPassthrough.md) — Plattformkompatibilität und Datenschutz.
+- [Backup and Restore](docs/BackupRestore.md) — verschlüsselte Sicherung und Wiederherstellung der Konfiguration.
+- [Security Model](docs/SecurityModel.md) und [Installer](docs/Installer.md) — Vertrauensgrenzen und Installationsdetails.
 
-Interne SHA-256-Datensätze erkennen fehlende, geänderte, injizierte, verlinkte und unerwartete Payloads und setzen den Dienst bei Fehlern in Tamper Lockdown. Die Authentizität offizieller Releases wird durch separat veröffentlichten Digest und GitHub-signierte Build Provenance abgesichert.
+## Hilfe benötigt?
 
-## Empfohlene Ersteinrichtung
+Nutze die **Logs**-Seite der WebUI oder die Modul-**Action**, um einen Notfall-Diagnosebericht zu erstellen. Prüfe das Archiv vor dem Teilen, da es Geräte- und Systeminformationen enthalten kann.
 
-Zuerst die Standardwerte einer Neuinstallation verwenden. Global Mode wählt geeignete App-UIDs, während Kernschutz für Boot und Keystore aktiv bleibt. Optionales Identity Spoofing bleibt aus, bis es im Identity-Bereich aktiviert wird.
+Unter [Diagnostics](docs/Diagnostics.md) findest du häufige Probleme und Schritte zur Fehlerbehebung.
 
-Custom-ROM-Nutzer können Auto Identity für eine aktuelle Pixel-beta- oder Canary-Build-Identity aus öffentlichen Google-Metadaten verwenden. Identity Spoof Engine nur aktivieren und neu starten, wenn diese Werte tatsächlich präsentiert werden sollen.
+## Projekt
 
-Für DRM-Identifier-Datenschutz eine Application Rule für die Medien-App erstellen und `privacy=isolate` setzen. DRM Keystore Passthrough kann aktiv bleiben, da echter Keystore-Zertifikatspfad und pseudonyme DRM-ID getrennt sind.
-
-## Hilfe und Projektinformationen
-
-Zur Diagnose WebUI Logs oder Android logcat mit Tag `CleveresTricky` verwenden. Details stehen in [Diagnostics](docs/i18n/de.md#diagnostics).
-
-Projektverlauf: [CHANGELOG](docs/i18n/de.md#changelog), Beiträge: [Contributing](docs/i18n/de.md#contributing), Sprachen: [Language Support](docs/i18n/de.md#languages), Theme: [Theme](docs/i18n/de.md#theme).
-
-Die offizielle [Android-Attestation-Dokumentation](https://source.android.com/docs/security/features/keystore/attestation), [Play-Integrity-Verdict-Dokumentation](https://developer.android.com/google/play/integrity/verdicts) und der [KernelSU-Modulguide](https://kernelsu.org/guide/module.html) bleiben die maßgeblichen Quellen.
-
-## Granulare optionale Identitätssteuerung
-
-CleveresTricky löst Device and Build Identity, Attestation Identity, Telephony Identity, Region Identity, Identity Refresh und Security Patch getrennt auf. Security Patch ist unabhängig von Device and Build Identity.
-
-Kern-Keystore-Interception, echte KeyMint- und StrongBox-Private-Key-Operationen, Root-of-Trust-Verarbeitung, Binder-Sicherheit und notwendige Boot-Kompatibilität bleiben davon unabhängig. Die Oberfläche trennt erfassten realen Zustand, konfigurierte Darstellung und effektiv für Apps sichtbaren Zustand.
-
-Security Patch bietet getrennte Richtlinien für System, Vendor und Boot. Profiles können Apps kohärente optionale Einstellungen zuweisen und Effective State inspector zeigt das tatsächliche Resolver-Ergebnis.
+[Changelog](CHANGELOG.md) · [Mitwirken](CONTRIBUTING.md) · [Sprachen](LANGUAGES.md) · [Lizenz](LICENSING.md) · [Telegram](https://t.me/cleverestech)

--- a/README.es.md
+++ b/README.es.md
@@ -3,141 +3,62 @@
 **Idioma:** [English](README.md) | [Türkçe](README.tr.md) | [简体中文](README.zh-CN.md) | **Español** | [Deutsch](README.de.md) | [Русский](README.ru.md) | [Bahasa Indonesia](README.id.md) | [हिन्दी](README.hi.md) | [العربية](README.ar.md)
 
 [![Release](https://img.shields.io/github/v/release/tryigit/CleveresTricky?display_name=tag&sort=semver&label=Release)](https://github.com/tryigit/CleveresTricky/releases/latest)
-[![Localization](https://img.shields.io/badge/Localization-9%20Languages-teal?logo=googletranslate)](LANGUAGES.md)
-[![Channel](https://img.shields.io/badge/Follow-Telegram-blue.svg?logo=telegram)](https://t.me/cleverestech)
-[![License: GPL-3.0-only](https://img.shields.io/badge/License-GPL--3.0--only-orange.svg?logo=gnu)](LICENSING.md)
 ![Android](https://img.shields.io/badge/Android-12--17-3DDC84?logo=android&logoColor=white)
 ![Module](https://img.shields.io/badge/Module-KernelSU%20%7C%20APatch-6f42c1)
-![Architecture](https://img.shields.io/badge/Arch-ARM64%20%7C%20x86--64-0969DA)
 
-CleveresTricky es un módulo para KernelSU y APatch orientado a Android Keystore, attestation, identidad y compatibilidad de aplicaciones. Combina un runtime nativo controlado con una WebUI móvil para administrar alcance, material de claves, identidad, niveles de parche, protección de Remote Key Provisioning y compatibilidad DRM desde un único lugar.
+CleveresTricky es un módulo para KernelSU y APatch en Android 12–17. Reúne compatibilidad con Android Keystore y attestation, gestión de Keybox/CBOX, selección de aplicaciones, controles opcionales de identidad, niveles de parche y herramientas de privacidad en una sola WebUI móvil.
 
-> Esta es una traducción de la documentación para usuarios. Si existe alguna diferencia técnica, la documentación en inglés es la referencia canónica.
+Empieza con los valores predeterminados y activa únicamente lo que realmente necesites.
 
-## Capacidades principales
+## Qué puedes hacer
 
-### Control del runtime
-
-[Spoof Engine](docs/i18n/es.md#spoof-engine) controla la sustitución opcional de identidad. La compatibilidad principal de Keystore y TEE y la protección de boot properties permanecen activas de forma independiente mientras el servicio esté sano.
-
-[Application Scope](docs/i18n/es.md#application-scope) explica el modo dirigido, el modo global, las reglas de paquetes, UID compartidos y las actualizaciones de caché en vivo.
-
-[Application Rules](docs/i18n/es.md#application-rules) explica plantillas por aplicación, selección de keybox e identidades privadas estables.
-
-[Profiles](docs/i18n/es.md#profiles) explica los perfiles Daily Compatibility, Default, Maximum Compatibility y Minimal.
-
-### Attestation e identidad
-
-[Attestation](docs/i18n/es.md#attestation) explica sustitución de cadenas de certificados, operaciones KeyMint reales, StrongBox y los límites de una capa de compatibilidad de software.
-
-[Certificate Safe Mode](docs/i18n/es.md#certificate-safe-mode) documenta el concepto de configuración heredado. El targeting principal ya no depende de ese interruptor.
-
-[Keybox Manager](docs/i18n/es.md#keybox-manager) cubre carga, verificación, selección, rotación, comprobación de revocación y monitorización de keyboxes.
-
-[Automatic Keybox Check](docs/i18n/es.md#automatic-keybox-check) explica el worker de mantenimiento acotado y su ciclo de vida.
-
-[Remote Sources](docs/i18n/es.md#remote-sources) cubre descargas autenticadas, firmas, política de actualización y fallos.
-
-[Encrypted Storage](docs/i18n/es.md#encrypted-storage) explica contenedores CBOX, cachés locales protegidas y manejo seguro del material de claves.
-
-[Patch Levels](docs/i18n/es.md#patch-levels) documenta los campos System, Vendor y Boot con reglas globales y por aplicación.
-
-[Build Identity](docs/i18n/es.md#build-identity) explica plantillas de dispositivo, fingerprint, campos Build visibles para las apps, activación temprana sincronizada y el asistente Pixel beta Auto Identity para Custom ROM.
-
-[Identity Refresh](docs/i18n/es.md#identity-refresh) explica la identidad preparada para el siguiente arranque y la consistencia de snapshots.
-
-[Telephony Identity](docs/i18n/es.md#telephony-identity) explica valores para doble SIM, conservación de permisos, APIs Android compatibles y límites del operador.
-
-### Compatibilidad de plataforma
-
-[Boot Properties](docs/i18n/es.md#boot-properties) explica la vista userspace de propiedades de arranque y la política de compatibilidad de identidad separada.
-
-[Region Properties](docs/i18n/es.md#region-properties) explica la vista opcional y acotada de país y región de hardware.
-
-[Provider Coexistence](docs/i18n/es.md#provider-coexistence) explica cómo el modo automático evita sobrescribir otro proveedor de fingerprint.
-
-[RKP Protection](docs/i18n/es.md#rkp-protection) explica la infraestructura Android protegida y el passthrough genuino de generated keys.
-
-[DRM Passthrough and Privacy](docs/i18n/es.md#drm-passthrough) documenta dos controles separados. Las aplicaciones multimedia seleccionadas pueden permanecer en la ruta genuina de certificados Keystore de Android, mientras que `privacy=isolate` puede sustituir el `deviceUniqueId` compatible por un pseudónimo estable específico de la aplicación.
-
-No es un bypass de Widevine ni de DRM. No cambia niveles de seguridad, licencias, provisioning, claves de contenido, sesiones, HDCP ni propiedades de texto.
-
-### Interfaz y operación
-
-[Web Interface](docs/i18n/es.md#web-interface) explica el transporte nativo del gestor, navegación móvil, estado en vivo, validación y accesibilidad.
-
-Los idiomas WebUI integrados son **English**, **Türkçe**, **简体中文**, **Español**, **Deutsch**, **Русский**, **Bahasa Indonesia**, **हिन्दी** y **العربية**. Los catálogos están incluidos localmente y cambiar de idioma no requiere conexión de red.
-
-[Backup and Restore](docs/i18n/es.md#backup-restore) explica exportaciones cifradas, importaciones acotadas y recuperación segura.
-
-[Installer](docs/i18n/es.md#installer) explica el paquete KernelSU/APatch, la verificación de payloads, dispositivos compatibles y el flujo de instalación.
-
-[Diagnostics](docs/i18n/es.md#diagnostics) cubre logs, comprobaciones de estado, fallos comunes y un proceso de diagnóstico controlado.
-
-### Referencias de ingeniería
-
-[Security Model](docs/i18n/es.md#security-model) documenta límites de confianza, archivos protegidos, validación de entradas y capacidades que el módulo no afirma tener.
-
-[Performance](docs/i18n/es.md#performance) documenta ciclo de vida de hooks, cachés acotadas, trabajo en segundo plano, CPU y memoria.
-
-[Building](docs/i18n/es.md#building) documenta toolchain, validaciones y artefactos generados.
-
-[Native Architecture](docs/i18n/es.md#native-architecture) documenta el injector Rust, el core nativo Rust, la política de lenguajes y el único límite Android C++ ABI requerido.
+- Gestionar, verificar, seleccionar y rotar archivos **Keybox/CBOX**.
+- Usar Global Mode o aplicar reglas a aplicaciones concretas.
+- Configurar de forma opcional la identidad de dispositivo/build, attestation, telefonía, región y security patch.
+- Proteger los flujos de Remote Key Provisioning y reducir la exposición de identificadores DRM compatibles sin pretender eludir DRM.
+- Crear copias de seguridad, revisar el estado efectivo y recopilar diagnósticos desde la WebUI o la Action del módulo.
 
 ## Inicio rápido
 
-1. Descarga el ZIP actual desde la página oficial de Releases.
-2. Si necesitas verificar el origen oficial, comprueba `SHA256SUMS` y la provenance de build de GitHub.
-3. Abre KernelSU o APatch con Android en ejecución.
-4. Instala el ZIP y reinicia.
-5. Abre CleveresTricky WebUI desde el gestor del módulo.
-6. Las instalaciones nuevas empiezan con Global Mode activado y el spoofing de identidad opcional desactivado.
-7. Añade solo material de claves que poseas o que estés autorizado a probar.
-8. Configura opciones de identidad solo cuando sean necesarias.
-9. Reinicia tras modificar valores de Build Identity de una plantilla.
+1. Descarga el ZIP más reciente desde la página oficial de [Releases](https://github.com/tryigit/CleveresTricky/releases/latest).
+2. Instala el ZIP desde KernelSU o APatch mientras Android está en funcionamiento.
+3. Abre la WebUI de CleveresTricky desde tu gestor de módulos.
+4. Añade únicamente un **Keybox o CBOX** que te pertenezca o para el que tengas autorización de prueba.
+5. Mantén primero la configuración predeterminada y activa identidad, reglas de aplicaciones o privacidad solo cuando sea necesario.
 
-El proyecto no incluye un keybox utilizable ni una clave privada de attestation.
+El proyecto no incluye ningún Keybox utilizable ni una clave privada de attestation.
 
 ## Entorno compatible
 
-CleveresTricky soporta Android 12 a Android 17, API 31 a 37, en ARM64 y x86 64. La instalación se realiza desde KernelSU o APatch mientras Android está funcionando.
+- Android **12–17** / API **31–37**
+- **ARM64** y **x86-64**
+- **KernelSU** y **APatch**
 
-Magisk y recovery no son compatibles. El instalador detiene esas rutas antes de dejar un módulo parcial.
+Magisk y la instalación desde recovery no son compatibles.
 
-## Límites importantes
+## Importante
 
-Los resultados dependen del estado real del dispositivo, firmware, certificación, material de claves, Google Play services y política remota. El módulo mejora la ruta local de compatibilidad pero no garantiza un veredicto remoto concreto.
+CleveresTricky mejora la ruta de compatibilidad local, pero los resultados remotos siguen dependiendo del dispositivo real, firmware, estado de certificación, Google Play services, políticas del servidor y los datos configurados. No puede garantizar un resultado concreto de Play Integrity o attestation.
 
-Los valores de telefonía solo se presentan mediante APIs compatibles. No modifican módem, baseband, EFS, SIM física ni la identidad que ve el operador.
+No vuelve a bloquear físicamente el bootloader, no reescribe mediciones de verified boot, no cambia el hardware root of trust, no modifica el módem/baseband y no convierte las funciones de privacidad DRM en un bypass de DRM.
 
-En Android moderno, Android ID está limitado por firma de aplicación, usuario y dispositivo dentro de SettingsProvider. CleveresTricky no presenta un control global engañoso de Android ID.
+Utiliza únicamente configuraciones y credenciales para las que tengas autorización.
 
-La versión real del kernel no cambia. La vista de boot properties no vuelve a bloquear físicamente el bootloader, no repara verified boot, no reescribe vbmeta y no cambia el root of trust de hardware.
+## Más información
 
-Un bootloader desbloqueado no implica por sí solo que todo DRM deje de funcionar. El resultado depende del dispositivo, vendor, provisioning, nivel de seguridad, política del servicio y firmware. El trabajo DRM actual está orientado a privacidad, no a bypass.
+- [Keybox Manager](docs/KeyboxManager.md) — carga, verificación, selección y comprobaciones de revocación de Keybox/CBOX.
+- [Application Scope](docs/ApplicationScope.md) y [Application Rules](docs/ApplicationRules.md) — elige dónde se aplican las funciones.
+- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md) y [Patch Levels](docs/PatchLevels.md) — controles opcionales de identidad.
+- [RKP Protection](docs/RkpProtection.md) y [DRM Privacy](docs/DrmPassthrough.md) — compatibilidad de plataforma y privacidad.
+- [Backup and Restore](docs/BackupRestore.md) — copia y restauración cifrada de la configuración.
+- [Security Model](docs/SecurityModel.md) e [Installer](docs/Installer.md) — límites de confianza y detalles de instalación.
 
-Los registros SHA 256 internos detectan payloads ausentes, modificados, añadidos, enlazados o inesperados y activan tamper lockdown cuando falla la verificación. La autenticidad de un release oficial se basa en el digest publicado por separado y la provenance firmada por GitHub.
+## ¿Necesitas ayuda?
 
-## Primera configuración recomendada
+Usa la página **Logs** de la WebUI o la **Action** del módulo para crear un informe de diagnóstico de emergencia. Revisa el archivo antes de compartirlo, ya que puede contener información del dispositivo y del sistema.
 
-Usa primero los valores predeterminados de una instalación nueva. Global Mode selecciona UID de aplicaciones elegibles mientras las protecciones principales de boot y Keystore permanecen activas. El spoofing de identidad opcional sigue desactivado hasta que lo habilites desde Identity.
+Consulta [Diagnostics](docs/Diagnostics.md) para problemas comunes y pasos de solución.
 
-Si usas una Custom ROM y necesitas una Build Identity actual para pruebas de Play Integrity, Auto Identity puede obtener una identidad Pixel beta o canary desde metadatos públicos de Google y guardarla localmente. Activa Identity Spoof Engine y reinicia solo cuando quieras exponer esos valores.
+## Proyecto
 
-Para privacidad del identificador DRM, crea una Application Rule para la aplicación multimedia y usa `privacy=isolate`. DRM Keystore Passthrough puede seguir activado porque la ruta genuina de certificados Keystore y la ruta pseudónima del ID DRM son independientes.
-
-## Ayuda e información del proyecto
-
-Para diagnosticar problemas, usa la pantalla WebUI Logs o Android logcat con la etiqueta `CleveresTricky`. Consulta [Diagnostics](docs/i18n/es.md#diagnostics).
-
-El historial está en [CHANGELOG](docs/i18n/es.md#changelog), la guía de contribución en [Contributing](docs/i18n/es.md#contributing), la estructura de idiomas en [Language Support](docs/i18n/es.md#languages) y el tema en [Theme](docs/i18n/es.md#theme).
-
-La [documentación oficial de Android attestation](https://source.android.com/docs/security/features/keystore/attestation), la [documentación de verdicts de Play Integrity](https://developer.android.com/google/play/integrity/verdicts) y la [guía de módulos KernelSU](https://kernelsu.org/guide/module.html) siguen siendo las referencias autoritativas.
-
-## Controles opcionales granulares de identidad
-
-CleveresTricky resuelve por separado Device and Build Identity, Attestation Identity, Telephony Identity, Region Identity, Identity Refresh y Security Patch. Security Patch es independiente de Device and Build Identity.
-
-La interceptación principal de Keystore, las operaciones privadas reales de KeyMint y StrongBox, root of trust, seguridad Binder y compatibilidad de arranque permanecen independientes de esos controles opcionales. La interfaz separa estado real capturado, estado configurado y estado efectivo visible para la aplicación.
-
-Security Patch ofrece políticas independientes para System, Vendor y Boot. Los perfiles pueden asignar opciones coherentes por aplicación y Effective State inspector muestra el resultado real del resolver.
+[Changelog](CHANGELOG.md) · [Contribuir](CONTRIBUTING.md) · [Idiomas](LANGUAGES.md) · [Licencia](LICENSING.md) · [Telegram](https://t.me/cleverestech)

--- a/README.es.md
+++ b/README.es.md
@@ -6,7 +6,7 @@
 ![Android](https://img.shields.io/badge/Android-12--17-3DDC84?logo=android&logoColor=white)
 ![Module](https://img.shields.io/badge/Module-KernelSU%20%7C%20APatch-6f42c1)
 
-CleveresTricky es un módulo para KernelSU y APatch en Android 12–17. Reúne compatibilidad con Android Keystore y attestation, gestión de Keybox/CBOX, selección de aplicaciones, controles opcionales de identidad, niveles de parche y herramientas de privacidad en una sola WebUI móvil.
+CleveresTricky es un módulo para KernelSU y APatch en Android 12-17. Reúne compatibilidad con Android Keystore y attestation, gestión de Keybox/CBOX, selección de aplicaciones, controles opcionales de identidad, niveles de parche y herramientas de privacidad en una sola WebUI móvil.
 
 Empieza con los valores predeterminados y activa únicamente lo que realmente necesites.
 
@@ -30,7 +30,7 @@ El proyecto no incluye ningún Keybox utilizable ni una clave privada de attesta
 
 ## Entorno compatible
 
-- Android **12–17** / API **31–37**
+- Android **12-17** / API **31-37**
 - **ARM64** y **x86-64**
 - **KernelSU** y **APatch**
 
@@ -46,12 +46,12 @@ Utiliza únicamente configuraciones y credenciales para las que tengas autorizac
 
 ## Más información
 
-- [Keybox Manager](docs/KeyboxManager.md) — carga, verificación, selección y comprobaciones de revocación de Keybox/CBOX.
-- [Application Scope](docs/ApplicationScope.md) y [Application Rules](docs/ApplicationRules.md) — elige dónde se aplican las funciones.
-- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md) y [Patch Levels](docs/PatchLevels.md) — controles opcionales de identidad.
-- [RKP Protection](docs/RkpProtection.md) y [DRM Privacy](docs/DrmPassthrough.md) — compatibilidad de plataforma y privacidad.
-- [Backup and Restore](docs/BackupRestore.md) — copia y restauración cifrada de la configuración.
-- [Security Model](docs/SecurityModel.md) e [Installer](docs/Installer.md) — límites de confianza y detalles de instalación.
+- [Keybox Manager](docs/KeyboxManager.md) - carga, verificación, selección y comprobaciones de revocación de Keybox/CBOX.
+- [Application Scope](docs/ApplicationScope.md) y [Application Rules](docs/ApplicationRules.md) - elige dónde se aplican las funciones.
+- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md) y [Patch Levels](docs/PatchLevels.md) - controles opcionales de identidad.
+- [RKP Protection](docs/RkpProtection.md) y [DRM Privacy](docs/DrmPassthrough.md) - compatibilidad de plataforma y privacidad.
+- [Backup and Restore](docs/BackupRestore.md) - copia y restauración cifrada de la configuración.
+- [Security Model](docs/SecurityModel.md) e [Installer](docs/Installer.md) - límites de confianza y detalles de instalación.
 
 ## ¿Necesitas ayuda?
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -6,7 +6,7 @@
 ![Android](https://img.shields.io/badge/Android-12--17-3DDC84?logo=android&logoColor=white)
 ![Module](https://img.shields.io/badge/Module-KernelSU%20%7C%20APatch-6f42c1)
 
-CleveresTricky Android 12–17 के लिए KernelSU और APatch मॉड्यूल है। यह Android Keystore और attestation compatibility, Keybox/CBOX management, app targeting, optional identity controls, patch-level controls और privacy tools को एक mobile WebUI में लाता है।
+CleveresTricky Android 12-17 के लिए KernelSU और APatch मॉड्यूल है। यह Android Keystore और attestation compatibility, Keybox/CBOX management, app targeting, optional identity controls, patch-level controls और privacy tools को एक mobile WebUI में लाता है।
 
 पहले default settings से शुरू करें और केवल वही features चालू करें जिनकी आपको वास्तव में ज़रूरत है।
 
@@ -30,7 +30,7 @@ Project के साथ कोई usable Keybox या private attestation key 
 
 ## Supported environment
 
-- Android **12–17** / API **31–37**
+- Android **12-17** / API **31-37**
 - **ARM64** और **x86-64**
 - **KernelSU** और **APatch**
 
@@ -46,12 +46,12 @@ CleveresTricky local compatibility path को बेहतर करता ह�
 
 ## और जानकारी
 
-- [Keybox Manager](docs/KeyboxManager.md) — Keybox/CBOX loading, verification, selection और revocation checks।
-- [Application Scope](docs/ApplicationScope.md) और [Application Rules](docs/ApplicationRules.md) — तय करें features किन apps पर लागू हों।
-- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md) और [Patch Levels](docs/PatchLevels.md) — optional identity controls।
-- [RKP Protection](docs/RkpProtection.md) और [DRM Privacy](docs/DrmPassthrough.md) — platform compatibility और privacy behavior।
-- [Backup and Restore](docs/BackupRestore.md) — encrypted configuration backup और recovery।
-- [Security Model](docs/SecurityModel.md) और [Installer](docs/Installer.md) — trust boundaries और installation details।
+- [Keybox Manager](docs/KeyboxManager.md) - Keybox/CBOX loading, verification, selection और revocation checks।
+- [Application Scope](docs/ApplicationScope.md) और [Application Rules](docs/ApplicationRules.md) - तय करें features किन apps पर लागू हों।
+- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md) और [Patch Levels](docs/PatchLevels.md) - optional identity controls।
+- [RKP Protection](docs/RkpProtection.md) और [DRM Privacy](docs/DrmPassthrough.md) - platform compatibility और privacy behavior।
+- [Backup and Restore](docs/BackupRestore.md) - encrypted configuration backup और recovery।
+- [Security Model](docs/SecurityModel.md) और [Installer](docs/Installer.md) - trust boundaries और installation details।
 
 ## मदद चाहिए?
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -3,141 +3,62 @@
 **भाषा:** [English](README.md) | [Türkçe](README.tr.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Русский](README.ru.md) | [Bahasa Indonesia](README.id.md) | **हिन्दी** | [العربية](README.ar.md)
 
 [![Release](https://img.shields.io/github/v/release/tryigit/CleveresTricky?display_name=tag&sort=semver&label=Release)](https://github.com/tryigit/CleveresTricky/releases/latest)
-[![Localization](https://img.shields.io/badge/Localization-9%20Languages-teal?logo=googletranslate)](LANGUAGES.md)
-[![Channel](https://img.shields.io/badge/Follow-Telegram-blue.svg?logo=telegram)](https://t.me/cleverestech)
-[![License: GPL-3.0-only](https://img.shields.io/badge/License-GPL--3.0--only-orange.svg?logo=gnu)](LICENSING.md)
 ![Android](https://img.shields.io/badge/Android-12--17-3DDC84?logo=android&logoColor=white)
 ![Module](https://img.shields.io/badge/Module-KernelSU%20%7C%20APatch-6f42c1)
-![Architecture](https://img.shields.io/badge/Arch-ARM64%20%7C%20x86--64-0969DA)
 
-CleveresTricky Android Keystore, attestation, identity और application compatibility के लिए KernelSU और APatch module है। यह controlled native runtime को mobile WebUI के साथ जोड़ता है ताकि application scope, key material, identity, patch level, Remote Key Provisioning protection और DRM compatibility एक ही जगह से प्रबंधित की जा सके।
+CleveresTricky Android 12–17 के लिए KernelSU और APatch मॉड्यूल है। यह Android Keystore और attestation compatibility, Keybox/CBOX management, app targeting, optional identity controls, patch-level controls और privacy tools को एक mobile WebUI में लाता है।
 
-> यह user documentation का localized version है। किसी technical अंतर की स्थिति में English documentation canonical source मानी जाएगी।
+पहले default settings से शुरू करें और केवल वही features चालू करें जिनकी आपको वास्तव में ज़रूरत है।
 
-## मुख्य क्षमताएँ
+## आप क्या कर सकते हैं
 
-### Runtime control
-
-[Spoof Engine](docs/i18n/hi.md#spoof-engine) optional identity replacement को नियंत्रित करता है। Module service स्वस्थ रहने पर core Keystore, TEE compatibility और boot property protection इससे स्वतंत्र रूप से सक्रिय रहते हैं।
-
-[Application Scope](docs/i18n/hi.md#application-scope) targeted mode, global mode, package rules, shared Android UID और live cache updates समझाता है।
-
-[Application Rules](docs/i18n/hi.md#application-rules) app-specific template, keybox selection और stable privacy identity समझाता है।
-
-[Profiles](docs/i18n/hi.md#profiles) Daily Compatibility, Default, Maximum Compatibility और Minimal presets समझाता है।
-
-### Attestation और identity
-
-[Attestation](docs/i18n/hi.md#attestation) certificate chain replacement, genuine KeyMint operations, StrongBox और software compatibility की सीमाएँ बताता है।
-
-[Certificate Safe Mode](docs/i18n/hi.md#certificate-safe-mode) legacy configuration concept बताता है। वर्तमान core targeting अब उस पुराने switch पर निर्भर नहीं है।
-
-[Keybox Manager](docs/i18n/hi.md#keybox-manager) keybox loading, verification, selection, rotation, revocation check और monitoring को कवर करता है।
-
-[Automatic Keybox Check](docs/i18n/hi.md#automatic-keybox-check) bounded maintenance worker और उसके lifecycle को समझाता है।
-
-[Remote Sources](docs/i18n/hi.md#remote-sources) authenticated retrieval, signature verification, refresh policy और failure behavior समझाता है।
-
-[Encrypted Storage](docs/i18n/hi.md#encrypted-storage) CBOX containers, local protected caches और सुरक्षित key material handling समझाता है।
-
-[Patch Levels](docs/i18n/hi.md#patch-levels) System, Vendor और Boot patch fields तथा global/per-app rules समझाता है।
-
-[Build Identity](docs/i18n/hi.md#build-identity) device templates, fingerprint, app-visible Build fields, synchronized early-boot activation और Custom ROM users के लिए Pixel beta Auto Identity helper समझाता है।
-
-[Identity Refresh](docs/i18n/hi.md#identity-refresh) अगले boot के लिए identity generation और snapshot consistency समझाता है।
-
-[Telephony Identity](docs/i18n/hi.md#telephony-identity) dual SIM values, Android permission decision preservation, supported APIs और operator limits समझाता है।
-
-### Platform compatibility
-
-[Boot Properties](docs/i18n/hi.md#boot-properties) core userspace boot property view और अलग identity compatibility policy समझाता है।
-
-[Region Properties](docs/i18n/hi.md#region-properties) optional bounded country/hardware region view समझाता है।
-
-[Provider Coexistence](docs/i18n/hi.md#provider-coexistence) बताता है कि automatic mode किसी अन्य fingerprint provider को overwrite करने से कैसे बचता है।
-
-[RKP Protection](docs/i18n/hi.md#rkp-protection) protected Android infrastructure और genuine generated-key passthrough समझाता है।
-
-[DRM Passthrough and Privacy](docs/i18n/hi.md#drm-passthrough) दो अलग behaviors समझाता है। Selected media apps Android के genuine Keystore certificate path पर रह सकती हैं, जबकि `privacy=isolate` supported modern DRM HAL `deviceUniqueId` को app-specific stable pseudonym से बदल सकता है।
-
-यह Widevine या DRM bypass नहीं है। Security level, licenses, provisioning, content keys, sessions, HDCP और string properties नहीं बदले जाते।
-
-### Interface और operation
-
-[Web Interface](docs/i18n/hi.md#web-interface) native module-manager transport, mobile navigation, live status, validation और accessibility समझाता है।
-
-Built-in WebUI languages हैं **English**, **Türkçe**, **简体中文**, **Español**, **Deutsch**, **Русский**, **Bahasa Indonesia**, **हिन्दी** और **العربية**। Translation catalogs local हैं, इसलिए language switch के लिए network की जरूरत नहीं है।
-
-[Backup and Restore](docs/i18n/hi.md#backup-restore) encrypted export, bounded import और safe recovery समझाता है।
-
-[Installer](docs/i18n/hi.md#installer) KernelSU/APatch package layout, payload verification, supported devices और installation flow समझाता है।
-
-[Diagnostics](docs/i18n/hi.md#diagnostics) logs, status checks, common failures और controlled troubleshooting sequence समझाता है।
-
-### Engineering references
-
-[Security Model](docs/i18n/hi.md#security-model) trust boundaries, protected files, input validation और वे capabilities दस्तावेज करता है जिनका module दावा नहीं करता।
-
-[Performance](docs/i18n/hi.md#performance) hook lifecycle, bounded caches, background work, CPU और memory behavior दस्तावेज करता है।
-
-[Building](docs/i18n/hi.md#building) toolchain, validation tasks और generated artifacts समझाता है।
-
-[Native Architecture](docs/i18n/hi.md#native-architecture) Rust injector, Rust native core, enforced language policy और केवल आवश्यक Android C++ ABI boundary दस्तावेज करता है।
+- **Keybox/CBOX** files को manage, verify, select और rotate करें।
+- Global Mode इस्तेमाल करें या अलग-अलग apps पर per-app rules लागू करें।
+- Device/build, attestation, telephony, region और security patch presentation को आवश्यकता के अनुसार configure करें।
+- Remote Key Provisioning flows को protect करें और DRM bypass का दावा किए बिना supported DRM identifiers की exposure कम करें।
+- Settings का backup लें, effective state देखें और WebUI या module Action से diagnostics इकट्ठा करें।
 
 ## Quick start
 
-1. Official project Release page से current ZIP डाउनलोड करें।
-2. Official build origin verify करना हो तो `SHA256SUMS` और GitHub build provenance जांचें।
-3. Android चलते समय KernelSU या APatch खोलें।
-4. ZIP install करके reboot करें।
-5. Module manager से CleveresTricky WebUI खोलें।
-6. Fresh install में Global Mode enabled और optional identity spoofing disabled रहता है।
-7. केवल अपना या authorized test key material जोड़ें।
-8. Identity options केवल जरूरत पर configure करें।
-9. Template Build Identity बदलने के बाद reboot करें।
+1. Official [Releases](https://github.com/tryigit/CleveresTricky/releases/latest) page से latest ZIP डाउनलोड करें।
+2. Android चल रहा हो तब ZIP को KernelSU या APatch से install करें।
+3. अपने module manager से CleveresTricky WebUI खोलें।
+4. केवल वही **Keybox या CBOX** जोड़ें जो आपका हो या जिसे test करने की आपको अनुमति हो।
+5. पहले default configuration रखें; identity, app rules या privacy options केवल ज़रूरत होने पर enable करें।
 
-Project या release में usable keybox या private attestation key शामिल नहीं है।
+Project के साथ कोई usable Keybox या private attestation key शामिल नहीं है।
 
 ## Supported environment
 
-CleveresTricky Android 12 से Android 17, API 31 से 37, ARM64 और x86 64 को support करता है। Installation Android running state में KernelSU या APatch से की जाती है।
+- Android **12–17** / API **31–37**
+- **ARM64** और **x86-64**
+- **KernelSU** और **APatch**
 
-Magisk और recovery install supported नहीं हैं। Installer unsupported path को partial module छोड़ने से पहले रोक देता है।
+Magisk और recovery installation supported नहीं हैं।
 
-## महत्वपूर्ण सीमाएँ
+## ज़रूरी बातें
 
-Result वास्तविक device state, firmware, certification, key material, Google Play services और remote policy पर निर्भर करता है। CleveresTricky local compatibility path सुधारता है लेकिन किसी specific remote verdict की guarantee नहीं देता।
+CleveresTricky local compatibility path को बेहतर करता है, लेकिन remote result असली device, firmware, certification state, Google Play services, server policy और आपकी configuration पर निर्भर रहता है। यह किसी खास Play Integrity या attestation verdict की guarantee नहीं दे सकता।
 
-Telephony values केवल supported app APIs में दिखाई देते हैं। Modem, baseband, EFS, physical SIM या operator को दिखने वाली identity नहीं बदलती।
+यह bootloader को physically relock नहीं करता, Verified Boot measurements को rewrite नहीं करता, hardware Root of Trust को नहीं बदलता, modem/baseband को modify नहीं करता और DRM privacy controls को DRM bypass में नहीं बदलता।
 
-Modern Android में Android ID, SettingsProvider के अंदर app signing identity, user और device से scoped है। CleveresTricky misleading global Android ID control नहीं देता।
+केवल वही configuration और credentials इस्तेमाल करें जिन्हें उपयोग करने की आपको अनुमति हो।
 
-Actual kernel version नहीं बदलता। Boot property view bootloader को physically relock नहीं करता, verified boot repair नहीं करता, vbmeta rewrite नहीं करता और hardware root of trust नहीं बदलता।
+## और जानकारी
 
-Unlocked bootloader का मतलब यह नहीं कि हर DRM implementation unusable है। व्यवहार device, vendor implementation, provisioning, security level, service policy और firmware पर निर्भर है। Current DRM feature privacy-focused है, bypass नहीं।
+- [Keybox Manager](docs/KeyboxManager.md) — Keybox/CBOX loading, verification, selection और revocation checks।
+- [Application Scope](docs/ApplicationScope.md) और [Application Rules](docs/ApplicationRules.md) — तय करें features किन apps पर लागू हों।
+- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md) और [Patch Levels](docs/PatchLevels.md) — optional identity controls।
+- [RKP Protection](docs/RkpProtection.md) और [DRM Privacy](docs/DrmPassthrough.md) — platform compatibility और privacy behavior।
+- [Backup and Restore](docs/BackupRestore.md) — encrypted configuration backup और recovery।
+- [Security Model](docs/SecurityModel.md) और [Installer](docs/Installer.md) — trust boundaries और installation details।
 
-Internal SHA 256 records missing, changed, injected, linked या unexpected payload detect करते हैं और validation failure पर tamper lockdown सक्रिय करते हैं। Official release authenticity अलग published digest और GitHub signed build provenance से आती है।
+## मदद चाहिए?
 
-## Recommended first setup
+WebUI के **Logs** page या module **Action** से emergency diagnostic report बनाएं। Share करने से पहले archive को देख लें, क्योंकि diagnostics में device और system information हो सकती है।
 
-पहले fresh-install defaults उपयोग करें। Global Mode eligible app UIDs चुनता है जबकि core boot और Keystore protection सक्रिय रहते हैं। Optional identity spoofing Identity section से enable करने तक बंद रहता है।
+Common problems और troubleshooting steps के लिए [Diagnostics](docs/Diagnostics.md) देखें।
 
-Custom ROM पर Play Integrity testing के लिए current Build Identity चाहिए तो Auto Identity Google public metadata से Pixel beta या canary identity प्राप्त कर local store कर सकता है। केवल तब Identity Spoof Engine enable करके reboot करें जब इन values को expose करना हो।
+## Project
 
-DRM identifier privacy के लिए media app पर Application Rule बनाएं और `privacy=isolate` सेट करें। DRM Keystore Passthrough enabled रह सकता है क्योंकि genuine Keystore certificate path और pseudonymous DRM ID path स्वतंत्र हैं।
-
-## सहायता और project information
-
-Troubleshooting के लिए WebUI Logs या `CleveresTricky` tag वाला Android logcat उपयोग करें। Details [Diagnostics](docs/i18n/hi.md#diagnostics) में हैं।
-
-Project history [CHANGELOG](docs/i18n/hi.md#changelog), contribution guide [Contributing](docs/i18n/hi.md#contributing), language structure [Language Support](docs/i18n/hi.md#languages), और theme [Theme](docs/i18n/hi.md#theme) में है।
-
-Official [Android attestation documentation](https://source.android.com/docs/security/features/keystore/attestation), [Play Integrity verdict documentation](https://developer.android.com/google/play/integrity/verdicts) और [KernelSU module guide](https://kernelsu.org/guide/module.html) संबंधित platforms के authoritative sources हैं।
-
-## Granular optional identity controls
-
-CleveresTricky Device and Build Identity, Attestation Identity, Telephony Identity, Region Identity, Identity Refresh और Security Patch को स्वतंत्र रूप से resolve करता है। Security Patch, Device and Build Identity से independent है।
-
-Core Keystore interception, genuine KeyMint/StrongBox private-key operations, root-of-trust handling, Binder safety और required boot compatibility इन optional controls से स्वतंत्र रहते हैं। Interface captured real state, configured presentation state और app-visible effective state अलग दिखाता है।
-
-Security Patch में System, Vendor और Boot के लिए independent policies हैं। Profiles applications को coherent optional settings assign कर सकते हैं और Effective State inspector runtime resolver का अंतिम परिणाम दिखाता है।
+[Changelog](CHANGELOG.md) · [Contributing](CONTRIBUTING.md) · [Languages](LANGUAGES.md) · [Licensing](LICENSING.md) · [Telegram](https://t.me/cleverestech)

--- a/README.id.md
+++ b/README.id.md
@@ -6,7 +6,7 @@
 ![Android](https://img.shields.io/badge/Android-12--17-3DDC84?logo=android&logoColor=white)
 ![Module](https://img.shields.io/badge/Module-KernelSU%20%7C%20APatch-6f42c1)
 
-CleveresTricky adalah modul KernelSU dan APatch untuk Android 12–17. Modul ini menyatukan kompatibilitas Android Keystore dan attestation, pengelolaan Keybox/CBOX, target aplikasi, kontrol identitas opsional, pengaturan patch level, dan fitur privasi dalam satu WebUI mobile.
+CleveresTricky adalah modul KernelSU dan APatch untuk Android 12-17. Modul ini menyatukan kompatibilitas Android Keystore dan attestation, pengelolaan Keybox/CBOX, target aplikasi, kontrol identitas opsional, pengaturan patch level, dan fitur privasi dalam satu WebUI mobile.
 
 Mulailah dengan pengaturan bawaan dan aktifkan hanya fitur yang benar-benar Anda perlukan.
 
@@ -30,7 +30,7 @@ Proyek ini tidak menyertakan Keybox siap pakai atau private attestation key.
 
 ## Lingkungan yang didukung
 
-- Android **12–17** / API **31–37**
+- Android **12-17** / API **31-37**
 - **ARM64** dan **x86-64**
 - **KernelSU** dan **APatch**
 
@@ -46,12 +46,12 @@ Gunakan hanya konfigurasi dan kredensial yang memang Anda berhak gunakan.
 
 ## Pelajari lebih lanjut
 
-- [Keybox Manager](docs/KeyboxManager.md) — pemuatan, verifikasi, pemilihan, dan pemeriksaan pencabutan Keybox/CBOX.
-- [Application Scope](docs/ApplicationScope.md) dan [Application Rules](docs/ApplicationRules.md) — pilih aplikasi tempat fitur diterapkan.
-- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md), dan [Patch Levels](docs/PatchLevels.md) — kontrol identitas opsional.
-- [RKP Protection](docs/RkpProtection.md) dan [DRM Privacy](docs/DrmPassthrough.md) — kompatibilitas platform dan perilaku privasi.
-- [Backup and Restore](docs/BackupRestore.md) — backup dan pemulihan konfigurasi terenkripsi.
-- [Security Model](docs/SecurityModel.md) dan [Installer](docs/Installer.md) — batas kepercayaan dan detail instalasi.
+- [Keybox Manager](docs/KeyboxManager.md) - pemuatan, verifikasi, pemilihan, dan pemeriksaan pencabutan Keybox/CBOX.
+- [Application Scope](docs/ApplicationScope.md) dan [Application Rules](docs/ApplicationRules.md) - pilih aplikasi tempat fitur diterapkan.
+- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md), dan [Patch Levels](docs/PatchLevels.md) - kontrol identitas opsional.
+- [RKP Protection](docs/RkpProtection.md) dan [DRM Privacy](docs/DrmPassthrough.md) - kompatibilitas platform dan perilaku privasi.
+- [Backup and Restore](docs/BackupRestore.md) - backup dan pemulihan konfigurasi terenkripsi.
+- [Security Model](docs/SecurityModel.md) dan [Installer](docs/Installer.md) - batas kepercayaan dan detail instalasi.
 
 ## Perlu bantuan?
 

--- a/README.id.md
+++ b/README.id.md
@@ -3,141 +3,62 @@
 **Bahasa:** [English](README.md) | [Türkçe](README.tr.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Русский](README.ru.md) | **Bahasa Indonesia** | [हिन्दी](README.hi.md) | [العربية](README.ar.md)
 
 [![Release](https://img.shields.io/github/v/release/tryigit/CleveresTricky?display_name=tag&sort=semver&label=Release)](https://github.com/tryigit/CleveresTricky/releases/latest)
-[![Localization](https://img.shields.io/badge/Localization-9%20Languages-teal?logo=googletranslate)](LANGUAGES.md)
-[![Channel](https://img.shields.io/badge/Follow-Telegram-blue.svg?logo=telegram)](https://t.me/cleverestech)
-[![License: GPL-3.0-only](https://img.shields.io/badge/License-GPL--3.0--only-orange.svg?logo=gnu)](LICENSING.md)
 ![Android](https://img.shields.io/badge/Android-12--17-3DDC84?logo=android&logoColor=white)
 ![Module](https://img.shields.io/badge/Module-KernelSU%20%7C%20APatch-6f42c1)
-![Architecture](https://img.shields.io/badge/Arch-ARM64%20%7C%20x86--64-0969DA)
 
-CleveresTricky adalah modul KernelSU dan APatch untuk Android Keystore, attestation, identitas, dan kompatibilitas aplikasi. Modul ini menggabungkan runtime native yang terkontrol dengan WebUI seluler agar pengguna dapat mengelola cakupan aplikasi, material kunci, identitas, level patch, perlindungan Remote Key Provisioning, dan kompatibilitas DRM dari satu tempat.
+CleveresTricky adalah modul KernelSU dan APatch untuk Android 12–17. Modul ini menyatukan kompatibilitas Android Keystore dan attestation, pengelolaan Keybox/CBOX, target aplikasi, kontrol identitas opsional, pengaturan patch level, dan fitur privasi dalam satu WebUI mobile.
 
-> Ini adalah dokumentasi pengguna yang dilokalkan. Jika ada perbedaan teknis, dokumentasi bahasa Inggris adalah sumber kanonik.
+Mulailah dengan pengaturan bawaan dan aktifkan hanya fitur yang benar-benar Anda perlukan.
 
-## Kemampuan utama
+## Yang dapat Anda lakukan
 
-### Kontrol runtime
-
-[Spoof Engine](docs/i18n/id.md#spoof-engine) mengontrol penggantian identitas opsional. Jalur inti Keystore, TEE, dan perlindungan boot property tetap aktif secara independen selama layanan modul sehat.
-
-[Application Scope](docs/i18n/id.md#application-scope) menjelaskan targeted mode, global mode, aturan paket, UID Android bersama, dan pembaruan cache live.
-
-[Application Rules](docs/i18n/id.md#application-rules) menjelaskan template khusus aplikasi, pemilihan keybox, dan identitas privasi stabil.
-
-[Profiles](docs/i18n/id.md#profiles) menjelaskan Daily Compatibility, Default, Maximum Compatibility, dan Minimal.
-
-### Attestation dan identitas
-
-[Attestation](docs/i18n/id.md#attestation) menjelaskan penggantian rantai sertifikat, operasi KeyMint asli, StrongBox, dan batas kompatibilitas berbasis software.
-
-[Certificate Safe Mode](docs/i18n/id.md#certificate-safe-mode) mendokumentasikan konsep konfigurasi lama. Targeting inti saat ini tidak lagi bergantung pada toggle tersebut.
-
-[Keybox Manager](docs/i18n/id.md#keybox-manager) mencakup pemuatan, verifikasi, pemilihan, rotasi, pemeriksaan revocation, dan pemantauan keybox.
-
-[Automatic Keybox Check](docs/i18n/id.md#automatic-keybox-check) menjelaskan worker pemeliharaan yang dibatasi dan lifecycle-nya.
-
-[Remote Sources](docs/i18n/id.md#remote-sources) menjelaskan pengambilan terautentikasi, verifikasi signature, kebijakan refresh, dan perilaku kegagalan.
-
-[Encrypted Storage](docs/i18n/id.md#encrypted-storage) menjelaskan container CBOX, cache lokal terlindungi, dan penanganan material kunci yang aman.
-
-[Patch Levels](docs/i18n/id.md#patch-levels) menjelaskan field patch System, Vendor, dan Boot dengan aturan global dan per aplikasi.
-
-[Build Identity](docs/i18n/id.md#build-identity) menjelaskan template perangkat, fingerprint, field Build yang terlihat aplikasi, aktivasi early boot tersinkronisasi, dan helper Pixel beta Auto Identity untuk pengguna Custom ROM.
-
-[Identity Refresh](docs/i18n/id.md#identity-refresh) menjelaskan identitas untuk boot berikutnya dan konsistensi snapshot.
-
-[Telephony Identity](docs/i18n/id.md#telephony-identity) menjelaskan nilai dual SIM, preservasi keputusan izin Android, API yang didukung, dan batas operator.
-
-### Kompatibilitas platform
-
-[Boot Properties](docs/i18n/id.md#boot-properties) menjelaskan tampilan userspace boot property inti dan kebijakan kompatibilitas identitas yang terpisah.
-
-[Region Properties](docs/i18n/id.md#region-properties) menjelaskan tampilan negara dan wilayah hardware opsional yang dibatasi.
-
-[Provider Coexistence](docs/i18n/id.md#provider-coexistence) menjelaskan bagaimana automatic mode menghindari menimpa fingerprint provider lain.
-
-[RKP Protection](docs/i18n/id.md#rkp-protection) menjelaskan infrastruktur Android yang dilindungi dan generated-key passthrough asli.
-
-[DRM Passthrough and Privacy](docs/i18n/id.md#drm-passthrough) memisahkan dua fungsi. Aplikasi media yang dipilih dapat tetap berada pada jalur sertifikat Keystore asli Android, sementara `privacy=isolate` dapat mengganti `deviceUniqueId` DRM modern yang didukung dengan pseudonim stabil khusus aplikasi.
-
-Fitur ini bukan bypass Widevine atau DRM. Security level, lisensi, provisioning, content key, session, HDCP, dan string property tidak diubah.
-
-### Antarmuka dan operasi
-
-[Web Interface](docs/i18n/id.md#web-interface) menjelaskan transport native module manager, navigasi seluler, live status, validasi, dan aksesibilitas.
-
-Bahasa WebUI bawaan adalah **English**, **Türkçe**, **简体中文**, **Español**, **Deutsch**, **Русский**, **Bahasa Indonesia**, **हिन्दी**, dan **العربية**. Semua katalog tersedia lokal sehingga mengganti bahasa tidak memerlukan jaringan.
-
-[Backup and Restore](docs/i18n/id.md#backup-restore) menjelaskan export terenkripsi, import yang dibatasi, dan recovery aman.
-
-[Installer](docs/i18n/id.md#installer) menjelaskan layout paket KernelSU/APatch, verifikasi payload, perangkat yang didukung, dan alur instalasi.
-
-[Diagnostics](docs/i18n/id.md#diagnostics) menjelaskan log, pemeriksaan status, masalah umum, dan urutan troubleshooting terkontrol.
-
-### Referensi engineering
-
-[Security Model](docs/i18n/id.md#security-model) mendokumentasikan trust boundary, file terlindungi, validasi input, dan kemampuan yang tidak diklaim modul.
-
-[Performance](docs/i18n/id.md#performance) mendokumentasikan lifecycle hook, cache terbatas, pekerjaan background, CPU, dan memori.
-
-[Building](docs/i18n/id.md#building) mendokumentasikan toolchain, tugas validasi, dan artifact hasil build.
-
-[Native Architecture](docs/i18n/id.md#native-architecture) mendokumentasikan Rust injector, Rust native core, kebijakan bahasa, dan satu batas Android C++ ABI yang diperlukan.
+- Mengelola, memverifikasi, memilih, dan mengganti file **Keybox/CBOX**.
+- Menggunakan Global Mode atau menerapkan aturan ke aplikasi tertentu.
+- Mengatur tampilan device/build, attestation, telephony, region, dan security patch secara opsional.
+- Melindungi alur Remote Key Provisioning dan mengurangi paparan identifier DRM yang didukung tanpa mengklaim DRM bypass.
+- Mencadangkan pengaturan, melihat effective state, dan mengumpulkan diagnostik melalui WebUI atau Action modul.
 
 ## Mulai cepat
 
-1. Unduh ZIP release terbaru dari halaman Release resmi.
-2. Jika perlu memastikan asal build resmi, verifikasi `SHA256SUMS` dan GitHub build provenance.
-3. Buka KernelSU atau APatch saat Android berjalan.
-4. Instal ZIP lalu reboot.
-5. Buka CleveresTricky WebUI dari module manager.
-6. Instalasi baru dimulai dengan Global Mode aktif dan identity spoofing opsional nonaktif.
-7. Tambahkan hanya material kunci yang Anda miliki atau berhak Anda uji.
-8. Konfigurasikan opsi identitas hanya saat diperlukan.
-9. Reboot setelah mengubah nilai template Build Identity.
+1. Unduh ZIP terbaru dari halaman resmi [Releases](https://github.com/tryigit/CleveresTricky/releases/latest).
+2. Pasang ZIP melalui KernelSU atau APatch saat Android sedang berjalan.
+3. Buka WebUI CleveresTricky dari pengelola modul Anda.
+4. Tambahkan hanya **Keybox atau CBOX** yang Anda miliki atau Anda memiliki izin untuk mengujinya.
+5. Gunakan konfigurasi bawaan terlebih dahulu, lalu aktifkan identitas, aturan aplikasi, atau opsi privasi hanya saat diperlukan.
 
-Tidak ada keybox yang dapat digunakan atau private attestation key yang dibundel di project atau release.
+Proyek ini tidak menyertakan Keybox siap pakai atau private attestation key.
 
 ## Lingkungan yang didukung
 
-CleveresTricky mendukung Android 12 hingga Android 17, API 31 hingga 37, ARM64 dan x86 64. Instalasi didukung melalui KernelSU atau APatch saat Android aktif.
+- Android **12–17** / API **31–37**
+- **ARM64** dan **x86-64**
+- **KernelSU** dan **APatch**
 
-Magisk dan recovery tidak didukung. Installer menghentikan jalur yang tidak didukung sebelum meninggalkan modul parsial.
+Magisk dan instalasi melalui recovery tidak didukung.
 
-## Batas penting
+## Hal penting
 
-Hasil bergantung pada kondisi perangkat asli, firmware, sertifikasi, material kunci, Google Play services, dan remote policy. CleveresTricky meningkatkan jalur kompatibilitas lokal tetapi tidak menjamin verdict remote tertentu.
+CleveresTricky meningkatkan jalur kompatibilitas lokal, tetapi hasil remote tetap bergantung pada perangkat asli, firmware, status sertifikasi, Google Play services, kebijakan server, dan data yang Anda konfigurasi. Modul ini tidak dapat menjamin hasil Play Integrity atau attestation tertentu.
 
-Nilai telephony hanya terlihat lewat API aplikasi yang didukung. Modem, baseband, EFS, SIM fisik, dan identitas yang terlihat operator tidak diubah.
+Modul ini tidak mengunci ulang bootloader secara fisik, tidak menulis ulang pengukuran Verified Boot, tidak mengubah hardware Root of Trust, modem/baseband, dan tidak mengubah fitur privasi DRM menjadi DRM bypass.
 
-Pada Android modern, Android ID dibatasi berdasarkan identitas tanda tangan aplikasi, pengguna, dan perangkat di SettingsProvider. CleveresTricky tidak menampilkan kontrol Android ID global yang menyesatkan.
+Gunakan hanya konfigurasi dan kredensial yang memang Anda berhak gunakan.
 
-Versi kernel asli tidak berubah. Boot property view tidak mengunci bootloader secara fisik, memperbaiki verified boot, menulis ulang vbmeta, atau mengubah hardware root of trust.
+## Pelajari lebih lanjut
 
-Bootloader yang terbuka tidak otomatis berarti semua DRM tidak bekerja. Perilaku nyata bergantung pada perangkat, implementasi vendor, provisioning, security level, firmware, dan service policy. Fitur DRM saat ini berfokus pada privasi, bukan bypass.
+- [Keybox Manager](docs/KeyboxManager.md) — pemuatan, verifikasi, pemilihan, dan pemeriksaan pencabutan Keybox/CBOX.
+- [Application Scope](docs/ApplicationScope.md) dan [Application Rules](docs/ApplicationRules.md) — pilih aplikasi tempat fitur diterapkan.
+- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md), dan [Patch Levels](docs/PatchLevels.md) — kontrol identitas opsional.
+- [RKP Protection](docs/RkpProtection.md) dan [DRM Privacy](docs/DrmPassthrough.md) — kompatibilitas platform dan perilaku privasi.
+- [Backup and Restore](docs/BackupRestore.md) — backup dan pemulihan konfigurasi terenkripsi.
+- [Security Model](docs/SecurityModel.md) dan [Installer](docs/Installer.md) — batas kepercayaan dan detail instalasi.
 
-Catatan SHA 256 internal mendeteksi payload yang hilang, berubah, ditambahkan, berupa link, atau tidak diharapkan dan mengaktifkan tamper lockdown bila validasi gagal. Keaslian release resmi ditopang oleh digest terpisah dan GitHub signed build provenance.
+## Perlu bantuan?
 
-## Konfigurasi awal yang disarankan
+Gunakan halaman **Logs** di WebUI atau **Action** modul untuk membuat laporan diagnostik darurat. Periksa arsip sebelum membagikannya karena diagnostik dapat berisi informasi perangkat dan sistem.
 
-Mulai dengan default instalasi baru. Global Mode memilih UID aplikasi yang memenuhi syarat sementara perlindungan boot dan Keystore inti tetap aktif. Identity spoofing opsional tetap nonaktif sampai Anda menyalakannya dari bagian Identity.
+Lihat [Diagnostics](docs/Diagnostics.md) untuk masalah umum dan langkah pemecahan masalah.
 
-Untuk Custom ROM, Auto Identity dapat mengambil Pixel beta atau canary Build Identity dari metadata publik Google dan menyimpannya lokal. Aktifkan Identity Spoof Engine dan reboot hanya saat Anda memang ingin menampilkan nilai itu.
+## Proyek
 
-Untuk privasi DRM identifier, buat Application Rule untuk aplikasi media dan gunakan `privacy=isolate`. DRM Keystore Passthrough dapat tetap aktif karena jalur sertifikat Keystore asli dan pseudonim DRM ID adalah jalur terpisah.
-
-## Bantuan dan informasi project
-
-Untuk diagnosis gunakan WebUI Logs atau Android logcat dengan tag `CleveresTricky`. Detail ada di [Diagnostics](docs/i18n/id.md#diagnostics).
-
-Riwayat project ada di [CHANGELOG](docs/i18n/id.md#changelog), panduan kontribusi di [Contributing](docs/i18n/id.md#contributing), bahasa di [Language Support](docs/i18n/id.md#languages), dan tema di [Theme](docs/i18n/id.md#theme).
-
-[Dokumentasi Android attestation](https://source.android.com/docs/security/features/keystore/attestation), [Play Integrity verdict](https://developer.android.com/google/play/integrity/verdicts), dan [panduan modul KernelSU](https://kernelsu.org/guide/module.html) tetap menjadi referensi resmi platform masing-masing.
-
-## Kontrol identitas opsional granular
-
-CleveresTricky menyelesaikan Device and Build Identity, Attestation Identity, Telephony Identity, Region Identity, Identity Refresh, dan Security Patch secara terpisah. Security Patch independen dari Device and Build Identity.
-
-Keystore interception inti, operasi private key KeyMint dan StrongBox asli, root of trust, Binder safety, dan boot compatibility tetap independen dari kontrol opsional tersebut. Antarmuka membedakan kondisi asli yang ditangkap, kondisi presentasi terkonfigurasi, dan kondisi efektif yang terlihat aplikasi.
-
-Security Patch menyediakan policy terpisah untuk System, Vendor, dan Boot. Profiles dapat menetapkan opsi yang koheren ke aplikasi, dan Effective State inspector menampilkan hasil resolver runtime.
+[Changelog](CHANGELOG.md) · [Kontribusi](CONTRIBUTING.md) · [Bahasa](LANGUAGES.md) · [Lisensi](LICENSING.md) · [Telegram](https://t.me/cleverestech)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![Android](https://img.shields.io/badge/Android-12--17-3DDC84?logo=android&logoColor=white)
 ![Module](https://img.shields.io/badge/Module-KernelSU%20%7C%20APatch-6f42c1)
 
-CleveresTricky is a KernelSU and APatch module for Android 12–17. It brings Android keystore and attestation compatibility, Keybox/CBOX management, application targeting, optional identity controls, patch-level controls, and privacy tools into one mobile WebUI.
+CleveresTricky is a KernelSU and APatch module for Android 12-17. It brings Android keystore and attestation compatibility, Keybox/CBOX management, application targeting, optional identity controls, patch-level controls, and privacy tools into one mobile WebUI.
 
 Start with the defaults and enable only the features you actually need.
 
@@ -30,7 +30,7 @@ No usable Keybox or private attestation key is bundled with the project.
 
 ## Supported environment
 
-- Android **12–17** / API **31–37**
+- Android **12-17** / API **31-37**
 - **ARM64** and **x86-64**
 - **KernelSU** and **APatch**
 
@@ -46,12 +46,12 @@ Use only configuration and credentials that you are authorized to use.
 
 ## Learn more
 
-- [Keybox Manager](docs/KeyboxManager.md) — Keybox/CBOX loading, verification, selection, and revocation checks.
-- [Application Scope](docs/ApplicationScope.md) and [Application Rules](docs/ApplicationRules.md) — choose where features apply.
-- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md), and [Patch Levels](docs/PatchLevels.md) — optional identity controls.
-- [RKP Protection](docs/RkpProtection.md) and [DRM Privacy](docs/DrmPassthrough.md) — platform compatibility and privacy behavior.
-- [Backup and Restore](docs/BackupRestore.md) — encrypted configuration backup and recovery.
-- [Security Model](docs/SecurityModel.md) and [Installer](docs/Installer.md) — trust boundaries and installation details.
+- [Keybox Manager](docs/KeyboxManager.md) - Keybox/CBOX loading, verification, selection, and revocation checks.
+- [Application Scope](docs/ApplicationScope.md) and [Application Rules](docs/ApplicationRules.md) - choose where features apply.
+- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md), and [Patch Levels](docs/PatchLevels.md) - optional identity controls.
+- [RKP Protection](docs/RkpProtection.md) and [DRM Privacy](docs/DrmPassthrough.md) - platform compatibility and privacy behavior.
+- [Backup and Restore](docs/BackupRestore.md) - encrypted configuration backup and recovery.
+- [Security Model](docs/SecurityModel.md) and [Installer](docs/Installer.md) - trust boundaries and installation details.
 
 ## Need help?
 

--- a/README.md
+++ b/README.md
@@ -3,147 +3,62 @@
 **Language:** **English** | [Türkçe](README.tr.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Русский](README.ru.md) | [Bahasa Indonesia](README.id.md) | [हिन्दी](README.hi.md) | [العربية](README.ar.md)
 
 [![Release](https://img.shields.io/github/v/release/tryigit/CleveresTricky?display_name=tag&sort=semver&label=Release)](https://github.com/tryigit/CleveresTricky/releases/latest)
-[![Localization](https://img.shields.io/badge/Localization-9%20Languages-teal?logo=googletranslate)](LANGUAGES.md)
-[![Channel](https://img.shields.io/badge/Follow-Telegram-blue.svg?logo=telegram)](https://t.me/cleverestech)
-[![License: GPL-3.0-only](https://img.shields.io/badge/License-GPL--3.0--only-orange.svg?logo=gnu)](LICENSING.md)
 ![Android](https://img.shields.io/badge/Android-12--17-3DDC84?logo=android&logoColor=white)
 ![Module](https://img.shields.io/badge/Module-KernelSU%20%7C%20APatch-6f42c1)
-![Architecture](https://img.shields.io/badge/Arch-ARM64%20%7C%20x86--64-0969DA)
 
-CleveresTricky is a KernelSU and APatch module for Android keystore, attestation, identity, and application compatibility. It combines a controlled native runtime with a mobile WebUI so users can manage scope, key material, identity, patch levels, Remote Key Provisioning protection, and DRM compatibility from one place.
+CleveresTricky is a KernelSU and APatch module for Android 12–17. It brings Android keystore and attestation compatibility, Keybox/CBOX management, application targeting, optional identity controls, patch-level controls, and privacy tools into one mobile WebUI.
 
-## Main capabilities
+Start with the defaults and enable only the features you actually need.
 
-### Runtime control
+## What you can do
 
-The [Spoof Engine](docs/SpoofEngine.md) controls optional identity substitution. Core Keystore and TEE compatibility plus the boot property protection path remain active independently while the module service is healthy.
-
-[Application Scope](docs/ApplicationScope.md) explains targeted mode, global mode, package rules, shared Android user identifiers, and live cache updates.
-
-[Application Rules](docs/ApplicationRules.md) explains application specific templates, keybox selection, and stable privacy identities.
-
-[Profiles](docs/Profiles.md) explains the Daily Compatibility, Default, Maximum Compatibility, and Minimal presets.
-
-### Attestation and identity
-
-[Attestation](docs/Attestation.md) explains certificate substitution, genuine KeyMint operations, StrongBox handling, and the limits of software based compatibility.
-
-[Certificate Safe Mode](docs/CertificateSafeMode.md) explains the legacy configuration concept for preserving genuine certificate responses. Core targeting no longer depends on this legacy switch.
-
-[Keybox Manager](docs/KeyboxManager.md) explains keybox loading, verification, selection, rotation, revocation checks, and automatic monitoring.
-
-[Automatic Keybox Check](docs/AutomaticKeyboxCheck.md) explains the bounded maintenance worker and its lifecycle.
-
-[Remote Sources](docs/RemoteSources.md) explains authenticated retrieval, signature checks, refresh policy, and failure behavior.
-
-[Encrypted Storage](docs/EncryptedStorage.md) explains CBOX containers, local protected caches, and safe key material handling.
-
-[Patch Levels](docs/PatchLevels.md) explains system, vendor, and boot patch fields with global and per application rules.
-
-[Build Identity](docs/BuildIdentity.md) explains device templates, fingerprints, app visible Build fields, synchronized early boot activation, and the optional Pixel beta Auto Identity helper for Custom ROM users.
-
-[Identity Refresh](docs/IdentityRefresh.md) explains next boot generation and snapshot consistency.
-
-[Telephony Identity](docs/TelephonyIdentity.md) explains dual SIM values, permission preservation, supported Android APIs, and network operator limits.
-
-### Platform compatibility
-
-[Boot Properties](docs/BootProperties.md) explains the core userspace boot property view and the separate identity compatibility policy.
-
-[Region Properties](docs/RegionProperties.md) explains the optional bounded country and hardware region view.
-
-[Provider Coexistence](docs/ProviderCoexistence.md) explains how automatic mode avoids overriding another active fingerprint provider.
-
-[RKP Protection](docs/RkpProtection.md) explains protected Android infrastructure and genuine generated key response passthrough.
-
-[DRM Passthrough and Privacy](docs/DrmPassthrough.md) explains two deliberately separate controls: selected media applications can remain on Android's genuine Keystore certificate path, while an application configured with `privacy=isolate` can receive a stable application scoped pseudonym instead of the modern DRM HAL `deviceUniqueId` byte array property. This narrow privacy hook is intended to stop that raw device identifier from becoming another persistent application tracking value. For example, a streaming application such as Netflix cannot use the genuine `deviceUniqueId` returned through this supported path while isolation is active.
-
-The DRM hook is intentionally not a Widevine or DRM bypass. It does not rewrite the reported security level, licenses, provisioning messages, content keys, sessions, HDCP state, or string properties. Building and maintaining a general DRM protection bypass would require substantially broader, vendor specific work and is not a primary project goal.
-
-### Interface and operation
-
-[Web Interface](docs/WebInterface.md) explains the native module manager transport, mobile navigation, live status, validation, and accessibility.
-
-Built in WebUI and user documentation languages are **English**, **Türkçe**, **简体中文**, **Español**, **Deutsch**, **Русский**, **Bahasa Indonesia**, **हिन्दी**, and **العربية**. The WebUI catalogs are bundled locally and the repository provides localized README files plus a complete language reference covering every user facing Markdown document. See [LANGUAGES.md](LANGUAGES.md).
-
-[Backup and Restore](docs/BackupRestore.md) explains encrypted exports, bounded imports, and safe recovery.
-
-[Installer](docs/Installer.md) explains the KernelSU and APatch package layout, payload verification, supported devices, and installation flow.
-
-[Diagnostics](docs/Diagnostics.md) explains logs, status checks, common failures, and a controlled troubleshooting sequence.
-
-### Engineering references
-
-[Security Model](docs/SecurityModel.md) documents trust boundaries, protected files, input validation, and capabilities the module does not claim.
-
-[Performance](docs/Performance.md) documents hook lifecycle, bounded caches, background work, CPU behavior, and memory controls.
-
-[Building](docs/Building.md) documents the toolchain, validation tasks, and generated artifacts.
-
-[Native Architecture](docs/NativeArchitecture.md) documents the Rust injector, the Rust native core, the enforced language policy, and the single narrowly required Android C++ ABI boundary.
+- Manage, verify, select, and rotate **Keybox/CBOX** files.
+- Use Global Mode or target individual applications with per-app rules.
+- Configure optional device/build, attestation, telephony, region, and security patch presentation.
+- Protect Remote Key Provisioning flows and reduce supported DRM identifier exposure without pretending to bypass DRM.
+- Back up settings, inspect effective state, and collect diagnostics from the WebUI or module Action.
 
 ## Quick start
 
-1. Download the current release ZIP from the official project release page.
+1. Download the latest release ZIP from the official [Releases](https://github.com/tryigit/CleveresTricky/releases/latest) page.
+2. Install the ZIP from KernelSU or APatch while Android is running.
+3. Open the CleveresTricky WebUI from your module manager.
+4. Add only a **Keybox or CBOX** that you own or are authorized to test.
+5. Keep the default setup first, then enable identity, application rules, or privacy options only when needed.
 
-2. For an official release, verify the published `SHA256SUMS` entry and GitHub build provenance when you need source authenticity in addition to the module's internal integrity checks.
-
-3. Open KernelSU or APatch while Android is running.
-
-4. Install the ZIP and reboot.
-
-5. Open the CleveresTricky WebUI from the module manager.
-
-6. Fresh installations start in Global Mode with optional identity spoofing off.
-
-7. Add only key material you own or are authorized to test.
-
-8. Configure identity options only when they are needed.
-
-9. Reboot after changing template build identity values.
-
-No usable keybox or private attestation key is bundled with the project.
+No usable Keybox or private attestation key is bundled with the project.
 
 ## Supported environment
 
-CleveresTricky supports Android 12 through Android 17, including API levels 31 through 37. Supported processor targets are ARM64 and x86 64. Installation is supported through KernelSU or APatch while Android is running.
+- Android **12–17** / API **31–37**
+- **ARM64** and **x86-64**
+- **KernelSU** and **APatch**
 
-Magisk and recovery installation are not supported. The installer stops unsupported paths instead of leaving a partial module.
+Magisk and recovery installation are not supported.
 
-## Important boundaries
+## Important to know
 
-Results depend on the real device state, firmware, certification, key material, Google Play services, and remote policy. CleveresTricky improves the local compatibility path but cannot promise a specific remote verdict for every device.
+CleveresTricky improves the local compatibility path, but remote results still depend on the real device, firmware, certification state, Google Play services, server policy, and the data you configure. It cannot guarantee a particular Play Integrity or attestation verdict.
 
-Telephony values are visible only through supported application APIs. They do not modify the modem, baseband, EFS storage, physical SIM, or identity seen by a mobile network operator.
+It does not physically relock the bootloader, rewrite verified boot measurements, change the hardware root of trust, modify the modem/baseband, or turn DRM privacy controls into a DRM bypass.
 
-Android ID on modern Android is scoped by application signing identity, user, and device inside SettingsProvider. CleveresTricky does not present a misleading global Android ID control.
+Use only configuration and credentials that you are authorized to use.
 
-The real kernel version returned by the operating system is unchanged. The core boot property view does not physically relock a bootloader, repair verified boot, rewrite vbmeta, or change the hardware root of trust.
+## Learn more
 
-An unlocked bootloader does not by itself mean that every DRM implementation is unusable. Actual DRM behavior depends on the device, vendor implementation, provisioning state, security level, service policy, and firmware. Because many devices can retain functional protected playback despite an unlocked bootloader, CleveresTricky treats DRM bypass as a separate vendor specific problem rather than a primary objective. The current DRM work is privacy oriented: it narrows exposure of `deviceUniqueId` on the supported modern stable AIDL path without pretending to upgrade or defeat the underlying DRM security state.
+- [Keybox Manager](docs/KeyboxManager.md) — Keybox/CBOX loading, verification, selection, and revocation checks.
+- [Application Scope](docs/ApplicationScope.md) and [Application Rules](docs/ApplicationRules.md) — choose where features apply.
+- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md), and [Patch Levels](docs/PatchLevels.md) — optional identity controls.
+- [RKP Protection](docs/RkpProtection.md) and [DRM Privacy](docs/DrmPassthrough.md) — platform compatibility and privacy behavior.
+- [Backup and Restore](docs/BackupRestore.md) — encrypted configuration backup and recovery.
+- [Security Model](docs/SecurityModel.md) and [Installer](docs/Installer.md) — trust boundaries and installation details.
 
-Internal SHA 256 records detect missing, changed, injected, linked, and unexpected installed payloads and place the service in tamper lockdown when verification fails. Those records are intentionally not described as proof of who produced a ZIP because a person who can replace every file in an archive can also replace archive internal checksum records. Official release authenticity is instead anchored by the separately published release digest and GitHub signed build provenance.
+## Need help?
 
-## Recommended first setup
+Use the **Logs** page in the WebUI or the module **Action** to create an emergency diagnostic report. Review the archive before sharing it because diagnostics can contain device and system information.
 
-Use the fresh installation defaults first. Global Mode selects eligible application UIDs while core boot and Keystore protection remain active. Optional identity spoofing stays off until you enable it from the Identity section.
+See [Diagnostics](docs/Diagnostics.md) for common problems and troubleshooting steps.
 
-If you use a Custom ROM and need a current build identity for Play Integrity testing, Auto Identity can retrieve a Pixel beta or canary identity from Google public metadata and save it locally. Enable Identity Spoof Engine and reboot only when you want those build identity values exposed.
+## Project
 
-For DRM identifier privacy, create an Application Rule for the media application and set its privacy mode to `isolate`. DRM Keystore Passthrough can remain enabled: the genuine Keystore certificate path and the pseudonymous DRM device ID path are intentionally independent.
-
-## Help and project information
-
-Use the WebUI Logs screen or Android logcat with the CleveresTricky tag when diagnosing a problem. Detailed guidance is available in [Diagnostics](docs/Diagnostics.md).
-
-Project history is recorded in [CHANGELOG.md](CHANGELOG.md). Contribution guidance is in [CONTRIBUTING.md](CONTRIBUTING.md). Translation information is in [LANGUAGES.md](LANGUAGES.md). Theme information is in [THEME.md](THEME.md).
-
-The official [Android attestation documentation](https://source.android.com/docs/security/features/keystore/attestation), [Play Integrity verdict documentation](https://developer.android.com/google/play/integrity/verdicts), and [KernelSU module guide](https://kernelsu.org/guide/module.html) remain authoritative for their platforms.
-
-## Granular optional identity controls
-
-CleveresTricky now resolves optional identity behavior through independent controls for Device and Build Identity, Attestation Identity, Telephony Identity, Region Identity, Identity Refresh, and Security Patch. Security Patch is independent from Device and Build Identity. A configuration can present a different supported patch level without enabling Build Identity, or present a different Build Identity while all patch levels remain genuine.
-
-Core Keystore interception, genuine platform KeyMint and StrongBox private key operations, root of trust handling, Binder safety, and required boot compatibility remain independent from these optional controls. The interface describes captured device state, configured presentation state, and effective application visible state separately. It does not claim to change physical bootloader state, verified boot measurements, firmware, or a remote integrity verdict.
-
-The Security Patch view exposes System, Vendor, and Boot as independent policies. Profiles can assign coherent optional settings to applications, and the Effective State inspector reports the resolver output that runtime decisions use.
+[Changelog](CHANGELOG.md) · [Contributing](CONTRIBUTING.md) · [Languages](LANGUAGES.md) · [Licensing](LICENSING.md) · [Telegram](https://t.me/cleverestech)

--- a/README.ru.md
+++ b/README.ru.md
@@ -3,141 +3,62 @@
 **Язык:** [English](README.md) | [Türkçe](README.tr.md) | [简体中文](README.zh-CN.md) | [Español](README.es.md) | [Deutsch](README.de.md) | **Русский** | [Bahasa Indonesia](README.id.md) | [हिन्दी](README.hi.md) | [العربية](README.ar.md)
 
 [![Release](https://img.shields.io/github/v/release/tryigit/CleveresTricky?display_name=tag&sort=semver&label=Release)](https://github.com/tryigit/CleveresTricky/releases/latest)
-[![Localization](https://img.shields.io/badge/Localization-9%20Languages-teal?logo=googletranslate)](LANGUAGES.md)
-[![Channel](https://img.shields.io/badge/Follow-Telegram-blue.svg?logo=telegram)](https://t.me/cleverestech)
-[![License: GPL-3.0-only](https://img.shields.io/badge/License-GPL--3.0--only-orange.svg?logo=gnu)](LICENSING.md)
 ![Android](https://img.shields.io/badge/Android-12--17-3DDC84?logo=android&logoColor=white)
 ![Module](https://img.shields.io/badge/Module-KernelSU%20%7C%20APatch-6f42c1)
-![Architecture](https://img.shields.io/badge/Arch-ARM64%20%7C%20x86--64-0969DA)
 
-CleveresTricky - модуль KernelSU и APatch для Android Keystore, attestation, идентичности устройства и совместимости приложений. Он объединяет контролируемый native runtime и мобильный WebUI, позволяя управлять областью применения, ключевым материалом, идентичностью, уровнями патчей, защитой Remote Key Provisioning и совместимостью DRM в одном месте.
+CleveresTricky — модуль для KernelSU и APatch на Android 12–17. Он объединяет совместимость Android Keystore и attestation, управление Keybox/CBOX, выбор приложений, дополнительные настройки идентичности, уровни патчей и инструменты приватности в одном мобильном WebUI.
 
-> Это локализованная пользовательская документация. При технических расхождениях канонической считается английская версия.
+Начните со стандартных настроек и включайте только те функции, которые действительно нужны.
 
-## Основные возможности
+## Что можно делать
 
-### Управление runtime
-
-[Spoof Engine](docs/i18n/ru.md#spoof-engine) управляет необязательной подменой идентичности. Основная совместимость Keystore и TEE, а также защита boot properties работают независимо, пока сервис модуля исправен.
-
-[Application Scope](docs/i18n/ru.md#application-scope) описывает Targeted Mode, Global Mode, правила пакетов, общие Android UID и обновление кэша без перезагрузки.
-
-[Application Rules](docs/i18n/ru.md#application-rules) описывает шаблоны на уровне приложения, выбор keybox и стабильные privacy identities.
-
-[Profiles](docs/i18n/ru.md#profiles) описывает Daily Compatibility, Default, Maximum Compatibility и Minimal.
-
-### Attestation и идентичность
-
-[Attestation](docs/i18n/ru.md#attestation) объясняет замену цепочки сертификатов, реальные операции KeyMint, StrongBox и границы программной совместимости.
-
-[Certificate Safe Mode](docs/i18n/ru.md#certificate-safe-mode) документирует устаревшую концепцию настройки. Основной targeting больше не зависит от этого переключателя.
-
-[Keybox Manager](docs/i18n/ru.md#keybox-manager) описывает загрузку, проверку, выбор, ротацию, проверку отзыва и мониторинг keybox.
-
-[Automatic Keybox Check](docs/i18n/ru.md#automatic-keybox-check) объясняет ограниченный worker обслуживания и его жизненный цикл.
-
-[Remote Sources](docs/i18n/ru.md#remote-sources) описывает аутентифицированное получение, проверку подписи, refresh policy и обработку ошибок.
-
-[Encrypted Storage](docs/i18n/ru.md#encrypted-storage) описывает контейнеры CBOX, локальные защищенные кэши и безопасную работу с ключевым материалом.
-
-[Patch Levels](docs/i18n/ru.md#patch-levels) описывает поля патчей System, Vendor и Boot с глобальными и приложенческими правилами.
-
-[Build Identity](docs/i18n/ru.md#build-identity) описывает шаблоны устройств, fingerprint, видимые приложениям Build-поля, синхронную активацию на ранней загрузке и Pixel beta Auto Identity для Custom ROM.
-
-[Identity Refresh](docs/i18n/ru.md#identity-refresh) описывает подготовку идентичности на следующую загрузку и согласованность snapshot.
-
-[Telephony Identity](docs/i18n/ru.md#telephony-identity) описывает значения для двух SIM, сохранение решений Android по разрешениям, поддерживаемые API и границы оператора.
-
-### Совместимость платформы
-
-[Boot Properties](docs/i18n/ru.md#boot-properties) объясняет основной userspace-вид boot properties и отдельную политику идентичности.
-
-[Region Properties](docs/i18n/ru.md#region-properties) описывает необязательный ограниченный вид страны и аппаратного региона.
-
-[Provider Coexistence](docs/i18n/ru.md#provider-coexistence) объясняет, как automatic mode не дает перезаписать другой fingerprint provider.
-
-[RKP Protection](docs/i18n/ru.md#rkp-protection) описывает защищенную инфраструктуру Android и настоящий generated-key passthrough.
-
-[DRM Passthrough and Privacy](docs/i18n/ru.md#drm-passthrough) разделяет две функции. Выбранные медиа-приложения могут оставаться на настоящем Keystore certificate path Android, а `privacy=isolate` может заменять поддерживаемый `deviceUniqueId` стабильным псевдонимом для конкретного приложения.
-
-Это не Widevine или DRM bypass. Уровни безопасности, лицензии, provisioning, content keys, сессии, HDCP и строковые свойства не изменяются.
-
-### Интерфейс и эксплуатация
-
-[Web Interface](docs/i18n/ru.md#web-interface) объясняет native transport менеджера модулей, мобильную навигацию, live status, валидацию и доступность.
-
-Встроенные языки WebUI: **English**, **Türkçe**, **简体中文**, **Español**, **Deutsch**, **Русский**, **Bahasa Indonesia**, **हिन्दी** и **العربية**. Каталоги локальны и переключение языка не требует сети.
-
-[Backup and Restore](docs/i18n/ru.md#backup-restore) описывает зашифрованный экспорт, ограниченный импорт и безопасное восстановление.
-
-[Installer](docs/i18n/ru.md#installer) описывает структуру KernelSU/APatch пакета, проверку payload, поддерживаемые устройства и установку.
-
-[Diagnostics](docs/i18n/ru.md#diagnostics) описывает логи, проверки состояния, частые ошибки и последовательную диагностику.
-
-### Инженерные справочники
-
-[Security Model](docs/i18n/ru.md#security-model) документирует границы доверия, защищенные файлы, проверку входных данных и то, чего модуль не обещает.
-
-[Performance](docs/i18n/ru.md#performance) документирует жизненный цикл hook, ограниченные кэши, фоновую работу, CPU и память.
-
-[Building](docs/i18n/ru.md#building) документирует toolchain, проверки и создаваемые артефакты.
-
-[Native Architecture](docs/i18n/ru.md#native-architecture) документирует Rust injector, Rust native core, языковую политику и единственную необходимую Android C++ ABI границу.
+- Управлять, проверять, выбирать и менять файлы **Keybox/CBOX**.
+- Использовать Global Mode или применять отдельные правила к выбранным приложениям.
+- При необходимости настраивать представление device/build, attestation, телефонии, региона и security patch.
+- Защищать потоки Remote Key Provisioning и уменьшать раскрытие поддерживаемых DRM-идентификаторов без заявления о DRM bypass.
+- Создавать резервные копии, смотреть эффективное состояние и собирать диагностику через WebUI или Action модуля.
 
 ## Быстрый старт
 
-1. Скачайте текущий release ZIP с официальной страницы Releases.
-2. При необходимости проверить происхождение официальной сборки проверьте `SHA256SUMS` и GitHub build provenance.
-3. Откройте KernelSU или APatch при работающем Android.
-4. Установите ZIP и перезагрузите устройство.
-5. Откройте CleveresTricky WebUI из менеджера модулей.
-6. Новая установка запускается с включенным Global Mode и выключенным необязательным identity spoofing.
-7. Добавляйте только принадлежащий вам или разрешенный для тестирования ключевой материал.
-8. Настраивайте идентичность только при необходимости.
-9. Перезагружайтесь после изменения template Build Identity.
+1. Скачайте последнюю ZIP-сборку с официальной страницы [Releases](https://github.com/tryigit/CleveresTricky/releases/latest).
+2. Установите ZIP через KernelSU или APatch при запущенном Android.
+3. Откройте WebUI CleveresTricky из менеджера модулей.
+4. Добавляйте только **Keybox или CBOX**, которыми вы владеете или которые вам разрешено тестировать.
+5. Сначала оставьте стандартную конфигурацию и включайте идентичность, правила приложений или приватность только при необходимости.
 
-В проекте и release-пакете нет пригодного keybox или приватного attestation key.
+Проект не содержит готового к использованию Keybox или приватного attestation-ключа.
 
 ## Поддерживаемая среда
 
-Поддерживаются Android 12-17, API 31-37, ARM64 и x86 64. Установка выполняется через KernelSU или APatch при запущенном Android.
+- Android **12–17** / API **31–37**
+- **ARM64** и **x86-64**
+- **KernelSU** и **APatch**
 
-Magisk и recovery не поддерживаются. Installer останавливает неподдерживаемый путь до появления частично установленного модуля.
+Magisk и установка из recovery не поддерживаются.
 
-## Важные границы
+## Важно знать
 
-Результат зависит от реального состояния устройства, firmware, сертификации, ключевого материала, Google Play services и удаленной политики. CleveresTricky улучшает локальный путь совместимости, но не гарантирует конкретный remote verdict.
+CleveresTricky улучшает локальный путь совместимости, но удалённый результат всё равно зависит от реального устройства, прошивки, статуса сертификации, Google Play services, политики сервера и ваших настроек. Модуль не может гарантировать конкретный результат Play Integrity или attestation.
 
-Telephony значения видимы только через поддерживаемые API приложений и не меняют modem, baseband, EFS, физическую SIM или идентичность у оператора.
+Он не блокирует bootloader физически заново, не переписывает измерения Verified Boot, не меняет аппаратный Root of Trust, модем или baseband и не превращает функции DRM-приватности в DRM bypass.
 
-На современном Android Android ID ограничен подписью приложения, пользователем и устройством в SettingsProvider. Модуль не предоставляет вводящий в заблуждение глобальный Android ID.
+Используйте только те конфигурации и учётные данные, на которые у вас есть разрешение.
 
-Реальная версия kernel не меняется. Boot properties не блокируют физически bootloader, не чинят verified boot, не переписывают vbmeta и не меняют hardware root of trust.
+## Подробнее
 
-Разблокированный bootloader сам по себе не означает отказ любого DRM. Поведение зависит от устройства, vendor stack, provisioning, security level, firmware и политики сервиса. Текущая DRM-функция ориентирована на privacy, а не bypass.
+- [Keybox Manager](docs/KeyboxManager.md) — загрузка, проверка, выбор и проверка отзыва Keybox/CBOX.
+- [Application Scope](docs/ApplicationScope.md) и [Application Rules](docs/ApplicationRules.md) — выбор приложений, к которым применяются функции.
+- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md) и [Patch Levels](docs/PatchLevels.md) — дополнительные настройки идентичности.
+- [RKP Protection](docs/RkpProtection.md) и [DRM Privacy](docs/DrmPassthrough.md) — совместимость платформы и приватность.
+- [Backup and Restore](docs/BackupRestore.md) — зашифрованное резервное копирование и восстановление конфигурации.
+- [Security Model](docs/SecurityModel.md) и [Installer](docs/Installer.md) — границы доверия и детали установки.
 
-Внутренние SHA 256 записи обнаруживают отсутствующие, измененные, добавленные, связанные или неожиданные payload и включают tamper lockdown при ошибке. Подлинность официального release подтверждается отдельным digest и GitHub signed build provenance.
+## Нужна помощь?
 
-## Рекомендуемая первая настройка
+Используйте страницу **Logs** в WebUI или **Action** модуля, чтобы создать аварийный диагностический отчёт. Перед отправкой проверьте архив: он может содержать сведения об устройстве и системе.
 
-Сначала используйте значения новой установки. Global Mode выбирает подходящие UID приложений, а основные Boot и Keystore защиты остаются активны. Необязательный identity spoofing выключен до явного включения в Identity.
+Типовые проблемы и шаги диагностики описаны в [Diagnostics](docs/Diagnostics.md).
 
-Для Custom ROM Auto Identity может получить актуальную Pixel beta или canary Build Identity из открытых метаданных Google и сохранить ее локально. Включайте Identity Spoof Engine и перезагружайтесь только когда эти значения действительно должны быть видимы приложениям.
+## Проект
 
-Для privacy DRM identifier создайте Application Rule для медиа-приложения и установите `privacy=isolate`. DRM Keystore Passthrough может остаться включенным, потому что настоящий путь Keystore certificate и псевдоним DRM ID независимы.
-
-## Помощь и информация о проекте
-
-Для диагностики используйте WebUI Logs или Android logcat с тегом `CleveresTricky`. Подробности в [Diagnostics](docs/i18n/ru.md#diagnostics).
-
-История проекта: [CHANGELOG](docs/i18n/ru.md#changelog), вклад: [Contributing](docs/i18n/ru.md#contributing), языки: [Language Support](docs/i18n/ru.md#languages), тема: [Theme](docs/i18n/ru.md#theme).
-
-Официальные [Android attestation docs](https://source.android.com/docs/security/features/keystore/attestation), [Play Integrity verdict docs](https://developer.android.com/google/play/integrity/verdicts) и [KernelSU module guide](https://kernelsu.org/guide/module.html) остаются авторитетными источниками.
-
-## Гранулярные необязательные элементы идентичности
-
-CleveresTricky отдельно разрешает Device and Build Identity, Attestation Identity, Telephony Identity, Region Identity, Identity Refresh и Security Patch. Security Patch не зависит от Device and Build Identity.
-
-Основная Keystore interception, реальные операции KeyMint/StrongBox private key, root of trust, Binder safety и необходимая boot compatibility не зависят от этих опций. Интерфейс отдельно показывает реальное захваченное состояние, настроенное представление и эффективное состояние для приложения.
-
-Security Patch предоставляет независимые политики для System, Vendor и Boot. Profiles могут назначать приложениям согласованные настройки, а Effective State inspector показывает итог resolver.
+[История изменений](CHANGELOG.md) · [Участие](CONTRIBUTING.md) · [Языки](LANGUAGES.md) · [Лицензия](LICENSING.md) · [Telegram](https://t.me/cleverestech)

--- a/README.ru.md
+++ b/README.ru.md
@@ -6,7 +6,7 @@
 ![Android](https://img.shields.io/badge/Android-12--17-3DDC84?logo=android&logoColor=white)
 ![Module](https://img.shields.io/badge/Module-KernelSU%20%7C%20APatch-6f42c1)
 
-CleveresTricky — модуль для KernelSU и APatch на Android 12–17. Он объединяет совместимость Android Keystore и attestation, управление Keybox/CBOX, выбор приложений, дополнительные настройки идентичности, уровни патчей и инструменты приватности в одном мобильном WebUI.
+CleveresTricky - модуль для KernelSU и APatch на Android 12-17. Он объединяет совместимость Android Keystore и attestation, управление Keybox/CBOX, выбор приложений, дополнительные настройки идентичности, уровни патчей и инструменты приватности в одном мобильном WebUI.
 
 Начните со стандартных настроек и включайте только те функции, которые действительно нужны.
 
@@ -30,7 +30,7 @@ CleveresTricky — модуль для KernelSU и APatch на Android 12–17. 
 
 ## Поддерживаемая среда
 
-- Android **12–17** / API **31–37**
+- Android **12-17** / API **31-37**
 - **ARM64** и **x86-64**
 - **KernelSU** и **APatch**
 
@@ -46,12 +46,12 @@ CleveresTricky улучшает локальный путь совместимо
 
 ## Подробнее
 
-- [Keybox Manager](docs/KeyboxManager.md) — загрузка, проверка, выбор и проверка отзыва Keybox/CBOX.
-- [Application Scope](docs/ApplicationScope.md) и [Application Rules](docs/ApplicationRules.md) — выбор приложений, к которым применяются функции.
-- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md) и [Patch Levels](docs/PatchLevels.md) — дополнительные настройки идентичности.
-- [RKP Protection](docs/RkpProtection.md) и [DRM Privacy](docs/DrmPassthrough.md) — совместимость платформы и приватность.
-- [Backup and Restore](docs/BackupRestore.md) — зашифрованное резервное копирование и восстановление конфигурации.
-- [Security Model](docs/SecurityModel.md) и [Installer](docs/Installer.md) — границы доверия и детали установки.
+- [Keybox Manager](docs/KeyboxManager.md) - загрузка, проверка, выбор и проверка отзыва Keybox/CBOX.
+- [Application Scope](docs/ApplicationScope.md) и [Application Rules](docs/ApplicationRules.md) - выбор приложений, к которым применяются функции.
+- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md) и [Patch Levels](docs/PatchLevels.md) - дополнительные настройки идентичности.
+- [RKP Protection](docs/RkpProtection.md) и [DRM Privacy](docs/DrmPassthrough.md) - совместимость платформы и приватность.
+- [Backup and Restore](docs/BackupRestore.md) - зашифрованное резервное копирование и восстановление конфигурации.
+- [Security Model](docs/SecurityModel.md) и [Installer](docs/Installer.md) - границы доверия и детали установки.
 
 ## Нужна помощь?
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -3,141 +3,62 @@
 **Dil:** [English](README.md) | **Türkçe** | [简体中文](README.zh-CN.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Русский](README.ru.md) | [Bahasa Indonesia](README.id.md) | [हिन्दी](README.hi.md) | [العربية](README.ar.md)
 
 [![Release](https://img.shields.io/github/v/release/tryigit/CleveresTricky?display_name=tag&sort=semver&label=Release)](https://github.com/tryigit/CleveresTricky/releases/latest)
-[![Localization](https://img.shields.io/badge/Localization-9%20Languages-teal?logo=googletranslate)](LANGUAGES.md)
-[![Channel](https://img.shields.io/badge/Follow-Telegram-blue.svg?logo=telegram)](https://t.me/cleverestech)
-[![License: GPL-3.0-only](https://img.shields.io/badge/License-GPL--3.0--only-orange.svg?logo=gnu)](LICENSING.md)
 ![Android](https://img.shields.io/badge/Android-12--17-3DDC84?logo=android&logoColor=white)
 ![Module](https://img.shields.io/badge/Module-KernelSU%20%7C%20APatch-6f42c1)
-![Architecture](https://img.shields.io/badge/Arch-ARM64%20%7C%20x86--64-0969DA)
 
-CleveresTricky, Android Keystore, attestation, kimlik ve uygulama uyumluluğu için geliştirilmiş bir KernelSU ve APatch modülüdür. Kontrollü bir native çalışma zamanını mobil WebUI ile birleştirir; uygulama kapsamı, anahtar materyali, kimlik, güvenlik yaması seviyeleri, Remote Key Provisioning koruması ve DRM uyumluluğu tek yerden yönetilebilir.
+CleveresTricky, Android 12–17 için bir KernelSU ve APatch modülüdür. Android Keystore ve attestation uyumluluğunu, Keybox/CBOX yönetimini, uygulama hedeflemeyi, isteğe bağlı kimlik kontrollerini, patch seviyesi ayarlarını ve gizlilik araçlarını tek bir mobil WebUI içinde toplar.
 
-> Bu çeviri kullanıcı dokümantasyonu içindir. Teknik bir çelişki olması durumunda İngilizce belge kanonik kaynaktır.
+Önce varsayılan ayarlarla başlayın; yalnızca gerçekten ihtiyaç duyduğunuz özellikleri açın.
 
-## Ana özellikler
+## Neler yapabilirsiniz?
 
-### Çalışma zamanı kontrolü
-
-[Spoof Engine](docs/i18n/tr.md#spoof-engine), isteğe bağlı kimlik değiştirme işlevini yönetir. Modül servisi sağlıklı olduğu sürece temel Keystore ve TEE uyumluluğu ile boot property koruması bundan bağımsız çalışır.
-
-[Application Scope](docs/i18n/tr.md#application-scope), hedefli ve global modu, paket kurallarını, paylaşılan Android kullanıcı kimliklerini ve canlı önbellek güncellemelerini açıklar.
-
-[Application Rules](docs/i18n/tr.md#application-rules), uygulamaya özel şablon, keybox seçimi ve kararlı gizlilik kimliklerini açıklar.
-
-[Profiles](docs/i18n/tr.md#profiles), Daily Compatibility, Default, Maximum Compatibility ve Minimal profillerini açıklar.
-
-### Attestation ve kimlik
-
-[Attestation](docs/i18n/tr.md#attestation), sertifika zinciri değiştirme, gerçek KeyMint işlemleri, StrongBox davranışı ve yazılım tabanlı uyumluluğun sınırlarını açıklar.
-
-[Certificate Safe Mode](docs/i18n/tr.md#certificate-safe-mode), eski yapılandırma kavramını açıklar. Güncel temel hedefleme bu eski anahtara bağlı değildir.
-
-[Keybox Manager](docs/i18n/tr.md#keybox-manager), keybox yükleme, doğrulama, seçim, rotasyon, iptal kontrolü ve otomatik izlemeyi açıklar.
-
-[Automatic Keybox Check](docs/i18n/tr.md#automatic-keybox-check), sınırlı bakım worker'ını ve yaşam döngüsünü açıklar.
-
-[Remote Sources](docs/i18n/tr.md#remote-sources), kimlik doğrulamalı indirme, imza doğrulama, yenileme politikası ve hata davranışını açıklar.
-
-[Encrypted Storage](docs/i18n/tr.md#encrypted-storage), CBOX konteynerlerini, yerel korumalı önbellekleri ve güvenli anahtar materyali kullanımını açıklar.
-
-[Patch Levels](docs/i18n/tr.md#patch-levels), system, vendor ve boot yama alanlarını global ve uygulama bazlı kurallarla açıklar.
-
-[Build Identity](docs/i18n/tr.md#build-identity), cihaz şablonlarını, fingerprint değerlerini, uygulamaların gördüğü Build alanlarını, erken boot aktivasyonunu ve Custom ROM kullanıcıları için Pixel beta Auto Identity yardımcısını açıklar.
-
-[Identity Refresh](docs/i18n/tr.md#identity-refresh), sonraki boot için yeni kimlik üretimini ve snapshot tutarlılığını açıklar.
-
-[Telephony Identity](docs/i18n/tr.md#telephony-identity), çift SIM değerlerini, izin korumasını, desteklenen Android API'lerini ve operatör sınırlarını açıklar.
-
-### Platform uyumluluğu
-
-[Boot Properties](docs/i18n/tr.md#boot-properties), temel userspace boot property görünümünü ve ayrı kimlik uyumluluk politikasını açıklar.
-
-[Region Properties](docs/i18n/tr.md#region-properties), isteğe bağlı sınırlı ülke ve donanım bölge görünümünü açıklar.
-
-[Provider Coexistence](docs/i18n/tr.md#provider-coexistence), otomatik modun başka bir fingerprint sağlayıcısını ezmesini nasıl önlediğini açıklar.
-
-[RKP Protection](docs/i18n/tr.md#rkp-protection), korunan Android altyapısını ve gerçek generated-key passthrough davranışını açıklar.
-
-[DRM Passthrough and Privacy](docs/i18n/tr.md#drm-passthrough), iki ayrı kontrolü açıklar. Seçilen medya uygulamaları Android'in gerçek Keystore sertifika yolunda kalabilir; `privacy=isolate` kullanılan uygulamalarda ise desteklenen modern DRM HAL `deviceUniqueId` değeri uygulamaya özel kararlı bir takma kimlikle değiştirilebilir.
-
-Bu DRM özelliği Widevine veya DRM bypass değildir. Raporlanan güvenlik seviyesini, lisansları, provisioning mesajlarını, içerik anahtarlarını, oturumları, HDCP durumunu veya string property değerlerini değiştirmez.
-
-### Arayüz ve kullanım
-
-[Web Interface](docs/i18n/tr.md#web-interface), native modül yöneticisi taşımasını, mobil navigasyonu, canlı durumu, doğrulamayı ve erişilebilirliği açıklar.
-
-Yerleşik WebUI dilleri: **English**, **Türkçe**, **简体中文**, **Español**, **Deutsch**, **Русский**, **Bahasa Indonesia**, **हिन्दी** ve **العربية**. Çeviri katalogları yereldir; dil değiştirmek ağ bağlantısı gerektirmez.
-
-[Backup and Restore](docs/i18n/tr.md#backup-restore), şifreli dışa aktarma, sınırlı içe aktarma ve güvenli kurtarmayı açıklar.
-
-[Installer](docs/i18n/tr.md#installer), KernelSU ve APatch paket yapısını, payload doğrulamasını, desteklenen cihazları ve kurulum akışını açıklar.
-
-[Diagnostics](docs/i18n/tr.md#diagnostics), logları, durum kontrollerini, sık hataları ve kontrollü sorun giderme sırasını açıklar.
-
-### Mühendislik referansları
-
-[Security Model](docs/i18n/tr.md#security-model), güven sınırlarını, korunan dosyaları, giriş doğrulamasını ve modülün iddia etmediği yetenekleri açıklar.
-
-[Performance](docs/i18n/tr.md#performance), hook yaşam döngüsünü, sınırlı önbellekleri, arka plan işlerini, CPU ve bellek davranışını açıklar.
-
-[Building](docs/i18n/tr.md#building), araç zincirini, doğrulama görevlerini ve üretilen artifact'leri açıklar.
-
-[Native Architecture](docs/i18n/tr.md#native-architecture), Rust injector'ı, Rust native core'u, zorunlu dil politikasını ve dar Android C++ ABI sınırını açıklar.
+- **Keybox/CBOX** dosyalarını yönetin, doğrulayın, seçin ve değiştirin.
+- Global Mode kullanın veya uygulamaları ayrı ayrı kurallarla hedefleyin.
+- Cihaz/build, attestation, telephony, bölge ve security patch sunumunu isteğe bağlı olarak yapılandırın.
+- Remote Key Provisioning akışlarını koruyun ve DRM bypass iddiası olmadan desteklenen DRM tanımlayıcılarının görünürlüğünü azaltın.
+- Ayarları yedekleyin, etkin durumu inceleyin ve WebUI ya da modül Action üzerinden tanılama raporu oluşturun.
 
 ## Hızlı başlangıç
 
-1. Güncel release ZIP dosyasını resmi proje release sayfasından indirin.
-2. Resmi build kaynağını doğrulamak gerekiyorsa yayımlanan `SHA256SUMS` kaydını ve GitHub build provenance bilgisini kontrol edin.
-3. Android çalışırken KernelSU veya APatch'i açın.
-4. ZIP dosyasını kurun ve yeniden başlatın.
-5. Modül yöneticisinden CleveresTricky WebUI'yi açın.
-6. Yeni kurulumlar Global Mode açık, isteğe bağlı kimlik spoofing kapalı başlar.
-7. Yalnızca size ait veya test etme yetkiniz olan anahtar materyalini ekleyin.
-8. Kimlik seçeneklerini yalnız gerektiğinde yapılandırın.
-9. Şablon build identity değerlerini değiştirdikten sonra yeniden başlatın.
+1. En güncel ZIP dosyasını resmi [Releases](https://github.com/tryigit/CleveresTricky/releases/latest) sayfasından indirin.
+2. Android çalışırken ZIP dosyasını KernelSU veya APatch üzerinden kurun.
+3. Modül yöneticinizden CleveresTricky WebUI'yi açın.
+4. Yalnızca sahibi olduğunuz veya test etmek için yetkiniz bulunan bir **Keybox veya CBOX** ekleyin.
+5. Önce varsayılan kurulumu kullanın; kimlik, uygulama kuralları veya gizlilik seçeneklerini yalnızca gerektiğinde etkinleştirin.
 
-Projeyle birlikte kullanılabilir bir keybox veya özel attestation anahtarı dağıtılmaz.
+Projeyle birlikte kullanılabilir bir Keybox veya özel attestation anahtarı verilmez.
 
 ## Desteklenen ortam
 
-CleveresTricky Android 12 ile Android 17 arasını, API 31 ile 37 arasını destekler. Desteklenen işlemci hedefleri ARM64 ve x86 64'tür. Kurulum Android çalışırken KernelSU veya APatch üzerinden desteklenir.
+- Android **12–17** / API **31–37**
+- **ARM64** ve **x86-64**
+- **KernelSU** ve **APatch**
 
-Magisk ve recovery kurulumu desteklenmez. Installer, yarım bir modül bırakmak yerine desteklenmeyen yolları durdurur.
+Magisk ve recovery üzerinden kurulum desteklenmez.
 
-## Önemli sınırlar
+## Bilmeniz gerekenler
 
-Sonuçlar gerçek cihaz durumuna, firmware'e, sertifikasyona, anahtar materyaline, Google Play services durumuna ve uzak servis politikasına bağlıdır. CleveresTricky yerel uyumluluk yolunu iyileştirir ancak her cihaz için belirli bir uzak doğrulama sonucu garanti etmez.
+CleveresTricky yerel uyumluluk yolunu iyileştirir; ancak uzak sonuçlar gerçek cihaz, firmware, sertifikasyon durumu, Google Play services, sunucu politikası ve kullandığınız verilere bağlıdır. Belirli bir Play Integrity veya attestation sonucu garanti edemez.
 
-Telephony değerleri yalnız desteklenen uygulama API'lerinde görünür. Modem, baseband, EFS, fiziksel SIM veya mobil operatörün gördüğü kimlik değiştirilmez.
+Bootloader'ı fiziksel olarak yeniden kilitlemez, verified boot ölçümlerini yeniden yazmaz, donanımsal root of trust'ı değiştirmez, modem/baseband üzerinde değişiklik yapmaz ve DRM gizlilik kontrollerini bir DRM bypass'a dönüştürmez.
 
-Modern Android'de Android ID uygulama imza kimliği, kullanıcı ve cihaz kapsamında SettingsProvider tarafından yönetilir. CleveresTricky yanıltıcı bir global Android ID kontrolü sunmaz.
+Yalnızca kullanmaya yetkili olduğunuz yapılandırma ve kimlik bilgilerini kullanın.
 
-Gerçek kernel sürümü değişmez. Boot property görünümü bootloader'ı fiziksel olarak kilitlemez, verified boot'u onarmaz, vbmeta'yı yeniden yazmaz ve donanım root of trust değerini değiştirmez.
+## Daha fazla bilgi
 
-Bootloader kilidinin açık olması her DRM uygulamasının çalışmayacağı anlamına gelmez. Gerçek davranış cihaz, vendor uygulaması, provisioning durumu, güvenlik seviyesi, servis politikası ve firmware'e bağlıdır. Mevcut DRM çalışması bypass değil gizlilik odaklıdır.
+- [Keybox Manager](docs/KeyboxManager.md) — Keybox/CBOX yükleme, doğrulama, seçim ve iptal kontrolleri.
+- [Application Scope](docs/ApplicationScope.md) ve [Application Rules](docs/ApplicationRules.md) — özelliklerin hangi uygulamalara uygulanacağını seçin.
+- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md) ve [Patch Levels](docs/PatchLevels.md) — isteğe bağlı kimlik kontrolleri.
+- [RKP Protection](docs/RkpProtection.md) ve [DRM Privacy](docs/DrmPassthrough.md) — platform uyumluluğu ve gizlilik davranışı.
+- [Backup and Restore](docs/BackupRestore.md) — şifreli yapılandırma yedeği ve geri yükleme.
+- [Security Model](docs/SecurityModel.md) ve [Installer](docs/Installer.md) — güven sınırları ve kurulum ayrıntıları.
 
-Modül içi SHA 256 kayıtları eksik, değiştirilmiş, eklenmiş, linklenmiş veya beklenmeyen payload'ları tespit eder ve doğrulama başarısız olduğunda servisi tamper lockdown durumuna alır. Resmi release kaynağı ise ayrı release digest ve GitHub imzalı build provenance ile doğrulanır.
+## Yardım mı gerekiyor?
 
-## Önerilen ilk yapılandırma
+WebUI içindeki **Logs** sayfasını veya modül **Action** seçeneğini kullanarak acil tanılama raporu oluşturabilirsiniz. Tanılama arşivi cihaz ve sistem bilgileri içerebileceği için paylaşmadan önce kontrol edin.
 
-Önce yeni kurulum varsayılanlarını kullanın. Global Mode uygun uygulama UID'lerini seçerken temel boot ve Keystore koruması aktif kalır. İsteğe bağlı kimlik spoofing, Identity bölümünden açılana kadar kapalıdır.
+Yaygın sorunlar ve çözüm adımları için [Diagnostics](docs/Diagnostics.md) sayfasına bakın.
 
-Custom ROM kullanıyorsanız ve Play Integrity testi için güncel build identity gerekiyorsa Auto Identity, Google'ın herkese açık metadata kaynaklarından Pixel beta veya canary kimliği alıp yerel olarak kaydedebilir. Kaydedilen değerleri göstermek istediğinizde Identity Spoof Engine'i açın ve yeniden başlatın.
+## Proje
 
-DRM identifier gizliliği için medya uygulamasına bir Application Rule oluşturun ve privacy mode değerini `isolate` yapın. DRM Keystore Passthrough açık kalabilir; gerçek Keystore sertifika yolu ile takma DRM cihaz kimliği birbirinden bağımsızdır.
-
-## Yardım ve proje bilgileri
-
-Sorun giderirken WebUI Logs ekranını veya `CleveresTricky` etiketli Android logcat'i kullanın. Ayrıntılı yönlendirme [Diagnostics](docs/i18n/tr.md#diagnostics) bölümündedir.
-
-Proje geçmişi [CHANGELOG](docs/i18n/tr.md#changelog), katkı rehberi [Contributing](docs/i18n/tr.md#contributing), çeviri yapısı [Language Support](docs/i18n/tr.md#languages) ve tema bilgileri [Theme](docs/i18n/tr.md#theme) bölümlerinde yer alır.
-
-Resmi [Android attestation dokümantasyonu](https://source.android.com/docs/security/features/keystore/attestation), [Play Integrity verdict dokümantasyonu](https://developer.android.com/google/play/integrity/verdicts) ve [KernelSU modül rehberi](https://kernelsu.org/guide/module.html) kendi platformları için yetkili kaynaklardır.
-
-## Ayrıntılı isteğe bağlı kimlik kontrolleri
-
-CleveresTricky, Device and Build Identity, Attestation Identity, Telephony Identity, Region Identity, Identity Refresh ve Security Patch davranışlarını birbirinden bağımsız çözümler. Security Patch, Device and Build Identity'den bağımsızdır.
-
-Temel Keystore interception, gerçek KeyMint ve StrongBox private key işlemleri, root of trust işleme, Binder güvenliği ve gerekli boot uyumluluğu bu isteğe bağlı kontrollerden bağımsız kalır. Arayüz yakalanan cihaz durumunu, yapılandırılmış sunum durumunu ve uygulamanın gördüğü etkin durumu ayrı gösterir.
-
-Security Patch görünümü System, Vendor ve Boot için bağımsız politikalar sunar. Profiller uygulamalara tutarlı isteğe bağlı ayarlar atayabilir ve Effective State inspector çalışma zamanında kullanılan resolver çıktısını gösterir.
+[Değişiklikler](CHANGELOG.md) · [Katkıda bulunma](CONTRIBUTING.md) · [Diller](LANGUAGES.md) · [Lisans](LICENSING.md) · [Telegram](https://t.me/cleverestech)

--- a/README.tr.md
+++ b/README.tr.md
@@ -6,7 +6,7 @@
 ![Android](https://img.shields.io/badge/Android-12--17-3DDC84?logo=android&logoColor=white)
 ![Module](https://img.shields.io/badge/Module-KernelSU%20%7C%20APatch-6f42c1)
 
-CleveresTricky, Android 12–17 için bir KernelSU ve APatch modülüdür. Android Keystore ve attestation uyumluluğunu, Keybox/CBOX yönetimini, uygulama hedeflemeyi, isteğe bağlı kimlik kontrollerini, patch seviyesi ayarlarını ve gizlilik araçlarını tek bir mobil WebUI içinde toplar.
+CleveresTricky, Android 12-17 için bir KernelSU ve APatch modülüdür. Android Keystore ve attestation uyumluluğunu, Keybox/CBOX yönetimini, uygulama hedeflemeyi, isteğe bağlı kimlik kontrollerini, patch seviyesi ayarlarını ve gizlilik araçlarını tek bir mobil WebUI içinde toplar.
 
 Önce varsayılan ayarlarla başlayın; yalnızca gerçekten ihtiyaç duyduğunuz özellikleri açın.
 
@@ -30,7 +30,7 @@ Projeyle birlikte kullanılabilir bir Keybox veya özel attestation anahtarı ve
 
 ## Desteklenen ortam
 
-- Android **12–17** / API **31–37**
+- Android **12-17** / API **31-37**
 - **ARM64** ve **x86-64**
 - **KernelSU** ve **APatch**
 
@@ -46,12 +46,12 @@ Yalnızca kullanmaya yetkili olduğunuz yapılandırma ve kimlik bilgilerini kul
 
 ## Daha fazla bilgi
 
-- [Keybox Manager](docs/KeyboxManager.md) — Keybox/CBOX yükleme, doğrulama, seçim ve iptal kontrolleri.
-- [Application Scope](docs/ApplicationScope.md) ve [Application Rules](docs/ApplicationRules.md) — özelliklerin hangi uygulamalara uygulanacağını seçin.
-- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md) ve [Patch Levels](docs/PatchLevels.md) — isteğe bağlı kimlik kontrolleri.
-- [RKP Protection](docs/RkpProtection.md) ve [DRM Privacy](docs/DrmPassthrough.md) — platform uyumluluğu ve gizlilik davranışı.
-- [Backup and Restore](docs/BackupRestore.md) — şifreli yapılandırma yedeği ve geri yükleme.
-- [Security Model](docs/SecurityModel.md) ve [Installer](docs/Installer.md) — güven sınırları ve kurulum ayrıntıları.
+- [Keybox Manager](docs/KeyboxManager.md) - Keybox/CBOX yükleme, doğrulama, seçim ve iptal kontrolleri.
+- [Application Scope](docs/ApplicationScope.md) ve [Application Rules](docs/ApplicationRules.md) - özelliklerin hangi uygulamalara uygulanacağını seçin.
+- [Build Identity](docs/BuildIdentity.md), [Telephony Identity](docs/TelephonyIdentity.md) ve [Patch Levels](docs/PatchLevels.md) - isteğe bağlı kimlik kontrolleri.
+- [RKP Protection](docs/RkpProtection.md) ve [DRM Privacy](docs/DrmPassthrough.md) - platform uyumluluğu ve gizlilik davranışı.
+- [Backup and Restore](docs/BackupRestore.md) - şifreli yapılandırma yedeği ve geri yükleme.
+- [Security Model](docs/SecurityModel.md) ve [Installer](docs/Installer.md) - güven sınırları ve kurulum ayrıntıları.
 
 ## Yardım mı gerekiyor?
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,141 +3,62 @@
 **语言：** [English](README.md) | [Türkçe](README.tr.md) | **简体中文** | [Español](README.es.md) | [Deutsch](README.de.md) | [Русский](README.ru.md) | [Bahasa Indonesia](README.id.md) | [हिन्दी](README.hi.md) | [العربية](README.ar.md)
 
 [![Release](https://img.shields.io/github/v/release/tryigit/CleveresTricky?display_name=tag&sort=semver&label=Release)](https://github.com/tryigit/CleveresTricky/releases/latest)
-[![Localization](https://img.shields.io/badge/Localization-9%20Languages-teal?logo=googletranslate)](LANGUAGES.md)
-[![Channel](https://img.shields.io/badge/Follow-Telegram-blue.svg?logo=telegram)](https://t.me/cleverestech)
-[![License: GPL-3.0-only](https://img.shields.io/badge/License-GPL--3.0--only-orange.svg?logo=gnu)](LICENSING.md)
 ![Android](https://img.shields.io/badge/Android-12--17-3DDC84?logo=android&logoColor=white)
 ![Module](https://img.shields.io/badge/Module-KernelSU%20%7C%20APatch-6f42c1)
-![Architecture](https://img.shields.io/badge/Arch-ARM64%20%7C%20x86--64-0969DA)
 
-CleveresTricky 是一个面向 Android Keystore、attestation、设备身份和应用兼容性的 KernelSU 与 APatch 模块。它把受控的原生运行时与移动 WebUI 结合在一起，让用户可以在同一处管理应用范围、密钥材料、身份、补丁级别、Remote Key Provisioning 保护和 DRM 兼容性。
+CleveresTricky 是面向 Android 12–17 的 KernelSU / APatch 模块。它把 Android Keystore 与证明兼容、Keybox/CBOX 管理、应用范围控制、可选身份设置、补丁级别控制和隐私工具整合到一个移动端 WebUI 中。
 
-> 本文是用户文档的本地化版本。如与技术实现或英文文档存在歧义，以英文文档为准。
+建议先使用默认设置，只开启自己真正需要的功能。
 
-## 主要功能
+## 你可以做什么
 
-### 运行时控制
-
-[Spoof Engine](docs/i18n/zh-CN.md#spoof-engine) 控制可选的身份替换。只要模块服务健康，核心 Keystore 与 TEE 兼容路径以及 boot property 保护都会独立保持工作。
-
-[Application Scope](docs/i18n/zh-CN.md#application-scope) 说明定向模式、全局模式、包规则、共享 Android UID 和实时缓存更新。
-
-[Application Rules](docs/i18n/zh-CN.md#application-rules) 说明应用专用模板、keybox 选择和稳定的隐私身份。
-
-[Profiles](docs/i18n/zh-CN.md#profiles) 说明 Daily Compatibility、Default、Maximum Compatibility 和 Minimal 预设。
-
-### Attestation 与身份
-
-[Attestation](docs/i18n/zh-CN.md#attestation) 说明证书链替换、真实 KeyMint 操作、StrongBox 行为以及软件兼容层的边界。
-
-[Certificate Safe Mode](docs/i18n/zh-CN.md#certificate-safe-mode) 说明旧版兼容配置。当前核心目标选择不再依赖这个旧开关。
-
-[Keybox Manager](docs/i18n/zh-CN.md#keybox-manager) 说明 keybox 加载、验证、选择、轮换、吊销检查和自动监控。
-
-[Automatic Keybox Check](docs/i18n/zh-CN.md#automatic-keybox-check) 说明有界后台维护任务及其生命周期。
-
-[Remote Sources](docs/i18n/zh-CN.md#remote-sources) 说明带认证的远程获取、签名校验、刷新策略和失败行为。
-
-[Encrypted Storage](docs/i18n/zh-CN.md#encrypted-storage) 说明 CBOX 容器、本地受保护缓存和安全的密钥材料处理方式。
-
-[Patch Levels](docs/i18n/zh-CN.md#patch-levels) 说明 System、Vendor、Boot 补丁字段以及全局和按应用规则。
-
-[Build Identity](docs/i18n/zh-CN.md#build-identity) 说明设备模板、fingerprint、应用可见 Build 字段、同步早期启动激活和供 Custom ROM 用户使用的 Pixel beta Auto Identity 辅助功能。
-
-[Identity Refresh](docs/i18n/zh-CN.md#identity-refresh) 说明下一次启动身份生成和快照一致性。
-
-[Telephony Identity](docs/i18n/zh-CN.md#telephony-identity) 说明双 SIM 值、权限保留、支持的 Android API 和运营商边界。
-
-### 平台兼容性
-
-[Boot Properties](docs/i18n/zh-CN.md#boot-properties) 说明核心 userspace boot property 视图和独立的身份兼容策略。
-
-[Region Properties](docs/i18n/zh-CN.md#region-properties) 说明可选且有界的国家和硬件区域视图。
-
-[Provider Coexistence](docs/i18n/zh-CN.md#provider-coexistence) 说明自动模式如何避免覆盖其他 fingerprint 提供者。
-
-[RKP Protection](docs/i18n/zh-CN.md#rkp-protection) 说明受保护的 Android 基础设施和真实 generated-key passthrough。
-
-[DRM Passthrough and Privacy](docs/i18n/zh-CN.md#drm-passthrough) 说明两个相互独立的 DRM 行为：选定媒体应用可以继续使用 Android 原生 Keystore 证书路径，而配置 `privacy=isolate` 的应用在支持的现代 DRM HAL `deviceUniqueId` 字节数组读取上可以获得稳定的应用级假名。
-
-该功能不是 Widevine 或 DRM 绕过。它不会修改安全级别、许可证、provisioning 消息、内容密钥、会话、HDCP 状态或字符串属性。
-
-### 界面与操作
-
-[Web Interface](docs/i18n/zh-CN.md#web-interface) 说明原生模块管理器传输、移动导航、实时状态、输入验证和无障碍行为。
-
-内置 WebUI 语言包括 **English**、**Türkçe**、**简体中文**、**Español**、**Deutsch**、**Русский**、**Bahasa Indonesia**、**हिन्दी** 和 **العربية**。所有翻译目录都随模块本地提供，切换语言不需要网络连接。
-
-[Backup and Restore](docs/i18n/zh-CN.md#backup-restore) 说明加密导出、有界导入和安全恢复。
-
-[Installer](docs/i18n/zh-CN.md#installer) 说明 KernelSU/APatch 包布局、payload 校验、支持设备和安装流程。
-
-[Diagnostics](docs/i18n/zh-CN.md#diagnostics) 说明日志、状态检查、常见问题和受控排查顺序。
-
-### 工程参考
-
-[Security Model](docs/i18n/zh-CN.md#security-model) 说明信任边界、受保护文件、输入验证和模块明确不承诺的能力。
-
-[Performance](docs/i18n/zh-CN.md#performance) 说明 hook 生命周期、有界缓存、后台工作、CPU 和内存行为。
-
-[Building](docs/i18n/zh-CN.md#building) 说明工具链、验证任务和生成产物。
-
-[Native Architecture](docs/i18n/zh-CN.md#native-architecture) 说明 Rust injector、Rust native core、强制语言策略以及唯一必要的 Android C++ ABI 边界。
+- 管理、验证、选择和轮换 **Keybox/CBOX** 文件。
+- 使用 Global Mode，或通过独立规则只作用于指定应用。
+- 按需配置设备/build、证明、电话、地区和安全补丁展示。
+- 保护 Remote Key Provisioning 流程，并在不声称绕过 DRM 的前提下降低受支持 DRM 标识符的暴露。
+- 备份设置、查看实际生效状态，并通过 WebUI 或模块 Action 收集诊断信息。
 
 ## 快速开始
 
-1. 从官方项目 Release 页面下载当前 ZIP。
-2. 如需验证官方构建来源，请检查发布的 `SHA256SUMS` 和 GitHub build provenance。
-3. Android 正常运行时打开 KernelSU 或 APatch。
-4. 安装 ZIP 并重启。
-5. 从模块管理器打开 CleveresTricky WebUI。
-6. 新安装默认开启 Global Mode，而可选身份 spoofing 默认关闭。
-7. 只添加你拥有或被授权测试的密钥材料。
-8. 仅在需要时配置身份功能。
-9. 修改模板 Build Identity 后重启。
+1. 从官方 [Releases](https://github.com/tryigit/CleveresTricky/releases/latest) 页面下载最新 ZIP。
+2. 在 Android 正常运行时，通过 KernelSU 或 APatch 安装 ZIP。
+3. 从模块管理器打开 CleveresTricky WebUI。
+4. 只添加你拥有或被授权用于测试的 **Keybox 或 CBOX**。
+5. 先保持默认配置，只在需要时启用身份、应用规则或隐私选项。
 
-项目和 Release 不包含可用的 keybox 或私有 attestation 密钥。
+项目不会附带可直接使用的 Keybox 或私有证明密钥。
 
 ## 支持环境
 
-CleveresTricky 支持 Android 12 到 Android 17，也就是 API 31 到 37。支持 ARM64 与 x86 64。安装必须在 Android 运行期间通过 KernelSU 或 APatch 完成。
+- Android **12–17** / API **31–37**
+- **ARM64** 和 **x86-64**
+- **KernelSU** 和 **APatch**
 
-不支持 Magisk 或 Recovery 安装。安装器会提前停止不受支持的路径，而不是留下不完整模块。
+不支持 Magisk 和 Recovery 安装。
 
-## 重要边界
+## 需要了解
 
-最终结果取决于真实设备状态、固件、认证、密钥材料、Google Play services 和远程策略。CleveresTricky 可以改善本地兼容路径，但不能保证任何特定远程服务的判定结果。
+CleveresTricky 改善的是本地兼容路径。最终远程结果仍取决于真实设备、固件、认证状态、Google Play 服务、服务器策略以及你的配置，因此无法保证特定的 Play Integrity 或证明结果。
 
-Telephony 值只通过受支持的应用 API 呈现，不会修改 modem、baseband、EFS、实体 SIM 或运营商看到的身份。
+它不会真正重新锁定 Bootloader、改写 Verified Boot 测量值、改变硬件 Root of Trust、修改基带/调制解调器，也不会把 DRM 隐私功能变成 DRM 绕过工具。
 
-现代 Android 的 Android ID 由 SettingsProvider 按应用签名身份、用户和设备进行作用域管理。CleveresTricky 不提供误导性的全局 Android ID 控制。
+请只使用你有权使用的配置和凭据。
 
-真实 kernel 版本不会被更改。核心 boot property 视图不会物理锁回 bootloader、修复 verified boot、重写 vbmeta 或改变硬件 root of trust。
+## 了解更多
 
-解锁 bootloader 并不自动意味着所有 DRM 都不可用。实际行为取决于设备、vendor 实现、provisioning 状态、安全级别、服务策略和固件。本项目当前 DRM 工作的目标是隐私，而不是绕过保护。
+- [Keybox Manager](docs/KeyboxManager.md) — Keybox/CBOX 加载、验证、选择和撤销检查。
+- [Application Scope](docs/ApplicationScope.md) 与 [Application Rules](docs/ApplicationRules.md) — 决定功能作用于哪些应用。
+- [Build Identity](docs/BuildIdentity.md)、[Telephony Identity](docs/TelephonyIdentity.md) 与 [Patch Levels](docs/PatchLevels.md) — 可选身份控制。
+- [RKP Protection](docs/RkpProtection.md) 与 [DRM Privacy](docs/DrmPassthrough.md) — 平台兼容和隐私行为。
+- [Backup and Restore](docs/BackupRestore.md) — 加密配置备份与恢复。
+- [Security Model](docs/SecurityModel.md) 与 [Installer](docs/Installer.md) — 信任边界和安装细节。
 
-模块内部 SHA 256 记录用于检测缺失、修改、注入、链接或意外 payload，并在验证失败时进入 tamper lockdown。官方 Release 的来源可信度则由独立发布摘要和 GitHub 签名的构建 provenance 提供。
+## 需要帮助？
 
-## 推荐的首次配置
+可以使用 WebUI 的 **Logs** 页面或模块 **Action** 生成紧急诊断报告。诊断压缩包可能包含设备和系统信息，分享前请先检查内容。
 
-先使用新安装默认值。Global Mode 选择适用应用 UID，同时核心 boot 和 Keystore 保护保持启用。可选身份 spoofing 在你从 Identity 页面启用前保持关闭。
+常见问题和排查步骤请查看 [Diagnostics](docs/Diagnostics.md)。
 
-Custom ROM 用户如需用于 Play Integrity 测试的当前 Build Identity，可以使用 Auto Identity 从 Google 公共元数据获取 Pixel beta 或 canary 身份并保存在本地。只有在确实要呈现这些值时才启用 Identity Spoof Engine 并重启。
+## 项目
 
-如需 DRM 标识符隐私，为媒体应用创建 Application Rule 并设置 `privacy=isolate`。DRM Keystore Passthrough 可以继续开启，因为真实 Keystore 证书路径与假名 DRM 设备标识路径彼此独立。
-
-## 帮助与项目信息
-
-排查问题时请使用 WebUI Logs 页面或带 `CleveresTricky` 标签的 Android logcat。详细步骤见 [Diagnostics](docs/i18n/zh-CN.md#diagnostics)。
-
-项目历史见 [CHANGELOG](docs/i18n/zh-CN.md#changelog)，贡献指南见 [Contributing](docs/i18n/zh-CN.md#contributing)，语言结构见 [Language Support](docs/i18n/zh-CN.md#languages)，主题说明见 [Theme](docs/i18n/zh-CN.md#theme)。
-
-官方 [Android attestation 文档](https://source.android.com/docs/security/features/keystore/attestation)、[Play Integrity verdict 文档](https://developer.android.com/google/play/integrity/verdicts) 和 [KernelSU 模块指南](https://kernelsu.org/guide/module.html) 仍是各自平台的权威来源。
-
-## 细粒度可选身份控制
-
-CleveresTricky 分别解析 Device and Build Identity、Attestation Identity、Telephony Identity、Region Identity、Identity Refresh 和 Security Patch。Security Patch 与 Device and Build Identity 相互独立。
-
-核心 Keystore interception、真实 KeyMint 与 StrongBox 私钥操作、root of trust 处理、Binder 安全和必要 boot 兼容路径都独立于这些可选功能。界面会分别显示捕获到的真实状态、配置的呈现状态和应用最终可见的有效状态。
-
-Security Patch 页面分别为 System、Vendor、Boot 提供独立策略。Profiles 可以向应用分配一致的可选设置，Effective State inspector 会显示运行时 resolver 的最终结果。
+[更新记录](CHANGELOG.md) · [参与贡献](CONTRIBUTING.md) · [语言](LANGUAGES.md) · [许可证](LICENSING.md) · [Telegram](https://t.me/cleverestech)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 ![Android](https://img.shields.io/badge/Android-12--17-3DDC84?logo=android&logoColor=white)
 ![Module](https://img.shields.io/badge/Module-KernelSU%20%7C%20APatch-6f42c1)
 
-CleveresTricky 是面向 Android 12–17 的 KernelSU / APatch 模块。它把 Android Keystore 与证明兼容、Keybox/CBOX 管理、应用范围控制、可选身份设置、补丁级别控制和隐私工具整合到一个移动端 WebUI 中。
+CleveresTricky 是面向 Android 12-17 的 KernelSU / APatch 模块。它把 Android Keystore 与证明兼容、Keybox/CBOX 管理、应用范围控制、可选身份设置、补丁级别控制和隐私工具整合到一个移动端 WebUI 中。
 
 建议先使用默认设置，只开启自己真正需要的功能。
 
@@ -30,7 +30,7 @@ CleveresTricky 是面向 Android 12–17 的 KernelSU / APatch 模块。它把 A
 
 ## 支持环境
 
-- Android **12–17** / API **31–37**
+- Android **12-17** / API **31-37**
 - **ARM64** 和 **x86-64**
 - **KernelSU** 和 **APatch**
 
@@ -46,12 +46,12 @@ CleveresTricky 改善的是本地兼容路径。最终远程结果仍取决于�
 
 ## 了解更多
 
-- [Keybox Manager](docs/KeyboxManager.md) — Keybox/CBOX 加载、验证、选择和撤销检查。
-- [Application Scope](docs/ApplicationScope.md) 与 [Application Rules](docs/ApplicationRules.md) — 决定功能作用于哪些应用。
-- [Build Identity](docs/BuildIdentity.md)、[Telephony Identity](docs/TelephonyIdentity.md) 与 [Patch Levels](docs/PatchLevels.md) — 可选身份控制。
-- [RKP Protection](docs/RkpProtection.md) 与 [DRM Privacy](docs/DrmPassthrough.md) — 平台兼容和隐私行为。
-- [Backup and Restore](docs/BackupRestore.md) — 加密配置备份与恢复。
-- [Security Model](docs/SecurityModel.md) 与 [Installer](docs/Installer.md) — 信任边界和安装细节。
+- [Keybox Manager](docs/KeyboxManager.md) - Keybox/CBOX 加载、验证、选择和撤销检查。
+- [Application Scope](docs/ApplicationScope.md) 与 [Application Rules](docs/ApplicationRules.md) - 决定功能作用于哪些应用。
+- [Build Identity](docs/BuildIdentity.md)、[Telephony Identity](docs/TelephonyIdentity.md) 与 [Patch Levels](docs/PatchLevels.md) - 可选身份控制。
+- [RKP Protection](docs/RkpProtection.md) 与 [DRM Privacy](docs/DrmPassthrough.md) - 平台兼容和隐私行为。
+- [Backup and Restore](docs/BackupRestore.md) - 加密配置备份与恢复。
+- [Security Model](docs/SecurityModel.md) 与 [Installer](docs/Installer.md) - 信任边界和安装细节。
 
 ## 需要帮助？
 

--- a/encryptor-app/build.gradle.kts
+++ b/encryptor-app/build.gradle.kts
@@ -66,8 +66,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     buildFeatures {
         compose = true
@@ -88,7 +88,7 @@ android {
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget("1.8"))
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget("11"))
     }
 }
 

--- a/encryptor-app/build.gradle.kts
+++ b/encryptor-app/build.gradle.kts
@@ -88,7 +88,7 @@ android {
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget("11"))
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
     }
 }
 

--- a/module/template/action.sh
+++ b/module/template/action.sh
@@ -2,7 +2,6 @@
 set -e
 
 MODULE_ID="cleverestricky"
-MODULE_NAME="CleveresTricky"
 MODDIR="/data/adb/modules/$MODULE_ID"
 CONFIG_DIR="/data/adb/$MODULE_ID"
 SHELL_DIR="/data/user_de/0/com.android.shell"
@@ -213,7 +212,9 @@ write_payload_hashes() {
     : > "$hashes_out"
     if [ -d "$MODDIR" ] && [ ! -L "$MODDIR" ]; then
         find "$MODDIR" -type f -name '*.sha256' 2>/dev/null | sort 2>/dev/null | while IFS= read -r hash_file; do
-            [ -f "$hash_file" ] && [ ! -L "$hash_file" ] || continue
+            if [ ! -f "$hash_file" ] || [ -L "$hash_file" ]; then
+                continue
+            fi
             relative_hash=${hash_file#"$MODDIR"/}
             printf '===== %s =====\n' "$relative_hash" >> "$hashes_out"
             cat "$hash_file" >> "$hashes_out" 2>/dev/null || true
@@ -331,7 +332,7 @@ module_state="enabled"
     printf '======== module directory ========\n'
     ls -la "$MODDIR" 2>/dev/null || true
     printf '\n======== process ========\n'
-    ps -A 2>/dev/null | grep -i 'cleverestricky' 2>/dev/null || true
+    ps -A 2>/dev/null | awk 'tolower($0) ~ /cleverestricky/' || true
     printf '\n======== mounts ========\n'
     mount 2>/dev/null | grep -i -e 'cleverestricky' -e '/data/adb/modules' 2>/dev/null || true
 } > "$tmp/runtime.txt"

--- a/module/template/action.sh
+++ b/module/template/action.sh
@@ -1,0 +1,393 @@
+#!/system/bin/sh
+set -e
+
+MODULE_ID="cleverestricky"
+MODULE_NAME="CleveresTricky"
+MODDIR="/data/adb/modules/$MODULE_ID"
+CONFIG_DIR="/data/adb/$MODULE_ID"
+SHELL_DIR="/data/user_de/0/com.android.shell"
+FROM_WEBUI="${FROM_WEBUI:-0}"
+LANG_CODE="en"
+RAW_LOCALE=""
+tmp=""
+
+umask 077
+
+cleanup() {
+    if [ -n "$tmp" ] && [ -e "$tmp" ]; then
+        rm -rf "$tmp" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT INT TERM
+
+detect_language() {
+    RAW_LOCALE=""
+
+    for locale_candidate in \
+        "$(getprop persist.sys.locale 2>/dev/null || true)" \
+        "$(settings get system system_locales 2>/dev/null | cut -d, -f1 || true)" \
+        "$(getprop ro.product.locale 2>/dev/null || true)" \
+        "$(getprop persist.sys.language 2>/dev/null || true)"; do
+        case "$locale_candidate" in
+            ""|null|NULL) ;;
+            *)
+                RAW_LOCALE="$locale_candidate"
+                break
+                ;;
+        esac
+    done
+
+    normalized_locale=$(printf '%s' "$RAW_LOCALE" | tr '_' '-' | tr '[:upper:]' '[:lower:]' 2>/dev/null || true)
+    case "$normalized_locale" in
+        tr|tr-*) LANG_CODE="tr" ;;
+        zh|zh-*) LANG_CODE="zh" ;;
+        es|es-*) LANG_CODE="es" ;;
+        de|de-*) LANG_CODE="de" ;;
+        ru|ru-*) LANG_CODE="ru" ;;
+        id|id-*|in|in-*) LANG_CODE="id" ;;
+        hi|hi-*) LANG_CODE="hi" ;;
+        ar|ar-*) LANG_CODE="ar" ;;
+        *) LANG_CODE="en" ;;
+    esac
+}
+
+message() {
+    case "$LANG_CODE:$1" in
+        tr:GENERATING) printf '%s\n' "Acil durum raporu oluşturuluyor ..." ;;
+        tr:BASIC) printf '%s\n' "Temel bilgiler toplanıyor ..." ;;
+        tr:ADDING) printf '%s\n' "Ekleniyor:" ;;
+        tr:LOGS) printf '%s\n' "Sistem günlükleri toplanıyor ..." ;;
+        tr:ROOT_LOGS) printf '%s\n' "Root ortamı günlükleri toplanıyor ..." ;;
+        tr:COMPRESSING) printf '%s\n' "Rapor sıkıştırılıyor ..." ;;
+        tr:GENERATED) printf '%s\n' "Rapor oluşturuldu:" ;;
+        tr:SHARING) printf '%s\n' "Rapor paylaşılmaya çalışılıyor ..." ;;
+        tr:SHARE_FAILED) printf '%s\n' "Paylaşım kullanılamıyor; rapor yerel olarak kaydedildi." ;;
+        tr:ARCHIVE_FAILED) printf '%s\n' "Rapor arşivi oluşturulamadı." ;;
+        tr:REPORT_INFO) printf '%s\n' "CleveresTricky acil durum raporu. Bu arşiv, sorun gidermek için cihaz/modül durumunu ve tanılama günlüklerini içerir." ;;
+        tr:REPORT_LANGUAGE) printf '%s\n' "Rapor dili:" ;;
+        tr:NOTICE) printf '%s\n' "Bu arşiv hassas sistem günlükleri içerebilir. Paylaşmadan önce inceleyin. CleveresTricky keybox XML/CBOX dosyaları bilerek toplanmaz." ;;
+
+        zh:GENERATING) printf '%s\n' "正在生成紧急诊断报告 ..." ;;
+        zh:BASIC) printf '%s\n' "正在收集基本信息 ..." ;;
+        zh:ADDING) printf '%s\n' "正在添加：" ;;
+        zh:LOGS) printf '%s\n' "正在收集系统日志 ..." ;;
+        zh:ROOT_LOGS) printf '%s\n' "正在收集 Root 环境日志 ..." ;;
+        zh:COMPRESSING) printf '%s\n' "正在压缩报告 ..." ;;
+        zh:GENERATED) printf '%s\n' "报告已生成：" ;;
+        zh:SHARING) printf '%s\n' "正在尝试分享报告 ..." ;;
+        zh:SHARE_FAILED) printf '%s\n' "无法使用分享功能；报告已保存在本地。" ;;
+        zh:ARCHIVE_FAILED) printf '%s\n' "无法创建报告压缩包。" ;;
+        zh:REPORT_INFO) printf '%s\n' "CleveresTricky 紧急诊断报告。此压缩包包含用于故障排查的设备/模块状态和诊断日志。" ;;
+        zh:REPORT_LANGUAGE) printf '%s\n' "报告语言：" ;;
+        zh:NOTICE) printf '%s\n' "此压缩包可能包含敏感的系统日志。分享前请先检查。CleveresTricky keybox XML/CBOX 文件不会被主动收集。" ;;
+
+        es:GENERATING) printf '%s\n' "Generando informe de emergencia ..." ;;
+        es:BASIC) printf '%s\n' "Recopilando información básica ..." ;;
+        es:ADDING) printf '%s\n' "Añadiendo:" ;;
+        es:LOGS) printf '%s\n' "Recopilando registros del sistema ..." ;;
+        es:ROOT_LOGS) printf '%s\n' "Recopilando registros del entorno root ..." ;;
+        es:COMPRESSING) printf '%s\n' "Comprimiendo el informe ..." ;;
+        es:GENERATED) printf '%s\n' "Informe generado en:" ;;
+        es:SHARING) printf '%s\n' "Intentando compartir el informe ..." ;;
+        es:SHARE_FAILED) printf '%s\n' "No se pudo compartir; el informe se guardó localmente." ;;
+        es:ARCHIVE_FAILED) printf '%s\n' "No se pudo crear el archivo del informe." ;;
+        es:REPORT_INFO) printf '%s\n' "Informe de emergencia de CleveresTricky. Este archivo contiene el estado del dispositivo/módulo y registros de diagnóstico para solucionar problemas." ;;
+        es:REPORT_LANGUAGE) printf '%s\n' "Idioma del informe:" ;;
+        es:NOTICE) printf '%s\n' "Este archivo puede contener registros sensibles del sistema. Revísalo antes de compartirlo. Los archivos keybox XML/CBOX de CleveresTricky se excluyen deliberadamente." ;;
+
+        de:GENERATING) printf '%s\n' "Notfallbericht wird erstellt ..." ;;
+        de:BASIC) printf '%s\n' "Grundlegende Informationen werden gesammelt ..." ;;
+        de:ADDING) printf '%s\n' "Wird hinzugefügt:" ;;
+        de:LOGS) printf '%s\n' "Systemprotokolle werden gesammelt ..." ;;
+        de:ROOT_LOGS) printf '%s\n' "Root-Umgebungsprotokolle werden gesammelt ..." ;;
+        de:COMPRESSING) printf '%s\n' "Bericht wird komprimiert ..." ;;
+        de:GENERATED) printf '%s\n' "Bericht erstellt unter:" ;;
+        de:SHARING) printf '%s\n' "Bericht wird zum Teilen geöffnet ..." ;;
+        de:SHARE_FAILED) printf '%s\n' "Teilen ist nicht verfügbar; der Bericht wurde lokal gespeichert." ;;
+        de:ARCHIVE_FAILED) printf '%s\n' "Das Berichtsarchiv konnte nicht erstellt werden." ;;
+        de:REPORT_INFO) printf '%s\n' "CleveresTricky-Notfallbericht. Dieses Archiv enthält Geräte-/Modulstatus und Diagnoseprotokolle zur Fehleranalyse." ;;
+        de:REPORT_LANGUAGE) printf '%s\n' "Berichtssprache:" ;;
+        de:NOTICE) printf '%s\n' "Dieses Archiv kann sensible Systemprotokolle enthalten. Vor dem Teilen prüfen. CleveresTricky-Keybox-Dateien im XML/CBOX-Format werden bewusst nicht gesammelt." ;;
+
+        ru:GENERATING) printf '%s\n' "Создаётся аварийный диагностический отчёт ..." ;;
+        ru:BASIC) printf '%s\n' "Сбор основной информации ..." ;;
+        ru:ADDING) printf '%s\n' "Добавляется:" ;;
+        ru:LOGS) printf '%s\n' "Сбор системных журналов ..." ;;
+        ru:ROOT_LOGS) printf '%s\n' "Сбор журналов root-среды ..." ;;
+        ru:COMPRESSING) printf '%s\n' "Сжатие отчёта ..." ;;
+        ru:GENERATED) printf '%s\n' "Отчёт создан:" ;;
+        ru:SHARING) printf '%s\n' "Попытка открыть отчёт для отправки ..." ;;
+        ru:SHARE_FAILED) printf '%s\n' "Отправка недоступна; отчёт сохранён локально." ;;
+        ru:ARCHIVE_FAILED) printf '%s\n' "Не удалось создать архив отчёта." ;;
+        ru:REPORT_INFO) printf '%s\n' "Аварийный отчёт CleveresTricky. Архив содержит состояние устройства/модуля и диагностические журналы для поиска неисправностей." ;;
+        ru:REPORT_LANGUAGE) printf '%s\n' "Язык отчёта:" ;;
+        ru:NOTICE) printf '%s\n' "Архив может содержать чувствительные системные журналы. Проверьте его перед отправкой. Файлы keybox CleveresTricky XML/CBOX намеренно не собираются." ;;
+
+        id:GENERATING) printf '%s\n' "Membuat laporan darurat ..." ;;
+        id:BASIC) printf '%s\n' "Mengumpulkan informasi dasar ..." ;;
+        id:ADDING) printf '%s\n' "Menambahkan:" ;;
+        id:LOGS) printf '%s\n' "Mengumpulkan log sistem ..." ;;
+        id:ROOT_LOGS) printf '%s\n' "Mengumpulkan log lingkungan root ..." ;;
+        id:COMPRESSING) printf '%s\n' "Mengompresi laporan ..." ;;
+        id:GENERATED) printf '%s\n' "Laporan dibuat di:" ;;
+        id:SHARING) printf '%s\n' "Mencoba membagikan laporan ..." ;;
+        id:SHARE_FAILED) printf '%s\n' "Berbagi tidak tersedia; laporan disimpan secara lokal." ;;
+        id:ARCHIVE_FAILED) printf '%s\n' "Arsip laporan tidak dapat dibuat." ;;
+        id:REPORT_INFO) printf '%s\n' "Laporan darurat CleveresTricky. Arsip ini berisi status perangkat/modul dan log diagnostik untuk pemecahan masalah." ;;
+        id:REPORT_LANGUAGE) printf '%s\n' "Bahasa laporan:" ;;
+        id:NOTICE) printf '%s\n' "Arsip ini dapat berisi log sistem sensitif. Tinjau sebelum membagikan. File keybox XML/CBOX CleveresTricky sengaja tidak dikumpulkan." ;;
+
+        hi:GENERATING) printf '%s\n' "आपातकालीन रिपोर्ट बनाई जा रही है ..." ;;
+        hi:BASIC) printf '%s\n' "मूल जानकारी एकत्र की जा रही है ..." ;;
+        hi:ADDING) printf '%s\n' "जोड़ा जा रहा है:" ;;
+        hi:LOGS) printf '%s\n' "सिस्टम लॉग एकत्र किए जा रहे हैं ..." ;;
+        hi:ROOT_LOGS) printf '%s\n' "रूट वातावरण के लॉग एकत्र किए जा रहे हैं ..." ;;
+        hi:COMPRESSING) printf '%s\n' "रिपोर्ट संपीड़ित की जा रही है ..." ;;
+        hi:GENERATED) printf '%s\n' "रिपोर्ट बनाई गई:" ;;
+        hi:SHARING) printf '%s\n' "रिपोर्ट साझा करने का प्रयास किया जा रहा है ..." ;;
+        hi:SHARE_FAILED) printf '%s\n' "साझा करना उपलब्ध नहीं है; रिपोर्ट स्थानीय रूप से सहेजी गई है।" ;;
+        hi:ARCHIVE_FAILED) printf '%s\n' "रिपोर्ट आर्काइव नहीं बनाया जा सका।" ;;
+        hi:REPORT_INFO) printf '%s\n' "CleveresTricky आपातकालीन रिपोर्ट। इस आर्काइव में समस्या निवारण के लिए डिवाइस/मॉड्यूल स्थिति और डायग्नोस्टिक लॉग शामिल हैं।" ;;
+        hi:REPORT_LANGUAGE) printf '%s\n' "रिपोर्ट भाषा:" ;;
+        hi:NOTICE) printf '%s\n' "इस आर्काइव में संवेदनशील सिस्टम लॉग हो सकते हैं। साझा करने से पहले इसकी समीक्षा करें। CleveresTricky keybox XML/CBOX फ़ाइलें जानबूझकर एकत्र नहीं की जातीं।" ;;
+
+        ar:GENERATING) printf '%s\n' "جارٍ إنشاء تقرير طوارئ ..." ;;
+        ar:BASIC) printf '%s\n' "جارٍ جمع المعلومات الأساسية ..." ;;
+        ar:ADDING) printf '%s\n' "جارٍ إضافة:" ;;
+        ar:LOGS) printf '%s\n' "جارٍ جمع سجلات النظام ..." ;;
+        ar:ROOT_LOGS) printf '%s\n' "جارٍ جمع سجلات بيئة الروت ..." ;;
+        ar:COMPRESSING) printf '%s\n' "جارٍ ضغط التقرير ..." ;;
+        ar:GENERATED) printf '%s\n' "تم إنشاء التقرير في:" ;;
+        ar:SHARING) printf '%s\n' "جارٍ محاولة مشاركة التقرير ..." ;;
+        ar:SHARE_FAILED) printf '%s\n' "المشاركة غير متاحة؛ تم حفظ التقرير محليًا." ;;
+        ar:ARCHIVE_FAILED) printf '%s\n' "تعذر إنشاء أرشيف التقرير." ;;
+        ar:REPORT_INFO) printf '%s\n' "تقرير طوارئ CleveresTricky. يحتوي هذا الأرشيف على حالة الجهاز/الوحدة وسجلات التشخيص لاستكشاف المشكلات." ;;
+        ar:REPORT_LANGUAGE) printf '%s\n' "لغة التقرير:" ;;
+        ar:NOTICE) printf '%s\n' "قد يحتوي هذا الأرشيف على سجلات نظام حساسة. راجعه قبل المشاركة. لا يتم جمع ملفات CleveresTricky keybox بصيغة XML/CBOX عمدًا." ;;
+
+        en:GENERATING|*:GENERATING) printf '%s\n' "Generating emergency report ..." ;;
+        en:BASIC|*:BASIC) printf '%s\n' "Collecting basic information ..." ;;
+        en:ADDING|*:ADDING) printf '%s\n' "Adding:" ;;
+        en:LOGS|*:LOGS) printf '%s\n' "Collecting system logs ..." ;;
+        en:ROOT_LOGS|*:ROOT_LOGS) printf '%s\n' "Collecting root environment logs ..." ;;
+        en:COMPRESSING|*:COMPRESSING) printf '%s\n' "Compressing report ..." ;;
+        en:GENERATED|*:GENERATED) printf '%s\n' "Report generated at:" ;;
+        en:SHARING|*:SHARING) printf '%s\n' "Trying to share the report ..." ;;
+        en:SHARE_FAILED|*:SHARE_FAILED) printf '%s\n' "Sharing is unavailable; the report was saved locally." ;;
+        en:ARCHIVE_FAILED|*:ARCHIVE_FAILED) printf '%s\n' "Could not create the report archive." ;;
+        en:REPORT_INFO|*:REPORT_INFO) printf '%s\n' "CleveresTricky emergency report. This archive contains device/module status and diagnostic logs for troubleshooting." ;;
+        en:REPORT_LANGUAGE|*:REPORT_LANGUAGE) printf '%s\n' "Report language:" ;;
+        en:NOTICE|*:NOTICE) printf '%s\n' "This archive may contain sensitive system logs. Review it before sharing. CleveresTricky keybox XML/CBOX files are intentionally not collected." ;;
+    esac
+}
+
+print_log() {
+    if [ "$FROM_WEBUI" != "1" ]; then
+        printf '%s\n' "$*"
+    fi
+}
+
+send_bugreport() {
+    share_file="$1"
+    case "$share_file" in
+        ""|*[!A-Za-z0-9._-]*) return 2 ;;
+    esac
+    share_path="$SHELL_DIR/files/bugreports/$share_file"
+    [ -f "$share_path" ] && [ ! -L "$share_path" ] || return 1
+
+    su 2000 -c "am start -a android.intent.action.SEND --eu android.intent.extra.STREAM content://com.android.shell/bugreports/$share_file -t '*/*' --grant-read-uri-permission" >/dev/null 2>&1
+}
+
+copy_report_path() {
+    copy_src="$1"
+    copy_group="$2"
+    if [ -e "$copy_src" ] && [ ! -L "$copy_src" ]; then
+        print_log "$(message ADDING) $copy_src"
+        mkdir -p "$tmp/$copy_group"
+        cp -a "$copy_src" "$tmp/$copy_group/" 2>/dev/null || true
+    fi
+}
+
+write_payload_hashes() {
+    hashes_out="$tmp/module-payload-hashes.txt"
+    : > "$hashes_out"
+    if [ -d "$MODDIR" ] && [ ! -L "$MODDIR" ]; then
+        find "$MODDIR" -type f -name '*.sha256' 2>/dev/null | sort 2>/dev/null | while IFS= read -r hash_file; do
+            [ -f "$hash_file" ] && [ ! -L "$hash_file" ] || continue
+            relative_hash=${hash_file#"$MODDIR"/}
+            printf '===== %s =====\n' "$relative_hash" >> "$hashes_out"
+            cat "$hash_file" >> "$hashes_out" 2>/dev/null || true
+            printf '\n' >> "$hashes_out"
+        done
+    fi
+}
+
+create_archive() {
+    archive_out="$1"
+    if [ -x /system/bin/tar ]; then
+        /system/bin/tar -czf "$archive_out" -C "$tmp" .
+        return $?
+    fi
+    if command -v tar >/dev/null 2>&1; then
+        tar -czf "$archive_out" -C "$tmp" .
+        return $?
+    fi
+    if [ -x /system/bin/toybox ]; then
+        /system/bin/toybox tar -czf "$archive_out" -C "$tmp" .
+        return $?
+    fi
+    return 1
+}
+
+detect_language
+
+if [ "$FROM_WEBUI" = "1" ] && [ "${1:-}" = "--send" ]; then
+    send_bugreport "${2:-}"
+    exit $?
+fi
+
+print_log "$(message GENERATING)"
+stamp=$(date +%Y%m%d-%H%M%S)
+tmp="/data/local/tmp/cleverestricky-bugreport-$$"
+
+has_shell=false
+outdir=""
+if [ -d "$SHELL_DIR" ] && [ ! -L "$SHELL_DIR" ]; then
+    shell_outdir="$SHELL_DIR/files/bugreports"
+    if mkdir -p "$shell_outdir" 2>/dev/null; then
+        chown 2000 "$SHELL_DIR/files" "$shell_outdir" 2>/dev/null || true
+        chgrp 2000 "$SHELL_DIR/files" "$shell_outdir" 2>/dev/null || true
+        outdir="$shell_outdir"
+        has_shell=true
+        rm -f "$outdir"/CleveresTricky-bugreport-*.tar.gz 2>/dev/null || true
+    fi
+fi
+
+if [ -z "$outdir" ]; then
+    for download_dir in /sdcard/Download /storage/emulated/0/Download /data/local/tmp; do
+        if mkdir -p "$download_dir" 2>/dev/null; then
+            outdir="$download_dir"
+            break
+        fi
+    done
+fi
+
+[ -n "$outdir" ] || exit 1
+filename="CleveresTricky-bugreport-$stamp.tar.gz"
+out="$outdir/$filename"
+
+rm -rf "$tmp" 2>/dev/null || true
+mkdir -p "$tmp"
+
+print_log "$(message BASIC)"
+root_managers=""
+[ -d /data/adb/ksu ] && root_managers="${root_managers} KernelSU"
+[ -d /data/adb/ap ] && root_managers="${root_managers} APatch"
+[ -d /data/adb/magisk ] && root_managers="${root_managers} Magisk"
+[ -n "$root_managers" ] || root_managers=" Unknown"
+
+daemon_pids=$(pidof CleveresTricky 2>/dev/null || true)
+[ -n "$daemon_pids" ] || daemon_pids="not running"
+module_state="enabled"
+[ -e "$MODDIR/disable" ] && module_state="disabled"
+[ -e "$MODDIR/remove" ] && module_state="pending removal"
+
+{
+    printf 'CleveresTricky Emergency Report\n'
+    printf 'Generated: %s\n' "$(date '+%Y-%m-%d %H:%M:%S %z' 2>/dev/null || date)"
+    printf 'Detected locale: %s\n' "${RAW_LOCALE:-unknown}"
+    printf 'Report language: %s\n\n' "$LANG_CODE"
+    printf 'Kernel: %s\n' "$(uname -r 2>/dev/null || true)"
+    printf 'Architecture: %s\n' "$(uname -m 2>/dev/null || true)"
+    printf 'SDK: %s\n' "$(getprop ro.build.version.sdk 2>/dev/null || true)"
+    printf 'SDK_FULL: %s\n' "$(getprop ro.build.version.sdk_full 2>/dev/null || true)"
+    printf 'Security patch: %s\n' "$(getprop ro.build.version.security_patch 2>/dev/null || true)"
+    printf 'Fingerprint: %s\n' "$(getprop ro.build.fingerprint 2>/dev/null || true)"
+    printf 'Manufacturer: %s\n' "$(getprop ro.product.manufacturer 2>/dev/null || true)"
+    printf 'Model: %s\n' "$(getprop ro.product.model 2>/dev/null || true)"
+    printf 'Device: %s\n' "$(getprop ro.product.device 2>/dev/null || true)"
+    printf 'ABI: %s\n' "$(getprop ro.product.cpu.abi 2>/dev/null || true)"
+    printf 'SELinux: %s\n' "$(getenforce 2>/dev/null || printf unknown)"
+    printf 'Root environment:%s\n' "$root_managers"
+    printf 'Module state: %s\n' "$module_state"
+    printf 'Daemon PID(s): %s\n' "$daemon_pids"
+    printf '\n======== module.prop ========\n'
+    if [ -f "$MODDIR/module.prop" ] && [ ! -L "$MODDIR/module.prop" ]; then
+        cat "$MODDIR/module.prop" 2>/dev/null || true
+    else
+        printf 'module.prop unavailable\n'
+    fi
+    printf '\n======== disk ========\n'
+    df -h /data "$outdir" 2>/dev/null || df /data "$outdir" 2>/dev/null || true
+} > "$tmp/basic.txt"
+
+{
+    message REPORT_INFO
+    printf '%s %s\n' "$(message REPORT_LANGUAGE)" "$LANG_CODE"
+    printf '\n%s\n' "$(message NOTICE)"
+} > "$tmp/REPORT.txt"
+
+{
+    printf '======== module directory ========\n'
+    ls -la "$MODDIR" 2>/dev/null || true
+    printf '\n======== process ========\n'
+    ps -A 2>/dev/null | grep -i 'cleverestricky' 2>/dev/null || true
+    printf '\n======== mounts ========\n'
+    mount 2>/dev/null | grep -i -e 'cleverestricky' -e '/data/adb/modules' 2>/dev/null || true
+} > "$tmp/runtime.txt"
+
+write_payload_hashes
+
+print_log "$(message LOGS)"
+if ! logcat -b all -d -v threadtime -f "$tmp/logcat-all.log" 2>/dev/null; then
+    logcat -d -v threadtime -f "$tmp/logcat-all.log" 2>/dev/null || true
+fi
+if [ -f "$tmp/logcat-all.log" ]; then
+    grep -i 'cleverestricky' "$tmp/logcat-all.log" > "$tmp/logcat-cleverestricky.log" 2>/dev/null || true
+fi
+
+dmesg > "$tmp/dmesg.log" 2>&1 || true
+
+copy_report_path "$CONFIG_DIR/logs" "cleverestricky"
+copy_report_path "$CONFIG_DIR/log" "cleverestricky"
+copy_report_path "$CONFIG_DIR/bugreports" "cleverestricky"
+copy_report_path "$CONFIG_DIR/crash" "cleverestricky"
+copy_report_path "$MODDIR/logs" "cleverestricky-module"
+
+print_log "$(message ROOT_LOGS)"
+copy_report_path "/data/adb/ksu/log" "root-manager/KernelSU"
+copy_report_path "/data/adb/ap/log" "root-manager/APatch"
+copy_report_path "/data/adb/magisk/log" "root-manager/Magisk"
+copy_report_path "/cache/magisk.log" "root-manager/Magisk"
+copy_report_path "/data/tombstones" "android"
+copy_report_path "/data/system/dropbox" "android"
+copy_report_path "/sys/fs/pstore" "android"
+copy_report_path "/data/anr" "android"
+
+print_log "$(message COMPRESSING)"
+rm -f "$out" 2>/dev/null || true
+if ! create_archive "$out"; then
+    print_log "$(message ARCHIVE_FAILED)"
+    exit 1
+fi
+
+if $has_shell; then
+    chown 2000 "$out" 2>/dev/null || true
+    chgrp 2000 "$out" 2>/dev/null || true
+    chmod 0640 "$out" 2>/dev/null || true
+else
+    chmod 0644 "$out" 2>/dev/null || true
+fi
+
+print_log "$(message GENERATED) $out"
+
+if $has_shell && [ "$FROM_WEBUI" != "1" ]; then
+    print_log "$(message SHARING)"
+    if ! send_bugreport "$filename"; then
+        print_log "$(message SHARE_FAILED)"
+    fi
+fi
+
+if [ "$FROM_WEBUI" = "1" ]; then
+    printf '%s\n' "$out"
+fi

--- a/module/template/customize.sh
+++ b/module/template/customize.sh
@@ -283,3 +283,88 @@ chown 0:0 "$CONFIG_DIR/spoof_build_vars" "$CONFIG_DIR/security_patch.txt" \
 [ ! -e "$CONFIG_DIR/drm_passthrough" ] || chown 0:0 "$CONFIG_DIR/drm_passthrough"
 [ ! -e "$CONFIG_DIR/hide_sensitive_props" ] || chown 0:0 "$CONFIG_DIR/hide_sensitive_props"
 [ ! -e "$CONFIG_DIR/debug_logging" ] || chown 0:0 "$CONFIG_DIR/debug_logging"
+
+# Remove mutually-exclusive keystore/TEE attestation modules only after the
+# CleveresTricky installation has completed successfully. Upstream module IDs:
+#   Tricky Store / Tricky Store OSS / TEESimulator-RS -> tricky_store
+#   TEESimulator                                      -> teesim
+# Exact normalized names are also recognized so forks that only change the ID
+# cannot silently coexist. User data under /data/adb/tricky_store is preserved.
+normalize_conflicting_module_name() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]_.-'
+}
+
+is_conflicting_attestation_module() {
+  conflict_id=$1
+  conflict_name=$2
+
+  case "$conflict_id" in
+    tricky_store|teesim) return 0 ;;
+  esac
+
+  normalized_conflict_name=$(normalize_conflicting_module_name "$conflict_name")
+  case "$normalized_conflict_name" in
+    trickystore|trickystoreoss|teesimulator|teesimulatorrs) return 0 ;;
+  esac
+
+  return 1
+}
+
+remove_conflicting_modules_from_root() {
+  modules_root=$1
+  [ -e "$modules_root" ] || return 0
+  [ -L "$modules_root" ] && abort "! Refusing symlinked modules root: $modules_root"
+  [ -d "$modules_root" ] || abort "! Modules root is not a directory: $modules_root"
+
+  for candidate in "$modules_root"/*; do
+    [ -e "$candidate" ] || [ -L "$candidate" ] || continue
+    candidate_dir=${candidate##*/}
+    [ "$candidate_dir" = "cleverestricky" ] && continue
+
+    if [ -L "$candidate" ]; then
+      case "$candidate_dir" in
+        tricky_store|teesim)
+          ui_print "- Removing conflicting module link: $candidate_dir"
+          rm -f "$candidate" || abort "! Could not remove conflicting module link: $candidate_dir"
+          ;;
+      esac
+      continue
+    fi
+
+    [ -d "$candidate" ] || continue
+    prop_file="$candidate/module.prop"
+
+    if [ -L "$prop_file" ]; then
+      case "$candidate_dir" in
+        tricky_store|teesim)
+          abort "! Refusing unsafe conflicting module metadata: $candidate_dir/module.prop"
+          ;;
+      esac
+      continue
+    fi
+
+    if [ ! -f "$prop_file" ]; then
+      case "$candidate_dir" in
+        tricky_store|teesim)
+          ui_print "- Removing incomplete conflicting module: $candidate_dir"
+          rm -rf "$candidate" || abort "! Could not remove incomplete conflicting module: $candidate_dir"
+          ;;
+      esac
+      continue
+    fi
+
+    conflict_id=$(grep_prop id "$prop_file" 2>/dev/null || true)
+    conflict_name=$(grep_prop name "$prop_file" 2>/dev/null || true)
+    [ "$conflict_id" = "cleverestricky" ] && continue
+
+    if is_conflicting_attestation_module "$conflict_id" "$conflict_name"; then
+      ui_print "- Removing conflicting module: ${conflict_name:-$candidate_dir} (${conflict_id:-unknown})"
+      rm -rf "$candidate" || abort "! Could not remove conflicting module: $candidate_dir"
+      [ ! -e "$candidate" ] && [ ! -L "$candidate" ] \
+        || abort "! Conflicting module still exists after removal: $candidate_dir"
+    fi
+  done
+}
+
+remove_conflicting_modules_from_root /data/adb/modules
+remove_conflicting_modules_from_root /data/adb/modules_update

--- a/module/template/customize.sh
+++ b/module/template/customize.sh
@@ -284,12 +284,6 @@ chown 0:0 "$CONFIG_DIR/spoof_build_vars" "$CONFIG_DIR/security_patch.txt" \
 [ ! -e "$CONFIG_DIR/hide_sensitive_props" ] || chown 0:0 "$CONFIG_DIR/hide_sensitive_props"
 [ ! -e "$CONFIG_DIR/debug_logging" ] || chown 0:0 "$CONFIG_DIR/debug_logging"
 
-# Remove mutually-exclusive keystore/TEE attestation modules only after the
-# CleveresTricky installation has completed successfully. Upstream module IDs:
-#   Tricky Store / Tricky Store OSS / TEESimulator-RS -> tricky_store
-#   TEESimulator                                      -> teesim
-# Exact normalized names are also recognized so forks that only change the ID
-# cannot silently coexist. User data under /data/adb/tricky_store is preserved.
 normalize_conflicting_module_name() {
   printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]_.-'
 }

--- a/module/template/customize.sh
+++ b/module/template/customize.sh
@@ -75,6 +75,7 @@ ui_print "- Extracting module files"
 extract "$ZIPFILE" 'module.prop'     "$MODPATH"
 extract "$ZIPFILE" 'post-fs-data.sh' "$MODPATH"
 extract "$ZIPFILE" 'service.sh'      "$MODPATH"
+extract "$ZIPFILE" 'action.sh'       "$MODPATH"
 extract "$ZIPFILE" 'service.apk'     "$MODPATH"
 extract "$ZIPFILE" 'sepolicy.rule'   "$MODPATH"
 extract "$ZIPFILE" 'daemon'          "$MODPATH"
@@ -96,7 +97,6 @@ if [ -L "$MODPATH/webroot" ] || [ ! -d "$MODPATH/webroot" ] || \
   [ -L "$MODPATH/webroot/ux.js" ] || [ ! -f "$MODPATH/webroot/ux.js" ]; then
   abort "! Native WebUI files are unsafe"
 fi
-rm -f "$MODPATH/action.sh" "$MODPATH/action.sh.sha256" || abort "! Could not remove legacy WebUI launcher"
 
 case "$ARCH" in
   "x64")
@@ -117,7 +117,7 @@ case "$ARCH" in
 esac
 
 chmod 755 "$MODPATH/inject" "$MODPATH/webui_bridge" "$MODPATH/daemon" "$MODPATH/service.sh" \
-  "$MODPATH/post-fs-data.sh" || abort "! Could not set module executable permissions"
+  "$MODPATH/post-fs-data.sh" "$MODPATH/action.sh" || abort "! Could not set module executable permissions"
 
 CONFIG_DIR=/data/adb/cleverestricky
 if [ -L "$CONFIG_DIR" ]; then

--- a/module/template/customize.sh
+++ b/module/template/customize.sh
@@ -354,8 +354,9 @@ remove_conflicting_modules_from_root() {
     if is_conflicting_attestation_module "$conflict_id" "$conflict_name"; then
       ui_print "- Removing conflicting module: ${conflict_name:-$candidate_dir} (${conflict_id:-unknown})"
       rm -rf "$candidate" || abort "! Could not remove conflicting module: $candidate_dir"
-      [ ! -e "$candidate" ] && [ ! -L "$candidate" ] \
-        || abort "! Conflicting module still exists after removal: $candidate_dir"
+      if [ -e "$candidate" ] || [ -L "$candidate" ]; then
+        abort "! Conflicting module still exists after removal: $candidate_dir"
+      fi
     fi
   done
 }


### PR DESCRIPTION
## Summary

- add a localized `action.sh` emergency diagnostic report for the module Action menu and WebUI sharing flow
- support all 9 built-in project languages with English fallback
- collect useful module/device/root-manager diagnostics while intentionally excluding CleveresTricky Keybox/CBOX payloads and general configuration
- install and SHA-256 verify `action.sh` through the existing installer verification path
- remove conflicting Tricky Store / Tricky Store OSS / TEESimulator / TEESimulator-RS modules after a successful CleveresTricky install
- preserve `/data/adb/tricky_store` user data while removing conflicting module payloads from `modules` and `modules_update`
- simplify all 9 localized README files into a shorter user-focused guide
- align the Encryptor JVM target with its Java 11 dependencies so the required Security Regression workflow can compile the app
- update Build validation so `action.sh` is a required, syntax-checked, checksum-verified module payload instead of being rejected as a legacy launcher

## Installer conflict handling

The installer recognizes the current upstream module identities:

- Tricky Store: `id=tricky_store`
- Tricky Store OSS: `id=tricky_store`
- TEESimulator: `id=teesim`
- TEESimulator-RS: `id=tricky_store`

Exact normalized module names are also recognized for forks that only change the ID. Cleanup runs only after the CleveresTricky installation completes, never removes `cleverestricky` itself, rejects unsafe module-root/metadata symlinks, and verifies that detected conflicts are actually gone.

## README cleanup

- reduce Quick Start to 5 steps
- remove the extra release-verification step from Quick Start
- remove README reboot instructions
- use `Keybox or CBOX` instead of vague `key material` wording
- keep detailed technical material in `docs/` instead of duplicating it in every README
- use repository-approved ASCII punctuation across all localized README files

## CI fixes

- resolve all ShellCheck findings introduced by the new Action/conflict cleanup
- remove the unused Action constant
- replace ambiguous `A && B || C` checks with explicit conditionals
- replace the `ps | grep` process filter with an `awk` filter
- align `encryptor-app` Java/Kotlin JVM target from 1.8 to 11
- require `action.sh` in module structure validation and in the built ZIP; the existing archive checksum walk requires its `.sha256` sidecar

## Verification

- Action script syntax was checked locally with `sh -n`
- installer uses the existing checksum-verified `extract()` helper for `action.sh` and requires `action.sh.sha256`
- conflict cleanup was exercised with mock Tricky Store OSS, TEESimulator, renamed-ID TEESimulator-RS, unrelated-module, and self-preservation cases
- repository Build and Security Regression workflows are required to pass before merge
