### PR TITLE
fix: bound bugreport collection

### DIFF
--- a/module/install-tests/action_bugreport_security.test.sh
+++ b/module/install-tests/action_bugreport_security.test.sh
@@ -22,7 +22,8 @@ assert_absent() {
 }
 
 helper=$(mktemp)
-trap 'rm -f "$helper"' EXIT
+test_root=$(mktemp -d)
+trap 'rm -f "$helper"; rm -rf "$test_root"' EXIT
 sed -n '/^generate_report_nonce() {$/,/^}$/p' "$ACTION_SH" > "$helper"
 # shellcheck source=/dev/null
 . "$helper"
@@ -37,6 +38,14 @@ assert_contains 'filename="CleveresTricky-bugreport-$stamp-$report_nonce.tar.gz"
 assert_contains 'WEBUI_BRIDGE="$MODDIR/webui_bridge"'
 assert_contains '(ulimit -f "$REPORT_FILE_BLOCK_LIMIT" && create_archive "$staged_archive")'
 assert_contains 'out=$("$WEBUI_BRIDGE" publish-report "$report_nonce" "$filename")'
+assert_contains 'REPORT_COPY_FILE_LIMIT=128'
+assert_contains 'REPORT_COPY_BLOCK_SIZE=4096'
+assert_contains 'REPORT_COPY_BLOCK_COUNT=256'
+assert_contains 'REPORT_LOG_FILE_BLOCK_LIMIT=8192'
+assert_contains 'find "$copy_src" -xdev -type f'
+assert_contains 'dd if="$report_file" of="$report_destination"'
+assert_contains 'write_bounded_log "$tmp/logcat-all.log" logcat -b all -d -v threadtime'
+assert_contains 'write_bounded_log "$tmp/dmesg.log" dmesg'
 
 assert_absent 'tmp="/data/local/tmp/cleverestricky-bugreport-$$"'
 assert_absent 'mkdir -p "$shell_outdir"'
@@ -46,5 +55,49 @@ assert_absent 'rm -f "$out"'
 assert_absent 'chown 2000 "$SHELL_DIR/files"'
 assert_absent 'chgrp 2000 "$SHELL_DIR/files"'
 assert_absent 'cat > '\''$out'\'''
+assert_absent 'cp -a "$copy_src"'
+
+sed -n '/^copy_report_path() {$/,/^}$/p' "$ACTION_SH" > "$helper"
+sed -n '/^write_bounded_log() {$/,/^}$/p' "$ACTION_SH" >> "$helper"
+# shellcheck source=/dev/null
+. "$helper"
+
+print_log() { :; }
+message() { printf '%s' "$1"; }
+workspace="$test_root/workspace"
+tmp="$workspace/payload"
+mkdir -p "$tmp" "$test_root/source/nested" "$test_root/second"
+printf '0123456789abcdef' > "$test_root/source/one.log"
+printf 'abcdefghijklmnop' > "$test_root/source/nested/two.log"
+printf 'ABCDEFGHIJKLMNOP' > "$test_root/source/three.log"
+printf 'must-not-be-copied' > "$test_root/second/four.log"
+
+REPORT_COPY_FILE_LIMIT=2
+REPORT_COPY_BLOCK_SIZE=4
+REPORT_COPY_BLOCK_COUNT=2
+report_copy_count=0
+copy_report_path "$test_root/source" bounded
+[ "$report_copy_count" -eq 2 ] || fail "collection did not enforce the total file-count limit"
+[ -d "$tmp/bounded/source" ] || fail "collection did not preserve the source directory label"
+[ "$(find "$tmp/bounded" -type f | wc -l)" -eq 2 ] || fail "collection copied too many files"
+while IFS= read -r copied_file; do
+  [ "$(wc -c < "$copied_file")" -le 8 ] || fail "collection copied more than the per-file byte limit"
+done < <(find "$tmp/bounded" -type f)
+copy_report_path "$test_root/second" bounded
+[ -z "$(find "$tmp/bounded" -name four.log -print -quit)" ] || fail "collection ignored its cross-source file-count limit"
+
+rm -rf "$tmp/bounded"
+mkdir -p "$tmp"
+REPORT_COPY_FILE_LIMIT=4
+report_copy_count=0
+ln -s "$test_root/second/four.log" "$test_root/source/linked.log"
+copy_report_path "$test_root/source" regular-only
+[ -z "$(find "$tmp/regular-only" -name linked.log -print -quit)" ] || fail "collection copied a symbolic link"
+
+REPORT_LOG_FILE_BLOCK_LIMIT=4
+if write_bounded_log "$tmp/bounded-command.log" dd if=/dev/zero bs=1024 count=32 2>/dev/null; then
+  fail "bounded command log unexpectedly accepted oversized output"
+fi
+[ "$(wc -c < "$tmp/bounded-command.log")" -le 4096 ] || fail "command log exceeded its ulimit bound"
 
 echo "bugreport archive security tests passed"

