### PR TITLE
fix: prevent bugreport symlink races

### DIFF
--- a/module/install-tests/action_bugreport_security.test.sh
+++ b/module/install-tests/action_bugreport_security.test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+ACTION_SH="$REPO_ROOT/module/template/action.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  needle=$1
+  grep -Fq -- "$needle" "$ACTION_SH" || fail "action.sh is missing security contract: $needle"
+}
+
+assert_absent() {
+  needle=$1
+  if grep -Fq -- "$needle" "$ACTION_SH"; then
+    fail "action.sh restored unsafe pattern: $needle"
+  fi
+}
+
+helper=$(mktemp)
+trap 'rm -f "$helper"' EXIT
+sed -n '/^generate_report_nonce() {$/,/^}$/p' "$ACTION_SH" > "$helper"
+# shellcheck source=/dev/null
+. "$helper"
+
+nonce=$(generate_report_nonce) || fail "could not obtain a report nonce"
+[[ $nonce =~ ^[0-9a-f]{32}$ ]] || fail "report nonce is not 128-bit lowercase hex"
+
+assert_contains 'workspace="$CONFIG_DIR/.bugreport-$report_nonce"'
+assert_contains 'tmp="$workspace/payload"'
+assert_contains 'staged_archive="$workspace/report.tar.gz"'
+assert_contains 'filename="CleveresTricky-bugreport-$stamp-$report_nonce.tar.gz"'
+assert_contains 'WEBUI_BRIDGE="$MODDIR/webui_bridge"'
+assert_contains '(ulimit -f "$REPORT_FILE_BLOCK_LIMIT" && create_archive "$staged_archive")'
+assert_contains 'out=$("$WEBUI_BRIDGE" publish-report "$report_nonce" "$filename")'
+
+assert_absent 'tmp="/data/local/tmp/cleverestricky-bugreport-$$"'
+assert_absent 'mkdir -p "$shell_outdir"'
+assert_absent 'mkdir -p "$download_dir"'
+assert_absent 'create_archive "$out"'
+assert_absent 'rm -f "$out"'
+assert_absent 'chown 2000 "$SHELL_DIR/files"'
+assert_absent 'chgrp 2000 "$SHELL_DIR/files"'
+assert_absent 'cat > '\''$out'\'''
+
+echo "bugreport archive security tests passed"

--- a/module/install-tests/verify_extract_security.test.sh
+++ b/module/install-tests/verify_extract_security.test.sh
@@ -114,5 +114,6 @@ assert_rejects_symlink_parent
 assert_rejects_non_regular_target
 assert_normal_extract_succeeds
 bash "$REPO_ROOT/module/install-tests/customize_bootstrap_security.test.sh"
+bash "$REPO_ROOT/module/install-tests/action_bugreport_security.test.sh"
 
 echo "installer extraction security tests passed"

--- a/module/template/action.sh
+++ b/module/template/action.sh
@@ -5,16 +5,22 @@ MODULE_ID="cleverestricky"
 MODDIR="/data/adb/modules/$MODULE_ID"
 CONFIG_DIR="/data/adb/$MODULE_ID"
 SHELL_DIR="/data/user_de/0/com.android.shell"
+WEBUI_BRIDGE="$MODDIR/webui_bridge"
 FROM_WEBUI="${FROM_WEBUI:-0}"
 LANG_CODE="en"
 RAW_LOCALE=""
+workspace=""
 tmp=""
+
+# Android shells use either 512-byte or 1 KiB file-size blocks. This keeps the
+# staged archive at or below the native publisher's 256 MiB streaming bound.
+REPORT_FILE_BLOCK_LIMIT=262144
 
 umask 077
 
 cleanup() {
-    if [ -n "$tmp" ] && [ -e "$tmp" ]; then
-        rm -rf "$tmp" 2>/dev/null || true
+    if [ -n "$workspace" ] && [ -d "$workspace" ] && [ ! -L "$workspace" ]; then
+        rm -rf "$workspace" 2>/dev/null || true
     fi
 }
 trap cleanup EXIT INT TERM
