### PR TITLE
perf: remove X509 work from measured getKeyEntry attestation path

### DIFF
--- a/rust/backend/src/certificate_wire.rs
+++ b/rust/backend/src/certificate_wire.rs
@@ -1,8 +1,8 @@
 // Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
 use crate::keybox_wire::key_store::{self, KeyId, KEY_ID_BYTES};
 use cleverestricky_certificate_core::{
-    inspect_certificate, rewrite_certificate, AttestationIdOverride, CertificateRewriteRequest,
-    PatchComponent, PatchLevels, SigningAlgorithm, MAX_ATTESTATION_ID_BYTES,
+    inspect_certificate, rewrite_certificate_prepared, AttestationIdOverride, PatchComponent,
+    PatchLevels, PreparedCertificateRewriteRequest, SigningAlgorithm, MAX_ATTESTATION_ID_BYTES,
     MAX_CERTIFICATE_DER_BYTES, MAX_MODULE_HASH_BYTES,
 };
 use zeroize::Zeroize;
@@ -60,27 +60,24 @@ pub fn rewrite_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'static str>
             return Err("certificate rewrite request rejected");
         }
         let parsed = parse_rewrite_request(&request)?;
-        key_store::with_key(
-            &parsed.key_id,
-            |stored_algorithm, issuer_private_key_pkcs8, issuer_certificate_der| {
-                if stored_algorithm != parsed.signing_algorithm {
-                    return Err("opaque key algorithm does not match rewrite request");
-                }
-                rewrite_certificate(&CertificateRewriteRequest {
-                    genuine_leaf_der: parsed.genuine_leaf_der,
-                    issuer_certificate_der,
-                    issuer_private_key_pkcs8,
-                    signing_algorithm: stored_algorithm,
-                    patch_levels: parsed.patch_levels,
-                    id_overrides: &parsed.id_overrides,
-                    module_hash: parsed.module_hash,
-                    verified_boot_key: parsed.verified_boot_key,
-                    verified_boot_hash: parsed.verified_boot_hash,
-                })
-                .map(|rewritten| rewritten.leaf_der)
-                .map_err(|_| "certificate rewrite rejected")
-            },
-        )
+        key_store::with_prepared_key(&parsed.key_id, |stored_algorithm, prepared_issuer| {
+            if stored_algorithm != parsed.signing_algorithm
+                || prepared_issuer.algorithm() != stored_algorithm
+            {
+                return Err("opaque key algorithm does not match rewrite request");
+            }
+            rewrite_certificate_prepared(&PreparedCertificateRewriteRequest {
+                genuine_leaf_der: parsed.genuine_leaf_der,
+                issuer: prepared_issuer,
+                patch_levels: parsed.patch_levels,
+                id_overrides: &parsed.id_overrides,
+                module_hash: parsed.module_hash,
+                verified_boot_key: parsed.verified_boot_key,
+                verified_boot_hash: parsed.verified_boot_hash,
+            })
+            .map(|rewritten| rewritten.leaf_der)
+            .map_err(|_| "certificate rewrite rejected")
+        })
     })();
     request.zeroize();
     result

--- a/rust/backend/src/key_store.rs
+++ b/rust/backend/src/key_store.rs
@@ -118,6 +118,7 @@ fn active_key(id: &KeyId) -> Result<Arc<StoredKey>, &'static str> {
     ))
 }
 
+#[cfg(test)]
 pub fn with_key<T>(
     id: &KeyId,
     operation: impl FnOnce(SigningAlgorithm, &[u8], &[u8]) -> Result<T, &'static str>,

--- a/rust/backend/src/key_store.rs
+++ b/rust/backend/src/key_store.rs
@@ -1,7 +1,9 @@
 // Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine as _;
-use cleverestricky_certificate_core::{SigningAlgorithm, MAX_CERTIFICATE_DER_BYTES};
+use cleverestricky_certificate_core::{
+    PreparedIssuer, SigningAlgorithm, MAX_CERTIFICATE_DER_BYTES,
+};
 use cleverestricky_keybox_core::{normalize_private_key_pkcs8, public_key_spki_from_pkcs8};
 use cleverestricky_xml_core::{KeyboxDocument, MAX_KEYBOXES_PER_FILE, MAX_KEYS_PER_KEYBOX};
 use sha2::{Digest, Sha256};
@@ -29,6 +31,7 @@ struct StoredKey {
     algorithm_name: String,
     private_key_pkcs8: Zeroizing<Vec<u8>>,
     certificates_der: Vec<Vec<u8>>,
+    prepared_issuer: Option<PreparedIssuer>,
 }
 
 #[derive(Default)]
@@ -101,28 +104,42 @@ pub fn register_document(document: &KeyboxDocument) -> Result<Vec<PublicKeyRecor
     Ok(public)
 }
 
+fn active_key(id: &KeyId) -> Result<Arc<StoredKey>, &'static str> {
+    let store = STORE.get_or_init(|| Mutex::new(KeyStore::default()));
+    let guard = store.lock().map_err(|_| "keybox store lock poisoned")?;
+    if !guard.active_ids.contains(id) {
+        return Err("opaque key identifier is not active");
+    }
+    Ok(Arc::clone(
+        guard
+            .keys
+            .get(id)
+            .ok_or("opaque key identifier is not registered")?,
+    ))
+}
+
 pub fn with_key<T>(
     id: &KeyId,
     operation: impl FnOnce(SigningAlgorithm, &[u8], &[u8]) -> Result<T, &'static str>,
 ) -> Result<T, &'static str> {
-    let key = {
-        let store = STORE.get_or_init(|| Mutex::new(KeyStore::default()));
-        let guard = store.lock().map_err(|_| "keybox store lock poisoned")?;
-        if !guard.active_ids.contains(id) {
-            return Err("opaque key identifier is not active");
-        }
-        Arc::clone(
-            guard
-                .keys
-                .get(id)
-                .ok_or("opaque key identifier is not registered")?,
-        )
-    };
+    let key = active_key(id)?;
     let issuer = key
         .certificates_der
         .first()
         .ok_or("registered key has no certificate")?;
     operation(key.algorithm, key.private_key_pkcs8.as_slice(), issuer)