--- a/module/template/action.sh
+++ b/module/template/action.sh
@@ -224,11 +224,11 @@ copy_report_path() {
     report_file_list="$workspace/.report-files"
     : > "$report_file_list"
     if [ -d "$copy_src" ]; then
-        copy_source_kind=directory
+        copy_source_kind="directory"
         copy_source_label=${copy_src##*/}
         find "$copy_src" -xdev -type f 2>/dev/null | head -n "$remaining_files" > "$report_file_list" || true
     elif [ -f "$copy_src" ]; then
-        copy_source_kind=file
+        copy_source_kind="file"
         printf '%s\n' "$copy_src" > "$report_file_list"
     else
         rm -f "$report_file_list"
@@ -237,7 +237,9 @@ copy_report_path() {
 
     while IFS= read -r report_file; do
         [ "$report_copy_count" -lt "$REPORT_COPY_FILE_LIMIT" ] || break
-        [ -f "$report_file" ] && [ ! -L "$report_file" ] || continue
+        if [ ! -f "$report_file" ] || [ -L "$report_file" ]; then
+            continue
+        fi
         if [ "$copy_source_kind" = directory ]; then
             case "$report_file" in
                 "$copy_src"/*)

--- a/module/template/action.sh
+++ b/module/template/action.sh
@@ -16,6 +16,16 @@ tmp=""
 # staged archive at or below the native publisher's 256 MiB streaming bound.
 REPORT_FILE_BLOCK_LIMIT=262144
 
+# Bound the uncompressed collection before tar sees it. Directory snapshots keep
+# at most 128 regular files and at most 1 MiB from each file. Generated command
+# logs are independently capped to at most 8 MiB on Android shells that use
+# 1 KiB ulimit blocks (and 4 MiB on 512-byte-block shells).
+REPORT_COPY_FILE_LIMIT=128
+REPORT_COPY_BLOCK_SIZE=4096
+REPORT_COPY_BLOCK_COUNT=256
+REPORT_LOG_FILE_BLOCK_LIMIT=8192
+report_copy_count=0
+
 umask 077
 
 cleanup() {
@@ -206,11 +216,61 @@ send_bugreport() {
 copy_report_path() {
     copy_src="$1"
     copy_group="$2"
-    if [ -e "$copy_src" ] && [ ! -L "$copy_src" ]; then
-        print_log "$(message ADDING) $copy_src"
-        mkdir -p "$tmp/$copy_group"
-        cp -a "$copy_src" "$tmp/$copy_group/" 2>/dev/null || true
+    [ "$report_copy_count" -lt "$REPORT_COPY_FILE_LIMIT" ] || return 0
+    [ -e "$copy_src" ] && [ ! -L "$copy_src" ] || return 0
+
+    print_log "$(message ADDING) $copy_src"
+    remaining_files=$((REPORT_COPY_FILE_LIMIT - report_copy_count))
+    report_file_list="$workspace/.report-files"
+    : > "$report_file_list"
+    if [ -d "$copy_src" ]; then
+        copy_source_kind=directory
+        copy_source_label=${copy_src##*/}
+        find "$copy_src" -xdev -type f 2>/dev/null | head -n "$remaining_files" > "$report_file_list" || true
+    elif [ -f "$copy_src" ]; then
+        copy_source_kind=file
+        printf '%s\n' "$copy_src" > "$report_file_list"
+    else
+        rm -f "$report_file_list"
+        return 0
     fi
+
+    while IFS= read -r report_file; do
+        [ "$report_copy_count" -lt "$REPORT_COPY_FILE_LIMIT" ] || break
+        [ -f "$report_file" ] && [ ! -L "$report_file" ] || continue
+        if [ "$copy_source_kind" = directory ]; then
+            case "$report_file" in
+                "$copy_src"/*)
+                    relative_report_path=${report_file#"$copy_src"/}
+                    relative_report_path="$copy_source_label/$relative_report_path"
+                    ;;
+                *) continue ;;
+            esac
+        else
+            relative_report_path=${report_file##*/}
+        fi
+        case "$relative_report_path" in
+            ""|/*|..|../*|*/..|*/../*) continue ;;
+        esac
+
+        report_destination="$tmp/$copy_group/$relative_report_path"
+        report_parent=${report_destination%/*}
+        mkdir -p "$report_parent" 2>/dev/null || continue
+        if dd if="$report_file" of="$report_destination" \
+            bs="$REPORT_COPY_BLOCK_SIZE" count="$REPORT_COPY_BLOCK_COUNT" 2>/dev/null; then
+            chmod 0600 "$report_destination" 2>/dev/null || true
+            report_copy_count=$((report_copy_count + 1))
+        else
+            rm -f "$report_destination"
+        fi
+    done < "$report_file_list"
+    rm -f "$report_file_list"
+}
+
+write_bounded_log() {
+    log_output="$1"
+    shift
+    (ulimit -f "$REPORT_LOG_FILE_BLOCK_LIMIT" && "$@") > "$log_output" 2>&1
 }
 
 write_payload_hashes() {
@@ -356,14 +416,14 @@ module_state="enabled"
 write_payload_hashes
 
 print_log "$(message LOGS)"
-if ! logcat -b all -d -v threadtime -f "$tmp/logcat-all.log" 2>/dev/null; then
-    logcat -d -v threadtime -f "$tmp/logcat-all.log" 2>/dev/null || true
+if ! write_bounded_log "$tmp/logcat-all.log" logcat -b all -d -v threadtime; then
+    write_bounded_log "$tmp/logcat-all.log" logcat -d -v threadtime || true
 fi
 if [ -f "$tmp/logcat-all.log" ]; then
-    grep -i 'cleverestricky' "$tmp/logcat-all.log" > "$tmp/logcat-cleverestricky.log" 2>/dev/null || true
+    write_bounded_log "$tmp/logcat-cleverestricky.log" grep -i 'cleverestricky' "$tmp/logcat-all.log" || true
 fi
 
-dmesg > "$tmp/dmesg.log" 2>&1 || true
+write_bounded_log "$tmp/dmesg.log" dmesg || true
 
 copy_report_path "$CONFIG_DIR/logs" "cleverestricky"
 copy_report_path "$CONFIG_DIR/log" "cleverestricky"


### PR DESCRIPTION
## Summary
- replace recursive `cp -a` report collection with regular-file-only snapshots
- cap the whole directory snapshot at 128 files and each copied file at 1 MiB while preserving source directory labels
- cap logcat, filtered logcat, and dmesg outputs with a per-file `ulimit`

## Root cause
The final compressed archive had a 256 MiB limit, but `action.sh` first recursively copied tombstones, Dropbox entries, ANR traces, root-manager logs, and module logs into `/data/adb` without any entry or byte bound. A sufficiently large but otherwise normal diagnostic history could fill `/data` before archive creation reached its limit. `cp -a` also preserved non-regular entries in the support bundle.

## Regression coverage
- global file-count cap persists across all source directories
- per-file copies stop at the configured byte bound
- source directory labels remain distinct
- symbolic links are excluded
- generated command logs stop at the configured file-size limit
- prior randomized workspace and secure native publication contracts remain enforced

## Local validation
- `git diff --check`
- POSIX shell syntax check for `action.sh`
- Bash syntax check for the regression test
- bugreport collection regression test
- full installer/bootstrap extraction security suite

Exact-head Build, Security Regression, and Native Hardening workflows are required before merge; Rust workflows must also be green if GitHub triggers them.