### PR TITLE
fix: close deep bug sweep regressions

### DIFF
--- a/module/template/webroot/bridge.js
+++ b/module/template/webroot/bridge.js
@@ -302,19 +302,15 @@
             throw new Error('Invalid staged response');
         }
         const output = new Uint8Array(size);
-        try {
-            for (let offset = 0; offset < size; offset += chunkBytes) {
-                throwIfAborted(signal);
-                const length = Math.min(chunkBytes, size - offset);
-                const encoded = await execNative(['stage-read', 'download', id, String(offset), String(length)], timeoutMs, false, signal);
-                const chunk = decodeBytes(encoded);
-                if (chunk.length !== length) throw new Error('Incomplete staged response');
-                output.set(chunk, offset);
-            }
-            return output;
-        } finally {
-            await dropStage('download', id);
+        for (let offset = 0; offset < size; offset += chunkBytes) {
+            throwIfAborted(signal);
+            const length = Math.min(chunkBytes, size - offset);
+            const encoded = await execNative(['stage-read', 'download', id, String(offset), String(length)], timeoutMs, false, signal);
+            const chunk = decodeBytes(encoded);
+            if (chunk.length !== length) throw new Error('Incomplete staged response');
+            output.set(chunk, offset);
         }
+        return output;
     }
 
     class NativeResponse {
@@ -329,27 +325,55 @@
             this.bodyUsed = false;
             this.bodyEncoded = typeof envelope.body === 'string' ? envelope.body : null;
             this.downloadId = typeof envelope.downloadId === 'string' ? envelope.downloadId : null;
+            this.downloadRef = this.downloadId ? { id: this.downloadId, readers: 1, completed: 0, error: null } : null;
             this.size = Number(envelope.size || 0);
             this.timeoutMs = timeoutMs;
             this.signal = signal;
             this.cachedBytes = null;
         }
 
