### PR TITLE
Fix 2.6.0 attestation timing parity regression

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -83,19 +83,11 @@ object KeystoreInterceptor : BinderInterceptor() {
                 if (originalChain == null) {
                     null
                 } else if (targeted) {
-                    // Keep ordinary key readback entirely local. Attested readback normally hits
-                    // CertHack's in-memory replacement cache; sending only the non-attested path
-                    // through CertificateBackend.inspect adds a measurable UDS/parser asymmetry.
-                    // The leaf is already parsed, so reject the negative case by fixed extension OID.
-                    val originalLeaf = originalChain.firstOrNull()
-                    if (
-                        originalLeaf == null ||
-                        !Utils.hasAndroidAttestationExtension(originalLeaf)
-                    ) {
-                        null
-                    } else {
-                        CertHack.hackCertificateChain(originalChain, callingUid).takeUnless { it === originalChain }
-                    }
+                    // Keep targeted readback on the same bounded certificate-inspection preflight
+                    // used by generateKey. Rust inspection decides whether the chain is attested;
+                    // a local negative OID shortcut makes ordinary readback measurably cheaper and
+                    // recreates the same timing distinguisher seen on the generateKey path.
+                    CertHack.hackCertificateChain(originalChain, callingUid).takeUnless { it === originalChain }
                 } else {
                     // A grant or isolated process is allowed to observe the chain already returned
                     // to the key owner, but it must not synthesize a new per-reader chain.

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -78,15 +78,13 @@ class SecurityLevelInterceptor : BinderInterceptor() {
                 return Skip
             }
 
-            // Parse only the leaf first. A normal asymmetric key without an Android attestation
-            // challenge still has a self-signed X.509 leaf, but it must never cross the Rust
-            // certificate backend boundary. 2.5.8 rejected that case locally; preserving the same
-            // zero-backend fast path avoids a measurable non-attested-only UDS/parser cost.
+            // Keep attested and ordinary asymmetric generateKey replies on the same bounded
+            // certificate-inspection preflight. Rust inspection decides whether the Android
+            // attestation extension is present. A JVM-only negative fast path makes ordinary
+            // calls measurably cheaper than attested calls and reintroduces a timing distinguisher.
+            // This restores the known-good 2.5.8 path without synthetic sleeps or threshold tuning.
             val originalLeaf = Utils.getLeafCertificate(metadata)
-            if (
-                originalLeaf == null ||
-                !Utils.hasAndroidAttestationExtension(originalLeaf)
-            ) {
+            if (originalLeaf == null) {
                 replacement.recycle()
                 return Skip
             }

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
@@ -18,7 +18,6 @@ import cleveres.tricky.cleverestech.util.FastByteArrayOutputStream;
 
 public final class Utils {
     private static final String TAG = "Utils";
-    private static final String ANDROID_ATTESTATION_EXTENSION_OID = "1.3.6.1.4.1.11129.2.1.17";
     private static final int MAX_CERTIFICATE_BYTES = 64 * 1024;
     private static final int MAX_CHAIN_BYTES = 512 * 1024;
     private static final int MAX_CERTIFICATES = 16;
@@ -74,25 +73,6 @@ public final class Utils {
         } catch (CertificateException | ClassCastException error) {
             Log.w(TAG, "Could not parse an X.509 certificate");
             return null;
-        }
-    }
-
-    /**
-     * Returns whether the already-parsed leaf carries Android's attestation extension.
-     *
-     * This check intentionally stays in-process. A normal AndroidKeyStore asymmetric key also
-     * carries a self-signed X.509 certificate, but forwarding that certificate to the Rust
-     * attestation parser creates a measurable UDS/parser cost on the non-attested generateKey path.
-     * The platform X509Certificate implementation has already parsed the certificate, so checking
-     * the fixed extension OID is bounded and avoids any backend IPC for that common negative case.
-     */
-    public static boolean hasAndroidAttestationExtension(Certificate certificate) {
-        if (!(certificate instanceof X509Certificate x509Certificate)) return false;
-        try {
-            return x509Certificate.getExtensionValue(ANDROID_ATTESTATION_EXTENSION_OID) != null;
-        } catch (RuntimeException error) {
-            Log.w(TAG, "Could not inspect Android attestation extension");
-            return false;
         }
     }
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
@@ -1,28 +1,13 @@
 package cleveres.tricky.cleverestech
 
-import cleveres.tricky.cleverestech.keystore.Utils
-import java.io.ByteArrayInputStream
 import java.io.File
-import java.security.cert.CertificateFactory
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class GenerateKeyTimingFastPathTest {
     @Test
-    fun `ordinary x509 leaf has no Android attestation extension`() {
-        val certificate =
-            CertificateFactory
-                .getInstance("X.509")
-                .generateCertificate(
-                    ByteArrayInputStream(TestKeyboxFixtures.certificate.toByteArray(Charsets.US_ASCII)),
-                )
-
-        assertFalse(Utils.hasAndroidAttestationExtension(certificate))
-    }
-
-    @Test
-    fun `generateKey rejects non-attested leaf before Rust certificate backend`() {
+    fun `generateKey keeps a shared certificate inspection preflight`() {
         val root = locateRoot()
         val source =
             File(
@@ -30,17 +15,17 @@ class GenerateKeyTimingFastPathTest {
                 "service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt",
             ).readText()
         val postTransact = source.indexOf("override fun onPostTransact")
-        val localExtensionGuard =
-            source.indexOf("!Utils.hasAndroidAttestationExtension(originalLeaf)", postTransact)
-        val backendRewrite = source.indexOf("CertHack.hackCertificateChain", postTransact)
+        val leafParse = source.indexOf("Utils.getLeafCertificate(metadata)", postTransact)
+        val backendInspection = source.indexOf("CertHack.hackCertificateChain", postTransact)
 
         assertTrue(postTransact >= 0)
-        assertTrue(localExtensionGuard > postTransact)
-        assertTrue(backendRewrite > localExtensionGuard)
+        assertTrue(leafParse > postTransact)
+        assertTrue(backendInspection > leafParse)
+        assertFalse(source.contains("hasAndroidAttestationExtension"))
     }
 
     @Test
-    fun `getKeyEntry rejects non-attested leaf before Rust certificate backend`() {
+    fun `getKeyEntry keeps the same bounded certificate preflight`() {
         val root = locateRoot()
         val source =
             File(
@@ -49,15 +34,46 @@ class GenerateKeyTimingFastPathTest {
             ).readText()
         val postTransact = source.indexOf("override fun onPostTransact")
         val chainRead = source.indexOf("val originalChain = Utils.getCertificateChain(response)", postTransact)
-        val localExtensionGuard =
-            source.indexOf("!Utils.hasAndroidAttestationExtension(originalLeaf)", chainRead)
-        val backendRewrite =
+        val backendInspection =
             source.indexOf("CertHack.hackCertificateChain(originalChain, callingUid)", chainRead)
 
         assertTrue(postTransact >= 0)
         assertTrue(chainRead > postTransact)
-        assertTrue(localExtensionGuard > chainRead)
-        assertTrue(backendRewrite > localExtensionGuard)
+        assertTrue(backendInspection > chainRead)
+        assertFalse(source.contains("hasAndroidAttestationExtension"))
+    }
+
+    @Test
+    fun `local attestation classifier cannot reintroduce asymmetric hot paths`() {
+        val root = locateRoot()
+        val utils =
+            File(
+                root,
+                "service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java",
+            ).readText()
+
+        assertFalse(utils.contains("hasAndroidAttestationExtension"))
+        assertFalse(utils.contains("ANDROID_ATTESTATION_EXTENSION_OID"))
+    }
+
+    @Test
+    fun `timing parity is not implemented with synthetic delay`() {
+        val root = locateRoot()
+        val sources =
+            listOf(
+                File(
+                    root,
+                    "service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt",
+                ).readText(),
+                File(
+                    root,
+                    "service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt",
+                ).readText(),
+            ).joinToString("\n")
+
+        assertFalse(sources.contains("Thread.sleep"))
+        assertFalse(sources.contains("parkNanos"))
+        assertFalse(sources.contains("busyWait"))
     }
 
     private fun locateRoot(): File {


### PR DESCRIPTION
## Device regression

Repeated device-side KeyMint timing tests on 2.6.0 show a stable attested/non-attested distinguisher that was not present on the known-good 2.5.8 `dd7d9a0f` build. A recent run measured approximately **0.411 ms attested vs 0.365 ms non-attested** (`+0.046 ms`, `1.126x`) and crossed the detector's `1.1x` threshold. An earlier run also crossed the threshold with a similar ~40 us magnitude.

## Root cause

This is not caused by the Rust certificate backend itself: the 2.5.8 `dd7d9a0f` baseline already used the bounded Rust inspect/rewrite path.

The regression was introduced later by local JVM negative fast paths in `SecurityLevelInterceptor` and `KeystoreInterceptor`. `Utils.hasAndroidAttestationExtension()` let ordinary non-attested certificates exit before the Rust inspection preflight, while attested certificates still paid the local X.509 OID check plus the backend path. That made the two observable Binder paths intentionally asymmetric.

The source regression test then encoded that asymmetry as desired behavior, so CI protected the regression instead of timing parity.

## Fix

- restore the 2.5.8-style shared bounded certificate-inspection preflight for targeted `generateKey` replies;
- restore the same shared preflight for targeted `getKeyEntry` readback;
- remove the local `hasAndroidAttestationExtension()` classifier and its fixed OID constant so the asymmetric shortcut cannot silently return;
- replace the old fast-path regression assertions with a parity contract covering both create and readback;
- explicitly reject synthetic `Thread.sleep`, `parkNanos`, or busy-wait equalization.

This PR does **not** change the detector threshold and does **not** add artificial delay. It removes the exact path asymmetry introduced after the known-good 2.5.8 baseline.

## Scope

The diff is intentionally isolated to four files: the two Keystore hot paths, the retired local classifier, and the regression contract. No cryptographic format, keybox semantics, Rust protocol, policy behavior, or UI code changes here.

## Validation

Validated head: `4ae899be8db1ac3778236e6d328186f9b0d69333`

- Build `32151864069`: **success** — ktlint, Android lint, JVM unit tests, module build, archive/checksum verification and native artifact hardening.
- Security Regression `32151864032`: **success** — including the new timing-parity contract.
- Native Hardening `32151864160`: **success**.
- Release artifact: `CleveresTricky-V2.6.0-2848-55dc9d02-release.zip`, Actions artifact id `9330389676`, SHA-256 `3f7521554938545e27df58129502b9b7f78a184ac9458bf6e160b5616686be84`.

Physical-device timing remains the final acceptance test. The PR intentionally remains Draft until the same device-side timing test is rerun on this artifact.