### PR TITLE
perf: remove invariant crypto from fresh attestation hot path

### DIFF
--- a/rust/backend/src/certificate_wire.rs
+++ b/rust/backend/src/certificate_wire.rs
@@ -1,8 +1,8 @@
 // Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
 use crate::keybox_wire::key_store::{self, KeyId, KEY_ID_BYTES};
 use cleverestricky_certificate_core::{
-    inspect_certificate, rewrite_certificate, AttestationIdOverride, CertificateRewriteRequest,
-    PatchComponent, PatchLevels, SigningAlgorithm, MAX_ATTESTATION_ID_BYTES,
+    inspect_certificate, rewrite_certificate_prepared, AttestationIdOverride, PatchComponent,
+    PatchLevels, PreparedCertificateRewriteRequest, SigningAlgorithm, MAX_ATTESTATION_ID_BYTES,
     MAX_CERTIFICATE_DER_BYTES, MAX_MODULE_HASH_BYTES,
 };
 use zeroize::Zeroize;
@@ -60,27 +60,24 @@ pub fn rewrite_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'static str>
             return Err("certificate rewrite request rejected");
         }
         let parsed = parse_rewrite_request(&request)?;
-        key_store::with_key(
-            &parsed.key_id,
-            |stored_algorithm, issuer_private_key_pkcs8, issuer_certificate_der| {
-                if stored_algorithm != parsed.signing_algorithm {
-                    return Err("opaque key algorithm does not match rewrite request");
-                }
-                rewrite_certificate(&CertificateRewriteRequest {
-                    genuine_leaf_der: parsed.genuine_leaf_der,
-                    issuer_certificate_der,
-                    issuer_private_key_pkcs8,
-                    signing_algorithm: stored_algorithm,
-                    patch_levels: parsed.patch_levels,
-                    id_overrides: &parsed.id_overrides,
-                    module_hash: parsed.module_hash,
-                    verified_boot_key: parsed.verified_boot_key,
-                    verified_boot_hash: parsed.verified_boot_hash,
-                })
-                .map(|rewritten| rewritten.leaf_der)
-                .map_err(|_| "certificate rewrite rejected")
-            },
-        )
+        key_store::with_prepared_key(&parsed.key_id, |stored_algorithm, prepared_issuer| {
+            if stored_algorithm != parsed.signing_algorithm
+                || prepared_issuer.algorithm() != stored_algorithm
+            {
+                return Err("opaque key algorithm does not match rewrite request");
+            }
+            rewrite_certificate_prepared(&PreparedCertificateRewriteRequest {
+                genuine_leaf_der: parsed.genuine_leaf_der,
+                issuer: prepared_issuer,
+                patch_levels: parsed.patch_levels,
+                id_overrides: &parsed.id_overrides,
+                module_hash: parsed.module_hash,
+                verified_boot_key: parsed.verified_boot_key,
+                verified_boot_hash: parsed.verified_boot_hash,
+            })
+            .map(|rewritten| rewritten.leaf_der)
+            .map_err(|_| "certificate rewrite rejected")
+        })
     })();
     request.zeroize();
     result

--- a/rust/backend/src/key_store.rs
+++ b/rust/backend/src/key_store.rs
@@ -118,6 +118,7 @@ fn active_key(id: &KeyId) -> Result<Arc<StoredKey>, &'static str> {
     ))
 }
 
