### PR TITLE
fix: preserve ZIP server cache across backend restarts

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/ServerManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ServerManager.kt
@@ -380,7 +380,7 @@ object ServerManager {
                                 ?: throw SecurityException("Could not decrypt server cache")
                             cachePayload = decodeServerCache(server, decrypted)
                                 ?: throw SecurityException("Server cache trust binding does not match current configuration")
-                            val parsed = KeyboxLoader.parse(cachePayload, "server_${server.name}")
+                            val parsed = parseCachedKeyboxes(cachePayload, server)
                             val statuses = parsed.map { KeyboxVerifier.verifyKeybox(it, revoked) }
                             if (parsed.isNotEmpty() && statuses.all { it == KeyboxVerifier.Status.VALID }) {
                                 serverKeyboxes[server.id] = parsed
@@ -401,6 +401,21 @@ object ServerManager {
                     }
                 }
             }
+        }
+    }
+
+    internal fun parseCachedKeyboxes(
+        bytes: ByteArray,
+        server: ServerConfig,
+    ): List<CertHack.KeyBox> {
+        val isZip = bytes.size > 4 && bytes[0] == 0x50.toByte() && bytes[1] == 0x4B.toByte()
+        if (!isZip) return KeyboxLoader.parse(bytes, "server_${server.name}")
+
+        val parsed = processContent(bytes, server)
+        return try {
+            parsed.first
+        } finally {
+            parsed.second?.fill(0)
         }
     }
 
@@ -653,10 +668,7 @@ object ServerManager {
                     }
 
                     if (allKeys.isNotEmpty()) {
-                        return Pair(
-                            allKeys,
-                            serializeKeyboxesForCache(allKeys).toByteArray(StandardCharsets.UTF_8),
-                        )
+                        return Pair(allKeys, bytes.copyOf())
                     }
                 } finally {
                     pack.cboxFiles.forEach { it.second.fill(0) }

--- a/service/src/test/java/cleveres/tricky/cleverestech/ServerManagerCacheTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ServerManagerCacheTest.kt
@@ -1,24 +1,97 @@
 package cleveres.tricky.cleverestech
 
-import cleveres.tricky.cleverestech.keystore.CertHack
+import cleveres.tricky.cleverestech.util.CboxDecryptor
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.ByteArrayOutputStream
 import java.io.StringReader
+import java.nio.charset.StandardCharsets
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 class ServerManagerCacheTest {
+    @After
+    fun tearDown() {
+        CboxDecryptor.resetForTesting()
+        KeyboxLoader.resetForTesting()
+        ManagedOpaqueKeyOracle.reset()
+    }
+
     @Test
-    fun `multi-keybox cache is serialized as one valid document`() {
-        val original =
-            CertHack.parseKeyboxXml(
-                StringReader(TestKeyboxFixtures.validEcKeyboxXml),
-                "source.xml",
-            ).single()
+    fun `zip cache preserves source payload and restores after opaque handles are reset`() {
+        val sourceXml = TestKeyboxFixtures.validEcKeyboxXml.toByteArray(StandardCharsets.UTF_8)
+        CboxDecryptor.backendOpenOverride = { _, _, _ ->
+            NativeBackend.CboxPayload(
+                author = "cache-test",
+                xmlContent = sourceXml.copyOf(),
+                hasSignature = false,
+            )
+        }
+        KeyboxLoader.parserOverride = { xml, filename ->
+            ManagedOpaqueKeyOracle.parse(
+                StringReader(String(xml, StandardCharsets.UTF_8)),
+                filename,
+            )
+        }
 
-        val cachedXml = ServerManager.serializeKeyboxesForCache(listOf(original, original))
-        val reparsed = CertHack.parseKeyboxXml(StringReader(cachedXml), "cache.xml")
+        val cbox = supportedCboxEnvelope()
+        val archive = zipOf("issuer.cbox", cbox)
+        val server = serverConfig()
+        val result = ServerManager.processContent(archive.copyOf(), server)
+        val cached = requireNotNull(result.second)
 
-        assertEquals(2, reparsed.size)
-        assertTrue(reparsed.all { it.certificates.isNotEmpty() })
+        try {
+            assertEquals(1, result.first.size)
+            assertEquals("CleveresTricky-KeyId-v1", result.first.single().keyPair().private.format)
+            assertArrayEquals(archive, cached)
+
+            // Simulate losing every managed mapping to the first Rust-owned opaque handles.
+            // A valid cache must reconstruct key material from the original archive payload.
+            ManagedOpaqueKeyOracle.reset()
+            val restored = ServerManager.parseCachedKeyboxes(cached.copyOf(), server)
+
+            assertEquals(1, restored.size)
+            assertEquals("CleveresTricky-KeyId-v1", restored.single().keyPair().private.format)
+        } finally {
+            cached.fill(0)
+            archive.fill(0)
+            cbox.fill(0)
+            sourceXml.fill(0)
+        }
+    }
+
+    private fun serverConfig() =
+        ServerManager.ServerConfig(
+            id = "cache-test",
+            name = "Cache Test",
+            url = "https://example.com/keyboxes.zip",
+            priority = 0,
+            enabled = true,
+            authType = "NONE",
+            authData = JSONObject(),
+            autoRefresh = false,
+            refreshIntervalHours = 24,
+        )
+
+    private fun supportedCboxEnvelope(): ByteArray =
+        ByteArray(4 + Int.SIZE_BYTES + 16 + 12 + 16).also { bytes ->
+            "CBOX".toByteArray(StandardCharsets.US_ASCII).copyInto(bytes)
+            bytes[7] = 1
+        }
+
+    private fun zipOf(
+        name: String,
+        content: ByteArray,
+    ): ByteArray {
+        val output = ByteArrayOutputStream()
+        ZipOutputStream(output).use { zip ->
+            zip.putNextEntry(ZipEntry(name))
+            zip.write(content)
+            zip.closeEntry()
+        }
+        return output.toByteArray()
     }
 }


### PR DESCRIPTION
## Summary
- cache validated ZIP server responses as the original archive bytes instead of re-serializing Rust-owned opaque key handles as PEM private keys
- restore ZIP cache entries through the normal archive/CBOX validation path while keeping existing XML cache compatibility
- replace the old serializer-focused cache test with an end-to-end regression that uses opaque backend handles, clears their managed mapping, and restores from cache

## Bug
`BackendKeyHandle.encoded` is a 16-byte opaque backend ID (`CleveresTricky-KeyId-v1`), not PKCS#8. The ZIP cache path re-serialized that ID under `BEGIN PRIVATE KEY`, so a later Rust parser rejected the cache after restart.

## Test coverage
`ServerManagerCacheTest` now verifies that the cached bytes equal the source ZIP and that the archive can reconstruct opaque handles after the original handle mapping is reset.