### PR TITLE
fix: make WebUI response clones lifecycle-safe

### DIFF
--- a/module/template/webroot/bridge.js
+++ b/module/template/webroot/bridge.js
@@ -313,6 +313,28 @@
         return output;
     }
 
+    async function materializeDownload(reference, size, timeoutMs, signal = null) {
+        if (reference.bytes) return reference.bytes;
+        if (reference.error) throw reference.error;
+        if (reference.promise) return reference.promise;
+        const id = reference.id;
+        if (!id) throw new Error('Staged response is unavailable');
+        reference.promise = (async () => {
+            try {
+                const bytes = await readDownload(id, size, timeoutMs, signal);
+                reference.bytes = bytes;
+                return bytes;
+            } catch (error) {
+                reference.error = error;
+                throw error;
+            } finally {
+                if (reference.id === id) reference.id = null;
+                await dropStage('download', id);
+            }
+        })();
+        return reference.promise;
+    }
+
     class NativeResponse {
         constructor(envelope, timeoutMs, signal = null) {
             this.status = Number(envelope.status);
@@ -325,7 +347,7 @@
             this.bodyUsed = false;
             this.bodyEncoded = typeof envelope.body === 'string' ? envelope.body : null;
             this.downloadId = typeof envelope.downloadId === 'string' ? envelope.downloadId : null;
-            this.downloadRef = this.downloadId ? { id: this.downloadId, readers: 1, completed: 0, error: null } : null;
+            this.downloadRef = this.downloadId ? { id: this.downloadId, promise: null, bytes: null, error: null, shared: false } : null;
             this.size = Number(envelope.size || 0);
             this.timeoutMs = timeoutMs;
             this.signal = signal;
@@ -342,25 +364,12 @@
                 this.bodyEncoded = null;
             } else if (this.downloadRef) {
                 const reference = this.downloadRef;
-                if (reference.error) throw reference.error;
-                const id = reference.id;
-                if (!id) throw new Error('Staged response is unavailable');
                 try {
-                    this.cachedBytes = await readDownload(id, this.size, this.timeoutMs, this.signal);
-                } catch (error) {
-                    reference.error = error;
-                    reference.id = null;
+                    const bytes = await materializeDownload(reference, this.size, this.timeoutMs, this.signal);
+                    this.cachedBytes = bytes.slice();
+                } finally {
                     this.downloadId = null;
                     this.downloadRef = null;
-                    await dropStage('download', id);
-                    throw error;
-                }
-                reference.completed += 1;
-                this.downloadId = null;
-                this.downloadRef = null;
-                if (reference.completed >= reference.readers && reference.id === id) {
-                    reference.id = null;
-                    await dropStage('download', id);
                 }
             } else {
                 this.cachedBytes = new Uint8Array(0);
@@ -393,9 +402,10 @@
             if (this.bodyUsed) throw new TypeError('Cannot clone a consumed response');
             const copy = Object.create(NativeResponse.prototype);
             Object.assign(copy, this);
+            copy.headers = new Headers(this.headers);
             copy.bodyUsed = false;
             copy.cachedBytes = this.cachedBytes ? this.cachedBytes.slice() : null;
-            if (copy.downloadRef) copy.downloadRef.readers += 1;
+            if (copy.downloadRef) copy.downloadRef.shared = true;
             return copy;
         }
     }
