### PR TITLE
chore(release): update V2.6.1 metadata

### DIFF
--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
-    "version": "V2.5.8 (2531-74c25526-release)",
-    "versionCode": 2531,
-    "zipUrl": "https://github.com/tryigit/CleveresTricky/releases/download/V2.5.8/CleveresTricky-V2.5.8-2531-74c25526-release.zip",
+    "version": "V2.6.1 (2947-13409cbd-release)",
+    "versionCode": 2947,
+    "zipUrl": "https://github.com/tryigit/CleveresTricky/releases/download/V2.6.1/CleveresTricky-V2.6.1-2947-13409cbd-release.zip",
     "changelog": "https://raw.githubusercontent.com/tryigit/CleveresTricky/refs/heads/master/CHANGELOG.md"
 }


### PR DESCRIPTION
Updates `update.json` from the stale V2.5.8 metadata to the published V2.6.1 release metadata.

- version: `V2.6.1 (2947-13409cbd-release)`
- versionCode: `2947`
- release ZIP: `CleveresTricky-V2.6.1-2947-13409cbd-release.zip`
- changelog URL remains on `master`

The V2.6.1 tag resolves to merge commit `13409cbdb24149d5472080b86f8fe19c72a497ad`.