### PR TITLE
fix: invalidate remote keybox cache when server trust changes

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/ServerManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ServerManager.kt
@@ -182,6 +182,16 @@ object ServerManager {
 
     internal fun findServer(id: String): ServerConfig? = if (validServerId.matches(id)) serversMap[id] else null
 
+    internal fun cacheBindingChanged(
+        previous: ServerConfig,
+        replacement: ServerConfig,
+    ): Boolean =
+        previous.url != replacement.url ||
+            previous.authType != replacement.authType ||
+            previous.authData.toString() != replacement.authData.toString() ||
+            previous.contentPassword != replacement.contentPassword ||
+            previous.contentPublicKey != replacement.contentPublicKey
+
     @Synchronized
     fun addServer(server: ServerConfig) {
         validateServer(server)
@@ -201,6 +211,9 @@ object ServerManager {
                 serversList.add(previous)
             }
             throw error
+        }
+        if (previous != null && cacheBindingChanged(previous, server)) {
+            deactivateServerContent(server.id, deleteCache = true)
         }
     }
 
@@ -239,6 +252,9 @@ object ServerManager {
                 serversMap[id] = previous
                 serversList.replaceAll { if (it.id == id) previous else it }
                 throw error
+            }
+            if (cacheBindingChanged(previous, s)) {
+                deactivateServerContent(id, deleteCache = true)
             }
         }
     }

--- a/service/src/test/java/cleveres/tricky/cleverestech/ServerManagerCacheBindingTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ServerManagerCacheBindingTest.kt
@@ -1,0 +1,75 @@
+package cleveres.tricky.cleverestech
+
+import org.json.JSONObject
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ServerManagerCacheBindingTest {
+    @Test
+    fun `cache binding changes when remote source or trust inputs change`() {
+        val original = server()
+
+        assertTrue(
+            ServerManager.cacheBindingChanged(
+                original,
+                original.copy(url = "https://other.example.com/keybox.xml"),
+            ),
+        )
+        assertTrue(
+            ServerManager.cacheBindingChanged(
+                original,
+                original.copy(
+                    authType = "BEARER",
+                    authData = JSONObject().put("token", "replacement-token"),
+                ),
+            ),
+        )
+        assertTrue(
+            ServerManager.cacheBindingChanged(
+                original,
+                original.copy(contentPassword = "new-password"),
+            ),
+        )
+        assertTrue(
+            ServerManager.cacheBindingChanged(
+                original,
+                original.copy(contentPublicKey = "new-public-key"),
+            ),
+        )
+    }
+
+    @Test
+    fun `cache binding ignores scheduling and presentation changes`() {
+        val original = server()
+        val replacement =
+            original.copy(
+                name = "Renamed server",
+                priority = 99,
+                enabled = false,
+                autoRefresh = false,
+                refreshIntervalHours = 48,
+                lastStatus = "NETWORK_ERROR",
+                lastChecked = 1234,
+                lastAuthor = "Different author label",
+                authData = JSONObject(original.authData.toString()),
+            )
+
+        assertFalse(ServerManager.cacheBindingChanged(original, replacement))
+    }
+
+    private fun server() =
+        ServerManager.ServerConfig(
+            id = "server-a",
+            name = "Server A",
+            url = "https://example.com/keybox.xml",
+            priority = 10,
+            enabled = true,
+            authType = "NONE",
+            authData = JSONObject(),
+            autoRefresh = true,
+            refreshIntervalHours = 24,
+            contentPassword = "password",
+            contentPublicKey = "public-key",
+        )
+}


### PR DESCRIPTION
## Bug

Replacing or updating a remote keybox server can change the URL, authentication context, CBOX password, or content verification key while keeping the same server ID. The in-memory `serverKeyboxes` entry and `server_cache_<id>.enc` were previously retained, so content verified under the old source/trust context could stay active and be loaded again on a later boot under the new server configuration.

## Fix

- Treat URL, auth type/data, content password, and content public key as the cache binding.
- After the updated server configuration is durably saved, invalidate both the in-memory keyboxes and persistent cache when that binding changes.
- Apply the same rule to both replacement (`addServer`) and mutable update (`updateServer`) paths.
- Preserve caches for presentation/scheduling-only changes such as name, priority, enabled state, auto-refresh, and status metadata.

## Tests

Added `ServerManagerCacheBindingTest` covering source/trust changes and non-binding scheduling/presentation changes.

This intentionally fails closed: a server trust/source change must require content to be fetched and verified again before its keyboxes can become active.