+#[cfg(test)]
 pub fn with_key<T>(
     id: &KeyId,
     operation: impl FnOnce(SigningAlgorithm, &[u8], &[u8]) -> Result<T, &'static str>,

--- a/rust/backend/src/key_store.rs
+++ b/rust/backend/src/key_store.rs
@@ -1,7 +1,9 @@
 // Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine as _;
-use cleverestricky_certificate_core::{SigningAlgorithm, MAX_CERTIFICATE_DER_BYTES};
+use cleverestricky_certificate_core::{
+    PreparedIssuer, SigningAlgorithm, MAX_CERTIFICATE_DER_BYTES,
+};
 use cleverestricky_keybox_core::{normalize_private_key_pkcs8, public_key_spki_from_pkcs8};
 use cleverestricky_xml_core::{KeyboxDocument, MAX_KEYBOXES_PER_FILE, MAX_KEYS_PER_KEYBOX};
 use sha2::{Digest, Sha256};
@@ -29,6 +31,7 @@ struct StoredKey {
     algorithm_name: String,
     private_key_pkcs8: Zeroizing<Vec<u8>>,
     certificates_der: Vec<Vec<u8>>,
+    prepared_issuer: Option<PreparedIssuer>,
 }
 
 #[derive(Default)]
@@ -101,28 +104,42 @@ pub fn register_document(document: &KeyboxDocument) -> Result<Vec<PublicKeyRecor
     Ok(public)
 }
 
+fn active_key(id: &KeyId) -> Result<Arc<StoredKey>, &'static str> {
+    let store = STORE.get_or_init(|| Mutex::new(KeyStore::default()));
+    let guard = store.lock().map_err(|_| "keybox store lock poisoned")?;
+    if !guard.active_ids.contains(id) {
+        return Err("opaque key identifier is not active");
+    }
+    Ok(Arc::clone(
+        guard
+            .keys
+            .get(id)
+            .ok_or("opaque key identifier is not registered")?,
+    ))
+}
+
 pub fn with_key<T>(
     id: &KeyId,
     operation: impl FnOnce(SigningAlgorithm, &[u8], &[u8]) -> Result<T, &'static str>,
 ) -> Result<T, &'static str> {
-    let key = {
-        let store = STORE.get_or_init(|| Mutex::new(KeyStore::default()));
-        let guard = store.lock().map_err(|_| "keybox store lock poisoned")?;
-        if !guard.active_ids.contains(id) {
-            return Err("opaque key identifier is not active");
-        }
-        Arc::clone(
-            guard
-                .keys
-                .get(id)
-                .ok_or("opaque key identifier is not registered")?,
-        )
-    };
+    let key = active_key(id)?;
     let issuer = key
         .certificates_der
         .first()
         .ok_or("registered key has no certificate")?;
     operation(key.algorithm, key.private_key_pkcs8.as_slice(), issuer)
+}
+
+pub fn with_prepared_key<T>(
+    id: &KeyId,
+    operation: impl FnOnce(SigningAlgorithm, &PreparedIssuer) -> Result<T, &'static str>,
+) -> Result<T, &'static str> {
+    let key = active_key(id)?;
+    let prepared = key
+        .prepared_issuer
+        .as_ref()
+        .ok_or("registered key has no prepared issuer")?;
+    operation(key.algorithm, prepared)
 }
 
 pub fn retain_only(ids: &[KeyId]) -> Result<(), &'static str> {
@@ -199,6 +216,17 @@ fn build_stored_key(
         return Err("keybox private key does not match leaf certificate");
     }
 
+    // 2.6.0 kept only raw PKCS#8 + issuer DER in this store. Certificate rewrite then parsed both
+    // and verified the just-created signature again for every fresh attested key. 2.5.8 prepared
+    // keybox signer state when keyboxes were loaded. Restore that invariant inside the unprivileged
+    // Rust boundary so the Binder hot path pays only the unavoidable per-leaf rewrite and signature.
+    let prepared_issuer = PreparedIssuer::new(
+        &certificates_der[0],
+        private_key_pkcs8.as_slice(),
+        signing_algorithm,
+    )
+    .map_err(|_| "keybox issuer preparation failed")?;
+
     let id = derive_key_id(
         algorithm_name,
         private_key_pkcs8.as_slice(),
@@ -210,6 +238,7 @@ fn build_stored_key(
         algorithm_name: algorithm_name.to_string(),
         private_key_pkcs8,
         certificates_der,
+        prepared_issuer: Some(prepared_issuer),
     })
 }
 