-        async bytes() {
+        async consumeBytes() {
             throwIfAborted(this.signal);
+            if (this.bodyUsed) throw new TypeError('Response body has already been consumed');
+            this.bodyUsed = true;
             if (this.cachedBytes) return this.cachedBytes;
-            if (this.bodyEncoded !== null) this.cachedBytes = decodeBytes(this.bodyEncoded);
-            else if (this.downloadId) {
-                this.cachedBytes = await readDownload(this.downloadId, this.size, this.timeoutMs, this.signal);
+            if (this.bodyEncoded !== null) {
+                this.cachedBytes = decodeBytes(this.bodyEncoded);
+                this.bodyEncoded = null;
+            } else if (this.downloadRef) {
+                const reference = this.downloadRef;
+                if (reference.error) throw reference.error;
+                const id = reference.id;
+                if (!id) throw new Error('Staged response is unavailable');
+                try {
+                    this.cachedBytes = await readDownload(id, this.size, this.timeoutMs, this.signal);
+                } catch (error) {
+                    reference.error = error;
+                    reference.id = null;
+                    this.downloadId = null;
+                    this.downloadRef = null;
+                    await dropStage('download', id);
+                    throw error;
+                }
+                reference.completed += 1;
                 this.downloadId = null;
+                this.downloadRef = null;
+                if (reference.completed >= reference.readers && reference.id === id) {
+                    reference.id = null;
+                    await dropStage('download', id);
+                }
+            } else {
+                this.cachedBytes = new Uint8Array(0);
             }
-            else this.cachedBytes = new Uint8Array(0);
             return this.cachedBytes;
         }
 
+        async bytes() {
+            return this.consumeBytes();
+        }
+
         async text() {
-            this.bodyUsed = true;
-            return new TextDecoder('utf-8', { fatal: false }).decode(await this.bytes());
+            return new TextDecoder('utf-8', { fatal: false }).decode(await this.consumeBytes());
         }
 
         async json() {
@@ -357,20 +381,21 @@
         }
 
         async blob() {
-            this.bodyUsed = true;
-            return new Blob([await this.bytes()], { type: this.headers.get('content-type') || 'application/octet-stream' });
+            return new Blob([await this.consumeBytes()], { type: this.headers.get('content-type') || 'application/octet-stream' });
         }
 
         async arrayBuffer() {
-            this.bodyUsed = true;
-            const bytes = await this.bytes();
+            const bytes = await this.consumeBytes();
             return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
         }
 
         clone() {
+            if (this.bodyUsed) throw new TypeError('Cannot clone a consumed response');
             const copy = Object.create(NativeResponse.prototype);
             Object.assign(copy, this);
             copy.bodyUsed = false;
+            copy.cachedBytes = this.cachedBytes ? this.cachedBytes.slice() : null;
+            if (copy.downloadRef) copy.downloadRef.readers += 1;
             return copy;
         }
     }
@@ -488,10 +513,14 @@
 
     async function exportResponse(response, filename) {
         if (!(response instanceof NativeResponse) || typeof filename !== 'string' || filename.length < 1 || filename.length > 128) throw new Error('Invalid download');
-        if (response.downloadId) {
-            const id = response.downloadId;
-            response.downloadId = null;
+        if (response.bodyUsed) throw new TypeError('Response body has already been consumed');
+        if (response.downloadRef && response.downloadRef.id && response.downloadRef.readers === 1) {
+            const reference = response.downloadRef;
+            const id = reference.id;
             response.bodyUsed = true;
+            response.downloadId = null;
+            response.downloadRef = null;
+            reference.id = null;
             try {
                 return await execNative(['export', 'download', id, encodeText(filename)], 120000);
             } catch (error) {

--- a/module/webui-tests/bridge-response-clone.test.js
+++ b/module/webui-tests/bridge-response-clone.test.js
@@ -1,0 +1,98 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+const bridgeSource = fs.readFileSync('module/template/webroot/bridge.js', 'utf8');
+const downloadId = '0123456789abcdef0123456789abcdef';
+const body = 'staged clone response';
+const encodedBody = Buffer.from(body, 'utf8').toString('base64url');
+const envelope = JSON.stringify({
+    version: 1,
+    status: 200,
+    statusText: '200 OK',
+    mimeType: 'text/plain',
+    size: Buffer.byteLength(body),
+    downloadId
+});
+
+function createBridge() {
+    let stageReads = 0;
+    let stageDrops = 0;
+    const context = {
+        console,
+        setTimeout,
+        clearTimeout,
+        URL,
+        URLSearchParams,
+        TextEncoder,
+        TextDecoder,
+        Uint8Array,
+        ArrayBuffer,
+        Blob,
+        Headers,
+        FormData,
+        File: globalThis.File || class File extends Blob {},
+        DOMException,
+        atob: value => Buffer.from(value, 'base64').toString('binary'),
+        btoa: value => Buffer.from(value, 'binary').toString('base64')
+    };
+    context.window = context;
+    context.ksu = {
+        exec(command, _options, callbackName) {
+            const callback = context[callbackName];
+            if (command.includes("'stage-read'")) {
+                stageReads += 1;
+                callback(0, encodedBody, '');
+            } else if (command.includes("'stage-drop'")) {
+                stageDrops += 1;
+                callback(0, '', '');
+            } else if (command.includes("'call'")) {
+                callback(0, envelope, '');
+            } else {
+                callback(1, '', `unexpected command: ${command}`);
+            }
+        },
+        enableEdgeToEdge() {},
+        enableInsets() {},
+        listPackages() { return '[]'; }
+    };
+    vm.createContext(context);
+    vm.runInContext(bridgeSource, context, { filename: 'bridge.js' });
+    return {
+        bridge: context.CleveresBridge,
+        stats: () => ({ stageReads, stageDrops })
+    };
+}
+
+async function main() {
+    const { bridge, stats } = createBridge();
+    const response = await bridge.fetch('/api/config');
+    const clone = response.clone();
+
+    assert.strictEqual(response.bodyUsed, false);
+    assert.strictEqual(clone.bodyUsed, false);
+    assert.strictEqual(await response.text(), body);
+    assert.strictEqual(response.bodyUsed, true);
+    assert.strictEqual(clone.bodyUsed, false);
+    assert.strictEqual(stats().stageDrops, 0, 'shared stage must stay alive until every clone consumes it');
+
+    assert.strictEqual(await clone.text(), body);
+    assert.strictEqual(clone.bodyUsed, true);
+    assert.deepStrictEqual(stats(), { stageReads: 2, stageDrops: 1 });
+
+    await assert.rejects(() => response.text(), /already been consumed/);
+    assert.throws(() => response.clone(), /Cannot clone a consumed response/);
+
+    const bytesResponse = await bridge.fetch('/api/config');
+    const bytes = await bytesResponse.bytes();
+    assert.strictEqual(Buffer.from(bytes).toString('utf8'), body);
+    assert.strictEqual(bytesResponse.bodyUsed, true, 'bytes() must consume the response body');
+    await assert.rejects(() => bytesResponse.arrayBuffer(), /already been consumed/);
+
+    console.log('Native WebUI staged response clone tests passed');
+}
+
+main().catch(error => {
+    console.error(error);
+    process.exit(1);
+});

--- a/rust/attestation-core/src/lib.rs
+++ b/rust/attestation-core/src/lib.rs
@@ -322,9 +322,7 @@ fn validate_request(request: &RewriteRequest<'_>) -> Result<(), Error> {
         request.patch_levels.boot,
     ]
     .into_iter()
-    .any(|component| {
-        component.disposition == PatchDisposition::Replace && component.value <= 0
-    })
+    .any(|component| component.disposition == PatchDisposition::Replace && component.value <= 0)
     {
         return Err(Error::InvalidOverride);
     }

--- a/rust/attestation-core/src/lib.rs
+++ b/rust/attestation-core/src/lib.rs
@@ -316,6 +316,18 @@ fn validate_request(request: &RewriteRequest<'_>) -> Result<(), Error> {
     {
         return Err(Error::InvalidStructure);
     }
+    if [
+        request.patch_levels.system,
+        request.patch_levels.vendor,
+        request.patch_levels.boot,
+    ]
+    .into_iter()
+    .any(|component| {
+        component.disposition == PatchDisposition::Replace && component.value <= 0
+    })
+    {
+        return Err(Error::InvalidOverride);
+    }
     let mut seen = [false; ATTESTATION_ID_TAGS.len()];
     for configured in request.id_overrides {
         let Some(index) = ATTESTATION_ID_TAGS

--- a/rust/attestation-core/tests/invalid_patch_replacement.rs
+++ b/rust/attestation-core/tests/invalid_patch_replacement.rs
@@ -32,6 +32,9 @@ fn non_positive_patch_replacements_fail_closed() {
             ..PatchLevels::default()
         },
     ] {
-        assert_eq!(rewrite_extension(&request(patch_levels)), Err(Error::InvalidOverride));
+        assert_eq!(
+            rewrite_extension(&request(patch_levels)),
+            Err(Error::InvalidOverride)
+        );
     }
 }

--- a/rust/attestation-core/tests/invalid_patch_replacement.rs
+++ b/rust/attestation-core/tests/invalid_patch_replacement.rs
@@ -1,0 +1,37 @@
+use cleverestricky_attestation_core::{
+    rewrite_extension, Error, PatchComponent, PatchLevels, RewriteRequest,
+};
+
+const BOOT_KEY: [u8; 32] = [0x11; 32];
+const BOOT_HASH: [u8; 32] = [0x22; 32];
+
+fn request(patch_levels: PatchLevels) -> RewriteRequest<'static> {
+    RewriteRequest {
+        extension_der: &[0x30],
+        patch_levels,
+        id_overrides: &[],
+        module_hash: None,
+        verified_boot_key: &BOOT_KEY,
+        verified_boot_hash: &BOOT_HASH,
+    }
+}
+
+#[test]
+fn non_positive_patch_replacements_fail_closed() {
+    for patch_levels in [
+        PatchLevels {
+            system: PatchComponent::replace(0),
+            ..PatchLevels::default()
+        },
+        PatchLevels {
+            vendor: PatchComponent::replace(-1),
+            ..PatchLevels::default()
+        },
+        PatchLevels {
+            boot: PatchComponent::replace(0),
+            ..PatchLevels::default()
+        },
+    ] {
+        assert_eq!(rewrite_extension(&request(patch_levels)), Err(Error::InvalidOverride));
+    }
+}

--- a/rust/webui-bridge/src/main.rs
+++ b/rust/webui-bridge/src/main.rs
@@ -4,9 +4,9 @@ use cleverestricky_service_core::ipc::{
 use cleverestricky_service_core::secure_fs::TrustedDir;
 use cleverestricky_service_core::unix_socket::{connect_abstract, DAEMON_SOCKET_NAME};
 use std::env;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, File};
 use std::io::{self, Read, Write};
-use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::process;
 use std::time::{Duration, SystemTime};
@@ -19,7 +19,6 @@ const MAX_DOWNLOAD_BYTES: usize = 20 * 1024 * 1024;
 const MAX_RESPONSE_ENVELOPE_BYTES: usize = 512 * 1024;
 const MAX_CHUNK_BYTES: usize = 64 * 1024;
 const STALE_AGE: Duration = Duration::from_secs(10 * 60);
-const O_NOFOLLOW: i32 = 0x20000;
 
 fn main() {
     if let Err(error) = run() {
@@ -293,8 +292,9 @@ fn export_file(
     let filename =
         String::from_utf8(filename_bytes).map_err(|_| "Download filename is not valid UTF-8")?;
     validate_filename(&filename)?;
-    let download_dir = select_download_dir()?;
-    let (destination, mut output) = create_export_destination(&download_dir, &filename)?;
+    let (download_path, download_dir) = select_download_dir()?;
+    let (destination_name, mut output) = create_export_destination(&download_dir, &filename)?;
+    let destination = download_path.join(&destination_name);
     let created_metadata = output
         .metadata()
         .map_err(|error| format!("Could not inspect download descriptor: {error}"))?;
@@ -316,7 +316,7 @@ fn export_file(
     })();
     if let Err(error) = export_result {
         drop(output);
-        remove_if_same_file(&destination, &created_metadata);
+        remove_if_same_file(&download_dir, &destination_name, &created_metadata);
         return Err(error);
     }
     drop(output);
@@ -325,14 +325,11 @@ fn export_file(
     Ok(())
 }
 
-fn select_download_dir() -> Result<PathBuf, String> {
-    let candidate = Path::new("/storage/emulated/0/Download");
-    if let Ok(metadata) = fs::symlink_metadata(candidate) {
-        if metadata.is_dir() && !metadata.file_type().is_symlink() {
-            return Ok(candidate.to_path_buf());
-        }
-    }
-    Err("Android Download directory is unavailable".to_string())
+fn select_download_dir() -> Result<(PathBuf, TrustedDir), String> {
+    let candidate = PathBuf::from("/storage/emulated/0/Download");
+    let directory = TrustedDir::open(&candidate)
+        .map_err(|error| format!("Android Download directory is unavailable: {error}"))?;
+    Ok((candidate, directory))
 }
 
 fn validate_filename(filename: &str) -> Result<(), String> {
@@ -353,22 +350,15 @@ fn validate_filename(filename: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn create_export_destination(directory: &Path, filename: &str) -> Result<(PathBuf, File), String> {
+fn create_export_destination(directory: &TrustedDir, filename: &str) -> Result<(String, File), String> {
     for attempt in 0..16 {
         let name = if attempt == 0 {
             filename.to_string()
         } else {
             suffixed_filename(filename, &random_id()?[..8])
         };
-        let path = directory.join(name);
-        match OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .mode(0o600)
-            .custom_flags(O_NOFOLLOW)
-            .open(&path)
-        {
-            Ok(file) => return Ok((path, file)),
+        match directory.create_new_file(&name, 0o600) {
+            Ok(file) => return Ok((name, file)),
             Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
             Err(error) => return Err(format!("Could not create download: {error}")),
         }
@@ -406,15 +396,15 @@ fn safe_file_metadata(path: &Path) -> Result<fs::Metadata, String> {
     Ok(metadata)
 }
 
-fn remove_if_same_file(path: &Path, expected: &fs::Metadata) {
-    if let Ok(metadata) = fs::symlink_metadata(path) {
-        if metadata.is_file()
-            && !metadata.file_type().is_symlink()
-            && metadata.dev() == expected.dev()
-            && metadata.ino() == expected.ino()
-        {
-            let _ = fs::remove_file(path);
-        }
+fn remove_if_same_file(directory: &TrustedDir, name: &str, expected: &fs::Metadata) {
+    let Ok((file, _)) = directory.open_file_bounded(name, MAX_DOWNLOAD_BYTES) else {
+        return;
+    };
+    let Ok(metadata) = file.metadata() else {
+        return;
+    };
+    if metadata.dev() == expected.dev() && metadata.ino() == expected.ino() {
+        let _ = directory.unlink_file(name);
     }
 }
 
@@ -522,6 +512,8 @@ fn encode_base64url(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::symlink;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     #[test]
     fn base64url_round_trip() {
@@ -558,6 +550,36 @@ mod tests {
         assert!(validate_filename("../backup.zip").is_err());
         assert!(validate_filename(".hidden").is_err());
         assert_eq!(suffixed_filename("backup.zip", "1234"), "backup_1234.zip");
+    }
+
+    #[test]
+    fn export_creation_stays_with_preopened_download_directory() {
+        static COUNTER: AtomicU64 = AtomicU64::new(1);
+        let base = env::temp_dir().join(format!(
+            "ct-webui-export-{}-{}",
+            process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        let download = base.join("Download");
+        let pinned = base.join("Download.pinned");
+        let outside = base.join("outside");
+        fs::create_dir_all(&download).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        let directory = TrustedDir::open(&download).unwrap();
+
+        fs::rename(&download, &pinned).unwrap();
+        symlink(&outside, &download).unwrap();
+
+        let (name, mut file) = create_export_destination(&directory, "report.txt").unwrap();
+        file.write_all(b"pinned-directory").unwrap();
+        file.sync_all().unwrap();
+        drop(file);
+
+        assert_eq!(fs::read(pinned.join(&name)).unwrap(), b"pinned-directory");
+        assert!(!outside.join(&name).exists());
+
+        fs::remove_file(&download).unwrap();
+        fs::remove_dir_all(&base).unwrap();
     }
 
     #[test]

--- a/rust/webui-bridge/src/main.rs
+++ b/rust/webui-bridge/src/main.rs
@@ -350,7 +350,10 @@ fn validate_filename(filename: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn create_export_destination(directory: &TrustedDir, filename: &str) -> Result<(String, File), String> {
+fn create_export_destination(
+    directory: &TrustedDir,
+    filename: &str,
+) -> Result<(String, File), String> {
     for attempt in 0..16 {
         let name = if attempt == 0 {
             filename.to_string()


### PR DESCRIPTION
## Summary

Fixes the three confirmed issues from the deep bug sweep:

- preserve staged WebUI response ownership across `NativeResponse.clone()` and enforce one-shot `bodyUsed` semantics
- reject non-positive attestation patch replacements instead of silently turning them into omission
- pin the Android Download directory as a `TrustedDir` capability so export creation/cleanup cannot be redirected by a parent-path race

## Tests

- adds staged response clone/body-consumption coverage
- adds invalid attestation replacement coverage
- adds a regression test that swaps the Download pathname after the directory capability is opened and verifies export creation stays in the pinned directory

## Audit correction

The previously suspected `securityPatch`/Identity coupling is intentionally part of the WebUI contract (Security Patch follows the Identity master switch), so this PR deliberately does not change that behavior.