@@ -240,6 +246,17 @@ create_archive() {
     return 1
 }
 
+generate_report_nonce() {
+    [ -r /proc/sys/kernel/random/uuid ] || return 1
+    IFS= read -r random_uuid < /proc/sys/kernel/random/uuid || return 1
+    report_nonce=$(printf '%s' "$random_uuid" | tr -d '-' | tr '[:upper:]' '[:lower:]')
+    [ "${#report_nonce}" -eq 32 ] || return 1
+    case "$report_nonce" in
+        *[!0-9a-f]*) return 1 ;;
+    esac
+    printf '%s\n' "$report_nonce"
+}
+
 detect_language
 
 if [ "$FROM_WEBUI" = "1" ] && [ "${1:-}" = "--send" ]; then
@@ -249,36 +266,35 @@ fi
 
 print_log "$(message GENERATING)"
 stamp=$(date +%Y%m%d-%H%M%S)
-tmp="/data/local/tmp/cleverestricky-bugreport-$$"
+case "$stamp" in
+    ""|*[!0-9-]*) stamp="unknown" ;;
+esac
 
+if [ ! -d "$CONFIG_DIR" ] || [ -L "$CONFIG_DIR" ]; then
+    print_log "$(message ARCHIVE_FAILED)"
+    exit 1
+fi
+if ! chown 0:0 "$CONFIG_DIR" 2>/dev/null || ! chmod 0700 "$CONFIG_DIR" 2>/dev/null; then
+    print_log "$(message ARCHIVE_FAILED)"
+    exit 1
+fi
+report_nonce=$(generate_report_nonce) || {
+    print_log "$(message ARCHIVE_FAILED)"
+    exit 1
+}
+workspace="$CONFIG_DIR/.bugreport-$report_nonce"
+if ! mkdir "$workspace" 2>/dev/null || ! chmod 0700 "$workspace" 2>/dev/null; then
+    print_log "$(message ARCHIVE_FAILED)"
+    exit 1
+fi
+tmp="$workspace/payload"
+if ! mkdir "$tmp" 2>/dev/null || ! chmod 0700 "$tmp" 2>/dev/null; then
+    print_log "$(message ARCHIVE_FAILED)"
+    exit 1
+fi
+staged_archive="$workspace/report.tar.gz"
 has_shell=false
-outdir=""
-if [ -d "$SHELL_DIR" ] && [ ! -L "$SHELL_DIR" ]; then
-    shell_outdir="$SHELL_DIR/files/bugreports"
-    if mkdir -p "$shell_outdir" 2>/dev/null; then
-        chown 2000 "$SHELL_DIR/files" "$shell_outdir" 2>/dev/null || true
-        chgrp 2000 "$SHELL_DIR/files" "$shell_outdir" 2>/dev/null || true
-        outdir="$shell_outdir"
-        has_shell=true
-        rm -f "$outdir"/CleveresTricky-bugreport-*.tar.gz 2>/dev/null || true
-    fi
-fi
-
-if [ -z "$outdir" ]; then
-    for download_dir in /sdcard/Download /storage/emulated/0/Download /data/local/tmp; do
-        if mkdir -p "$download_dir" 2>/dev/null; then
-            outdir="$download_dir"
-            break
-        fi
-    done
-fi
-
-[ -n "$outdir" ] || exit 1
-filename="CleveresTricky-bugreport-$stamp.tar.gz"
-out="$outdir/$filename"
-
-rm -rf "$tmp" 2>/dev/null || true
-mkdir -p "$tmp"
+filename="CleveresTricky-bugreport-$stamp-$report_nonce.tar.gz"
 
 print_log "$(message BASIC)"
 root_managers=""
@@ -319,7 +335,7 @@ module_state="enabled"
         printf 'module.prop unavailable\n'
     fi
     printf '\n======== disk ========\n'