@@ -301,6 +330,7 @@ mod tests {
             algorithm_name: "EC".to_string(),
             private_key_pkcs8: Zeroizing::new(vec![id[0].max(1)]),
             certificates_der: vec![vec![0x30, id[0]]],
+            prepared_issuer: None,
         }
     }
 
@@ -341,11 +371,18 @@ mod tests {
         let second = register_document(&document).unwrap()[0].id;
         assert_eq!(first, second);
         assert!(with_key(&first, |_, _, _| Ok(())).is_err());
+        assert!(with_prepared_key(&first, |_, _| Ok(())).is_err());
         retain_only(&[first]).unwrap();
         with_key(&first, |algorithm, private, issuer| {
             assert_eq!(algorithm, SigningAlgorithm::EcP256Sha256);
             assert!(!private.is_empty());
             assert!(!issuer.is_empty());
+            Ok(())
+        })
+        .unwrap();
+        with_prepared_key(&first, |algorithm, prepared| {
+            assert_eq!(algorithm, SigningAlgorithm::EcP256Sha256);
+            assert_eq!(prepared.algorithm(), algorithm);
             Ok(())
         })
         .unwrap();
@@ -416,9 +453,8 @@ mod tests {
         let (crypto_started_tx, crypto_started_rx) = mpsc::channel();
         let (release_crypto_tx, release_crypto_rx) = mpsc::channel();
         let crypto = std::thread::spawn(move || {
-            with_key(&id, |_, private, issuer| {
-                assert!(!private.is_empty());
-                assert!(!issuer.is_empty());
+            with_prepared_key(&id, |_, prepared| {
+                assert_eq!(prepared.algorithm(), SigningAlgorithm::EcP256Sha256);
                 crypto_started_tx.send(()).unwrap();
                 release_crypto_rx.recv().unwrap();
                 Ok(())

--- a/rust/certificate-core/src/lib.rs
+++ b/rust/certificate-core/src/lib.rs
@@ -66,7 +66,7 @@ pub struct PreparedCertificateRewriteRequest<'a> {
 
 enum PreparedSigner {
     Ec(EcSigningKey),
-    Rsa(RsaSigningKey<Sha256>),
+    Rsa(Box<RsaSigningKey<Sha256>>),
 }
 
 /// Keybox-owned issuer state that is expensive to validate but invariant across generated keys.
@@ -134,7 +134,7 @@ impl PreparedIssuer {
                 verifier
                     .verify(PREPARED_ISSUER_VALIDATION_MESSAGE, &signature)
                     .map_err(|_| Error::IssuerKeyMismatch)?;
-                PreparedSigner::Rsa(signer)
+                PreparedSigner::Rsa(Box::new(signer))
             }
         };
 

--- a/rust/certificate-core/src/lib.rs
+++ b/rust/certificate-core/src/lib.rs
@@ -34,6 +34,7 @@ const ECDSA_SHA256_ALGORITHM_DER: &[u8] = &[
 const RSA_SHA256_ALGORITHM_DER: &[u8] = &[
     0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b, 0x05, 0x00,
 ];
+const PREPARED_ISSUER_VALIDATION_MESSAGE: &[u8] = b"CleveresTricky prepared issuer validation";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SigningAlgorithm {
@@ -51,6 +52,117 @@ pub struct CertificateRewriteRequest<'a> {
     pub module_hash: Option<&'a [u8]>,
     pub verified_boot_key: &'a [u8; 32],
     pub verified_boot_hash: &'a [u8; 32],
+}
+
+pub struct PreparedCertificateRewriteRequest<'a> {
+    pub genuine_leaf_der: &'a [u8],
+    pub issuer: &'a PreparedIssuer,
+    pub patch_levels: PatchLevels,
+    pub id_overrides: &'a [AttestationIdOverride<'a>],
+    pub module_hash: Option<&'a [u8]>,
+    pub verified_boot_key: &'a [u8; 32],
+    pub verified_boot_hash: &'a [u8; 32],
+}
+
+enum PreparedSigner {
+    Ec(EcSigningKey),
+    Rsa(RsaSigningKey<Sha256>),
+}
+
+/// Keybox-owned issuer state that is expensive to validate but invariant across generated keys.
+///
+/// Construct this when a keybox is registered, not on the generateKey reply path. The constructor
+/// parses the private key and issuer certificate and proves that the key can verify under the issuer
+/// SPKI exactly once. Fresh attestation rewrites then perform only the unavoidable genuine-leaf DER
+/// rewrite plus one signature operation.
+pub struct PreparedIssuer {
+    algorithm: SigningAlgorithm,
+    issuer_name_der: Vec<u8>,
+    signer: PreparedSigner,
+}
+
+impl PreparedIssuer {
+    pub fn new(
+        issuer_certificate_der: &[u8],
+        issuer_private_key_pkcs8: &[u8],
+        signing_algorithm: SigningAlgorithm,
+    ) -> Result<Self, Error> {
+        if issuer_certificate_der.is_empty()
+            || issuer_certificate_der.len() > MAX_CERTIFICATE_DER_BYTES
+            || issuer_private_key_pkcs8.is_empty()
+            || issuer_private_key_pkcs8.len() > MAX_PRIVATE_KEY_DER_BYTES
+        {
+            return Err(Error::Bounds);
+        }
+
+        let issuer = Certificate::from_der(issuer_certificate_der)
+            .map_err(|_| Error::InvalidCertificate)?;
+        let issuer_name_der = issuer
+            .tbs_certificate()
+            .subject()
+            .to_der()
+            .map_err(|_| Error::Encoding)?;
+        let issuer_spki = issuer
+            .tbs_certificate()
+            .subject_public_key_info()
+            .to_der()
+            .map_err(|_| Error::Encoding)?;
+
+        let signer = match signing_algorithm {
+            SigningAlgorithm::EcP256Sha256 => {
+                let signer = EcSigningKey::from_pkcs8_der(issuer_private_key_pkcs8)
+                    .map_err(|_| Error::InvalidPrivateKey)?;
+                let verifier = EcVerifyingKey::from_public_key_der(&issuer_spki)
+                    .map_err(|_| Error::IssuerKeyMismatch)?;
+                let signature: EcSignature = signer
+                    .try_sign(PREPARED_ISSUER_VALIDATION_MESSAGE)
+                    .map_err(|_| Error::Signature)?;
+                verifier
+                    .verify(PREPARED_ISSUER_VALIDATION_MESSAGE, &signature)
+                    .map_err(|_| Error::IssuerKeyMismatch)?;
+                PreparedSigner::Ec(signer)
+            }
+            SigningAlgorithm::RsaPkcs1Sha256 => {
+                let signer = RsaSigningKey::<Sha256>::from_pkcs8_der(issuer_private_key_pkcs8)
+                    .map_err(|_| Error::InvalidPrivateKey)?;
+                let issuer_public = rsa::RsaPublicKey::from_public_key_der(&issuer_spki)
+                    .map_err(|_| Error::IssuerKeyMismatch)?;
+                let verifier = RsaVerifyingKey::<Sha256>::new(issuer_public);
+                let signature: RsaSignature = signer
+                    .try_sign(PREPARED_ISSUER_VALIDATION_MESSAGE)
+                    .map_err(|_| Error::Signature)?;
+                verifier
+                    .verify(PREPARED_ISSUER_VALIDATION_MESSAGE, &signature)
+                    .map_err(|_| Error::IssuerKeyMismatch)?;
+                PreparedSigner::Rsa(signer)
+            }
+        };
+
+        Ok(Self {
+            algorithm: signing_algorithm,
+            issuer_name_der,
+            signer,
+        })
+    }
+
+    pub fn algorithm(&self) -> SigningAlgorithm {
+        self.algorithm
+    }
+
+    fn sign_certificate(&self, tbs_der: &[u8], algorithm_der: &[u8]) -> Result<Vec<u8>, Error> {
+        match &self.signer {
+            PreparedSigner::Ec(signer) => {
+                let signature: EcSignature = signer.try_sign(tbs_der).map_err(|_| Error::Signature)?;
+                let signature_der = signature.to_der();
+                encode_signed_certificate(tbs_der, algorithm_der, signature_der.as_bytes())
+            }
+            PreparedSigner::Rsa(signer) => {
+                let signature: RsaSignature = signer.try_sign(tbs_der).map_err(|_| Error::Signature)?;
+                let signature_bytes = signature.to_vec();
+                encode_signed_certificate(tbs_der, algorithm_der, &signature_bytes)
+            }
+        }
+    }
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -94,11 +206,33 @@ pub fn rewrite_certificate(
     request: &CertificateRewriteRequest<'_>,
 ) -> Result<CertificateRewriteResult, Error> {
     validate_bounds(request)?;
+    let issuer = PreparedIssuer::new(
+        request.issuer_certificate_der,
+        request.issuer_private_key_pkcs8,
+        request.signing_algorithm,
+    )?;
+    rewrite_certificate_prepared(&PreparedCertificateRewriteRequest {
+        genuine_leaf_der: request.genuine_leaf_der,
+        issuer: &issuer,
+        patch_levels: request.patch_levels,
+        id_overrides: request.id_overrides,
+        module_hash: request.module_hash,
+        verified_boot_key: request.verified_boot_key,
+        verified_boot_hash: request.verified_boot_hash,
+    })
+}
+
+pub fn rewrite_certificate_prepared(
+    request: &PreparedCertificateRewriteRequest<'_>,
+) -> Result<CertificateRewriteResult, Error> {
+    if request.genuine_leaf_der.is_empty()
+        || request.genuine_leaf_der.len() > MAX_CERTIFICATE_DER_BYTES
+    {
+        return Err(Error::Bounds);
+    }
+
     let leaf =
         Certificate::from_der(request.genuine_leaf_der).map_err(|_| Error::InvalidCertificate)?;
-    let issuer = Certificate::from_der(request.issuer_certificate_der)
-        .map_err(|_| Error::InvalidCertificate)?;
-
     let mut extensions = leaf
         .tbs_certificate()
         .extensions()
@@ -124,22 +258,14 @@ pub fn rewrite_certificate(
     extensions[index].extn_value =
         OctetString::new(rewritten.extension_der).map_err(|_| Error::Encoding)?;
 
-    let algorithm_der = signature_algorithm_der(request.signing_algorithm);
-    let tbs_der = rebuild_tbs_certificate(&leaf, &issuer, &extensions, algorithm_der)?;
-    let leaf_der = match request.signing_algorithm {
-        SigningAlgorithm::EcP256Sha256 => sign_ec(
-            &tbs_der,
-            &issuer,
-            request.issuer_private_key_pkcs8,
-            algorithm_der,
-        )?,
-        SigningAlgorithm::RsaPkcs1Sha256 => sign_rsa(
-            &tbs_der,
-            &issuer,
-            request.issuer_private_key_pkcs8,
-            algorithm_der,
-        )?,
-    };
+    let algorithm_der = signature_algorithm_der(request.issuer.algorithm());
+    let tbs_der = rebuild_tbs_certificate(
+        &leaf,
+        &request.issuer.issuer_name_der,
+        &extensions,
+        algorithm_der,
+    )?;
+    let leaf_der = request.issuer.sign_certificate(&tbs_der, algorithm_der)?;
     if leaf_der.len() > MAX_CERTIFICATE_DER_BYTES {
         return Err(Error::Bounds);
     }
@@ -171,12 +297,11 @@ fn signature_algorithm_der(algorithm: SigningAlgorithm) -> &'static [u8] {
 
 fn rebuild_tbs_certificate(
     leaf: &Certificate,
-    issuer: &Certificate,
+    issuer_name_der: &[u8],
     extensions: &Extensions,
     algorithm_der: &[u8],
 ) -> Result<Vec<u8>, Error> {
     let leaf_tbs = leaf.tbs_certificate();
-    let issuer_tbs = issuer.tbs_certificate();
 
     // Match the managed X509v3CertificateBuilder oracle: rebuild from genuine serial, validity,
     // subject, SPKI and extensions; issuer comes from the selected keybox. The managed builder did
@@ -186,7 +311,6 @@ fn rebuild_tbs_certificate(
         .serial_number()
         .to_der()
         .map_err(|_| Error::Encoding)?;
-    let issuer_name = issuer_tbs.subject().to_der().map_err(|_| Error::Encoding)?;
     let validity = leaf_tbs.validity().to_der().map_err(|_| Error::Encoding)?;
     let subject = leaf_tbs.subject().to_der().map_err(|_| Error::Encoding)?;
     let spki = leaf_tbs
@@ -200,7 +324,7 @@ fn rebuild_tbs_certificate(
         &version,
         &serial,
         algorithm_der,
-        &issuer_name,
+        issuer_name_der,
         &validity,
         &subject,
         &spki,
@@ -248,57 +372,6 @@ fn encode_sequence(fields: &[&[u8]]) -> Result<Vec<u8>, Error> {
         .map_err(|_| Error::Encoding)?
         .to_der()
         .map_err(|_| Error::Encoding)
-}
-
-fn sign_ec(
-    tbs_der: &[u8],
-    issuer: &Certificate,
-    private_key_pkcs8: &[u8],
-    algorithm_der: &[u8],
-) -> Result<Vec<u8>, Error> {
-    let signer =
-        EcSigningKey::from_pkcs8_der(private_key_pkcs8).map_err(|_| Error::InvalidPrivateKey)?;
-    let signature: EcSignature = signer.try_sign(tbs_der).map_err(|_| Error::Signature)?;
-
-    let issuer_spki = issuer
-        .tbs_certificate()
-        .subject_public_key_info()
-        .to_der()
-        .map_err(|_| Error::Encoding)?;
-    let verifier =
-        EcVerifyingKey::from_public_key_der(&issuer_spki).map_err(|_| Error::IssuerKeyMismatch)?;
-    verifier
-        .verify(tbs_der, &signature)
-        .map_err(|_| Error::IssuerKeyMismatch)?;
-
-    let signature_der = signature.to_der();
-    encode_signed_certificate(tbs_der, algorithm_der, signature_der.as_bytes())
-}
-
-fn sign_rsa(
-    tbs_der: &[u8],
-    issuer: &Certificate,
-    private_key_pkcs8: &[u8],
-    algorithm_der: &[u8],
-) -> Result<Vec<u8>, Error> {
-    let signer = RsaSigningKey::<Sha256>::from_pkcs8_der(private_key_pkcs8)
-        .map_err(|_| Error::InvalidPrivateKey)?;
-    let signature: RsaSignature = signer.try_sign(tbs_der).map_err(|_| Error::Signature)?;
-
-    let issuer_spki = issuer
-        .tbs_certificate()
-        .subject_public_key_info()
-        .to_der()
-        .map_err(|_| Error::Encoding)?;
-    let issuer_public = rsa::RsaPublicKey::from_public_key_der(&issuer_spki)
-        .map_err(|_| Error::IssuerKeyMismatch)?;
-    let verifier = RsaVerifyingKey::<Sha256>::new(issuer_public);
-    verifier
-        .verify(tbs_der, &signature)
-        .map_err(|_| Error::IssuerKeyMismatch)?;
-
-    let signature_bytes = signature.to_vec();
-    encode_signed_certificate(tbs_der, algorithm_der, &signature_bytes)
 }
 
 fn encode_signed_certificate(

--- a/rust/certificate-core/src/lib.rs
+++ b/rust/certificate-core/src/lib.rs
@@ -95,8 +95,8 @@ impl PreparedIssuer {
             return Err(Error::Bounds);
         }
 
-        let issuer = Certificate::from_der(issuer_certificate_der)
-            .map_err(|_| Error::InvalidCertificate)?;
+        let issuer =
+            Certificate::from_der(issuer_certificate_der).map_err(|_| Error::InvalidCertificate)?;
         let issuer_name_der = issuer
             .tbs_certificate()
             .subject()
@@ -152,12 +152,14 @@ impl PreparedIssuer {
     fn sign_certificate(&self, tbs_der: &[u8], algorithm_der: &[u8]) -> Result<Vec<u8>, Error> {
         match &self.signer {
             PreparedSigner::Ec(signer) => {
-                let signature: EcSignature = signer.try_sign(tbs_der).map_err(|_| Error::Signature)?;
+                let signature: EcSignature =
+                    signer.try_sign(tbs_der).map_err(|_| Error::Signature)?;
                 let signature_der = signature.to_der();
                 encode_signed_certificate(tbs_der, algorithm_der, signature_der.as_bytes())
             }
             PreparedSigner::Rsa(signer) => {
-                let signature: RsaSignature = signer.try_sign(tbs_der).map_err(|_| Error::Signature)?;
+                let signature: RsaSignature =
+                    signer.try_sign(tbs_der).map_err(|_| Error::Signature)?;
                 let signature_bytes = signature.to_vec();
                 encode_signed_certificate(tbs_der, algorithm_der, &signature_bytes)
             }

--- a/rust/certificate-core/tests/prepared_rewrite.rs
+++ b/rust/certificate-core/tests/prepared_rewrite.rs
@@ -1,0 +1,90 @@
+// Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
+mod fixture {
+    include!("rewrite.rs");
+
+    pub(super) fn run_prepared_fixture(xml: &[u8], algorithm: SigningAlgorithm) {
+        let document = parse_keybox_xml_bytes(xml).expect("fixture XML");
+        let key = document.keys.first().expect("fixture key");
+        let private_key = normalize_private_key_pkcs8(&key.algorithm, &key.private_key_pem)
+            .expect("fixture key DER");
+        let issuer_pem = key
+            .certificates_pem
+            .first()
+            .expect("fixture issuer certificate");
+        let issuer = Certificate::from_pem(normalized_pem(issuer_pem).as_bytes())
+            .expect("fixture issuer DER");
+        let genuine = synthetic_genuine_leaf(&issuer);
+        let genuine_der = genuine.to_der().expect("genuine DER");
+        let issuer_der = issuer.to_der().expect("issuer DER");
+        let ids = [AttestationIdOverride {
+            tag: IMEI_TAG,
+            value: b"new-imei",
+        }];
+        let prepared = cleverestricky_certificate_core::PreparedIssuer::new(
+            &issuer_der,
+            private_key.as_slice(),
+            algorithm,
+        )
+        .expect("prepared issuer");
+
+        let rewritten = cleverestricky_certificate_core::rewrite_certificate_prepared(
+            &cleverestricky_certificate_core::PreparedCertificateRewriteRequest {
+                genuine_leaf_der: &genuine_der,
+                issuer: &prepared,
+                patch_levels: PatchLevels {
+                    system: PatchComponent::replace(202512),
+                    vendor: PatchComponent::KEEP,
+                    boot: PatchComponent::KEEP,
+                },
+                id_overrides: &ids,
+                module_hash: Some(b"new-module-hash"),
+                verified_boot_key: &BOOT_KEY,
+                verified_boot_hash: &BOOT_HASH,
+            },
+        )
+        .expect("prepared Rust certificate rewrite");
+
+        assert_eq!(
+            rewritten.captured_patch_levels,
+            CapturedPatchLevels {
+                system: Some(202401),
+                vendor: None,
+                boot: None,
+            },
+        );
+        let output = Certificate::from_der(&rewritten.leaf_der).expect("rewritten certificate DER");
+        assert_eq!(
+            output.tbs_certificate().subject_public_key_info(),
+            genuine.tbs_certificate().subject_public_key_info(),
+        );
+        assert_eq!(
+            output.tbs_certificate().issuer(),
+            issuer.tbs_certificate().subject(),
+        );
+        verify_signature(&output, &issuer, algorithm);
+    }
+
+    pub(super) fn ec() -> &'static [u8] {
+        VALID_EC
+    }
+
+    pub(super) fn rsa() -> &'static [u8] {
+        VALID_RSA
+    }
+}
+
+#[test]
+fn prepared_ec_issuer_rewrites_and_signs_without_per_call_key_parse() {
+    fixture::run_prepared_fixture(
+        fixture::ec(),
+        cleverestricky_certificate_core::SigningAlgorithm::EcP256Sha256,
+    );
+}
+
+#[test]
+fn prepared_rsa_issuer_rewrites_and_signs_without_per_call_key_parse() {
+    fixture::run_prepared_fixture(
+        fixture::rsa(),
+        cleverestricky_certificate_core::SigningAlgorithm::RsaPkcs1Sha256,
+    );
+}


### PR DESCRIPTION
## Problem

The post-#960 device replay is still positive and is now clearly outside noise: **attested 0.571 ms**, **non-attested 0.492 ms**, **diff 0.079 ms**, **ratio 1.160x**, `failedPairs=0/500`, `samples=440`, threshold `>1.1x`.

#960 removed an avoidable inspection round trip on the default path, but the result proves that was not the dominant cost. This PR follows the remaining rewrite path all the way into the Rust crypto implementation instead of applying another small managed-side shortcut.

## Root cause

The 2.5.8 implementation prepared keybox signing state when keyboxes were loaded. The fresh `generateKey` path reused the already-parsed private key/provider state and performed the certificate rewrite/sign operation.

The 2.6 Rust-first migration changed that invariant. The backend key store retained raw PKCS#8 and issuer DER, and every fresh attested key then called `rewrite_certificate()` which:

1. parsed the genuine leaf,
2. parsed the invariant issuer certificate again,
3. parsed the invariant EC/RSA private key from PKCS#8 again,
4. rewrote/rebuilt the certificate,
5. signed it,
6. re-encoded and reparsed the issuer public key,
7. verified the signature that had just been generated,
8. encoded the result.

All of the invariant keybox crypto above is paid only on the attested path. The non-attested control exits before the Rust certificate backend. That makes the work directly observable in the paired timing probe. The new 79us delta is consistent with this class of repeated crypto preparation/verification and explains why merely removing the inspection IPC did not solve the regression.

## Fix

- Add a Rust `PreparedIssuer` owned by the unprivileged backend key store.
- Build it once when a keybox is registered: parse issuer DER, parse the private key, encode issuer identity, and prove key/certificate pairing once with a validation signature.
- Keep the key opaque to the Android service; no private key material crosses the backend boundary.
- Fresh certificate rewrite now reuses the prepared signer and issuer identity and performs only genuine-leaf parse/rewrite, the unavoidable one certificate signature, and encoding.
- Remove the redundant per-attestation issuer/private-key parsing and post-signature self-verification from the production hot path.
- Keep the existing LocalSocket protocol/opcode unchanged.
- Keep all DER/attestation rewriting and signing in Rust.
- No synthetic delay, no slower non-attested path, and no threshold relaxation.

## Why this is structurally different from #960

#960 optimized orchestration around the rewrite. This PR removes invariant cryptographic work *inside* the remaining rewrite transaction and restores the same preparation boundary that made 2.5.8 fast: keybox-specific work happens at keybox activation, per-key work happens at `generateKey`.

## Validation

Required before this leaves draft:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- Build + Security Regression + Native Hardening + Rust Fuzz/Lockfile workflows
- physical-device fresh-key paired replay, 500 pairs; acceptance remains **ratio < 1.1x** and `failedPairs=0`

The PR remains draft until CI is fully green and the device timing gate is actually below the existing threshold.