@@ -514,7 +524,7 @@
     async function exportResponse(response, filename) {
         if (!(response instanceof NativeResponse) || typeof filename !== 'string' || filename.length < 1 || filename.length > 128) throw new Error('Invalid download');
         if (response.bodyUsed) throw new TypeError('Response body has already been consumed');
-        if (response.downloadRef && response.downloadRef.id && response.downloadRef.readers === 1) {
+        if (response.downloadRef && response.downloadRef.id && !response.downloadRef.shared && !response.downloadRef.promise && !response.downloadRef.bytes) {
             const reference = response.downloadRef;
             const id = reference.id;
             response.bodyUsed = true;
@@ -623,7 +633,7 @@
     scheduleCommunityCard();
     routeExternalLinks();
     global.CleveresBridge = Object.freeze({
-        revision: 10,
+        revision: 11,
         fetch: nativeFetch,
         exportBlob,
         exportResponse,

--- a/module/webui-tests/bridge-response-clone.test.js
+++ b/module/webui-tests/bridge-response-clone.test.js
@@ -15,7 +15,7 @@ const envelope = JSON.stringify({
     downloadId
 });
 
-function createBridge() {
+function createBridge({ failRead = false } = {}) {
     let stageReads = 0;
     let stageDrops = 0;
     const context = {
@@ -42,7 +42,8 @@ function createBridge() {
             const callback = context[callbackName];
             if (command.includes("'stage-read'")) {
                 stageReads += 1;
-                callback(0, encodedBody, '');
+                if (failRead) callback(1, '', 'staged read failed');
+                else callback(0, encodedBody, '');
             } else if (command.includes("'stage-drop'")) {
                 stageDrops += 1;
                 callback(0, '', '');
@@ -65,29 +66,69 @@ function createBridge() {
 }
 
 async function main() {
-    const { bridge, stats } = createBridge();
-    const response = await bridge.fetch('/api/config');
-    const clone = response.clone();
+    {
+        const { bridge, stats } = createBridge();
+        const response = await bridge.fetch('/api/config');
+        const abandonedClone = response.clone();
 
-    assert.strictEqual(response.bodyUsed, false);
-    assert.strictEqual(clone.bodyUsed, false);
-    assert.strictEqual(await response.text(), body);
-    assert.strictEqual(response.bodyUsed, true);
-    assert.strictEqual(clone.bodyUsed, false);
-    assert.strictEqual(stats().stageDrops, 0, 'shared stage must stay alive until every clone consumes it');
+        abandonedClone.headers.set('x-clone-only', 'clone');
+        assert.strictEqual(response.headers.get('x-clone-only'), null, 'clone header mutations must not affect the source response');
+        response.headers.set('x-source-only', 'source');
+        assert.strictEqual(abandonedClone.headers.get('x-source-only'), null, 'source header mutations must not affect the clone');
 
-    assert.strictEqual(await clone.text(), body);
-    assert.strictEqual(clone.bodyUsed, true);
-    assert.deepStrictEqual(stats(), { stageReads: 2, stageDrops: 1 });
+        assert.strictEqual(await response.text(), body);
+        assert.strictEqual(response.bodyUsed, true);
+        assert.strictEqual(abandonedClone.bodyUsed, false);
+        assert.deepStrictEqual(
+            stats(),
+            { stageReads: 1, stageDrops: 1 },
+            'the staged file must be released after the first materialization even when a clone is abandoned'
+        );
 
-    await assert.rejects(() => response.text(), /already been consumed/);
-    assert.throws(() => response.clone(), /Cannot clone a consumed response/);
+        assert.strictEqual(await abandonedClone.text(), body, 'an unconsumed clone must remain readable from shared materialized bytes');
+        assert.deepStrictEqual(stats(), { stageReads: 1, stageDrops: 1 }, 'later clone consumption must not re-read or re-drop the stage');
+        await assert.rejects(() => response.text(), /already been consumed/);
+        assert.throws(() => response.clone(), /Cannot clone a consumed response/);
+    }
 
-    const bytesResponse = await bridge.fetch('/api/config');
-    const bytes = await bytesResponse.bytes();
-    assert.strictEqual(Buffer.from(bytes).toString('utf8'), body);
-    assert.strictEqual(bytesResponse.bodyUsed, true, 'bytes() must consume the response body');
-    await assert.rejects(() => bytesResponse.arrayBuffer(), /already been consumed/);
+    {
+        const { bridge, stats } = createBridge();
+        const response = await bridge.fetch('/api/config');
+        const clone = response.clone();
+        const [sourceText, cloneText] = await Promise.all([response.text(), clone.text()]);
+
+        assert.strictEqual(sourceText, body);
+        assert.strictEqual(cloneText, body);
+        assert.deepStrictEqual(
+            stats(),
+            { stageReads: 1, stageDrops: 1 },
+            'concurrent clone consumption must coalesce to one staged read and one cleanup'
+        );
+    }
+
+    {
+        const { bridge, stats } = createBridge({ failRead: true });
+        const response = await bridge.fetch('/api/config');
+        const clone = response.clone();
+
+        await assert.rejects(() => response.text(), /staged read failed/);
+        assert.deepStrictEqual(stats(), { stageReads: 1, stageDrops: 1 }, 'failed staged reads must still clean up exactly once');
+        await assert.rejects(() => clone.text(), /staged read failed/);
+        assert.deepStrictEqual(
+            stats(),
+            { stageReads: 1, stageDrops: 1 },
+            'a shared staged-read failure must be memoized instead of repeating I/O or cleanup'
+        );
+    }
+
+    {
+        const { bridge } = createBridge();
+        const bytesResponse = await bridge.fetch('/api/config');
+        const bytes = await bytesResponse.bytes();
+        assert.strictEqual(Buffer.from(bytes).toString('utf8'), body);
+        assert.strictEqual(bytesResponse.bodyUsed, true, 'bytes() must consume the response body');
+        await assert.rejects(() => bytesResponse.arrayBuffer(), /already been consumed/);
+    }
 
     console.log('Native WebUI staged response clone tests passed');
 }


### PR DESCRIPTION
## Summary

Follow-up to #987 for two confirmed `NativeResponse.clone()` regressions.

- clone `Headers` objects instead of sharing mutable header state between source and clone
- replace staged-download reader ref-counting with one shared materialization promise
- drop the `.download` stage immediately after the first successful or failed materialization, so an unconsumed clone cannot keep the stage alive
- keep later/sequential/concurrent clones readable from independently copied in-memory bytes without repeated native stage reads
- preserve the direct staged export fast path only for an unshared, untouched response

## Regression coverage

`module/webui-tests/bridge-response-clone.test.js` now locks:

- source/clone header isolation in both directions
- an unconsumed clone does not delay stage cleanup
- a later clone consumes shared materialized bytes without another stage read/drop
- concurrent clone consumption coalesces to one stage read and one cleanup
- staged-read failures are cleaned up once and memoized across clones
- one-shot `bodyUsed` behavior remains enforced

## History / rationale

#987 fixed the original staged-response ownership bug by counting clone readers. That made the stage lifetime depend on every clone eventually being consumed. This follow-up removes that assumption: the stage is only transport storage, so once one branch has materialized the bytes it can be released and all clones can share the materialized result safely.

The native bridge also performs a 10-minute stale-stage sweep on every helper invocation; this PR keeps that as a fallback rather than relying on it for normal clone cleanup.

Merge condition: required PR workflows green.