-    df -h /data "$outdir" 2>/dev/null || df /data "$outdir" 2>/dev/null || true
+    df -h /data 2>/dev/null || df /data 2>/dev/null || true
 } > "$tmp/basic.txt"
 
 {
@@ -366,19 +382,33 @@ copy_report_path "/sys/fs/pstore" "android"
 copy_report_path "/data/anr" "android"
 
 print_log "$(message COMPRESSING)"
-rm -f "$out" 2>/dev/null || true
-if ! create_archive "$out"; then
+if ! (ulimit -f "$REPORT_FILE_BLOCK_LIMIT" && create_archive "$staged_archive"); then
     print_log "$(message ARCHIVE_FAILED)"
     exit 1
 fi
-
-if $has_shell; then
-    chown 2000 "$out" 2>/dev/null || true
-    chgrp 2000 "$out" 2>/dev/null || true
-    chmod 0640 "$out" 2>/dev/null || true
-else
-    chmod 0644 "$out" 2>/dev/null || true
+if [ ! -x "$WEBUI_BRIDGE" ] || [ -L "$WEBUI_BRIDGE" ]; then
+    print_log "$(message ARCHIVE_FAILED)"
+    exit 1
 fi
+out=$("$WEBUI_BRIDGE" publish-report "$report_nonce" "$filename") || {
+    print_log "$(message ARCHIVE_FAILED)"
+    exit 1
+}
+case "$out" in
+    "$SHELL_DIR/files/bugreports/"*) has_shell=true ;;
+    /storage/emulated/0/Download/*|/data/local/tmp/*) ;;
+    *)
+        print_log "$(message ARCHIVE_FAILED)"
+        exit 1
+        ;;
+esac
+filename=${out##*/}
+case "$filename" in
+    ""|*[!A-Za-z0-9._-]*)
+        print_log "$(message ARCHIVE_FAILED)"
+        exit 1
+        ;;
+esac
 
 print_log "$(message GENERATED) $out"
 

--- a/rust/service-core/src/secure_fs.rs
+++ b/rust/service-core/src/secure_fs.rs
@@ -119,6 +119,41 @@ impl TrustedDir {
         Ok(File::from(fd))
     }
 
+    pub fn chown(&self, owner: u32, group: u32) -> io::Result<()> {
+        // SAFETY: `self.fd` is a live owned descriptor. `fchown` retains no pointer or FD.
+        if unsafe { libc::fchown(self.fd.as_raw_fd(), owner, group) } == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    pub fn entry_names_bounded(&self, max_entries: usize) -> io::Result<Vec<String>> {
+        if max_entries == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "entry limit must be non-zero",
+            ));
+        }
+        let descriptor_path = format!("/proc/self/fd/{}", self.fd.as_raw_fd());
+        let mut names = Vec::new();
+        let mut scanned = 0usize;
+        for entry in std::fs::read_dir(descriptor_path)? {
+            if scanned == max_entries {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "directory entry count exceeds configured bound",
+                ));
+            }
+            scanned += 1;
+            let name = entry?.file_name();
+            if let Some(name) = name.to_str() {
+                names.push(name.to_string());
+            }
+        }
+        Ok(names)
+    }
+
     pub fn file_size_bounded(&self, name: &str, max_bytes: usize) -> io::Result<usize> {
         let (_, size) = self.open_file_bounded(name, max_bytes)?;
         Ok(size)
@@ -394,6 +429,15 @@ impl TrustedDir {
     }
 }
 
