### PR TITLE
fix: consolidate 2.6.0 timing repair and dependency bumps

### DIFF
--- a/encryptor-app/src/test/java/cleveres/tricky/encryptor/MobileSecurityContractTest.kt
+++ b/encryptor-app/src/test/java/cleveres/tricky/encryptor/MobileSecurityContractTest.kt
@@ -64,7 +64,9 @@ class MobileSecurityContractTest {
         assertTrue(native.contains("unlink_file"))
         assertTrue(native.contains("0o700"))
         assertTrue(native.contains("0o600"))
-        assertTrue(native.contains("panic::catch_unwind"))
+        assertTrue(native.contains("EnvUnowned"))
+        assertTrue(native.contains(".with_env("))
+        assertTrue(native.contains("Outcome::Panic(_)"))
         assertFalse("Mobile Rust code must not contain unsafe blocks", native.contains("unsafe {"))
         assertEquals(
             "Unsafe-code allowances must remain confined to the six JNI symbol exports",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ androidx-test-runner = "1.7.0"
 robolectric = "4.16.1"
 coroutines = "1.10.2"
 kxml = "2.3.0"
-json = "20260719"
+json = "20260814"
 mockito = "5.23.0"
 
 [libraries]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -347,9 +347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "der_derive",
- "flagset",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "zeroize",
 ]
 
@@ -359,14 +357,18 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
+ "const-oid 0.10.2",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
 [[package]]
 name = "der_derive"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -407,7 +409,7 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "signature",
- "spki",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -422,7 +424,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "pkcs8",
  "rand_core",
  "sec1",
@@ -704,6 +706,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,7 +722,7 @@ checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
  "der 0.7.10",
  "pkcs8",
- "spki",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -721,7 +732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.10",
- "spki",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -843,7 +854,7 @@ dependencies = [
  "rand_core",
  "sha2",
  "signature",
- "spki",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -966,6 +977,16 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -1173,13 +1194,13 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "x509-cert"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+checksum = "105ef4642d9cb137ef83d623d0e4bf08b8adf69e9918ca904a174adb6d3d038b"
 dependencies = [
- "const-oid 0.9.6",
- "der 0.7.10",
- "spki",
+ "const-oid 0.10.2",
+ "der 0.8.1",
+ "spki 0.8.0",
  "tls_codec",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -339,7 +339,7 @@ dependencies = [
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c759083"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
 ]
@@ -395,7 +395,7 @@ dependencies = [
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
  "const-oid 0.10.2",
@@ -440,7 +440,7 @@ dependencies = [
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+checksum = "c0b50bfb653653f9ca9095b427bed08b8d75a137839cad84eb11810d5b6393f"
 dependencies = [
  "rand_core",
  "subtle",
@@ -450,13 +450,13 @@ dependencies = [
 name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a351a2d749af3c0e8f4fe"
 
 [[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "85649ac51fd72272d782ada274ad91c288277113d78d671dfba7e67affd40ba"
 dependencies = [
  "typenum",
  "version_check",
@@ -467,7 +467,7 @@ dependencies = [
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb02739e4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -528,7 +528,7 @@ dependencies = [
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751a"
 dependencies = [
  "generic-array",
 ]
@@ -557,7 +557,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "jni-macros"
+name = "jini-iacros"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
@@ -579,7 +579,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "jni-sys-macros"
+name = "jini-innenmac"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
@@ -592,7 +592,7 @@ dependencies = [
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316a66fe"
 dependencies = [
  "spin",
 ]
@@ -607,7 +607,7 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+checksum = "b6d2cec3eae94f13e68a7b45932f1ada835be2f0d819699782f8cca3c14807981"
 
 [[package]]
 name = "log"
@@ -619,7 +619,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+checksum = "69b6441f590336821bb897fb28fc622898cceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
  "digest 0.11.3",
@@ -629,24 +629,13 @@ dependencies = [
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d04"
 
 [[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand",
- "serde",
- "smallvec",
- "zeroize",
-]
 
 [[package]]
 name = "num-integer"
@@ -681,7 +670,7 @@ dependencies = [
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+checksum = "c08d65885ee38876c4f86fa503a2728f592895ee6854fd9bc13f2ffda266ff1"
 
 [[package]]
 name = "p256"
@@ -727,7 +716,7 @@ dependencies = [
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a52e7d724ed16323b68ace47f"
 dependencies = [
  "der 0.7.10",
  "pkcs8",
@@ -748,7 +737,7 @@ dependencies = [
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+checksum = "9d1fe60d06143b2430a541c94a8330d9e297830f020d7fd359a9a51b729afa25"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -760,16 +749,13 @@ dependencies = [
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
+checksum = "85eae3b4ed2f50dcfe72643da4beff10deadb458a9b590d720cde2f2b1e97da9"
 
 [[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "353e1ca18966c16b9deb1c69278edbc5f194139612772bd9537af60ac231e6b"
 dependencies = [
  "elliptic-curve",
 ]
@@ -805,13 +791,13 @@ dependencies = [
 name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+checksum = "f8dccc9c7d52a811697d215c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1f"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -822,7 +808,7 @@ dependencies = [
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1aaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -832,7 +818,7 @@ dependencies = [
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "ec0be479b5e2f6a28069bec0baf9baf6bf796e9adc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
 ]
@@ -841,7 +827,7 @@ dependencies = [
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "f8dd2a808d456c4a54a300a23e9f5a67e122c3024119acbfd73e3bf6644913cb"
 dependencies = [
  "hmac",
  "subtle",
@@ -872,7 +858,7 @@ dependencies = [
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb659d63d4d67c19c225ea6e9b92"
 dependencies = [
  "semver",
 ]
@@ -881,7 +867,7 @@ dependencies = [
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+checksum = "93fc1dc3aaa5b0739cf512df669335ea0b7ae307b8d0d1b4d7b6b68378900502"
 dependencies = [
  "winapi-util",
 ]
@@ -890,7 +876,7 @@ dependencies = [
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "d3e97a565f76233a6003f9c5c54be1d9c5dbfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der 0.7.10",
@@ -904,7 +890,7 @@ dependencies = [
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+checksum = "8a7852d02fc848982e0c167ef163aff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -946,8 +932,7 @@ dependencies = [
  "memchr",
  "serde",
  "serde_core",
- "zmij",
-]
+ "zmij",]
 
 [[package]]
 name = "sha1"
@@ -957,8 +942,7 @@ checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.3",
-]
+ "digest 0.11.3",]
 
 [[package]]
 name = "sha2"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -122,6 +122,7 @@ dependencies = [
  "cleverestricky-service-core",
  "cleverestricky-xml-core",
  "der 0.7.10",
+ "der 0.8.1",
  "getrandom 0.2.17",
  "libc",
  "sha2",
@@ -338,7 +339,7 @@ dependencies = [
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c759083"
 dependencies = [
  "cipher",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -295,6 +295,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -731,7 +740,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -916,13 +925,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.7"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -932,7 +941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -78,12 +78,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,27 +485,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
+ "simd_cesu8",
  "thiserror",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -805,6 +804,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +834,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -903,6 +917,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,22 +984,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1043,7 +1073,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1054,78 +1084,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "x509-cert"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -52,9 +52,9 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.22.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -395,7 +395,7 @@ dependencies = [
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f994983d5c2"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
  "const-oid 0.10.2",
@@ -440,7 +440,7 @@ dependencies = [
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08b8d75a137839cad84eb11810d5b6393f"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core",
  "subtle",
@@ -450,13 +450,13 @@ dependencies = [
 name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a351a2d749af3c0e8f4fe"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ac51fd72272d782ada274ad91c288277113d78d671dfba7e67affd40ba"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -467,7 +467,7 @@ dependencies = [
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb02739e4614ad0"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -528,7 +528,7 @@ dependencies = [
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751a"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
@@ -557,7 +557,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "jini-iacros"
+name = "jni-macros"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
@@ -579,7 +579,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "jini-innenmac"
+name = "jni-sys-macros"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
@@ -592,7 +592,7 @@ dependencies = [
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316a66fe"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
@@ -607,7 +607,7 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f13e68a7b45932f1ada835be2f0d819699782f8cca3c14807981"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "log"
@@ -619,7 +619,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b6441f590336821bb897fb28fc622898cceb1d6cea3fde5ea86b090c4de98"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
  "digest 0.11.3",
@@ -629,13 +629,24 @@ dependencies = [
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d04"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "serde",
+ "smallvec",
+ "zeroize",
+]
 
 [[package]]
 name = "num-integer"
@@ -670,7 +681,7 @@ dependencies = [
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503a2728f592895ee6854fd9bc13f2ffda266ff1"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "p256"
@@ -716,7 +727,7 @@ dependencies = [
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a52e7d724ed16323b68ace47f"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
  "der 0.7.10",
  "pkcs8",
@@ -737,7 +748,7 @@ dependencies = [
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430a541c94a8330d9e297830f020d7fd359a9a51b729afa25"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -749,13 +760,16 @@ dependencies = [
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3b4ed2f50dcfe72643da4beff10deadb458a9b590d720cde2f2b1e97da9"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16b9deb1c69278edbc5f194139612772bd9537af60ac231e6b"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
 ]
@@ -791,13 +805,13 @@ dependencies = [
 name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dccc9c7d52a811697d215c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1f"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -808,7 +822,7 @@ dependencies = [
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1aaa8141b9b127d88"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -818,7 +832,7 @@ dependencies = [
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be479b5e2f6a28069bec0baf9baf6bf796e9adc3547996c5c816922c"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
 ]
@@ -827,7 +841,7 @@ dependencies = [
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54a300a23e9f5a67e122c3024119acbfd73e3bf6644913cb"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
@@ -858,7 +872,7 @@ dependencies = [
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb659d63d4d67c19c225ea6e9b92"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
@@ -867,7 +881,7 @@ dependencies = [
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa5b0739cf512df669335ea0b7ae307b8d0d1b4d7b6b68378900502"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
@@ -876,7 +890,7 @@ dependencies = [
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9c5c54be1d9c5dbfa3eccfb189469f11ec4901c47dc"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der 0.7.10",
@@ -890,7 +904,7 @@ dependencies = [
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aff9cd91dc640ba85e263cb1ce46fae51cd"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -932,7 +946,8 @@ dependencies = [
  "memchr",
  "serde",
  "serde_core",
- "zmij",]
+ "zmij",
+]
 
 [[package]]
 name = "sha1"
@@ -942,7 +957,8 @@ checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.3",]
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "sha2"

--- a/rust/attestation-core/tests/managed_regressions.rs
+++ b/rust/attestation-core/tests/managed_regressions.rs
@@ -8,6 +8,7 @@ use der::{Decode, Encode, Tag, TagNumber, Tagged};
 const ROOT_OF_TRUST_TAG: u32 = 704;
 const SYSTEM_PATCH_TAG: u32 = 706;
 const BRAND_TAG: u32 = 710;
+const DEVICE_TAG: u32 = 711;
 const VENDOR_PATCH_TAG: u32 = 718;
 const BOOT_PATCH_TAG: u32 = 719;
 const MODULE_HASH_TAG: u32 = 724;
@@ -56,6 +57,35 @@ fn replaces_present_brand_and_keeps_authorization_tags_sorted() {
 }
 
 #[test]
+fn ignores_configured_attestation_id_that_is_absent_from_the_genuine_leaf() {
+    let tee = auth_list([
+        explicit_tag(ROOT_OF_TRUST_TAG, &root_of_trust([0; 32], [0; 32])),
+        explicit_octet(BRAND_TAG, b"OriginalBrand"),
+    ]);
+    let extension = key_description(100, 100, auth_list([]), tee);
+    let ids = [AttestationIdOverride {
+        tag: DEVICE_TAG,
+        value: b"ConfiguredButAbsent",
+    }];
+
+    let rewritten = rewrite(&extension, &ids, None);
+    let tee_fields = authorization_fields(&rewritten, 7);
+
+    assert!(tee_fields.iter().all(|(tag, _)| *tag != DEVICE_TAG));
+    assert_eq!(
+        decode_explicit_octets(
+            tee_fields
+                .iter()
+                .find(|(tag, _)| *tag == BRAND_TAG)
+                .expect("brand tag")
+                .1
+                .as_slice(),
+        ),
+        b"OriginalBrand",
+    );
+}
+
+#[test]
 fn inserts_supported_module_hash_only_in_software_list() {
     let tee = auth_list([explicit_tag(
         ROOT_OF_TRUST_TAG,
@@ -75,6 +105,22 @@ fn inserts_supported_module_hash_only_in_software_list() {
         decode_explicit_octets(module.1.as_slice()),
         &[0xde, 0xad, 0xbe, 0xef],
     );
+    assert!(tee.iter().all(|(tag, _)| *tag != MODULE_HASH_TAG));
+}
+
+#[test]
+fn ignores_configured_module_hash_when_the_genuine_leaf_does_not_support_it() {
+    let tee = auth_list([explicit_tag(
+        ROOT_OF_TRUST_TAG,
+        &root_of_trust([0; 32], [0; 32]),
+    )]);
+    let extension = key_description(100, 100, auth_list([]), tee);
+
+    let rewritten = rewrite(&extension, &[], Some(&[0xde, 0xad, 0xbe, 0xef]));
+    let software = authorization_fields(&rewritten, 6);
+    let tee = authorization_fields(&rewritten, 7);
+
+    assert!(software.iter().all(|(tag, _)| *tag != MODULE_HASH_TAG));
     assert!(tee.iter().all(|(tag, _)| *tag != MODULE_HASH_TAG));
 }
 

--- a/rust/backend/Cargo.toml
+++ b/rust/backend/Cargo.toml
@@ -11,7 +11,7 @@ name = "cleverestricky_backend"
 path = "src/main.rs"
 
 [dependencies]
-base64 = "=0.22.1"
+base64 = "=0.23.1"
 cleverestricky-cbox-recovery-core = { path = "../cbox-recovery-core" }
 cleverestricky-certificate-core = { path = "../certificate-core" }
 cleverestricky-crl-core = { path = "../crl-core" }
@@ -27,4 +27,4 @@ x509-cert = { version = "=0.2.5", default-features = false, features = ["std"] }
 zeroize = "1.8"
 
 [dev-dependencies]
-base64 = "=0.22.1"
+base64 = "=0.23.1"

--- a/rust/backend/Cargo.toml
+++ b/rust/backend/Cargo.toml
@@ -23,7 +23,7 @@ der = { version = "=0.7.10", features = ["alloc", "oid"] }
 getrandom = "=0.2.17"
 libc = "0.2"
 sha2 = "=0.10.9"
-x509-cert = { version = "=0.2.5", default-features = false, features = ["std"] }
+x509-cert = { version = "=0.3.0", default-features = false, features = ["std"] }
 zeroize = "1.8"
 
 [dev-dependencies]

--- a/rust/backend/Cargo.toml
+++ b/rust/backend/Cargo.toml
@@ -20,6 +20,7 @@ cleverestricky-keybox-core = { path = "../keybox-core" }
 cleverestricky-service-core = { path = "../service-core" }
 cleverestricky-xml-core = { path = "../xml-core" }
 der = { version = "=0.7.10", features = ["alloc", "oid"] }
+x509-der = { package = "der", version = "=0.8.1", features = ["alloc", "oid"] }
 getrandom = "=0.2.17"
 libc = "0.2"
 sha2 = "=0.10.9"

--- a/rust/backend/src/key_store.rs
+++ b/rust/backend/src/key_store.rs
@@ -4,11 +4,11 @@ use base64::Engine as _;
 use cleverestricky_certificate_core::{SigningAlgorithm, MAX_CERTIFICATE_DER_BYTES};
 use cleverestricky_keybox_core::{normalize_private_key_pkcs8, public_key_spki_from_pkcs8};
 use cleverestricky_xml_core::{KeyboxDocument, MAX_KEYBOXES_PER_FILE, MAX_KEYS_PER_KEYBOX};
-use der::{Decode, Encode};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::sync::{Arc, Mutex, OnceLock};
 use x509_cert::Certificate;
+use x509_der::{Decode as X509Decode, Encode as X509Encode};
 use zeroize::Zeroizing;
 
 pub const KEY_ID_BYTES: usize = 16;
@@ -191,8 +191,8 @@ fn build_stored_key(
     )
     .map_err(|_| "keybox leaf certificate rejected")?;
     let leaf_spki = leaf
-        .tbs_certificate
-        .subject_public_key_info
+        .tbs_certificate()
+        .subject_public_key_info()
         .to_der()
         .map_err(|_| "keybox leaf public key encoding failed")?;
     if private_spki != leaf_spki {

--- a/rust/cbox-recovery-core/Cargo.toml
+++ b/rust/cbox-recovery-core/Cargo.toml
@@ -16,4 +16,4 @@ sha2 = "=0.10.9"
 zeroize = "=1.9.0"
 
 [dev-dependencies]
-base64 = "=0.22.1"
+base64 = "=0.23.1"

--- a/rust/certificate-core/Cargo.toml
+++ b/rust/certificate-core/Cargo.toml
@@ -18,7 +18,7 @@ p256 = { version = "=0.13.2", features = ["ecdsa", "pkcs8"] }
 rsa = { version = "=0.9.10", features = ["sha2"] }
 sha2 = { version = "=0.10.9", features = ["oid"] }
 signature = "=2.2.0"
-x509-cert = { version = "=0.2.5", default-features = false, features = ["pem", "std"] }
+x509-cert = { version = "=0.3.0", default-features = false, features = ["pem", "std"] }
 zeroize = "=1.9.0"
 
 [dev-dependencies]

--- a/rust/certificate-core/src/inspection.rs
+++ b/rust/certificate-core/src/inspection.rs
@@ -3,7 +3,6 @@ use crate::{Error, ANDROID_ATTESTATION_OID, MAX_CERTIFICATE_DER_BYTES};
 use attestation_der::asn1::AnyRef;
 use attestation_der::{Decode as AttestationDecode, Tag, Tagged};
 use cleverestricky_attestation_core::{inspect_captured_patch_levels, CapturedPatchLevels};
-use der::Decode;
 use x509_cert::Certificate;
 
 const SOFTWARE_INDEX: usize = 6;
@@ -28,9 +27,8 @@ pub fn inspect_certificate(leaf_der: &[u8]) -> Result<CertificateInspection, Err
     }
     let leaf = Certificate::from_der(leaf_der).map_err(|_| Error::InvalidCertificate)?;
     let extensions = leaf
-        .tbs_certificate
-        .extensions
-        .as_deref()
+        .tbs_certificate()
+        .extensions()
         .ok_or(Error::MissingAttestationExtension)?;
     let mut attestation = None;
     for extension in extensions {

--- a/rust/certificate-core/src/lib.rs
+++ b/rust/certificate-core/src/lib.rs
@@ -182,7 +182,10 @@ fn rebuild_tbs_certificate(
     // subject, SPKI and extensions; issuer comes from the selected keybox. The managed builder did
     // not preserve issuer/subject unique IDs, so they are intentionally omitted here as well.
     let version = encode_explicit(0, &2i32.to_der().map_err(|_| Error::Encoding)?)?;
-    let serial = leaf_tbs.serial_number().to_der().map_err(|_| Error::Encoding)?;
+    let serial = leaf_tbs
+        .serial_number()
+        .to_der()
+        .map_err(|_| Error::Encoding)?;
     let issuer_name = issuer_tbs.subject().to_der().map_err(|_| Error::Encoding)?;
     let validity = leaf_tbs.validity().to_der().map_err(|_| Error::Encoding)?;
     let subject = leaf_tbs.subject().to_der().map_err(|_| Error::Encoding)?;

--- a/rust/certificate-core/src/lib.rs
+++ b/rust/certificate-core/src/lib.rs
@@ -1,11 +1,11 @@
 // Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
 #![forbid(unsafe_code)]
 
+use attestation_der::asn1::{Any, BitString, OctetString};
+use attestation_der::{Decode as X509Decode, Encode as X509Encode, Tag, TagNumber};
 use cleverestricky_attestation_core::{
     rewrite_extension, AttestationIdOverride, CapturedPatchLevels, PatchLevels, RewriteRequest,
 };
-use der::asn1::{BitString, OctetString};
-use der::{Decode, Encode};
 use p256::ecdsa::{
     Signature as EcSignature, SigningKey as EcSigningKey, VerifyingKey as EcVerifyingKey,
 };
@@ -16,13 +16,24 @@ use rsa::pkcs1v15::{
 use sha2::Sha256;
 use signature::{SignatureEncoding, Signer, Verifier};
 use std::fmt;
-use x509_cert::spki::{DynSignatureAlgorithmIdentifier, ObjectIdentifier};
-use x509_cert::{Certificate, TbsCertificate};
+use x509_cert::ext::Extensions;
+use x509_cert::spki::ObjectIdentifier;
+use x509_cert::Certificate;
 
 pub const MAX_CERTIFICATE_DER_BYTES: usize = 256 * 1024;
 pub const MAX_PRIVATE_KEY_DER_BYTES: usize = 3 * MAX_CERTIFICATE_DER_BYTES;
 pub const ANDROID_ATTESTATION_OID: ObjectIdentifier =
     ObjectIdentifier::new_unwrap("1.3.6.1.4.1.11129.2.1.17");
+
+// Keep these canonical encodings local instead of mixing the spki 0.7 traits used by the
+// signing-key crates with the spki 0.8 types used by x509-cert 0.3. They are the two fixed
+// algorithms accepted by the certificate wire protocol.
+const ECDSA_SHA256_ALGORITHM_DER: &[u8] = &[
+    0x30, 0x0a, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x02,
+];
+const RSA_SHA256_ALGORITHM_DER: &[u8] = &[
+    0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b, 0x05, 0x00,
+];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SigningAlgorithm {
@@ -83,15 +94,15 @@ pub fn rewrite_certificate(
     request: &CertificateRewriteRequest<'_>,
 ) -> Result<CertificateRewriteResult, Error> {
     validate_bounds(request)?;
-    let mut leaf =
+    let leaf =
         Certificate::from_der(request.genuine_leaf_der).map_err(|_| Error::InvalidCertificate)?;
     let issuer = Certificate::from_der(request.issuer_certificate_der)
         .map_err(|_| Error::InvalidCertificate)?;
 
-    let extensions = leaf
-        .tbs_certificate
-        .extensions
-        .as_mut()
+    let mut extensions = leaf
+        .tbs_certificate()
+        .extensions()
+        .cloned()
         .ok_or(Error::MissingAttestationExtension)?;
     let mut matching_index = None;
     for (index, extension) in extensions.iter().enumerate() {
@@ -113,22 +124,20 @@ pub fn rewrite_certificate(
     extensions[index].extn_value =
         OctetString::new(rewritten.extension_der).map_err(|_| Error::Encoding)?;
 
-    // Match the managed X509v3CertificateBuilder oracle: rebuild from the genuine serial,
-    // validity, subject, SPKI and extensions. The builder does not carry issuer/subject unique IDs.
-    leaf.tbs_certificate.issuer = issuer.tbs_certificate.subject.clone();
-    leaf.tbs_certificate.issuer_unique_id = None;
-    leaf.tbs_certificate.subject_unique_id = None;
-
+    let algorithm_der = signature_algorithm_der(request.signing_algorithm);
+    let tbs_der = rebuild_tbs_certificate(&leaf, &issuer, &extensions, algorithm_der)?;
     let leaf_der = match request.signing_algorithm {
         SigningAlgorithm::EcP256Sha256 => sign_ec(
-            leaf.tbs_certificate,
+            &tbs_der,
             &issuer,
             request.issuer_private_key_pkcs8,
+            algorithm_der,
         )?,
         SigningAlgorithm::RsaPkcs1Sha256 => sign_rsa(
-            leaf.tbs_certificate,
+            &tbs_der,
             &issuer,
             request.issuer_private_key_pkcs8,
+            algorithm_der,
         )?,
     };
     if leaf_der.len() > MAX_CERTIFICATE_DER_BYTES {
@@ -153,83 +162,150 @@ fn validate_bounds(request: &CertificateRewriteRequest<'_>) -> Result<(), Error>
     Ok(())
 }
 
+fn signature_algorithm_der(algorithm: SigningAlgorithm) -> &'static [u8] {
+    match algorithm {
+        SigningAlgorithm::EcP256Sha256 => ECDSA_SHA256_ALGORITHM_DER,
+        SigningAlgorithm::RsaPkcs1Sha256 => RSA_SHA256_ALGORITHM_DER,
+    }
+}
+
+fn rebuild_tbs_certificate(
+    leaf: &Certificate,
+    issuer: &Certificate,
+    extensions: &Extensions,
+    algorithm_der: &[u8],
+) -> Result<Vec<u8>, Error> {
+    let leaf_tbs = leaf.tbs_certificate();
+    let issuer_tbs = issuer.tbs_certificate();
+
+    // Match the managed X509v3CertificateBuilder oracle: rebuild from genuine serial, validity,
+    // subject, SPKI and extensions; issuer comes from the selected keybox. The managed builder did
+    // not preserve issuer/subject unique IDs, so they are intentionally omitted here as well.
+    let version = encode_explicit(0, &2i32.to_der().map_err(|_| Error::Encoding)?)?;
+    let serial = leaf_tbs.serial_number().to_der().map_err(|_| Error::Encoding)?;
+    let issuer_name = issuer_tbs.subject().to_der().map_err(|_| Error::Encoding)?;
+    let validity = leaf_tbs.validity().to_der().map_err(|_| Error::Encoding)?;
+    let subject = leaf_tbs.subject().to_der().map_err(|_| Error::Encoding)?;
+    let spki = leaf_tbs
+        .subject_public_key_info()
+        .to_der()
+        .map_err(|_| Error::Encoding)?;
+    let extensions = encode_extensions(extensions)?;
+    let extensions = encode_explicit(3, &extensions)?;
+
+    encode_sequence(&[
+        &version,
+        &serial,
+        algorithm_der,
+        &issuer_name,
+        &validity,
+        &subject,
+        &spki,
+        &extensions,
+    ])
+}
+
+fn encode_extensions(extensions: &Extensions) -> Result<Vec<u8>, Error> {
+    let mut encoded = Vec::new();
+    for extension in extensions {
+        let field = extension.to_der().map_err(|_| Error::Encoding)?;
+        encoded
+            .try_reserve(field.len())
+            .map_err(|_| Error::Encoding)?;
+        encoded.extend_from_slice(&field);
+    }
+    Any::new(Tag::Sequence, encoded)
+        .map_err(|_| Error::Encoding)?
+        .to_der()
+        .map_err(|_| Error::Encoding)
+}
+
+fn encode_explicit(tag: u32, inner: &[u8]) -> Result<Vec<u8>, Error> {
+    Any::new(
+        Tag::ContextSpecific {
+            constructed: true,
+            number: TagNumber(tag),
+        },
+        inner.to_vec(),
+    )
+    .map_err(|_| Error::Encoding)?
+    .to_der()
+    .map_err(|_| Error::Encoding)
+}
+
+fn encode_sequence(fields: &[&[u8]]) -> Result<Vec<u8>, Error> {
+    let mut encoded = Vec::new();
+    for field in fields {
+        encoded
+            .try_reserve(field.len())
+            .map_err(|_| Error::Encoding)?;
+        encoded.extend_from_slice(field);
+    }
+    Any::new(Tag::Sequence, encoded)
+        .map_err(|_| Error::Encoding)?
+        .to_der()
+        .map_err(|_| Error::Encoding)
+}
+
 fn sign_ec(
-    mut tbs: TbsCertificate,
+    tbs_der: &[u8],
     issuer: &Certificate,
     private_key_pkcs8: &[u8],
+    algorithm_der: &[u8],
 ) -> Result<Vec<u8>, Error> {
     let signer =
         EcSigningKey::from_pkcs8_der(private_key_pkcs8).map_err(|_| Error::InvalidPrivateKey)?;
-    let algorithm = signer
-        .signature_algorithm_identifier()
-        .map_err(|_| Error::Encoding)?;
-    tbs.signature = algorithm.clone();
-    let tbs_der = tbs.to_der().map_err(|_| Error::Encoding)?;
-    let signature: EcSignature = signer.try_sign(&tbs_der).map_err(|_| Error::Signature)?;
+    let signature: EcSignature = signer.try_sign(tbs_der).map_err(|_| Error::Signature)?;
 
     let issuer_spki = issuer
-        .tbs_certificate
-        .subject_public_key_info
+        .tbs_certificate()
+        .subject_public_key_info()
         .to_der()
         .map_err(|_| Error::Encoding)?;
     let verifier =
         EcVerifyingKey::from_public_key_der(&issuer_spki).map_err(|_| Error::IssuerKeyMismatch)?;
     verifier
-        .verify(&tbs_der, &signature)
+        .verify(tbs_der, &signature)
         .map_err(|_| Error::IssuerKeyMismatch)?;
 
     let signature_der = signature.to_der();
-    encode_certificate(
-        tbs,
-        algorithm,
-        BitString::from_bytes(signature_der.as_bytes()).map_err(|_| Error::Encoding)?,
-    )
+    encode_signed_certificate(tbs_der, algorithm_der, signature_der.as_bytes())
 }
 
 fn sign_rsa(
-    mut tbs: TbsCertificate,
+    tbs_der: &[u8],
     issuer: &Certificate,
     private_key_pkcs8: &[u8],
+    algorithm_der: &[u8],
 ) -> Result<Vec<u8>, Error> {
     let signer = RsaSigningKey::<Sha256>::from_pkcs8_der(private_key_pkcs8)
         .map_err(|_| Error::InvalidPrivateKey)?;
-    let algorithm = signer
-        .signature_algorithm_identifier()
-        .map_err(|_| Error::Encoding)?;
-    tbs.signature = algorithm.clone();
-    let tbs_der = tbs.to_der().map_err(|_| Error::Encoding)?;
-    let signature: RsaSignature = signer.try_sign(&tbs_der).map_err(|_| Error::Signature)?;
+    let signature: RsaSignature = signer.try_sign(tbs_der).map_err(|_| Error::Signature)?;
 
     let issuer_spki = issuer
-        .tbs_certificate
-        .subject_public_key_info
+        .tbs_certificate()
+        .subject_public_key_info()
         .to_der()
         .map_err(|_| Error::Encoding)?;
     let issuer_public = rsa::RsaPublicKey::from_public_key_der(&issuer_spki)
         .map_err(|_| Error::IssuerKeyMismatch)?;
     let verifier = RsaVerifyingKey::<Sha256>::new(issuer_public);
     verifier
-        .verify(&tbs_der, &signature)
+        .verify(tbs_der, &signature)
         .map_err(|_| Error::IssuerKeyMismatch)?;
 
     let signature_bytes = signature.to_vec();
-    encode_certificate(
-        tbs,
-        algorithm,
-        BitString::from_bytes(&signature_bytes).map_err(|_| Error::Encoding)?,
-    )
+    encode_signed_certificate(tbs_der, algorithm_der, &signature_bytes)
 }
 
-fn encode_certificate(
-    tbs_certificate: TbsCertificate,
-    signature_algorithm: x509_cert::spki::AlgorithmIdentifierOwned,
-    signature: BitString,
+fn encode_signed_certificate(
+    tbs_der: &[u8],
+    algorithm_der: &[u8],
+    signature: &[u8],
 ) -> Result<Vec<u8>, Error> {
-    Certificate {
-        tbs_certificate,
-        signature_algorithm,
-        signature,
-    }
-    .to_der()
-    .map_err(|_| Error::Encoding)
+    let signature = BitString::from_bytes(signature)
+        .map_err(|_| Error::Encoding)?
+        .to_der()
+        .map_err(|_| Error::Encoding)?;
+    encode_sequence(&[tbs_der, algorithm_der, &signature])
 }

--- a/rust/certificate-core/tests/rewrite.rs
+++ b/rust/certificate-core/tests/rewrite.rs
@@ -8,8 +8,8 @@ use cleverestricky_certificate_core::{
 };
 use cleverestricky_keybox_core::normalize_private_key_pkcs8;
 use cleverestricky_xml_core::parse_keybox_xml_bytes;
-use der::asn1::{BitString, OctetString};
-use der::{Decode, DecodePem, Encode};
+use x509_cert::der::asn1::{Any, OctetString};
+use x509_cert::der::{Decode, DecodePem, Encode, Tag, TagNumber};
 use x509_cert::ext::Extension;
 use x509_cert::Certificate;
 
@@ -77,12 +77,12 @@ fn ec_issuer_resigns_rsa_subject_without_changing_subject_spki() {
     let output = Certificate::from_der(&rewritten.leaf_der).expect("rewritten certificate DER");
 
     assert_eq!(
-        output.tbs_certificate.subject_public_key_info,
-        genuine.tbs_certificate.subject_public_key_info,
+        output.tbs_certificate().subject_public_key_info(),
+        genuine.tbs_certificate().subject_public_key_info(),
     );
     assert_eq!(
-        output.tbs_certificate.issuer,
-        ec_issuer.tbs_certificate.subject,
+        output.tbs_certificate().issuer(),
+        ec_issuer.tbs_certificate().subject(),
     );
     verify_signature(&output, &ec_issuer, SigningAlgorithm::EcP256Sha256);
 }
@@ -133,28 +133,28 @@ fn run_fixture(xml: &[u8], algorithm: SigningAlgorithm) {
     );
     let output = Certificate::from_der(&rewritten.leaf_der).expect("rewritten certificate DER");
     assert_eq!(
-        output.tbs_certificate.serial_number,
-        genuine.tbs_certificate.serial_number,
+        output.tbs_certificate().serial_number(),
+        genuine.tbs_certificate().serial_number(),
     );
     assert_eq!(
-        output.tbs_certificate.validity,
-        genuine.tbs_certificate.validity
+        output.tbs_certificate().validity(),
+        genuine.tbs_certificate().validity()
     );
     assert_eq!(
-        output.tbs_certificate.subject,
-        genuine.tbs_certificate.subject
+        output.tbs_certificate().subject(),
+        genuine.tbs_certificate().subject()
     );
     assert_eq!(
-        output.tbs_certificate.subject_public_key_info,
-        genuine.tbs_certificate.subject_public_key_info,
+        output.tbs_certificate().subject_public_key_info(),
+        genuine.tbs_certificate().subject_public_key_info(),
     );
-    assert!(genuine.tbs_certificate.issuer_unique_id.is_some());
-    assert!(genuine.tbs_certificate.subject_unique_id.is_some());
-    assert!(output.tbs_certificate.issuer_unique_id.is_none());
-    assert!(output.tbs_certificate.subject_unique_id.is_none());
+    assert!(genuine.tbs_certificate().issuer_unique_id().is_some());
+    assert!(genuine.tbs_certificate().subject_unique_id().is_some());
+    assert!(output.tbs_certificate().issuer_unique_id().is_none());
+    assert!(output.tbs_certificate().subject_unique_id().is_none());
     assert_eq!(
-        output.tbs_certificate.issuer,
-        issuer.tbs_certificate.subject
+        output.tbs_certificate().issuer(),
+        issuer.tbs_certificate().subject()
     );
     assert_eq!(
         non_attestation_extensions(&output),
@@ -162,9 +162,9 @@ fn run_fixture(xml: &[u8], algorithm: SigningAlgorithm) {
     );
 
     let attestation = output
-        .tbs_certificate
-        .extensions
-        .as_deref()
+        .tbs_certificate()
+        .extensions()
+        .map(Vec::as_slice)
         .unwrap_or(&[])
         .iter()
         .find(|extension| extension.extn_id == ANDROID_ATTESTATION_OID)
@@ -194,23 +194,93 @@ fn normalized_pem(value: &str) -> String {
 }
 
 fn synthetic_genuine_leaf(issuer: &Certificate) -> Certificate {
-    let mut leaf = issuer.clone();
-    leaf.tbs_certificate.serial_number = 0x012345u32.into();
-    leaf.tbs_certificate.issuer = issuer.tbs_certificate.subject.clone();
-    leaf.tbs_certificate.issuer_unique_id =
-        Some(BitString::from_bytes(&[0xa0]).expect("issuer unique id"));
-    leaf.tbs_certificate.subject_unique_id =
-        Some(BitString::from_bytes(&[0xb0]).expect("subject unique id"));
+    let issuer_tbs = issuer.tbs_certificate();
+    let version = explicit_x509_tag(0, &2i32.to_der().expect("v3 DER"));
+    let serial = 0x012345i32.to_der().expect("serial DER");
+    let signature = issuer_tbs.signature().to_der().expect("signature algorithm DER");
+    let issuer_name = issuer_tbs.subject().to_der().expect("issuer name DER");
+    let validity = issuer_tbs.validity().to_der().expect("validity DER");
+    let subject = issuer_tbs.subject().to_der().expect("subject DER");
+    let spki = issuer_tbs
+        .subject_public_key_info()
+        .to_der()
+        .expect("SPKI DER");
+    let issuer_unique_id = implicit_unique_id(1, 0xa0);
+    let subject_unique_id = implicit_unique_id(2, 0xb0);
+
     let extension_der = synthetic_attestation_extension();
-    let mut extensions = leaf.tbs_certificate.extensions.take().unwrap_or_default();
+    let mut extensions = issuer_tbs.extensions().cloned().unwrap_or_default();
     extensions.retain(|extension| extension.extn_id != ANDROID_ATTESTATION_OID);
     extensions.push(Extension {
         extn_id: ANDROID_ATTESTATION_OID,
         critical: false,
         extn_value: OctetString::new(extension_der).expect("attestation octets"),
     });
-    leaf.tbs_certificate.extensions = Some(extensions);
-    leaf
+    let extensions = extensions
+        .to_der()
+        .expect("extensions DER");
+    let extensions = explicit_x509_tag(3, &extensions);
+
+    let tbs = x509_sequence([
+        version.as_slice(),
+        serial.as_slice(),
+        signature.as_slice(),
+        issuer_name.as_slice(),
+        validity.as_slice(),
+        subject.as_slice(),
+        spki.as_slice(),
+        issuer_unique_id.as_slice(),
+        subject_unique_id.as_slice(),
+        extensions.as_slice(),
+    ]);
+    let outer_algorithm = issuer
+        .signature_algorithm()
+        .to_der()
+        .expect("outer signature algorithm DER");
+    let outer_signature = issuer.signature().to_der().expect("outer signature DER");
+    let certificate = x509_sequence([
+        tbs.as_slice(),
+        outer_algorithm.as_slice(),
+        outer_signature.as_slice(),
+    ]);
+    Certificate::from_der(&certificate).expect("synthetic genuine certificate")
+}
+
+fn explicit_x509_tag(tag: u32, inner: &[u8]) -> Vec<u8> {
+    Any::new(
+        Tag::ContextSpecific {
+            constructed: true,
+            number: TagNumber(tag),
+        },
+        inner.to_vec(),
+    )
+    .expect("explicit tag")
+    .to_der()
+    .expect("explicit tag DER")
+}
+
+fn implicit_unique_id(tag: u32, value: u8) -> Vec<u8> {
+    Any::new(
+        Tag::ContextSpecific {
+            constructed: false,
+            number: TagNumber(tag),
+        },
+        vec![0, value],
+    )
+    .expect("unique id")
+    .to_der()
+    .expect("unique id DER")
+}
+
+fn x509_sequence<'a>(parts: impl IntoIterator<Item = &'a [u8]>) -> Vec<u8> {
+    let mut value = Vec::new();
+    for part in parts {
+        value.extend_from_slice(part);
+    }
+    Any::new(Tag::Sequence, value)
+        .expect("sequence")
+        .to_der()
+        .expect("sequence DER")
 }
 
 fn synthetic_attestation_extension() -> Vec<u8> {
@@ -239,22 +309,22 @@ fn verify_signature(output: &Certificate, issuer: &Certificate, algorithm: Signi
     use sha2::Sha256;
     use signature::Verifier;
 
-    let tbs = output.tbs_certificate.to_der().expect("TBS DER");
+    let tbs = output.tbs_certificate().to_der().expect("TBS DER");
     let issuer_spki = issuer
-        .tbs_certificate
-        .subject_public_key_info
+        .tbs_certificate()
+        .subject_public_key_info()
         .to_der()
         .expect("issuer SPKI");
     match algorithm {
         SigningAlgorithm::EcP256Sha256 => {
             let key = EcVerifyingKey::from_public_key_der(&issuer_spki).expect("EC issuer key");
-            let signature = EcSignature::from_der(output.signature.raw_bytes()).expect("EC sig");
+            let signature = EcSignature::from_der(output.signature().raw_bytes()).expect("EC sig");
             key.verify(&tbs, &signature).expect("EC verification");
         }
         SigningAlgorithm::RsaPkcs1Sha256 => {
             let key = rsa::RsaPublicKey::from_public_key_der(&issuer_spki).expect("RSA issuer key");
             let verifying = RsaVerifyingKey::<Sha256>::new(key);
-            let signature = RsaSignature::try_from(output.signature.raw_bytes()).expect("RSA sig");
+            let signature = RsaSignature::try_from(output.signature().raw_bytes()).expect("RSA sig");
             verifying
                 .verify(&tbs, &signature)
                 .expect("RSA verification");
@@ -264,9 +334,9 @@ fn verify_signature(output: &Certificate, issuer: &Certificate, algorithm: Signi
 
 fn non_attestation_extensions(certificate: &Certificate) -> Vec<Vec<u8>> {
     certificate
-        .tbs_certificate
-        .extensions
-        .as_deref()
+        .tbs_certificate()
+        .extensions()
+        .map(Vec::as_slice)
         .unwrap_or(&[])
         .iter()
         .filter(|extension| extension.extn_id != ANDROID_ATTESTATION_OID)

--- a/rust/certificate-core/tests/rewrite.rs
+++ b/rust/certificate-core/tests/rewrite.rs
@@ -197,7 +197,10 @@ fn synthetic_genuine_leaf(issuer: &Certificate) -> Certificate {
     let issuer_tbs = issuer.tbs_certificate();
     let version = explicit_x509_tag(0, &2i32.to_der().expect("v3 DER"));
     let serial = 0x012345i32.to_der().expect("serial DER");
-    let signature = issuer_tbs.signature().to_der().expect("signature algorithm DER");
+    let signature = issuer_tbs
+        .signature()
+        .to_der()
+        .expect("signature algorithm DER");
     let issuer_name = issuer_tbs.subject().to_der().expect("issuer name DER");
     let validity = issuer_tbs.validity().to_der().expect("validity DER");
     let subject = issuer_tbs.subject().to_der().expect("subject DER");
@@ -216,9 +219,7 @@ fn synthetic_genuine_leaf(issuer: &Certificate) -> Certificate {
         critical: false,
         extn_value: OctetString::new(extension_der).expect("attestation octets"),
     });
-    let extensions = extensions
-        .to_der()
-        .expect("extensions DER");
+    let extensions = extensions.to_der().expect("extensions DER");
     let extensions = explicit_x509_tag(3, &extensions);
 
     let tbs = x509_sequence([
@@ -324,7 +325,8 @@ fn verify_signature(output: &Certificate, issuer: &Certificate, algorithm: Signi
         SigningAlgorithm::RsaPkcs1Sha256 => {
             let key = rsa::RsaPublicKey::from_public_key_der(&issuer_spki).expect("RSA issuer key");
             let verifying = RsaVerifyingKey::<Sha256>::new(key);
-            let signature = RsaSignature::try_from(output.signature().raw_bytes()).expect("RSA sig");
+            let signature =
+                RsaSignature::try_from(output.signature().raw_bytes()).expect("RSA sig");
             verifying
                 .verify(&tbs, &signature)
                 .expect("RSA verification");

--- a/rust/crl-core/Cargo.toml
+++ b/rust/crl-core/Cargo.toml
@@ -11,5 +11,5 @@ md-5 = "0.11.0"
 num-bigint = { package = "num-bigint-dig", version = "0.8.6" }
 serde = "1.0"
 serde_json = "1.0"
-sha1 = "0.10.6"
+sha1 = "0.11.0"
 sha2 = "0.10.9"

--- a/rust/crl-core/src/lib.rs
+++ b/rust/crl-core/src/lib.rs
@@ -1,11 +1,11 @@
 // Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
 #![forbid(unsafe_code)]
 
-use md5::Md5;
+use md5::{Digest as Md5Digest, Md5};
 use num_bigint::{BigInt, Sign};
 use serde::de::{self, DeserializeSeed, Deserializer, IgnoredAny, MapAccess, Visitor};
-use sha1::Sha1;
-use sha2::{Digest, Sha256};
+use sha1::{Digest as Sha1Digest, Sha1};
+use sha2::{Digest as Sha2Digest, Sha256};
 use std::collections::HashSet;
 use std::fmt;
 
@@ -105,18 +105,20 @@ pub fn fingerprints(
     if serial.len() > MAX_NORMALIZED_ENTRY_BYTES {
         return Err(CrlError::Size);
     }
+    let md5 = <Md5 as Md5Digest>::digest(subject_public_key_info);
+    let sha1 = <Sha1 as Sha1Digest>::digest(subject_public_key_info);
+    let sha256 = <Sha256 as Sha2Digest>::digest(subject_public_key_info);
     Ok(RevocationFingerprints {
         serial_hex: serial,
-        md5_hex: digest_hex::<Md5>(subject_public_key_info),
-        sha1_hex: digest_hex::<Sha1>(subject_public_key_info),
-        sha256_hex: digest_hex::<Sha256>(subject_public_key_info),
+        md5_hex: bytes_hex(md5.as_ref()),
+        sha1_hex: bytes_hex(sha1.as_ref()),
+        sha256_hex: bytes_hex(sha256.as_ref()),
     })
 }
 
-fn digest_hex<D: Digest>(input: &[u8]) -> String {
-    let digest = D::digest(input);
-    let mut output = String::with_capacity(digest.len() * 2);
-    for byte in digest {
+fn bytes_hex(input: &[u8]) -> String {
+    let mut output = String::with_capacity(input.len() * 2);
+    for byte in input {
         use std::fmt::Write as _;
         let _ = write!(output, "{byte:02x}");
     }

--- a/rust/crypto-core/Cargo.toml
+++ b/rust/crypto-core/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-only"
 
 [dependencies]
 aes-gcm = { version = "0.10.3", features = ["zeroize"] }
-base64 = "0.22.1"
+base64 = "0.23.1"
 getrandom = "0.4.3"
 p256 = { version = "0.13.2", features = ["ecdsa", "pkcs8"] }
 pbkdf2 = "0.12.2"

--- a/rust/encryptor-native/Cargo.toml
+++ b/rust/encryptor-native/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 aes-gcm = { version = "0.10.3", features = ["zeroize"] }
 getrandom = "0.4.3"
-jni = { version = "=0.21.1", default-features = false }
+jni = { version = "=0.22.4", default-features = false }
 pbkdf2 = "0.12.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rust/encryptor-native/src/lib.rs
+++ b/rust/encryptor-native/src/lib.rs
@@ -11,10 +11,10 @@ use jni::{Env, EnvUnowned, Outcome};
 use pbkdf2::pbkdf2_hmac;
 use serde::Serialize;
 use sha2::Sha256;
+use std::io;
 use std::path::Path;
 use std::ptr;
 use std::str;
-use std::io;
 use zeroize::{Zeroize, Zeroizing};
 
 const KDF_ITERATIONS: u32 = 250_000;
@@ -274,10 +274,9 @@ fn read_bytes_bounded(
     input: &JByteArray<'_>,
     max_bytes: usize,
 ) -> Result<Zeroizing<Vec<u8>>, EncryptError> {
-    let length = env
-        .get_array_length(input)
+    let length = input
+        .len(env)
         .map_err(|_| EncryptError::InvalidInput)?;
-    let length = usize::try_from(length).map_err(|_| EncryptError::InvalidInput)?;
     if length > max_bytes {
         return Err(EncryptError::InvalidInput);
     }
@@ -290,15 +289,15 @@ fn read_password(
     env: &mut Env<'_>,
     input: &JCharArray<'_>,
 ) -> Result<Zeroizing<String>, EncryptError> {
-    let length = env
-        .get_array_length(input)
+    let length = input
+        .len(env)
         .map_err(|_| EncryptError::InvalidInput)?;
-    let length = usize::try_from(length).map_err(|_| EncryptError::InvalidInput)?;
     if !(MIN_PASSWORD_UTF16_UNITS..=MAX_PASSWORD_UTF16_UNITS).contains(&length) {
         return Err(EncryptError::InvalidInput);
     }
     let mut units = Zeroizing::new(vec![0u16; length]);
-    env.get_char_array_region(input, 0, &mut units)
+    input
+        .get_region(env, 0, &mut units)
         .map_err(|_| EncryptError::InvalidInput)?;
     String::from_utf16(&units)
         .map(Zeroizing::new)
@@ -321,8 +320,8 @@ fn read_string_bounded(
 
 fn throw_native_failure(env: &mut Env<'_>) {
     let _ = env.throw_new(
-        "java/lang/IllegalStateException",
-        "Native keybox operation failed",
+        jni::jni_str!("java/lang/IllegalStateException"),
+        jni::jni_str!("Native keybox operation failed"),
     );
 }
 

--- a/rust/encryptor-native/src/lib.rs
+++ b/rust/encryptor-native/src/lib.rs
@@ -274,9 +274,7 @@ fn read_bytes_bounded(
     input: &JByteArray<'_>,
     max_bytes: usize,
 ) -> Result<Zeroizing<Vec<u8>>, EncryptError> {
-    let length = input
-        .len(env)
-        .map_err(|_| EncryptError::InvalidInput)?;
+    let length = input.len(env).map_err(|_| EncryptError::InvalidInput)?;
     if length > max_bytes {
         return Err(EncryptError::InvalidInput);
     }
@@ -289,9 +287,7 @@ fn read_password(
     env: &mut Env<'_>,
     input: &JCharArray<'_>,
 ) -> Result<Zeroizing<String>, EncryptError> {
-    let length = input
-        .len(env)
-        .map_err(|_| EncryptError::InvalidInput)?;
+    let length = input.len(env).map_err(|_| EncryptError::InvalidInput)?;
     if !(MIN_PASSWORD_UTF16_UNITS..=MAX_PASSWORD_UTF16_UNITS).contains(&length) {
         return Err(EncryptError::InvalidInput);
     }

--- a/rust/encryptor-native/src/lib.rs
+++ b/rust/encryptor-native/src/lib.rs
@@ -7,14 +7,14 @@ use cleverestricky_service_core::secure_fs::TrustedDir;
 use cleverestricky_xml_core::parse_keybox_xml_bytes;
 use jni::objects::{JByteArray, JCharArray, JObject, JString};
 use jni::sys::{jboolean, jbyteArray, JNI_FALSE, JNI_TRUE};
-use jni::JNIEnv;
+use jni::{Env, EnvUnowned, Outcome};
 use pbkdf2::pbkdf2_hmac;
 use serde::Serialize;
 use sha2::Sha256;
 use std::path::Path;
 use std::ptr;
 use std::str;
-use std::{io, panic};
+use std::io;
 use zeroize::{Zeroize, Zeroizing};
 
 const KDF_ITERATIONS: u32 = 250_000;
@@ -270,7 +270,7 @@ fn utf16_units(value: &str) -> usize {
 }
 
 fn read_bytes_bounded(
-    env: &mut JNIEnv<'_>,
+    env: &mut Env<'_>,
     input: &JByteArray<'_>,
     max_bytes: usize,
 ) -> Result<Zeroizing<Vec<u8>>, EncryptError> {
@@ -287,7 +287,7 @@ fn read_bytes_bounded(
 }
 
 fn read_password(
-    env: &mut JNIEnv<'_>,
+    env: &mut Env<'_>,
     input: &JCharArray<'_>,
 ) -> Result<Zeroizing<String>, EncryptError> {
     let length = env
@@ -306,171 +306,204 @@ fn read_password(
 }
 
 fn read_string_bounded(
-    env: &mut JNIEnv<'_>,
+    env: &Env<'_>,
     input: &JString<'_>,
     max_utf16_units: usize,
 ) -> Result<Zeroizing<String>, EncryptError> {
-    let java = env
-        .get_string(input)
+    let value = input
+        .try_to_string(env)
         .map_err(|_| EncryptError::InvalidInput)?;
-    let value: String = java.into();
     if utf16_units(&value) > max_utf16_units {
         return Err(EncryptError::InvalidInput);
     }
     Ok(Zeroizing::new(value))
 }
 
-fn throw_native_failure(env: &mut JNIEnv<'_>) {
+fn throw_native_failure(env: &mut Env<'_>) {
     let _ = env.throw_new(
         "java/lang/IllegalStateException",
         "Native keybox operation failed",
     );
 }
 
-// JNI requires stable exported symbol names. The unsafe attribute is confined to
-// the symbol export itself; these functions contain no unsafe block and every
-// panic is contained before returning through the JNI ABI.
+// JNI requires stable exported symbol names. EnvUnowned is the FFI-safe jni 0.22 wrapper for
+// the raw JNIEnv pointer. with_env upgrades it to the full Env API and contains panics before the
+// native frame returns to the JVM.
 #[allow(unsafe_code)]
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_cleveres_tricky_encryptor_NativeCrypto_validateKeyboxXml(
-    mut env: JNIEnv<'_>,
-    _this: JObject<'_>,
-    xml: JByteArray<'_>,
+pub extern "system" fn Java_cleveres_tricky_encryptor_NativeCrypto_validateKeyboxXml<'caller>(
+    mut unowned_env: EnvUnowned<'caller>,
+    _this: JObject<'caller>,
+    xml: JByteArray<'caller>,
 ) -> jboolean {
-    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        let xml = read_bytes_bounded(&mut env, &xml, MAX_XML_BYTES)?;
-        parse_keybox_xml_bytes(&xml).map_err(|_| EncryptError::InvalidInput)?;
-        Ok::<(), EncryptError>(())
-    }));
-    if matches!(result, Ok(Ok(()))) {
-        JNI_TRUE
-    } else {
-        JNI_FALSE
+    match unowned_env
+        .with_env(|env| -> jni::errors::Result<jboolean> {
+            let result = (|| -> Result<(), EncryptError> {
+                let xml = read_bytes_bounded(env, &xml, MAX_XML_BYTES)?;
+                parse_keybox_xml_bytes(&xml).map_err(|_| EncryptError::InvalidInput)?;
+                Ok(())
+            })();
+            Ok(if result.is_ok() { JNI_TRUE } else { JNI_FALSE })
+        })
+        .into_outcome()
+    {
+        Outcome::Ok(value) => value,
+        Outcome::Err(_) | Outcome::Panic(_) => JNI_FALSE,
     }
 }
 
 #[allow(unsafe_code)]
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_cleveres_tricky_encryptor_NativeCrypto_encryptAndSave(
-    mut env: JNIEnv<'_>,
-    _this: JObject<'_>,
-    no_backup_dir: JString<'_>,
-    filename: JString<'_>,
-    author: JByteArray<'_>,
-    xml: JByteArray<'_>,
-    signature_base64: JByteArray<'_>,
-    password: JCharArray<'_>,
+pub extern "system" fn Java_cleveres_tricky_encryptor_NativeCrypto_encryptAndSave<'caller>(
+    mut unowned_env: EnvUnowned<'caller>,
+    _this: JObject<'caller>,
+    no_backup_dir: JString<'caller>,
+    filename: JString<'caller>,
+    author: JByteArray<'caller>,
+    xml: JByteArray<'caller>,
+    signature_base64: JByteArray<'caller>,
+    password: JCharArray<'caller>,
 ) -> jboolean {
-    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        let no_backup_dir =
-            read_string_bounded(&mut env, &no_backup_dir, MAX_DIRECTORY_UTF16_UNITS)?;
-        let filename = read_string_bounded(&mut env, &filename, MAX_FILENAME_UTF16_UNITS)?;
-        let author = read_bytes_bounded(&mut env, &author, MAX_AUTHOR_UTF8_BYTES)?;
-        let xml = read_bytes_bounded(&mut env, &xml, MAX_XML_BYTES)?;
-        let signature_base64 =
-            read_bytes_bounded(&mut env, &signature_base64, MAX_SIGNATURE_BYTES)?;
-        let password = read_password(&mut env, &password)?;
-        encrypt_and_save(
-            &no_backup_dir,
-            &filename,
-            &author,
-            &xml,
-            &signature_base64,
-            &password,
-        )
-    }));
-    match result {
-        Ok(Ok(())) => JNI_TRUE,
-        Ok(Err(_)) | Err(_) => {
-            throw_native_failure(&mut env);
-            JNI_FALSE
-        }
+    match unowned_env
+        .with_env(|env| -> jni::errors::Result<jboolean> {
+            let result = (|| -> Result<(), EncryptError> {
+                let no_backup_dir =
+                    read_string_bounded(env, &no_backup_dir, MAX_DIRECTORY_UTF16_UNITS)?;
+                let filename = read_string_bounded(env, &filename, MAX_FILENAME_UTF16_UNITS)?;
+                let author = read_bytes_bounded(env, &author, MAX_AUTHOR_UTF8_BYTES)?;
+                let xml = read_bytes_bounded(env, &xml, MAX_XML_BYTES)?;
+                let signature_base64 =
+                    read_bytes_bounded(env, &signature_base64, MAX_SIGNATURE_BYTES)?;
+                let password = read_password(env, &password)?;
+                encrypt_and_save(
+                    &no_backup_dir,
+                    &filename,
+                    &author,
+                    &xml,
+                    &signature_base64,
+                    &password,
+                )
+            })();
+            match result {
+                Ok(()) => Ok(JNI_TRUE),
+                Err(_) => {
+                    throw_native_failure(env);
+                    Ok(JNI_FALSE)
+                }
+            }
+        })
+        .into_outcome()
+    {
+        Outcome::Ok(value) => value,
+        Outcome::Err(_) | Outcome::Panic(_) => JNI_FALSE,
     }
 }
 
 #[allow(unsafe_code)]
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_cleveres_tricky_encryptor_NativeCrypto_ensureVault(
-    mut env: JNIEnv<'_>,
-    _this: JObject<'_>,
-    no_backup_dir: JString<'_>,
+pub extern "system" fn Java_cleveres_tricky_encryptor_NativeCrypto_ensureVault<'caller>(
+    mut unowned_env: EnvUnowned<'caller>,
+    _this: JObject<'caller>,
+    no_backup_dir: JString<'caller>,
 ) -> jboolean {
-    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        let no_backup_dir =
-            read_string_bounded(&mut env, &no_backup_dir, MAX_DIRECTORY_UTF16_UNITS)?;
-        ensure_vault(&no_backup_dir)
-    }));
-    if matches!(result, Ok(Ok(()))) {
-        JNI_TRUE
-    } else {
-        JNI_FALSE
+    match unowned_env
+        .with_env(|env| -> jni::errors::Result<jboolean> {
+            let result = (|| -> Result<(), EncryptError> {
+                let no_backup_dir =
+                    read_string_bounded(env, &no_backup_dir, MAX_DIRECTORY_UTF16_UNITS)?;
+                ensure_vault(&no_backup_dir)
+            })();
+            Ok(if result.is_ok() { JNI_TRUE } else { JNI_FALSE })
+        })
+        .into_outcome()
+    {
+        Outcome::Ok(value) => value,
+        Outcome::Err(_) | Outcome::Panic(_) => JNI_FALSE,
     }
 }
 
 #[allow(unsafe_code)]
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_cleveres_tricky_encryptor_NativeCrypto_storeEncrypted(
-    mut env: JNIEnv<'_>,
-    _this: JObject<'_>,
-    no_backup_dir: JString<'_>,
-    filename: JString<'_>,
-    ciphertext: JByteArray<'_>,
+pub extern "system" fn Java_cleveres_tricky_encryptor_NativeCrypto_storeEncrypted<'caller>(
+    mut unowned_env: EnvUnowned<'caller>,
+    _this: JObject<'caller>,
+    no_backup_dir: JString<'caller>,
+    filename: JString<'caller>,
+    ciphertext: JByteArray<'caller>,
 ) -> jboolean {
-    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        let no_backup_dir =
-            read_string_bounded(&mut env, &no_backup_dir, MAX_DIRECTORY_UTF16_UNITS)?;
-        let filename = read_string_bounded(&mut env, &filename, MAX_FILENAME_UTF16_UNITS)?;
-        let ciphertext = read_bytes_bounded(&mut env, &ciphertext, MAX_CBOX_WIRE_BYTES)?;
-        store_encrypted(&no_backup_dir, &filename, &ciphertext)
-    }));
-    if matches!(result, Ok(Ok(()))) {
-        JNI_TRUE
-    } else {
-        JNI_FALSE
+    match unowned_env
+        .with_env(|env| -> jni::errors::Result<jboolean> {
+            let result = (|| -> Result<(), EncryptError> {
+                let no_backup_dir =
+                    read_string_bounded(env, &no_backup_dir, MAX_DIRECTORY_UTF16_UNITS)?;
+                let filename = read_string_bounded(env, &filename, MAX_FILENAME_UTF16_UNITS)?;
+                let ciphertext = read_bytes_bounded(env, &ciphertext, MAX_CBOX_WIRE_BYTES)?;
+                store_encrypted(&no_backup_dir, &filename, &ciphertext)
+            })();
+            Ok(if result.is_ok() { JNI_TRUE } else { JNI_FALSE })
+        })
+        .into_outcome()
+    {
+        Outcome::Ok(value) => value,
+        Outcome::Err(_) | Outcome::Panic(_) => JNI_FALSE,
     }
 }
 
 #[allow(unsafe_code)]
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_cleveres_tricky_encryptor_NativeCrypto_readEncrypted(
-    mut env: JNIEnv<'_>,
-    _this: JObject<'_>,
-    no_backup_dir: JString<'_>,
-    filename: JString<'_>,
+pub extern "system" fn Java_cleveres_tricky_encryptor_NativeCrypto_readEncrypted<'caller>(
+    mut unowned_env: EnvUnowned<'caller>,
+    _this: JObject<'caller>,
+    no_backup_dir: JString<'caller>,
+    filename: JString<'caller>,
 ) -> jbyteArray {
-    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        let no_backup_dir =
-            read_string_bounded(&mut env, &no_backup_dir, MAX_DIRECTORY_UTF16_UNITS)?;
-        let filename = read_string_bounded(&mut env, &filename, MAX_FILENAME_UTF16_UNITS)?;
-        let bytes = read_encrypted(&no_backup_dir, &filename)?;
-        let output = env
-            .byte_array_from_slice(&bytes)
-            .map_err(|_| EncryptError::StorageFailed)?;
-        Ok::<jbyteArray, EncryptError>(output.into_raw())
-    }));
-    match result {
-        Ok(Ok(output)) => output,
-        Ok(Err(_)) | Err(_) => ptr::null_mut(),
+    match unowned_env
+        .with_env(|env| -> jni::errors::Result<jbyteArray> {
+            let result = (|| -> Result<jbyteArray, EncryptError> {
+                let no_backup_dir =
+                    read_string_bounded(env, &no_backup_dir, MAX_DIRECTORY_UTF16_UNITS)?;
+                let filename = read_string_bounded(env, &filename, MAX_FILENAME_UTF16_UNITS)?;
+                let bytes = read_encrypted(&no_backup_dir, &filename)?;
+                let output = env
+                    .byte_array_from_slice(&bytes)
+                    .map_err(|_| EncryptError::StorageFailed)?;
+                Ok(output.into_raw())
+            })();
+            Ok(result.unwrap_or_else(|_| ptr::null_mut()))
+        })
+        .into_outcome()
+    {
+        Outcome::Ok(value) => value,
+        Outcome::Err(_) | Outcome::Panic(_) => ptr::null_mut(),
     }
 }
 
 #[allow(unsafe_code)]
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_cleveres_tricky_encryptor_NativeCrypto_deleteEncrypted(
-    mut env: JNIEnv<'_>,
-    _this: JObject<'_>,
-    no_backup_dir: JString<'_>,
-    filename: JString<'_>,
+pub extern "system" fn Java_cleveres_tricky_encryptor_NativeCrypto_deleteEncrypted<'caller>(
+    mut unowned_env: EnvUnowned<'caller>,
+    _this: JObject<'caller>,
+    no_backup_dir: JString<'caller>,
+    filename: JString<'caller>,
 ) -> jboolean {
-    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        let no_backup_dir =
-            read_string_bounded(&mut env, &no_backup_dir, MAX_DIRECTORY_UTF16_UNITS)?;
-        let filename = read_string_bounded(&mut env, &filename, MAX_FILENAME_UTF16_UNITS)?;
-        delete_encrypted(&no_backup_dir, &filename)
-    }));
-    match result {
-        Ok(Ok(true)) => JNI_TRUE,
-        _ => JNI_FALSE,
+    match unowned_env
+        .with_env(|env| -> jni::errors::Result<jboolean> {
+            let result = (|| -> Result<bool, EncryptError> {
+                let no_backup_dir =
+                    read_string_bounded(env, &no_backup_dir, MAX_DIRECTORY_UTF16_UNITS)?;
+                let filename = read_string_bounded(env, &filename, MAX_FILENAME_UTF16_UNITS)?;
+                delete_encrypted(&no_backup_dir, &filename)
+            })();
+            Ok(if matches!(result, Ok(true)) {
+                JNI_TRUE
+            } else {
+                JNI_FALSE
+            })
+        })
+        .into_outcome()
+    {
+        Outcome::Ok(value) => value,
+        Outcome::Err(_) | Outcome::Panic(_) => JNI_FALSE,
     }
 }
 

--- a/rust/encryptor-native/src/lib.rs
+++ b/rust/encryptor-native/src/lib.rs
@@ -464,7 +464,7 @@ pub extern "system" fn Java_cleveres_tricky_encryptor_NativeCrypto_readEncrypted
                     .map_err(|_| EncryptError::StorageFailed)?;
                 Ok(output.into_raw())
             })();
-            Ok(result.unwrap_or_else(|_| ptr::null_mut()))
+            Ok(result.unwrap_or(ptr::null_mut()))
         })
         .into_outcome()
     {

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -276,13 +276,42 @@ public final class CertHack {
                 if (cached != null) return cached.clone();
             }
 
-            inspection = CertificateBackend.inspect(leafEncoded);
-            if (inspection == null) return caList;
-            Config.AttestationPatchLevels patchLevels = PolicyState.INSTANCE.resolveAttestationPatchLevels(
-                    uid,
-                    inspection.getSystemPatch(),
-                    inspection.getVendorPatch(),
-                    inspection.getBootPatch());
+            // In 2.6.0 every fresh attested key paid one backend round trip just to inspect fields
+            // that are irrelevant when security-patch rewriting is disabled. Non-attested keys
+            // already bypass the backend, so that extra request/response became a stable timing
+            // distinguisher. Keep DER parsing and signing in the hardened Rust backend, but do not
+            // ask it to inspect a leaf unless policy or verified-boot fallback actually needs data
+            // from that leaf.
+            boolean needsCapturedPatchLevels = PolicyState.INSTANCE.isFeatureEnabled(
+                    PolicyState.Feature.SECURITY_PATCH, uid);
+            byte[] verifiedBootKey = usableBootDigest(UtilKt.getBootKey());
+            byte[] verifiedBootHash = usableBootDigest(UtilKt.getBootHash());
+            boolean needsInspection = needsCapturedPatchLevels
+                    || verifiedBootKey == null
+                    || verifiedBootHash == null;
+
+            Config.AttestationPatchLevels patchLevels;
+            if (needsInspection) {
+                inspection = CertificateBackend.inspect(leafEncoded);
+                if (inspection == null) return caList;
+                patchLevels = needsCapturedPatchLevels
+                        ? PolicyState.INSTANCE.resolveAttestationPatchLevels(
+                                uid,
+                                inspection.getSystemPatch(),
+                                inspection.getVendorPatch(),
+                                inspection.getBootPatch())
+                        : keepPatchLevels();
+                if (verifiedBootKey == null) {
+                    verifiedBootKey = firstUsableBootDigest(
+                            null, inspection.getOriginalBootKey(), UtilKt.getPersistentBootKey());
+                }
+                if (verifiedBootHash == null) {
+                    verifiedBootHash = firstUsableBootDigest(
+                            null, inspection.getOriginalBootHash(), UtilKt.getPersistentBootHash());
+                }
+            } else {
+                patchLevels = keepPatchLevels();
+            }
 
             String preferredSignerAlgorithm = KeyProperties.KEY_ALGORITHM_EC;
             var appConfig = Config.INSTANCE.getAppConfig(uid);
@@ -301,17 +330,17 @@ public final class CertHack {
             int signingAlgorithm = signingWireAlgorithm(prepared.signatureAlgorithm);
             if (signingAlgorithm == 0) return caList;
 
-            byte[] verifiedBootKey = firstUsableBootDigest(
-                    UtilKt.getBootKey(), inspection.getOriginalBootKey(), UtilKt.getPersistentBootKey());
-            byte[] verifiedBootHash = firstUsableBootDigest(
-                    UtilKt.getBootHash(), inspection.getOriginalBootHash(), UtilKt.getPersistentBootHash());
             if (verifiedBootKey == null || verifiedBootHash == null) {
                 Logger.e("Verified boot key/hash is unavailable; preserving the original certificate chain");
                 return caList;
             }
 
-            Map<Integer, byte[]> idOverrides = presentIdOverrides(uid, inspection.getPresentIdMask());
-            byte[] moduleHash = inspection.getSupportsModuleHash() ? Config.INSTANCE.getModuleHash() : null;
+            Map<Integer, byte[]> idOverrides = inspection == null
+                    ? configuredIdOverrides(uid)
+                    : presentIdOverrides(uid, inspection.getPresentIdMask());
+            byte[] moduleHash = inspection == null || inspection.getSupportsModuleHash()
+                    ? Config.INSTANCE.getModuleHash()
+                    : null;
             keyId = keybox.keyPair.getPrivate().getEncoded();
             if (keyId == null || keyId.length != BACKEND_KEY_ID_BYTES) return caList;
 
@@ -345,6 +374,21 @@ public final class CertHack {
             if (keyId != null) Arrays.fill(keyId, (byte) 0);
             if (inspection != null) inspection.wipe();
         }
+    }
+
+    private static Config.AttestationPatchLevels keepPatchLevels() {
+        Config.AttestationPatchComponent keep =
+                new Config.AttestationPatchComponent(Config.PatchDisposition.KEEP, 0);
+        return new Config.AttestationPatchLevels(keep, keep, keep);
+    }
+
+    private static Map<Integer, byte[]> configuredIdOverrides(int uid) {
+        Map<Integer, byte[]> overrides = new HashMap<>();
+        for (int index = 0; index < ATTESTATION_ID_TAGS.length; index++) {
+            byte[] value = Config.INSTANCE.getAttestationId(ATTESTATION_ID_NAMES[index], uid);
+            if (value != null) overrides.put(ATTESTATION_ID_TAGS[index], value);
+        }
+        return overrides;
     }
 
     private static Map<Integer, byte[]> presentIdOverrides(int uid, int mask) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
@@ -40,6 +40,35 @@ class GenerateKeyTimingFastPathTest {
     }
 
     @Test
+    fun `default attested generateKey does not require a Rust inspection round trip`() {
+        val root = locateRoot()
+        val source =
+            File(
+                root,
+                "service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java",
+            ).readText()
+        val featureGate =
+            source.indexOf("PolicyState.Feature.SECURITY_PATCH, uid")
+        val inspectionDecision =
+            source.indexOf("boolean needsInspection = needsCapturedPatchLevels", featureGate)
+        val conditionalInspection =
+            source.indexOf("if (needsInspection)", inspectionDecision)
+        val backendInspect =
+            source.indexOf("inspection = CertificateBackend.inspect(leafEncoded)", conditionalInspection)
+        val configuredIds =
+            source.indexOf("? configuredIdOverrides(uid)", backendInspect)
+        val backendRewrite =
+            source.indexOf("byte[] rewrittenDer = CertificateBackend.rewrite", configuredIds)
+
+        assertTrue(featureGate >= 0)
+        assertTrue(inspectionDecision > featureGate)
+        assertTrue(conditionalInspection > inspectionDecision)
+        assertTrue(backendInspect > conditionalInspection)
+        assertTrue(configuredIds > backendInspect)
+        assertTrue(backendRewrite > configuredIds)
+    }
+
+    @Test
     fun `getKeyEntry rejects non-attested leaf before Rust certificate backend`() {
         val root = locateRoot()
         val source =

--- a/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
@@ -89,6 +89,30 @@ class GenerateKeyTimingFastPathTest {
         assertTrue(backendRewrite > localExtensionGuard)
     }
 
+    @Test
+    fun `timing fix cannot use synthetic delay equalization`() {
+        val root = locateRoot()
+        val sources =
+            listOf(
+                File(
+                    root,
+                    "service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt",
+                ).readText(),
+                File(
+                    root,
+                    "service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt",
+                ).readText(),
+                File(
+                    root,
+                    "service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java",
+                ).readText(),
+            ).joinToString("\n")
+
+        assertFalse(sources.contains("Thread.sleep"))
+        assertFalse(sources.contains("parkNanos"))
+        assertFalse(sources.contains("busyWait"))
+    }
+
     private fun locateRoot(): File {
         var current = File(requireNotNull(System.getProperty("user.dir"))).canonicalFile
         repeat(6) {


### PR DESCRIPTION
## Problem

Fresh KeyMint timing is still distinguishable on-device after 2.6.0. The reported probe is positive at **1.126x** (`attested 0.411 ms`, `non-attested 0.365 ms`, `diff 0.046 ms`, threshold `> 1.1x`). This is a release blocker; the threshold is not relaxed and no synthetic delay is added.

Compared with 2.5.8, the 2.6.0 Rust-first path introduced a separate certificate-inspection backend transaction before the certificate-rewrite transaction for every uncached attested key. Non-attested keys already return locally, so that extra LocalSocket request/response is directly observable by a paired timing probe.

## Consolidation

This PR is now the **single active PR** for the timing repair and the pending dependency bumps. It supersedes #959 and incorporates #962, #963, #964, #965 and #966 into this branch; the superseded PRs are closed.

The useful guardrail from #959 is carried here: regression tests explicitly reject synthetic timing equalization (`Thread.sleep`, `parkNanos`, or busy-wait style padding). The alternative #959 implementation that deliberately sends ordinary/non-attested certificates through the Rust backend is not carried forward because it makes the cheaper path slower instead of removing module-only work from the attested path.

Integrated bumps:

- #962: `x509-cert` 0.3.0
- #963: `base64` 0.23.1
- #964: `jni` 0.22.4
- #965: `sha1` 0.11.0
- #966: `org.json` 20260814

The major-version API changes are handled in this PR rather than leaving red Dependabot branches behind: certificate parsing/re-encoding is migrated to the `x509-cert` 0.3 / DER 0.8 boundary, and the Android encryptor JNI bridge is migrated from the deprecated `JNIEnv` alias to the FFI-safe `EnvUnowned` + `with_env` model required by jni 0.22.

## Root cause

`CertHack.hackCertificateChain()` currently performs:

1. `CertificateBackend.inspect(leaf)` -> Rust backend IPC
2. resolve Android policy from the inspection result
3. `CertificateBackend.rewrite(...)` -> Rust backend IPC

On the normal/default policy path, the first round trip is unnecessary when:

- security-patch rewriting is disabled for the UID, and
- live verified-boot key/hash are already available.

The remaining inspection outputs are only filters/hints: the Rust rewrite already ignores configured attestation-ID overrides for tags absent from the genuine leaf, and already ignores a configured module hash when the attestation/keymint version does not support tag 724.

## Fix

- Skip `CertificateBackend.inspect()` on that default hot path.
- Keep **all X.509/DER parsing, authorization-list rewriting, and signing in the unprivileged Rust backend**; no managed DER parser is introduced.
- Keep ordinary/non-attested generateKey and getKeyEntry negative cases local instead of paying backend IPC just to equalize timing.
- Send configured attestation-ID overrides directly when inspection is skipped; Rust applies only IDs that were present in the genuine TEE authorization list.
- Send module hash directly when inspection is skipped; Rust already gates it on attestation/keymint v400+ support.
- Preserve the old inspection path whenever captured patch levels are required or live verified-boot digests are unavailable, so policy semantics and Root-of-Trust fallback remain unchanged.
- Preserve fail-closed behavior and the opaque-key boundary.
- Explicitly forbid synthetic delay/padding as a regression workaround.
- Resolve the dependency-bump build regressions on the consolidated branch instead of merging broken bumps independently.

This removes one full backend round trip from the default fresh-attestation path instead of masking the timing signal.

## Regression coverage

- Extend the generateKey timing fast-path contract test so `CertificateBackend.inspect()` remains conditional and the default path reaches rewrite without it.
- Preserve local non-attested rejection before the Rust certificate backend for both generateKey and getKeyEntry.
- Add a regression guard forbidding synthetic timing delays/padding.
- Add Rust regression tests proving that an override for an attestation ID absent from the genuine leaf is inert and a configured module hash is inert on pre-v400 attestation records.
- Run the complete Rust workspace, Android JVM tests, native hardening and dependency/security gates against the combined dependency set.

## Validation required before ready-for-review

- `cargo test --workspace`
- service JVM tests, especially `GenerateKeyTimingFastPathTest`
- repository Build + Security Regression + Native Hardening workflows
- physical-device paired timing replay with fresh keys. Acceptance remains **ratio < 1.1x** with no threshold change, no injected delay, and no failed pairs.

The PR stays draft until CI is green and the physical-device probe confirms the side-channel is no longer positive.