+}
+
+pub fn with_prepared_key<T>(
+    id: &KeyId,
+    operation: impl FnOnce(SigningAlgorithm, &PreparedIssuer) -> Result<T, &'static str>,
+) -> Result<T, &'static str> {
+    let key = active_key(id)?;
+    let prepared = key
+        .prepared_issuer
+        .as_ref()
+        .ok_or("registered key has no prepared issuer")?;
+    operation(key.algorithm, prepared)
 }
 
 pub fn retain_only(ids: &[KeyId]) -> Result<(), &'static str> {
@@ -199,6 +216,17 @@ fn build_stored_key(
         return Err("keybox private key does not match leaf certificate");
     }
 
+    // 2.6.0 kept only raw PKCS#8 + issuer DER in this store. Certificate rewrite then parsed both
+    // and verified the just-created signature again for every fresh attested key. 2.5.8 prepared
+    // keybox signer state when keyboxes were loaded. Restore that invariant inside the unprivileged
+    // Rust boundary so the Binder hot path pays only the unavoidable per-leaf rewrite and signature.
+    let prepared_issuer = PreparedIssuer::new(
+        &certificates_der[0],
+        private_key_pkcs8.as_slice(),
+        signing_algorithm,
+    )
+    .map_err(|_| "keybox issuer preparation failed")?;
+
     let id = derive_key_id(
         algorithm_name,
         private_key_pkcs8.as_slice(),
@@ -210,6 +238,7 @@ fn build_stored_key(
         algorithm_name: algorithm_name.to_string(),
         private_key_pkcs8,
         certificates_der,
+        prepared_issuer: Some(prepared_issuer),
     })
 }
 
@@ -301,6 +330,7 @@ mod tests {
             algorithm_name: "EC".to_string(),
             private_key_pkcs8: Zeroizing::new(vec![id[0].max(1)]),
             certificates_der: vec![vec![0x30, id[0]]],
+            prepared_issuer: None,
         }
     }
 