+pub fn chown_file(file: &File, owner: u32, group: u32) -> io::Result<()> {
+    // SAFETY: `file` owns a live descriptor. `fchown` retains no pointer or descriptor.
+    if unsafe { libc::fchown(file.as_raw_fd(), owner, group) } == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
 fn owned_fd(raw: RawFd) -> io::Result<OwnedFd> {
     if raw < 0 {
         return Err(io::Error::last_os_error());
@@ -617,6 +661,27 @@ mod tests {
         assert!(dir.read_range_bounded("stage", 5, 2, 8).is_err());
         assert!(dir.unlink_file("stage").unwrap());
         assert!(!dir.unlink_file("stage").unwrap());
+    }
+
+    #[test]
+    fn directory_enumeration_is_descriptor_relative_and_bounded() {
+        let root = TestDir::new();
+        let pinned = root.path.with_extension("pinned");
+        fs::write(root.path.join("first"), b"one").unwrap();
+        fs::write(root.path.join("third"), b"three").unwrap();
+        let dir = TrustedDir::open(&root.path).unwrap();
+        fs::rename(&root.path, &pinned).unwrap();
+        fs::create_dir(&root.path).unwrap();
+        fs::write(root.path.join("second"), b"two").unwrap();
+
+        assert!(dir.entry_names_bounded(1).is_err());
+        let mut names = dir.entry_names_bounded(2).unwrap();
+        names.sort();
+        assert_eq!(names, ["first", "third"]);
+        assert!(dir.entry_names_bounded(0).is_err());
+        drop(dir);
+        fs::remove_dir_all(&root.path).unwrap();
+        fs::rename(&pinned, &root.path).unwrap();
     }
 
     #[test]

--- a/rust/service-core/src/secure_fs.rs
+++ b/rust/service-core/src/secure_fs.rs
@@ -137,15 +137,13 @@ impl TrustedDir {
         }
         let descriptor_path = format!("/proc/self/fd/{}", self.fd.as_raw_fd());
         let mut names = Vec::new();
-        let mut scanned = 0usize;
-        for entry in std::fs::read_dir(descriptor_path)? {
+        for (scanned, entry) in std::fs::read_dir(descriptor_path)?.enumerate() {
             if scanned == max_entries {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "directory entry count exceeds configured bound",
                 ));
             }
-            scanned += 1;
             let name = entry?.file_name();
             if let Some(name) = name.to_str() {
                 names.push(name.to_string());

--- a/rust/webui-bridge/src/main.rs
+++ b/rust/webui-bridge/src/main.rs
@@ -416,15 +416,13 @@ fn select_download_dir() -> Result<(PathBuf, TrustedDir), String> {
 
 fn select_report_directory() -> Result<ExportDirectory, String> {
     match shell_report_directory() {
-        Ok(directory) => {
-            Ok(ExportDirectory {
-                display_path: PathBuf::from(SHELL_REPORT_DIR),
-                directory,
-                mode: 0o640,
-                owner: Some((SHELL_UID, SHELL_GID)),
-                clean_old_reports: true,
-            })
-        }
+        Ok(directory) => Ok(ExportDirectory {
+            display_path: PathBuf::from(SHELL_REPORT_DIR),
+            directory,
+            mode: 0o640,
+            owner: Some((SHELL_UID, SHELL_GID)),
+            clean_old_reports: true,
+        }),
         Err(shell_error) => {
             if let Ok((display_path, directory)) = select_download_dir() {
                 return Ok(ExportDirectory {

--- a/rust/webui-bridge/src/main.rs
+++ b/rust/webui-bridge/src/main.rs
@@ -365,8 +365,7 @@ fn export_open_file(
     filename: &str,
     target: ExportDirectory,
 ) -> Result<PathBuf, String> {
-    let (destination_name, mut output) =
-        create_export_destination(&target.directory, filename)?;
+    let (destination_name, mut output) = create_export_destination(&target.directory, filename)?;
     let destination = target.display_path.join(&destination_name);
     let created_metadata = output
         .metadata()
@@ -393,7 +392,12 @@ fn export_open_file(
     })();
     if let Err(error) = export_result {
         drop(output);
-        remove_if_same_file(&target.directory, &destination_name, &created_metadata, limit);
+        remove_if_same_file(
+            &target.directory,
+            &destination_name,
+            &created_metadata,
+            limit,
+        );
         return Err(error);
     }
     drop(output);
@@ -550,12 +554,7 @@ fn safe_file_metadata(path: &Path) -> Result<fs::Metadata, String> {
     Ok(metadata)
 }
 
-fn remove_if_same_file(
-    directory: &TrustedDir,
-    name: &str,
-    expected: &fs::Metadata,
-    limit: usize,
-) {
+fn remove_if_same_file(directory: &TrustedDir, name: &str, expected: &fs::Metadata, limit: usize) {
     let Ok((file, _)) = directory.open_file_bounded(name, limit) else {
         return;
     };

--- a/rust/webui-bridge/src/main.rs
+++ b/rust/webui-bridge/src/main.rs
@@ -1,7 +1,7 @@
 use cleverestricky_service_core::ipc::{
     read_header, write_header, FrameHeader, FLAG_ERROR, MAX_FRAME_BYTES, OP_WEB_REQUEST,
 };
-use cleverestricky_service_core::secure_fs::TrustedDir;
+use cleverestricky_service_core::secure_fs::{chown_file, TrustedDir};
 use cleverestricky_service_core::unix_socket::{connect_abstract, DAEMON_SOCKET_NAME};
 use std::env;
 use std::fs::{self, File};
@@ -13,11 +13,21 @@ use std::time::{Duration, SystemTime};
 
 const CONFIG_DIR: &str = "/data/adb/cleverestricky";
 const STAGING_DIR: &str = "/data/adb/cleverestricky/webui_bridge/staging";
+const SHELL_DIR: &str = "/data/user_de/0/com.android.shell";
+const SHELL_REPORT_DIR: &str = "/data/user_de/0/com.android.shell/files/bugreports";
+const DOWNLOAD_DIR: &str = "/storage/emulated/0/Download";
+const LOCAL_TMP_DIR: &str = "/data/local/tmp";
+const REPORT_WORKSPACE_PREFIX: &str = ".bugreport-";
+const REPORT_SOURCE_NAME: &str = "report.tar.gz";
+const SHELL_UID: u32 = 2000;
+const SHELL_GID: u32 = 2000;
 const MAX_REQUEST_BYTES: usize = MAX_FRAME_BYTES;
 const MAX_UPLOAD_BYTES: usize = 20 * 1024 * 1024;
 const MAX_DOWNLOAD_BYTES: usize = 20 * 1024 * 1024;
+const MAX_REPORT_BYTES: usize = 256 * 1024 * 1024;
 const MAX_RESPONSE_ENVELOPE_BYTES: usize = 512 * 1024;
 const MAX_CHUNK_BYTES: usize = 64 * 1024;
+const MAX_REPORT_DIRECTORY_ENTRIES: usize = 1024;
 const STALE_AGE: Duration = Duration::from_secs(10 * 60);
 
 fn main() {
@@ -53,6 +63,7 @@ fn run() -> Result<(), String> {
         }
         "stage-drop" if args.len() == 3 => stage_drop(&staging, &args[1], &args[2]),
         "export" if args.len() == 4 => export_file(&staging, &args[1], &args[2], &args[3]),
+        "publish-report" if args.len() == 3 => publish_report(&args[1], &args[2]),
         _ => Err("Invalid command".to_string()),
     }
 }
@@ -293,15 +304,81 @@ fn export_file(
         String::from_utf8(filename_bytes).map_err(|_| "Download filename is not valid UTF-8")?;
     validate_filename(&filename)?;
     let (download_path, download_dir) = select_download_dir()?;
-    let (destination_name, mut output) = create_export_destination(&download_dir, &filename)?;
-    let destination = download_path.join(&destination_name);
+    let destination = export_open_file(
+        &mut source,
+        limit,
+        &filename,
+        ExportDirectory {
+            display_path: download_path,
+            directory: download_dir,
+            mode: 0o644,
+            owner: None,
+            clean_old_reports: false,
+        },
+    )?;
+    let _ = staging.unlink_file(&source_name);
+    println!("{}", destination.display());
+    Ok(())
+}
+
+fn publish_report(id: &str, filename: &str) -> Result<(), String> {
+    validate_id(id)?;
+    validate_filename(filename)?;
+    let config = TrustedDir::open(Path::new(CONFIG_DIR))
+        .map_err(|error| format!("Configuration directory is unavailable: {error}"))?;
+    let mut source = open_report_source(&config, id)?;
+    let destination = export_open_file(
+        &mut source,
+        MAX_REPORT_BYTES,
+        filename,
+        select_report_directory()?,
+    )?;
+    println!("{}", destination.display());
+    Ok(())
+}
+
+fn open_report_source(config: &TrustedDir, id: &str) -> Result<File, String> {
+    let id = validate_id(id)?;
+    let workspace = config
+        .open_child(&format!("{REPORT_WORKSPACE_PREFIX}{id}"))
+        .map_err(|error| format!("Report workspace is unavailable: {error}"))?;
+    let (source, source_size) = workspace
+        .open_file_bounded(REPORT_SOURCE_NAME, MAX_REPORT_BYTES)
+        .map_err(|error| format!("Could not open staged report: {error}"))?;
+    if source_size == 0 {
+        return Err("Report archive is empty".to_string());
+    }
+    Ok(source)
+}
+
+struct ExportDirectory {
+    display_path: PathBuf,
+    directory: TrustedDir,
+    mode: u32,
+    owner: Option<(u32, u32)>,
+    clean_old_reports: bool,
+}
+
+fn export_open_file(
+    source: &mut File,
+    limit: usize,
+    filename: &str,
+    target: ExportDirectory,
+) -> Result<PathBuf, String> {
+    let (destination_name, mut output) =
+        create_export_destination(&target.directory, filename)?;
+    let destination = target.display_path.join(&destination_name);
     let created_metadata = output
         .metadata()
         .map_err(|error| format!("Could not inspect download descriptor: {error}"))?;
     let export_result = (|| -> Result<(), String> {
-        copy_bounded(&mut source, &mut output, limit as u64)?;
+        copy_bounded(source, &mut output, limit as u64)?;
+        if let Some((owner, group)) = target.owner {
+            chown_file(&output, owner, group)
+                .map_err(|error| format!("Could not set download ownership: {error}"))?;
+        }
         output
-            .set_permissions(fs::Permissions::from_mode(0o644))
+            .set_permissions(fs::Permissions::from_mode(target.mode))
             .map_err(|error| format!("Could not set download permissions: {error}"))?;
         output
             .sync_all()
@@ -316,20 +393,94 @@ fn export_file(
     })();
     if let Err(error) = export_result {
         drop(output);
-        remove_if_same_file(&download_dir, &destination_name, &created_metadata);
+        remove_if_same_file(&target.directory, &destination_name, &created_metadata, limit);
         return Err(error);
     }
     drop(output);
-    let _ = staging.unlink_file(&source_name);
-    println!("{}", destination.display());
-    Ok(())
+    if target.clean_old_reports {
+        cleanup_old_reports(&target.directory, &destination_name);
+    }
+    Ok(destination)
 }
 
 fn select_download_dir() -> Result<(PathBuf, TrustedDir), String> {
-    let candidate = PathBuf::from("/storage/emulated/0/Download");
+    let candidate = PathBuf::from(DOWNLOAD_DIR);
     let directory = TrustedDir::open(&candidate)
         .map_err(|error| format!("Android Download directory is unavailable: {error}"))?;
     Ok((candidate, directory))
+}
+
+fn select_report_directory() -> Result<ExportDirectory, String> {
+    match shell_report_directory() {
+        Ok(directory) => {
+            return Ok(ExportDirectory {
+                display_path: PathBuf::from(SHELL_REPORT_DIR),
+                directory,
+                mode: 0o640,
+                owner: Some((SHELL_UID, SHELL_GID)),
+                clean_old_reports: true,
+            });
+        }
+        Err(shell_error) => {
+            if let Ok((display_path, directory)) = select_download_dir() {
+                return Ok(ExportDirectory {
+                    display_path,
+                    directory,
+                    mode: 0o644,
+                    owner: None,
+                    clean_old_reports: true,
+                });
+            }
+            let display_path = PathBuf::from(LOCAL_TMP_DIR);
+            let directory = TrustedDir::open(&display_path).map_err(|tmp_error| {
+                format!(
+                    "No report destination is available (shell: {shell_error}; tmp: {tmp_error})"
+                )
+            })?;
+            Ok(ExportDirectory {
+                display_path,
+                directory,
+                mode: 0o640,
+                owner: Some((SHELL_UID, SHELL_GID)),
+                clean_old_reports: true,
+            })
+        }
+    }
+}
+
+fn shell_report_directory() -> Result<TrustedDir, String> {
+    let shell = TrustedDir::open(Path::new(SHELL_DIR))
+        .map_err(|error| format!("Android shell directory is unavailable: {error}"))?;
+    let files = shell
+        .mkdir_child("files", 0o700)
+        .map_err(|error| format!("Android shell files directory is unavailable: {error}"))?;
+    files
+        .chown(SHELL_UID, SHELL_GID)
+        .map_err(|error| format!("Could not set shell files ownership: {error}"))?;
+    let reports = files
+        .mkdir_child("bugreports", 0o700)
+        .map_err(|error| format!("Android shell report directory is unavailable: {error}"))?;
+    reports
+        .chown(SHELL_UID, SHELL_GID)
+        .map_err(|error| format!("Could not set shell report ownership: {error}"))?;
+    reports
+        .sync()
+        .map_err(|error| format!("Could not persist shell report directory: {error}"))?;
+    Ok(reports)
+}
+
+fn cleanup_old_reports(directory: &TrustedDir, keep: &str) {
+    let Ok(names) = directory.entry_names_bounded(MAX_REPORT_DIRECTORY_ENTRIES) else {
+        return;
+    };
+    for name in names {
+        if name != keep
+            && name.starts_with("CleveresTricky-bugreport-")
+            && name.ends_with(".tar.gz")
+        {
+            let _ = directory.unlink_file(&name);
+        }
+    }
 }
 
 fn validate_filename(filename: &str) -> Result<(), String> {
@@ -399,8 +550,13 @@ fn safe_file_metadata(path: &Path) -> Result<fs::Metadata, String> {
     Ok(metadata)
 }
 
-fn remove_if_same_file(directory: &TrustedDir, name: &str, expected: &fs::Metadata) {
-    let Ok((file, _)) = directory.open_file_bounded(name, MAX_DOWNLOAD_BYTES) else {
+fn remove_if_same_file(
+    directory: &TrustedDir,
+    name: &str,
+    expected: &fs::Metadata,
+    limit: usize,
+) {
+    let Ok((file, _)) = directory.open_file_bounded(name, limit) else {
         return;
     };
     let Ok(metadata) = file.metadata() else {
@@ -582,6 +738,91 @@ mod tests {
         assert!(!outside.join(&name).exists());
 
         fs::remove_file(&download).unwrap();
+        fs::remove_dir_all(&base).unwrap();
+    }
+
+    #[test]
+    fn report_source_rejects_symlinked_workspace_and_pins_open_file() {
+        static COUNTER: AtomicU64 = AtomicU64::new(1);
+        let base = env::temp_dir().join(format!(
+            "ct-report-source-{}-{}",
+            process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        let config_path = base.join("config");
+        let outside = base.join("outside");
+        let id = "0123456789abcdef0123456789abcdef";
+        let workspace_name = format!("{REPORT_WORKSPACE_PREFIX}{id}");
+        let workspace_path = config_path.join(&workspace_name);
+        fs::create_dir_all(&config_path).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(outside.join(REPORT_SOURCE_NAME), b"outside").unwrap();
+        let config = TrustedDir::open(&config_path).unwrap();
+
+        symlink(&outside, &workspace_path).unwrap();
+        assert!(open_report_source(&config, id).is_err());
+        fs::remove_file(&workspace_path).unwrap();
+
+        fs::create_dir(&workspace_path).unwrap();
+        fs::write(workspace_path.join(REPORT_SOURCE_NAME), b"original").unwrap();
+        let mut source = open_report_source(&config, id).unwrap();
+        let pinned = config_path.join("workspace.pinned");
+        fs::rename(&workspace_path, &pinned).unwrap();
+        symlink(&outside, &workspace_path).unwrap();
+        let mut bytes = Vec::new();
+        source.read_to_end(&mut bytes).unwrap();
+        assert_eq!(bytes, b"original");
+
+        drop(source);
+        drop(config);
+        fs::remove_file(&workspace_path).unwrap();
+        fs::remove_dir_all(&base).unwrap();
+    }
+
+    #[test]
+    fn report_export_cleans_only_prior_report_files_after_success() {
+        static COUNTER: AtomicU64 = AtomicU64::new(1);
+        let base = env::temp_dir().join(format!(
+            "ct-report-cleanup-{}-{}",
+            process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        let output_path = base.join("output");
+        let source_path = base.join("source.tar.gz");
+        fs::create_dir_all(&output_path).unwrap();
+        fs::write(&source_path, b"report").unwrap();
+        fs::write(
+            output_path.join("CleveresTricky-bugreport-old.tar.gz"),
+            b"old",
+        )
+        .unwrap();
+        fs::write(output_path.join("unrelated.tar.gz"), b"keep").unwrap();
+        let directory = TrustedDir::open(&output_path).unwrap();
+        let mut source = File::open(&source_path).unwrap();
+        let filename = "CleveresTricky-bugreport-new.tar.gz";
+
+        let destination = export_open_file(
+            &mut source,
+            64,
+            filename,
+            ExportDirectory {
+                display_path: output_path.clone(),
+                directory,
+                mode: 0o600,
+                owner: None,
+                clean_old_reports: true,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(fs::read(destination).unwrap(), b"report");
+        assert!(!output_path
+            .join("CleveresTricky-bugreport-old.tar.gz")
+            .exists());
+        assert_eq!(
+            fs::read(output_path.join("unrelated.tar.gz")).unwrap(),
+            b"keep"
+        );
         fs::remove_dir_all(&base).unwrap();
     }
 

--- a/rust/webui-bridge/src/main.rs
+++ b/rust/webui-bridge/src/main.rs
@@ -417,13 +417,13 @@ fn select_download_dir() -> Result<(PathBuf, TrustedDir), String> {
 fn select_report_directory() -> Result<ExportDirectory, String> {
     match shell_report_directory() {
         Ok(directory) => {
-            return Ok(ExportDirectory {
+            Ok(ExportDirectory {
                 display_path: PathBuf::from(SHELL_REPORT_DIR),
                 directory,
                 mode: 0o640,
                 owner: Some((SHELL_UID, SHELL_GID)),
                 clean_old_reports: true,
-            });
+            })
         }
         Err(shell_error) => {
             if let Ok((display_path, directory)) = select_download_dir() {


### PR DESCRIPTION
## Summary
- stage diagnostic payloads and archives inside a randomized, root-only configuration workspace with a hard file-size limit
- publish reports through the native secure-file capability layer using descriptor-relative directories, `O_NOFOLLOW|O_EXCL`, bounded streaming, inode revalidation, and descriptor-based ownership changes
- preserve the Android shell content-provider/share path, with safe Download and local-tmp fallbacks
- clean previous report files only through the pinned directory capability

## Root cause
`action.sh` used predictable PID/timestamp paths and performed root `mkdir`, `chown`, `tar -czf`, and post-write permission changes through directories writable by uid 2000. A local shell process could replace an intermediate path or race the final filename with a symlink, turning report generation into an arbitrary privileged write/chown.

## Regression coverage
- randomized 128-bit report workspace/name contract
- no direct shell-side creation or publication into attacker-controlled output paths
- descriptor-relative bounded directory enumeration
- symlinked report workspaces are rejected and an opened source remains snapshot-bound
- successful publication removes only prior CleveresTricky reports and preserves unrelated files
- existing export destination path-replacement regression remains shared by report publication

## Local validation
- `git diff --check`
- Bash syntax checks for all module template/install-test scripts
- installer/bootstrap and bugreport security regression suites

The local environment does not include Cargo, rustfmt, or shellcheck; the exact-head Build, Security Regression, Native Hardening, Rust Lockfile Check, and Rust Fuzz Smoke workflows are required before merge.