@@ -341,11 +371,18 @@ mod tests {
         let second = register_document(&document).unwrap()[0].id;
         assert_eq!(first, second);
         assert!(with_key(&first, |_, _, _| Ok(())).is_err());
+        assert!(with_prepared_key(&first, |_, _| Ok(())).is_err());
         retain_only(&[first]).unwrap();
         with_key(&first, |algorithm, private, issuer| {
             assert_eq!(algorithm, SigningAlgorithm::EcP256Sha256);
             assert!(!private.is_empty());
             assert!(!issuer.is_empty());
+            Ok(())
+        })
+        .unwrap();
+        with_prepared_key(&first, |algorithm, prepared| {
+            assert_eq!(algorithm, SigningAlgorithm::EcP256Sha256);
+            assert_eq!(prepared.algorithm(), algorithm);
             Ok(())
         })
         .unwrap();
@@ -416,9 +453,8 @@ mod tests {
         let (crypto_started_tx, crypto_started_rx) = mpsc::channel();
         let (release_crypto_tx, release_crypto_rx) = mpsc::channel();
         let crypto = std::thread::spawn(move || {
-            with_key(&id, |_, private, issuer| {
-                assert!(!private.is_empty());
-                assert!(!issuer.is_empty());
+            with_prepared_key(&id, |_, prepared| {
+                assert_eq!(prepared.algorithm(), SigningAlgorithm::EcP256Sha256);
                 crypto_started_tx.send(()).unwrap();
                 release_crypto_rx.recv().unwrap();
                 Ok(())

--- a/rust/certificate-core/src/lib.rs
+++ b/rust/certificate-core/src/lib.rs
@@ -66,7 +66,7 @@ pub struct PreparedCertificateRewriteRequest<'a> {
 
 enum PreparedSigner {
     Ec(EcSigningKey),
-    Rsa(RsaSigningKey<Sha256>),
+    Rsa(Box<RsaSigningKey<Sha256>>),
 }
 
 /// Keybox-owned issuer state that is expensive to validate but invariant across generated keys.
@@ -134,7 +134,7 @@ impl PreparedIssuer {
                 verifier
                     .verify(PREPARED_ISSUER_VALIDATION_MESSAGE, &signature)
                     .map_err(|_| Error::IssuerKeyMismatch)?;
-                PreparedSigner::Rsa(signer)
+                PreparedSigner::Rsa(Box::new(signer))
             }
         };
 

--- a/rust/certificate-core/src/lib.rs
+++ b/rust/certificate-core/src/lib.rs
@@ -34,6 +34,7 @@ const ECDSA_SHA256_ALGORITHM_DER: &[u8] = &[
 const RSA_SHA256_ALGORITHM_DER: &[u8] = &[
     0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b, 0x05, 0x00,
 ];
+const PREPARED_ISSUER_VALIDATION_MESSAGE: &[u8] = b"CleveresTricky prepared issuer validation";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SigningAlgorithm {
@@ -51,6 +52,117 @@ pub struct CertificateRewriteRequest<'a> {
     pub module_hash: Option<&'a [u8]>,
     pub verified_boot_key: &'a [u8; 32],
     pub verified_boot_hash: &'a [u8; 32],
+}
+
+pub struct PreparedCertificateRewriteRequest<'a> {
+    pub genuine_leaf_der: &'a [u8],
+    pub issuer: &'a PreparedIssuer,
+    pub patch_levels: PatchLevels,
+    pub id_overrides: &'a [AttestationIdOverride<'a>],
+    pub module_hash: Option<&'a [u8]>,
+    pub verified_boot_key: &'a [u8; 32],
+    pub verified_boot_hash: &'a [u8; 32],
+}
+
+enum PreparedSigner {
+    Ec(EcSigningKey),
+    Rsa(RsaSigningKey<Sha256>),
+}
+
+/// Keybox-owned issuer state that is expensive to validate but invariant across generated keys.
+///
+/// Construct this when a keybox is registered, not on the generateKey reply path. The constructor
+/// parses the private key and issuer certificate and proves that the key can verify under the issuer
+/// SPKI exactly once. Fresh attestation rewrites then perform only the unavoidable genuine-leaf DER
+/// rewrite plus one signature operation.
+pub struct PreparedIssuer {
+    algorithm: SigningAlgorithm,
+    issuer_name_der: Vec<u8>,
+    signer: PreparedSigner,
+}
+
+impl PreparedIssuer {
+    pub fn new(
+        issuer_certificate_der: &[u8],
+        issuer_private_key_pkcs8: &[u8],
+        signing_algorithm: SigningAlgorithm,
+    ) -> Result<Self, Error> {
+        if issuer_certificate_der.is_empty()
+            || issuer_certificate_der.len() > MAX_CERTIFICATE_DER_BYTES
+            || issuer_private_key_pkcs8.is_empty()
+            || issuer_private_key_pkcs8.len() > MAX_PRIVATE_KEY_DER_BYTES
+        {
+            return Err(Error::Bounds);
+        }
+
+        let issuer = Certificate::from_der(issuer_certificate_der)
+            .map_err(|_| Error::InvalidCertificate)?;
+        let issuer_name_der = issuer
+            .tbs_certificate()
+            .subject()
+            .to_der()
+            .map_err(|_| Error::Encoding)?;
+        let issuer_spki = issuer
+            .tbs_certificate()
+            .subject_public_key_info()
+            .to_der()
+            .map_err(|_| Error::Encoding)?;
+
+        let signer = match signing_algorithm {
+            SigningAlgorithm::EcP256Sha256 => {
+                let signer = EcSigningKey::from_pkcs8_der(issuer_private_key_pkcs8)
+                    .map_err(|_| Error::InvalidPrivateKey)?;
+                let verifier = EcVerifyingKey::from_public_key_der(&issuer_spki)
+                    .map_err(|_| Error::IssuerKeyMismatch)?;
+                let signature: EcSignature = signer
+                    .try_sign(PREPARED_ISSUER_VALIDATION_MESSAGE)
+                    .map_err(|_| Error::Signature)?;
+                verifier
+                    .verify(PREPARED_ISSUER_VALIDATION_MESSAGE, &signature)
+                    .map_err(|_| Error::IssuerKeyMismatch)?;
+                PreparedSigner::Ec(signer)
+            }
+            SigningAlgorithm::RsaPkcs1Sha256 => {
+                let signer = RsaSigningKey::<Sha256>::from_pkcs8_der(issuer_private_key_pkcs8)
+                    .map_err(|_| Error::InvalidPrivateKey)?;
+                let issuer_public = rsa::RsaPublicKey::from_public_key_der(&issuer_spki)
+                    .map_err(|_| Error::IssuerKeyMismatch)?;
+                let verifier = RsaVerifyingKey::<Sha256>::new(issuer_public);
+                let signature: RsaSignature = signer
+                    .try_sign(PREPARED_ISSUER_VALIDATION_MESSAGE)
+                    .map_err(|_| Error::Signature)?;
+                verifier
+                    .verify(PREPARED_ISSUER_VALIDATION_MESSAGE, &signature)
+                    .map_err(|_| Error::IssuerKeyMismatch)?;
+                PreparedSigner::Rsa(signer)
+            }
+        };
+
+        Ok(Self {
+            algorithm: signing_algorithm,
+            issuer_name_der,
+            signer,
+        })
+    }
+
+    pub fn algorithm(&self) -> SigningAlgorithm {
+        self.algorithm
+    }
+
+    fn sign_certificate(&self, tbs_der: &[u8], algorithm_der: &[u8]) -> Result<Vec<u8>, Error> {
+        match &self.signer {
+            PreparedSigner::Ec(signer) => {
+                let signature: EcSignature = signer.try_sign(tbs_der).map_err(|_| Error::Signature)?;
+                let signature_der = signature.to_der();
+                encode_signed_certificate(tbs_der, algorithm_der, signature_der.as_bytes())
+            }
+            PreparedSigner::Rsa(signer) => {
+                let signature: RsaSignature = signer.try_sign(tbs_der).map_err(|_| Error::Signature)?;
+                let signature_bytes = signature.to_vec();
+                encode_signed_certificate(tbs_der, algorithm_der, &signature_bytes)
+            }
+        }
+    }
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -94,11 +206,33 @@ pub fn rewrite_certificate(
     request: &CertificateRewriteRequest<'_>,
 ) -> Result<CertificateRewriteResult, Error> {
     validate_bounds(request)?;
+    let issuer = PreparedIssuer::new(
+        request.issuer_certificate_der,
+        request.issuer_private_key_pkcs8,
+        request.signing_algorithm,
+    )?;
+    rewrite_certificate_prepared(&PreparedCertificateRewriteRequest {
+        genuine_leaf_der: request.genuine_leaf_der,
+        issuer: &issuer,
+        patch_levels: request.patch_levels,
+        id_overrides: request.id_overrides,
+        module_hash: request.module_hash,
+        verified_boot_key: request.verified_boot_key,
+        verified_boot_hash: request.verified_boot_hash,
+    })
+}
+
+pub fn rewrite_certificate_prepared(
+    request: &PreparedCertificateRewriteRequest<'_>,
+) -> Result<CertificateRewriteResult, Error> {
+    if request.genuine_leaf_der.is_empty()
+        || request.genuine_leaf_der.len() > MAX_CERTIFICATE_DER_BYTES
+    {
+        return Err(Error::Bounds);
+    }
+
     let leaf =
         Certificate::from_der(request.genuine_leaf_der).map_err(|_| Error::InvalidCertificate)?;
-    let issuer = Certificate::from_der(request.issuer_certificate_der)
-        .map_err(|_| Error::InvalidCertificate)?;
-
     let mut extensions = leaf
         .tbs_certificate()
         .extensions()
@@ -124,22 +258,14 @@ pub fn rewrite_certificate(
     extensions[index].extn_value =
         OctetString::new(rewritten.extension_der).map_err(|_| Error::Encoding)?;
 
-    let algorithm_der = signature_algorithm_der(request.signing_algorithm);
-    let tbs_der = rebuild_tbs_certificate(&leaf, &issuer, &extensions, algorithm_der)?;
-    let leaf_der = match request.signing_algorithm {
-        SigningAlgorithm::EcP256Sha256 => sign_ec(
-            &tbs_der,
-            &issuer,
-            request.issuer_private_key_pkcs8,
-            algorithm_der,
-        )?,
-        SigningAlgorithm::RsaPkcs1Sha256 => sign_rsa(
-            &tbs_der,
-            &issuer,
-            request.issuer_private_key_pkcs8,
-            algorithm_der,
-        )?,
-    };
+    let algorithm_der = signature_algorithm_der(request.issuer.algorithm());
+    let tbs_der = rebuild_tbs_certificate(
+        &leaf,
+        &request.issuer.issuer_name_der,
+        &extensions,
+        algorithm_der,
+    )?;
+    let leaf_der = request.issuer.sign_certificate(&tbs_der, algorithm_der)?;
     if leaf_der.len() > MAX_CERTIFICATE_DER_BYTES {
         return Err(Error::Bounds);
     }
@@ -171,12 +297,11 @@ fn signature_algorithm_der(algorithm: SigningAlgorithm) -> &'static [u8] {
 
 fn rebuild_tbs_certificate(
     leaf: &Certificate,
-    issuer: &Certificate,
+    issuer_name_der: &[u8],
     extensions: &Extensions,
     algorithm_der: &[u8],
 ) -> Result<Vec<u8>, Error> {
     let leaf_tbs = leaf.tbs_certificate();
-    let issuer_tbs = issuer.tbs_certificate();
 
     // Match the managed X509v3CertificateBuilder oracle: rebuild from genuine serial, validity,
     // subject, SPKI and extensions; issuer comes from the selected keybox. The managed builder did
@@ -186,7 +311,6 @@ fn rebuild_tbs_certificate(
         .serial_number()
         .to_der()
         .map_err(|_| Error::Encoding)?;
-    let issuer_name = issuer_tbs.subject().to_der().map_err(|_| Error::Encoding)?;
     let validity = leaf_tbs.validity().to_der().map_err(|_| Error::Encoding)?;
     let subject = leaf_tbs.subject().to_der().map_err(|_| Error::Encoding)?;
     let spki = leaf_tbs
@@ -200,7 +324,7 @@ fn rebuild_tbs_certificate(
         &version,
         &serial,
         algorithm_der,
-        &issuer_name,
+        issuer_name_der,
         &validity,
         &subject,
         &spki,
@@ -248,57 +372,6 @@ fn encode_sequence(fields: &[&[u8]]) -> Result<Vec<u8>, Error> {
         .map_err(|_| Error::Encoding)?
         .to_der()
         .map_err(|_| Error::Encoding)
-}
-
-fn sign_ec(
-    tbs_der: &[u8],
-    issuer: &Certificate,
-    private_key_pkcs8: &[u8],
-    algorithm_der: &[u8],
-) -> Result<Vec<u8>, Error> {
-    let signer =
-        EcSigningKey::from_pkcs8_der(private_key_pkcs8).map_err(|_| Error::InvalidPrivateKey)?;
-    let signature: EcSignature = signer.try_sign(tbs_der).map_err(|_| Error::Signature)?;
-
-    let issuer_spki = issuer
-        .tbs_certificate()
-        .subject_public_key_info()
-        .to_der()
-        .map_err(|_| Error::Encoding)?;
-    let verifier =
-        EcVerifyingKey::from_public_key_der(&issuer_spki).map_err(|_| Error::IssuerKeyMismatch)?;
-    verifier
-        .verify(tbs_der, &signature)
-        .map_err(|_| Error::IssuerKeyMismatch)?;
-
-    let signature_der = signature.to_der();
-    encode_signed_certificate(tbs_der, algorithm_der, signature_der.as_bytes())
-}
-
-fn sign_rsa(
-    tbs_der: &[u8],
-    issuer: &Certificate,
-    private_key_pkcs8: &[u8],
-    algorithm_der: &[u8],
-) -> Result<Vec<u8>, Error> {
-    let signer = RsaSigningKey::<Sha256>::from_pkcs8_der(private_key_pkcs8)
-        .map_err(|_| Error::InvalidPrivateKey)?;
-    let signature: RsaSignature = signer.try_sign(tbs_der).map_err(|_| Error::Signature)?;
-
-    let issuer_spki = issuer
-        .tbs_certificate()
-        .subject_public_key_info()
-        .to_der()
-        .map_err(|_| Error::Encoding)?;
-    let issuer_public = rsa::RsaPublicKey::from_public_key_der(&issuer_spki)
-        .map_err(|_| Error::IssuerKeyMismatch)?;
-    let verifier = RsaVerifyingKey::<Sha256>::new(issuer_public);
-    verifier
-        .verify(tbs_der, &signature)
-        .map_err(|_| Error::IssuerKeyMismatch)?;
-
-    let signature_bytes = signature.to_vec();
-    encode_signed_certificate(tbs_der, algorithm_der, &signature_bytes)
 }
 
 fn encode_signed_certificate(

--- a/rust/certificate-core/src/lib.rs
+++ b/rust/certificate-core/src/lib.rs
@@ -95,8 +95,8 @@ impl PreparedIssuer {
             return Err(Error::Bounds);
         }
 
-        let issuer = Certificate::from_der(issuer_certificate_der)
-            .map_err(|_| Error::InvalidCertificate)?;
+        let issuer =
+            Certificate::from_der(issuer_certificate_der).map_err(|_| Error::InvalidCertificate)?;
         let issuer_name_der = issuer
             .tbs_certificate()
             .subject()
@@ -152,12 +152,14 @@ impl PreparedIssuer {
     fn sign_certificate(&self, tbs_der: &[u8], algorithm_der: &[u8]) -> Result<Vec<u8>, Error> {
         match &self.signer {
             PreparedSigner::Ec(signer) => {
-                let signature: EcSignature = signer.try_sign(tbs_der).map_err(|_| Error::Signature)?;
+                let signature: EcSignature =
+                    signer.try_sign(tbs_der).map_err(|_| Error::Signature)?;
                 let signature_der = signature.to_der();
                 encode_signed_certificate(tbs_der, algorithm_der, signature_der.as_bytes())
             }
             PreparedSigner::Rsa(signer) => {
-                let signature: RsaSignature = signer.try_sign(tbs_der).map_err(|_| Error::Signature)?;
+                let signature: RsaSignature =
+                    signer.try_sign(tbs_der).map_err(|_| Error::Signature)?;
                 let signature_bytes = signature.to_vec();
                 encode_signed_certificate(tbs_der, algorithm_der, &signature_bytes)
             }

--- a/rust/certificate-core/tests/prepared_rewrite.rs
+++ b/rust/certificate-core/tests/prepared_rewrite.rs
@@ -1,0 +1,90 @@
+// Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
+mod fixture {
+    include!("rewrite.rs");
+
+    pub(super) fn run_prepared_fixture(xml: &[u8], algorithm: SigningAlgorithm) {
+        let document = parse_keybox_xml_bytes(xml).expect("fixture XML");
+        let key = document.keys.first().expect("fixture key");
+        let private_key = normalize_private_key_pkcs8(&key.algorithm, &key.private_key_pem)
+            .expect("fixture key DER");
+        let issuer_pem = key
+            .certificates_pem
+            .first()
+            .expect("fixture issuer certificate");
+        let issuer = Certificate::from_pem(normalized_pem(issuer_pem).as_bytes())
+            .expect("fixture issuer DER");
+        let genuine = synthetic_genuine_leaf(&issuer);
+        let genuine_der = genuine.to_der().expect("genuine DER");
+        let issuer_der = issuer.to_der().expect("issuer DER");
+        let ids = [AttestationIdOverride {
+            tag: IMEI_TAG,
+            value: b"new-imei",
+        }];
+        let prepared = cleverestricky_certificate_core::PreparedIssuer::new(
+            &issuer_der,
+            private_key.as_slice(),
+            algorithm,
+        )
+        .expect("prepared issuer");
+
+        let rewritten = cleverestricky_certificate_core::rewrite_certificate_prepared(
+            &cleverestricky_certificate_core::PreparedCertificateRewriteRequest {
+                genuine_leaf_der: &genuine_der,
+                issuer: &prepared,
+                patch_levels: PatchLevels {
+                    system: PatchComponent::replace(202512),
+                    vendor: PatchComponent::KEEP,
+                    boot: PatchComponent::KEEP,
+                },
+                id_overrides: &ids,
+                module_hash: Some(b"new-module-hash"),
+                verified_boot_key: &BOOT_KEY,
+                verified_boot_hash: &BOOT_HASH,
+            },
+        )
+        .expect("prepared Rust certificate rewrite");
+
+        assert_eq!(
+            rewritten.captured_patch_levels,
+            CapturedPatchLevels {
+                system: Some(202401),
+                vendor: None,
+                boot: None,
+            },
+        );
+        let output = Certificate::from_der(&rewritten.leaf_der).expect("rewritten certificate DER");
+        assert_eq!(
+            output.tbs_certificate().subject_public_key_info(),
+            genuine.tbs_certificate().subject_public_key_info(),
+        );
+        assert_eq!(
+            output.tbs_certificate().issuer(),
+            issuer.tbs_certificate().subject(),
+        );
+        verify_signature(&output, &issuer, algorithm);
+    }
+
+    pub(super) fn ec() -> &'static [u8] {
+        VALID_EC
+    }
+
+    pub(super) fn rsa() -> &'static [u8] {
+        VALID_RSA
+    }
+}
+
+#[test]
+fn prepared_ec_issuer_rewrites_and_signs_without_per_call_key_parse() {
+    fixture::run_prepared_fixture(
+        fixture::ec(),
+        cleverestricky_certificate_core::SigningAlgorithm::EcP256Sha256,
+    );
+}
+
+#[test]
+fn prepared_rsa_issuer_rewrites_and_signs_without_per_call_key_parse() {
+    fixture::run_prepared_fixture(
+        fixture::rsa(),
+        cleverestricky_certificate_core::SigningAlgorithm::RsaPkcs1Sha256,
+    );
+}

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -77,39 +77,48 @@ object KeystoreInterceptor : BinderInterceptor() {
         val p = Parcel.obtain()
         try {
             val response = reply.readTypedObject(KeyEntryResponse.CREATOR)
-            val originalChain = Utils.getCertificateChain(response)
+            if (response == null || response.metadata == null) {
+                p.recycle()
+                return Skip
+            }
             val targeted = Config.needHack(callingUid)
-            val newChain =
-                if (originalChain == null) {
-                    null
-                } else if (targeted) {
-                    // Keep ordinary key readback entirely local. Attested readback normally hits
-                    // CertHack's in-memory replacement cache; sending only the non-attested path
-                    // through CertificateBackend.inspect adds a measurable UDS/parser asymmetry.
-                    // The leaf is already parsed, so reject the negative case by fixed extension OID.
-                    val originalLeaf = originalChain.firstOrNull()
-                    if (
-                        originalLeaf == null ||
-                        !Utils.hasAndroidAttestationExtension(originalLeaf)
-                    ) {
-                        null
-                    } else {
-                        CertHack.hackCertificateChain(originalChain, callingUid).takeUnless { it === originalChain }
-                    }
-                } else {
-                    // A grant or isolated process is allowed to observe the chain already returned
-                    // to the key owner, but it must not synthesize a new per-reader chain.
-                    CertHack.getCachedCertificateChain(originalChain)
-                }
+            val mayReadGrantedChain = callingUid >= FIRST_APPLICATION_UID
 
+            // Duck Detector's timing probe creates the keys once and then measures repeated
+            // service.getKeyEntry calls. generateKey has already populated CertHack's replacement
+            // cache for an attested key, so try the genuine raw leaf DER before constructing any
+            // X509Certificate objects. A hit assigns the already-encoded replacement leaf/issuers
+            // directly to KeyMetadata and avoids CertificateFactory, Certificate[] allocation,
+            // getEncoded(), issuer parsing and every Rust backend operation on the measured path.
+            if (
+                (targeted || mayReadGrantedChain) &&
+                CertHack.applyCachedCertificateChain(response.metadata)
+            ) {
+                p.writeNoException()
+                p.writeTypedObject(response, 0)
+                return OverrideReply(0, p)
+            }
+
+            if (!targeted) {
+                p.recycle()
+                return Skip
+            }
+
+            // Cache miss is the exceptional/recovery path. Match the 2.5.8 ordering here: parse the
+            // returned chain and let CertHack classify the uncached leaf after its own cache lookup.
+            // CertHack rejects an ordinary non-attested leaf locally before any Rust IPC.
+            val originalChain = Utils.getCertificateChain(response)
+            val newChain =
+                originalChain?.let {
+                    CertHack.hackCertificateChain(it, callingUid).takeUnless { rewritten -> rewritten === it }
+                }
             if (newChain != null) {
                 Utils.putCertificateChain(response, newChain)
                 p.writeNoException()
                 p.writeTypedObject(response, 0)
                 return OverrideReply(0, p)
-            } else {
-                p.recycle()
             }
+            p.recycle()
         } catch (t: Throwable) {
             Logger.e("Failed to rewrite a stored attestation certificate chain", t)
             p.recycle()

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -1,6 +1,7 @@
 package cleveres.tricky.cleverestech.keystore;
 
 import android.security.keystore.KeyProperties;
+import android.system.keystore2.KeyMetadata;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -72,11 +73,43 @@ public final class CertHack {
         }
     }
 
+    /**
+     * One immutable cache value serves both compatibility APIs and the latency-sensitive raw
+     * KeyMetadata readback path. Certificate bytes are public data. Keeping their already-encoded
+     * form avoids reparsing the genuine chain and re-encoding the replacement on every getKeyEntry.
+     */
+    private static final class CachedCertificateChain {
+        final Certificate[] certificates;
+        final byte[] leafEncoded;
+        final byte[] issuerChainEncoded;
+
+        CachedCertificateChain(
+                Certificate[] certificates,
+                byte[] leafEncoded,
+                byte[] issuerChainEncoded
+        ) {
+            this.certificates = certificates.clone();
+            this.leafEncoded = Objects.requireNonNull(leafEncoded, "leafEncoded");
+            this.issuerChainEncoded = Objects.requireNonNull(issuerChainEncoded, "issuerChainEncoded");
+        }
+
+        Certificate[] certificateCopy() {
+            return certificates.clone();
+        }
+
+        void applyTo(KeyMetadata metadata) {
+            // Parcel.writeTypedObject copies these byte arrays synchronously. The transient
+            // KeyMetadata object never owns or mutates the cache storage after the reply is built.
+            metadata.certificate = leafEncoded;
+            metadata.certificateChain = issuerChainEncoded;
+        }
+    }
+
     private static class State {
         final Map<String, List<KeyBox>> keyboxes;
         final Map<String, List<KeyBox>> keyboxFiles;
         final Map<KeyBox, PreparedKeyBox> preparedKeyboxes;
-        final Map<CacheKey, Certificate[]> certificateCache;
+        final Map<CacheKey, CachedCertificateChain> certificateCache;
 
         State(Map<String, List<KeyBox>> keyboxes, Map<String, List<KeyBox>> keyboxFiles) {
             this.keyboxes = immutableLists(keyboxes);
@@ -94,9 +127,11 @@ public final class CertHack {
             }
             this.preparedKeyboxes = Collections.unmodifiableMap(prepared);
             this.certificateCache = Collections.synchronizedMap(
-                    new LinkedHashMap<CacheKey, Certificate[]>(32, 0.75f, true) {
+                    new LinkedHashMap<CacheKey, CachedCertificateChain>(32, 0.75f, true) {
                         @Override
-                        protected boolean removeEldestEntry(Map.Entry<CacheKey, Certificate[]> eldest) {
+                        protected boolean removeEldestEntry(
+                                Map.Entry<CacheKey, CachedCertificateChain> eldest
+                        ) {
                             return size() > MAX_CERTIFICATE_CACHE_ENTRIES;
                         }
                     });
@@ -237,13 +272,36 @@ public final class CertHack {
         return !state.certificateCache.isEmpty();
     }
 
+    /**
+     * Applies an already-produced attestation replacement directly to the raw KeyMetadata bytes.
+     * Duck Detector's side-channel probe repeatedly measures service.getKeyEntry for the same two
+     * keys, so the attested key should hit this path after generateKey populated the cache. A hit
+     * performs only one bounded DER hash/equality lookup and the later Parcel serialization: no
+     * CertificateFactory, no issuer-chain parsing, no getEncoded(), and no Rust IPC.
+     */
+    public static boolean applyCachedCertificateChain(KeyMetadata metadata) {
+        if (metadata == null || metadata.certificate == null ||
+                metadata.certificate.length == 0 ||
+                metadata.certificate.length > MAX_LEAF_CERTIFICATE_BYTES) {
+            return false;
+        }
+        State currentState = state;
+        CachedCertificateChain cached;
+        synchronized (currentState.certificateCache) {
+            cached = currentState.certificateCache.get(new CacheKey(metadata.certificate));
+        }
+        if (cached == null) return false;
+        cached.applyTo(metadata);
+        return true;
+    }
+
     public static Certificate[] getCachedCertificateChain(Certificate[] caList) {
         if (caList == null || caList.length == 0 || caList[0] == null) return null;
         try {
             byte[] leafEncoded = caList[0].getEncoded();
             if (leafEncoded.length == 0 || leafEncoded.length > MAX_LEAF_CERTIFICATE_BYTES) return null;
-            Certificate[] cached = state.certificateCache.get(new CacheKey(leafEncoded));
-            return cached == null ? null : cached.clone();
+            CachedCertificateChain cached = state.certificateCache.get(new CacheKey(leafEncoded));
+            return cached == null ? null : cached.certificateCopy();
         } catch (Throwable error) {
             Logger.e("Could not resolve a cached attestation chain", error);
             return null;
@@ -270,18 +328,22 @@ public final class CertHack {
                 return caList;
             }
             CacheKey cacheKey = new CacheKey(leafEncoded);
-            Map<CacheKey, Certificate[]> cache = currentState.certificateCache;
+            Map<CacheKey, CachedCertificateChain> cache = currentState.certificateCache;
             synchronized (cache) {
-                Certificate[] cached = cache.get(cacheKey);
-                if (cached != null) return cached.clone();
+                CachedCertificateChain cached = cache.get(cacheKey);
+                if (cached != null) return cached.certificateCopy();
             }
 
+            // Preserve 2.5.8's ordering: look for a completed replacement first, then classify an
+            // uncached leaf locally. This keeps repeated attested getKeyEntry off the X.509/OID
+            // classifier while guaranteeing a non-attested cache miss never enters the Rust
+            // certificate backend.
+            if (!Utils.hasAndroidAttestationExtension(caList[0])) return caList;
+
             // In 2.6.0 every fresh attested key paid one backend round trip just to inspect fields
-            // that are irrelevant when security-patch rewriting is disabled. Non-attested keys
-            // already bypass the backend, so that extra request/response became a stable timing
-            // distinguisher. Keep DER parsing and signing in the hardened Rust backend, but do not
-            // ask it to inspect a leaf unless policy or verified-boot fallback actually needs data
-            // from that leaf.
+            // that are irrelevant when security-patch rewriting is disabled. Keep DER parsing and
+            // signing in the hardened Rust backend, but do not ask it to inspect a leaf unless
+            // policy or verified-boot fallback actually needs data from that leaf.
             boolean needsCapturedPatchLevels = PolicyState.INSTANCE.isFeatureEnabled(
                     PolicyState.Feature.SECURITY_PATCH, uid);
             byte[] verifiedBootKey = usableBootDigest(UtilKt.getBootKey());
@@ -361,10 +423,13 @@ public final class CertHack {
             Certificate[] result = new Certificate[prepared.issuerChain.length + 1];
             result[0] = rewrittenLeaf;
             System.arraycopy(prepared.issuerChain, 0, result, 1, prepared.issuerChain.length);
+            byte[] issuerChainEncoded = Utils.encodeIssuerChain(result);
+            CachedCertificateChain completed =
+                    new CachedCertificateChain(result, rewrittenDer, issuerChainEncoded);
             synchronized (cache) {
-                Certificate[] raced = cache.get(cacheKey);
-                if (raced != null) return raced.clone();
-                cache.put(cacheKey, result.clone());
+                CachedCertificateChain raced = cache.get(cacheKey);
+                if (raced != null) return raced.certificateCopy();
+                cache.put(cacheKey, completed);
             }
             return result;
         } catch (Throwable t) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
@@ -154,7 +154,7 @@ public final class Utils {
         return chain;
     }
 
-    private static byte[] encodeIssuerChain(Certificate[] chain) throws CertificateException {
+    static byte[] encodeIssuerChain(Certificate[] chain) throws CertificateException {
         if (chain.length == 1) return new byte[0];
 
         IdentityHashMap<Certificate, EncodedIssuerChain> cache = ENCODED_ISSUER_CHAINS.get();

--- a/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
@@ -69,7 +69,7 @@ class GenerateKeyTimingFastPathTest {
     }
 
     @Test
-    fun `getKeyEntry rejects non-attested leaf before Rust certificate backend`() {
+    fun `measured getKeyEntry serves encoded cache before X509 chain parsing`() {
         val root = locateRoot()
         val source =
             File(
@@ -77,16 +77,81 @@ class GenerateKeyTimingFastPathTest {
                 "service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt",
             ).readText()
         val postTransact = source.indexOf("override fun onPostTransact")
-        val chainRead = source.indexOf("val originalChain = Utils.getCertificateChain(response)", postTransact)
-        val localExtensionGuard =
-            source.indexOf("!Utils.hasAndroidAttestationExtension(originalLeaf)", chainRead)
-        val backendRewrite =
-            source.indexOf("CertHack.hackCertificateChain(originalChain, callingUid)", chainRead)
+        val responseRead = source.indexOf("val response = reply.readTypedObject", postTransact)
+        val encodedCache =
+            source.indexOf("CertHack.applyCachedCertificateChain(response.metadata)", responseRead)
+        val chainRead =
+            source.indexOf("val originalChain = Utils.getCertificateChain(response)", encodedCache)
 
         assertTrue(postTransact >= 0)
-        assertTrue(chainRead > postTransact)
-        assertTrue(localExtensionGuard > chainRead)
+        assertTrue(responseRead > postTransact)
+        assertTrue(encodedCache > responseRead)
+        assertTrue(chainRead > encodedCache)
+    }
+
+    @Test
+    fun `cached getKeyEntry applies raw replacement bytes without certificate reencoding`() {
+        val root = locateRoot()
+        val source =
+            File(
+                root,
+                "service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java",
+            ).readText()
+        val method = source.indexOf("public static boolean applyCachedCertificateChain")
+        val methodEnd = source.indexOf("public static Certificate[] getCachedCertificateChain", method)
+        val body = source.substring(method, methodEnd)
+
+        assertTrue(method >= 0)
+        assertTrue(methodEnd > method)
+        assertTrue(body.contains("new CacheKey(metadata.certificate)"))
+        assertTrue(body.contains("cached.applyTo(metadata)"))
+        assertFalse(body.contains("CERTIFICATE_FACTORY"))
+        assertFalse(body.contains("getEncoded()"))
+        assertFalse(body.contains("CertificateBackend"))
+    }
+
+    @Test
+    fun `uncached non-attested getKeyEntry leaf is rejected locally after cache lookup`() {
+        val root = locateRoot()
+        val source =
+            File(
+                root,
+                "service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java",
+            ).readText()
+        val method = source.indexOf("public static Certificate[] hackCertificateChain")
+        val cacheLookup = source.indexOf("CachedCertificateChain cached = cache.get(cacheKey)", method)
+        val localExtensionGuard =
+            source.indexOf("!Utils.hasAndroidAttestationExtension(caList[0])", cacheLookup)
+        val backendInspect =
+            source.indexOf("inspection = CertificateBackend.inspect(leafEncoded)", localExtensionGuard)
+        val backendRewrite =
+            source.indexOf("byte[] rewrittenDer = CertificateBackend.rewrite", localExtensionGuard)
+
+        assertTrue(method >= 0)
+        assertTrue(cacheLookup > method)
+        assertTrue(localExtensionGuard > cacheLookup)
+        assertTrue(backendInspect > localExtensionGuard)
         assertTrue(backendRewrite > localExtensionGuard)
+    }
+
+    @Test
+    fun `completed rewrite cache retains encoded leaf and issuer bytes`() {
+        val root = locateRoot()
+        val source =
+            File(
+                root,
+                "service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java",
+            ).readText()
+        val rewrite = source.indexOf("byte[] rewrittenDer = CertificateBackend.rewrite")
+        val issuerEncoding = source.indexOf("byte[] issuerChainEncoded = Utils.encodeIssuerChain(result)", rewrite)
+        val completed =
+            source.indexOf("new CachedCertificateChain(result, rewrittenDer, issuerChainEncoded)", issuerEncoding)
+        val cachePut = source.indexOf("cache.put(cacheKey, completed)", completed)
+
+        assertTrue(rewrite >= 0)
+        assertTrue(issuerEncoding > rewrite)
+        assertTrue(completed > issuerEncoding)
+        assertTrue(cachePut > completed)
     }
 
     @Test


### PR DESCRIPTION
## Problem

The latest physical-device replay is still positive: **attested 0.493 ms**, **non-attested 0.430 ms**, **diff 0.063 ms**, **ratio 1.147x**, `failedPairs=0/500`, `samples=447`, threshold `>1.1x`.

The earlier fixes improved fresh attestation generation but did not remove the detector signal. The reason is now verified from the detector source rather than inferred from the UI.

## What the detector actually measures

Duck Detector's `TimingSideChannelProbe` creates the attested/non-attested keys once, then its 500-pair loop times repeated **`service.getKeyEntry(...)`** calls. `generateKey` is outside the measured sample loop.

Source: `eltavine/Duck-Detector-Refactoring`, `TimingSideChannelProbe.kt` (`measurePrivateGetKeyEntryMillis` / `samplePairedSeries`).

This means #960/#967 optimized real costs, but mostly on the wrong side of the detector's measurement boundary. The 1.160x -> 1.147x change is consistent with that: useful work was removed, but only ~16us of the reported delta disappeared.

## 2.5.8 comparison and root cause

The 2.5.8 `getKeyEntry` path called `CertHack.hackCertificateChain` for a targeted readback. `CertHack` looked in the replacement cache first; only a cache miss continued into local leaf classification/rewrite.

The 2.6 timing work moved the local Android-attestation OID check into `KeystoreInterceptor` *before* `CertHack`:

- non-attested readback: parse chain -> OID check false -> return
- attested readback: parse chain -> OID check true -> enter `CertHack` -> cache lookup -> clone replacement -> `getEncoded`/issuer encoding -> serialize replacement Parcel

That ordering makes the negative control deliberately cheaper than the cached attested readback and adds X.509 work to every measured attested sample.

There is a second avoidable cost: even a successful attested cache hit currently starts by converting the raw `KeyMetadata.certificate`/`certificateChain` bytes into X.509 objects, allocating a `Certificate[]`, cloning the cached chain, then encoding the replacement certificate objects back to bytes before writing the override Parcel. Duck Detector repeats exactly this same read hundreds of times.

## Fix

- Extend the bounded 64-entry attestation replacement cache to retain both compatibility `Certificate[]` and the already-encoded replacement leaf/issuer-chain bytes.
- On `getKeyEntry`, read the `KeyEntryResponse` and perform the cache lookup directly with the raw genuine `KeyMetadata.certificate` DER **before any CertificateFactory/X.509 chain parsing**.
- A cache hit assigns the already-encoded replacement leaf and issuer bytes directly to `KeyMetadata` and serializes the reply. No `CertificateFactory`, no genuine issuer parsing, no replacement `getEncoded()`, no issuer re-encoding, and no Rust IPC occur on the repeated attested readback path.
- On cache miss, restore the 2.5.8 ordering: parse the returned chain and enter `CertHack`; `CertHack` now checks its cache first and then rejects a non-attested leaf locally by the fixed Android attestation OID before any Rust backend operation.
- Keep grant/isolated-reader semantics: they may consume an already-created cached replacement but never synthesize a new chain.
- No sleep, busy wait, padding, threshold change, or synthetic slowing of the control path.
- The Rust-first DER/signing boundary for fresh uncached attestation remains unchanged.

## Why this is different from #967

#967 removed invariant crypto from fresh `generateKey`. This PR targets the operation that the reported 500-pair probe actually times: repeated `IKeystoreService.getKeyEntry` readback.

## Regression guards

The JVM timing contract now asserts that:

- encoded-cache lookup occurs before `Utils.getCertificateChain` on `getKeyEntry`;
- a cached readback performs no `CertificateFactory`, `getEncoded()` or `CertificateBackend` operation;
- an uncached non-attested leaf is rejected locally after cache lookup and before Rust inspect/rewrite;
- completed rewrites retain encoded leaf and issuer bytes for later readback;
- synthetic delay equalization remains forbidden.

## Acceptance

Keep this PR draft until:

- Build, Security Regression, Native Hardening, Rust Fuzz Smoke and Rust Lockfile checks are green;
- the same physical-device Duck Detector replay completes 500 pairs with `failedPairs=0` and **ratio < 1.1x**.

This PR intentionally includes the prepared-signer work from #967 because that improvement is still valid for fresh attestation generation; #967 should be treated as superseded by this measurement-correct fix.