### PR TITLE
fix: bind bugreport reads to pinned source descriptors

### DIFF
--- a/module/install-tests/action_bugreport_security.test.sh
+++ b/module/install-tests/action_bugreport_security.test.sh
@@ -39,11 +39,9 @@ assert_contains 'WEBUI_BRIDGE="$MODDIR/webui_bridge"'
 assert_contains '(ulimit -f "$REPORT_FILE_BLOCK_LIMIT" && create_archive "$staged_archive")'
 assert_contains 'out=$("$WEBUI_BRIDGE" publish-report "$report_nonce" "$filename")'
 assert_contains 'REPORT_COPY_FILE_LIMIT=128'
-assert_contains 'REPORT_COPY_BLOCK_SIZE=4096'
-assert_contains 'REPORT_COPY_BLOCK_COUNT=256'
 assert_contains 'REPORT_LOG_FILE_BLOCK_LIMIT=8192'
 assert_contains 'find "$copy_src" -xdev -type f'
-assert_contains 'dd if="$report_file" of="$report_destination"'
+assert_contains '"$WEBUI_BRIDGE" copy-report-file "$report_nonce" "$1" "$2" "$3"'
 assert_contains 'write_bounded_log "$tmp/logcat-all.log" logcat -b all -d -v threadtime'
 assert_contains 'write_bounded_log "$tmp/dmesg.log" dmesg'
 
@@ -56,6 +54,7 @@ assert_absent 'chown 2000 "$SHELL_DIR/files"'
 assert_absent 'chgrp 2000 "$SHELL_DIR/files"'
 assert_absent 'cat > '\''$out'\'''
 assert_absent 'cp -a "$copy_src"'
+assert_absent 'dd if="$report_file"'
 
 sed -n '/^copy_report_path() {$/,/^}$/p' "$ACTION_SH" > "$helper"
 sed -n '/^write_bounded_log() {$/,/^}$/p' "$ACTION_SH" >> "$helper"
@@ -66,6 +65,7 @@ print_log() { :; }
 message() { printf '%s' "$1"; }
 workspace="$test_root/workspace"
 tmp="$workspace/payload"
+report_nonce=0123456789abcdef0123456789abcdef
 mkdir -p "$tmp" "$test_root/source/nested" "$test_root/second"
 printf '0123456789abcdef' > "$test_root/source/one.log"
 printf 'abcdefghijklmnop' > "$test_root/source/nested/two.log"
@@ -73,8 +73,14 @@ printf 'ABCDEFGHIJKLMNOP' > "$test_root/source/three.log"
 printf 'must-not-be-copied' > "$test_root/second/four.log"
 
 REPORT_COPY_FILE_LIMIT=2
-REPORT_COPY_BLOCK_SIZE=4
-REPORT_COPY_BLOCK_COUNT=2
+copy_report_file() {
+  source_root=$1
+  source_relative_path=$2
+  destination_relative_path=$3
+  destination="$tmp/$destination_relative_path"
+  mkdir -p "${destination%/*}"
+  dd if="$source_root/$source_relative_path" of="$destination" bs=4 count=2 2>/dev/null
+}
 report_copy_count=0
 copy_report_path "$test_root/source" bounded
 [ "$report_copy_count" -eq 2 ] || fail "collection did not enforce the total file-count limit"

--- a/module/template/action.sh
+++ b/module/template/action.sh
@@ -17,12 +17,11 @@ tmp=""
 REPORT_FILE_BLOCK_LIMIT=262144
 
 # Bound the uncompressed collection before tar sees it. Directory snapshots keep
-# at most 128 regular files and at most 1 MiB from each file. Generated command
-# logs are independently capped to at most 8 MiB on Android shells that use
-# 1 KiB ulimit blocks (and 4 MiB on 512-byte-block shells).
+# at most 128 regular files. The native collector pins each source directory and
+# reads at most 1 MiB from a single O_NOFOLLOW descriptor. Generated command logs
+# are independently capped to at most 8 MiB on Android shells that use 1 KiB
+# ulimit blocks (and 4 MiB on 512-byte-block shells).
 REPORT_COPY_FILE_LIMIT=128
-REPORT_COPY_BLOCK_SIZE=4096
-REPORT_COPY_BLOCK_COUNT=256
 REPORT_LOG_FILE_BLOCK_LIMIT=8192
 report_copy_count=0
 
@@ -213,6 +212,10 @@ send_bugreport() {
     su 2000 -c "am start -a android.intent.action.SEND --eu android.intent.extra.STREAM content://com.android.shell/bugreports/$share_file -t '*/*' --grant-read-uri-permission" >/dev/null 2>&1
 }
 
+copy_report_file() {
+    "$WEBUI_BRIDGE" copy-report-file "$report_nonce" "$1" "$2" "$3"
+}
+
 copy_report_path() {
     copy_src="$1"
     copy_group="$2"
@@ -243,27 +246,30 @@ copy_report_path() {
         if [ "$copy_source_kind" = directory ]; then
             case "$report_file" in
                 "$copy_src"/*)
-                    relative_report_path=${report_file#"$copy_src"/}
-                    relative_report_path="$copy_source_label/$relative_report_path"
+                    source_root="$copy_src"
+                    source_relative_path=${report_file#"$copy_src"/}
+                    relative_report_path="$copy_source_label/$source_relative_path"
                     ;;
                 *) continue ;;
             esac
         else
+            source_root=${copy_src%/*}
+            [ -n "$source_root" ] || source_root=/
+            source_relative_path=${copy_src##*/}
             relative_report_path=${report_file##*/}
         fi
-        case "$relative_report_path" in
+        case "$source_relative_path" in
+            ""|/*|..|../*|*/..|*/../*) continue ;;
+        esac
+        destination_relative_path="$copy_group/$relative_report_path"
+        case "$destination_relative_path" in
             ""|/*|..|../*|*/..|*/../*) continue ;;
         esac
 
-        report_destination="$tmp/$copy_group/$relative_report_path"
-        report_parent=${report_destination%/*}
-        mkdir -p "$report_parent" 2>/dev/null || continue
-        if dd if="$report_file" of="$report_destination" \
-            bs="$REPORT_COPY_BLOCK_SIZE" count="$REPORT_COPY_BLOCK_COUNT" 2>/dev/null; then
-            chmod 0600 "$report_destination" 2>/dev/null || true
+        if copy_report_file \
+            "$source_root" "$source_relative_path" "$destination_relative_path" \
+            >/dev/null 2>&1; then
             report_copy_count=$((report_copy_count + 1))
-        else
-            rm -f "$report_destination"
         fi
     done < "$report_file_list"
     rm -f "$report_file_list"

--- a/rust/service-core/src/secure_fs.rs
+++ b/rust/service-core/src/secure_fs.rs
@@ -104,6 +104,26 @@ impl TrustedDir {
         }
     }
 
+    /// Read at most `max_bytes` from a regular file opened relative to this pinned directory.
+    ///
+    /// Unlike [`Self::read_bounded`], this intentionally accepts a larger source and returns its
+    /// bounded prefix. The final component is opened once with `O_NOFOLLOW`; validation and reads
+    /// therefore stay attached to the same descriptor even if the path is replaced concurrently.
+    pub fn read_prefix_bounded(&self, name: &str, max_bytes: usize) -> io::Result<Vec<u8>> {
+        if max_bytes == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "read limit must be non-zero",
+            ));
+        }
+        let name = component(name)?;
+        let fd = self.open_regular(&name, libc::O_RDONLY, 0)?;
+        let mut file = File::from(fd).take(max_bytes as u64);
+        let mut output = Vec::new();
+        file.read_to_end(&mut output)?;
+        Ok(output)
+    }
+
     pub fn open_file_bounded(&self, name: &str, max_bytes: usize) -> io::Result<(File, usize)> {
         let name = component(name)?;
         let fd = self.open_regular(&name, libc::O_RDONLY, 0)?;
@@ -731,6 +751,24 @@ mod tests {
         dir.atomic_write("escape", b"inside", 0o600).unwrap();
         assert_eq!(fs::read(&outside).unwrap(), b"outside");
         assert_eq!(fs::read(root.path.join("escape")).unwrap(), b"inside");
+        let _ = fs::remove_file(outside);
+    }
+
+    #[test]
+    fn prefix_read_is_bounded_and_rejects_replaced_symlink() {
+        let root = TestDir::new();
+        let outside = root.path.with_extension("prefix-outside");
+        fs::write(root.path.join("source"), b"0123456789").unwrap();
+        fs::write(&outside, b"outside-secret").unwrap();
+        let dir = TrustedDir::open(&root.path).unwrap();
+
+        assert_eq!(dir.read_prefix_bounded("source", 4).unwrap(), b"0123");
+        assert!(dir.read_prefix_bounded("source", 0).is_err());
+
+        fs::remove_file(root.path.join("source")).unwrap();
+        symlink(&outside, root.path.join("source")).unwrap();
+        assert!(dir.read_prefix_bounded("source", 64).is_err());
+        assert_eq!(fs::read(&outside).unwrap(), b"outside-secret");
         let _ = fs::remove_file(outside);
     }
 

--- a/rust/webui-bridge/src/main.rs
+++ b/rust/webui-bridge/src/main.rs
@@ -422,11 +422,7 @@ fn read_report_file(directory: &TrustedDir, components: &[&str]) -> io::Result<V
     }
 }
 
-fn write_report_file(
-    directory: &TrustedDir,
-    components: &[&str],
-    bytes: &[u8],
-) -> io::Result<()> {
+fn write_report_file(directory: &TrustedDir, components: &[&str], bytes: &[u8]) -> io::Result<()> {
     match components {
         [name] => directory.atomic_write(name, bytes, 0o600),
         [directory_name, remaining @ ..] => {
@@ -914,11 +910,7 @@ mod tests {
         assert!(copied.iter().all(|byte| *byte == 0x5a));
 
         symlink(&outside_path, pinned_path.join("escape-dir")).unwrap();
-        symlink(
-            outside_path.join("secret"),
-            pinned_path.join("escape-file"),
-        )
-        .unwrap();
+        symlink(outside_path.join("secret"), pinned_path.join("escape-file")).unwrap();
         assert!(copy_report_file_between(
             &source,
             &["escape-dir", "secret"],

--- a/rust/webui-bridge/src/main.rs
+++ b/rust/webui-bridge/src/main.rs
@@ -25,6 +25,9 @@ const MAX_REQUEST_BYTES: usize = MAX_FRAME_BYTES;
 const MAX_UPLOAD_BYTES: usize = 20 * 1024 * 1024;
 const MAX_DOWNLOAD_BYTES: usize = 20 * 1024 * 1024;
 const MAX_REPORT_BYTES: usize = 256 * 1024 * 1024;
+const MAX_REPORT_SOURCE_BYTES: usize = 1024 * 1024;
+const MAX_REPORT_RELATIVE_PATH_BYTES: usize = 4096;
+const MAX_REPORT_PATH_COMPONENTS: usize = 64;
 const MAX_RESPONSE_ENVELOPE_BYTES: usize = 512 * 1024;
 const MAX_CHUNK_BYTES: usize = 64 * 1024;
 const MAX_REPORT_DIRECTORY_ENTRIES: usize = 1024;
@@ -63,6 +66,9 @@ fn run() -> Result<(), String> {
         }
         "stage-drop" if args.len() == 3 => stage_drop(&staging, &args[1], &args[2]),
         "export" if args.len() == 4 => export_file(&staging, &args[1], &args[2], &args[3]),
+        "copy-report-file" if args.len() == 5 => {
+            copy_report_file(&args[1], &args[2], &args[3], &args[4])
+        }
         "publish-report" if args.len() == 3 => publish_report(&args[1], &args[2]),
         _ => Err("Invalid command".to_string()),
     }
@@ -335,6 +341,103 @@ fn publish_report(id: &str, filename: &str) -> Result<(), String> {
     )?;
     println!("{}", destination.display());
     Ok(())
+}
+
+fn copy_report_file(
+    id: &str,
+    source_root: &str,
+    source_relative: &str,
+    destination_relative: &str,
+) -> Result<(), String> {
+    validate_id(id)?;
+    let source_path = Path::new(source_root);
+    if !source_path.is_absolute() || source_root.len() > MAX_REPORT_RELATIVE_PATH_BYTES {
+        return Err("Invalid report source root".to_string());
+    }
+    let source_components = report_path_components(source_relative)?;
+    let destination_components = report_path_components(destination_relative)?;
+
+    let config = TrustedDir::open(Path::new(CONFIG_DIR))
+        .map_err(|error| format!("Configuration directory is unavailable: {error}"))?;
+    let workspace = config
+        .open_child(&format!("{REPORT_WORKSPACE_PREFIX}{id}"))
+        .map_err(|error| format!("Report workspace is unavailable: {error}"))?;
+    let payload = workspace
+        .open_child("payload")
+        .map_err(|error| format!("Report payload directory is unavailable: {error}"))?;
+    let source = TrustedDir::open(source_path)
+        .map_err(|error| format!("Report source directory is unavailable: {error}"))?;
+
+    copy_report_file_between(
+        &source,
+        &source_components,
+        &payload,
+        &destination_components,
+    )
+    .map_err(|error| format!("Could not snapshot report source: {error}"))?;
+    println!("1");
+    Ok(())
+}
+
+fn report_path_components(value: &str) -> Result<Vec<&str>, String> {
+    if value.is_empty()
+        || value.len() > MAX_REPORT_RELATIVE_PATH_BYTES
+        || value.starts_with('/')
+        || value.ends_with('/')
+    {
+        return Err("Invalid report-relative path".to_string());
+    }
+    let components: Vec<_> = value.split('/').collect();
+    if components.len() > MAX_REPORT_PATH_COMPONENTS
+        || components
+            .iter()
+            .any(|component| component.is_empty() || *component == "." || *component == "..")
+    {
+        return Err("Invalid report-relative path".to_string());
+    }
+    Ok(components)
+}
+
+fn copy_report_file_between(
+    source: &TrustedDir,
+    source_components: &[&str],
+    destination: &TrustedDir,
+    destination_components: &[&str],
+) -> io::Result<()> {
+    let bytes = read_report_file(source, source_components)?;
+    write_report_file(destination, destination_components, &bytes)
+}
+
+fn read_report_file(directory: &TrustedDir, components: &[&str]) -> io::Result<Vec<u8>> {
+    match components {
+        [name] => directory.read_prefix_bounded(name, MAX_REPORT_SOURCE_BYTES),
+        [directory_name, remaining @ ..] => {
+            let child = directory.open_child(directory_name)?;
+            read_report_file(&child, remaining)
+        }
+        [] => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "report source path is empty",
+        )),
+    }
+}
+
+fn write_report_file(
+    directory: &TrustedDir,
+    components: &[&str],
+    bytes: &[u8],
+) -> io::Result<()> {
+    match components {
+        [name] => directory.atomic_write(name, bytes, 0o600),
+        [directory_name, remaining @ ..] => {
+            let child = directory.mkdir_child(directory_name, 0o700)?;
+            write_report_file(&child, remaining, bytes)
+        }
+        [] => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "report destination path is empty",
+        )),
+    }
 }
 
 fn open_report_source(config: &TrustedDir, id: &str) -> Result<File, String> {
@@ -773,6 +876,69 @@ mod tests {
         drop(source);
         drop(config);
         fs::remove_file(&workspace_path).unwrap();
+        fs::remove_dir_all(&base).unwrap();
+    }
+
+    #[test]
+    fn report_collection_pins_source_tree_rejects_symlinks_and_bounds_reads() {
+        static COUNTER: AtomicU64 = AtomicU64::new(1);
+        let base = env::temp_dir().join(format!(
+            "ct-report-collection-{}-{}",
+            process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        let source_path = base.join("source");
+        let pinned_path = base.join("source.pinned");
+        let outside_path = base.join("outside");
+        let payload_path = base.join("payload");
+        fs::create_dir_all(source_path.join("nested")).unwrap();
+        fs::create_dir_all(&outside_path).unwrap();
+        fs::create_dir_all(&payload_path).unwrap();
+        let oversized = vec![0x5a; MAX_REPORT_SOURCE_BYTES + 37];
+        fs::write(source_path.join("nested/device.log"), &oversized).unwrap();
+        fs::write(outside_path.join("secret"), b"outside-secret").unwrap();
+        let source = TrustedDir::open(&source_path).unwrap();
+        let payload = TrustedDir::open(&payload_path).unwrap();
+
+        fs::rename(&source_path, &pinned_path).unwrap();
+        symlink(&outside_path, &source_path).unwrap();
+        copy_report_file_between(
+            &source,
+            &["nested", "device.log"],
+            &payload,
+            &["android", "source", "device.log"],
+        )
+        .unwrap();
+        let copied = fs::read(payload_path.join("android/source/device.log")).unwrap();
+        assert_eq!(copied.len(), MAX_REPORT_SOURCE_BYTES);
+        assert!(copied.iter().all(|byte| *byte == 0x5a));
+
+        symlink(&outside_path, pinned_path.join("escape-dir")).unwrap();
+        symlink(
+            outside_path.join("secret"),
+            pinned_path.join("escape-file"),
+        )
+        .unwrap();
+        assert!(copy_report_file_between(
+            &source,
+            &["escape-dir", "secret"],
+            &payload,
+            &["android", "leaked-dir"],
+        )
+        .is_err());
+        assert!(copy_report_file_between(
+            &source,
+            &["escape-file"],
+            &payload,
+            &["android", "leaked-file"],
+        )
+        .is_err());
+        assert!(!payload_path.join("android/leaked-dir").exists());
+        assert!(!payload_path.join("android/leaked-file").exists());
+        assert!(report_path_components("../escape").is_err());
+
+        drop(source);
+        drop(payload);
         fs::remove_dir_all(&base).unwrap();
     }
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/CboxManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CboxManager.kt
@@ -136,7 +136,7 @@ object CboxManager {
     ): Boolean {
         if (!validFilename.matches(filename) || password.length !in 1..MAX_PASSWORD_CHARS) return false
         val verificationKey = publicKey?.takeUnless { it.isBlank() }
-        if ((verificationKey?.length ?: 0) > MAX_PUBLIC_KEY_CHARS) return false
+        if (!FusedCboxBackend.isPublicKeyWithinLimit(verificationKey)) return false
         val file = File(Config.keyboxDirectory, filename)
         if (!isSafeCbox(file)) return false
 
@@ -422,7 +422,6 @@ object CboxManager {
     private const val MAX_CACHE_BYTES = 64L * 1024
     private const val MAX_CBOX_FILES = 64
     private const val MAX_PASSWORD_CHARS = 1024
-    private const val MAX_PUBLIC_KEY_CHARS = 16 * 1024
     private const val MAX_PUBLIC_KEY_BYTES = 16 * 1024
     private val CACHE_MAGIC = byteArrayOf('C'.code.toByte(), 'T'.code.toByte(), 'C'.code.toByte(), 'B'.code.toByte(), '3'.code.toByte())
     private val CACHE_PREFIX_BYTES = CACHE_MAGIC.size + SHA256_BYTES + RECOVERY_KEY_BYTES + 2

--- a/service/src/main/java/cleveres/tricky/cleverestech/FusedCboxBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/FusedCboxBackend.kt
@@ -49,7 +49,13 @@ internal object FusedCboxBackend {
         recoveryKey: ByteArray,
         publicKey: String?,
     ): Payload? {
-        if (encrypted.isEmpty() || encrypted.size > MAX_CBOX_BYTES || recoveryKey.size != RECOVERY_KEY_BYTES) return null
+        if (encrypted.isEmpty() ||
+            encrypted.size > MAX_CBOX_BYTES ||
+            recoveryKey.size != RECOVERY_KEY_BYTES ||
+            !isPublicKeyWithinLimit(publicKey)
+        ) {
+            return null
+        }
         val publicKeyBytes = publicKey?.toByteArray(Charsets.UTF_8) ?: EMPTY_BYTES
         try {
             if (publicKeyBytes.size > MAX_PUBLIC_KEY_BYTES || recoveryKey.all { it == 0.toByte() }) return null
@@ -77,6 +83,14 @@ internal object FusedCboxBackend {
         openOverride = null
     }
 
+    internal fun isPublicKeyWithinLimit(publicKey: String?): Boolean {
+        if (publicKey == null) return true
+        // Every UTF-16 code unit produces at least one UTF-8 byte. Reject oversized strings
+        // before encoding so callers cannot turn validation into an unbounded allocation.
+        if (publicKey.length > MAX_PUBLIC_KEY_BYTES) return false
+        return publicKey.toByteArray(Charsets.UTF_8).size <= MAX_PUBLIC_KEY_BYTES
+    }
+
     private fun passwordRequest(
         opcode: Int,
         encrypted: ByteArray,
@@ -84,7 +98,7 @@ internal object FusedCboxBackend {
         publicKey: String?,
         expectRecoveryKey: Boolean,
     ): UnlockPayload? {
-        if (encrypted.isEmpty() || encrypted.size > MAX_CBOX_BYTES) return null
+        if (encrypted.isEmpty() || encrypted.size > MAX_CBOX_BYTES || !isPublicKeyWithinLimit(publicKey)) return null
         val passwordBytes = password.toByteArray(Charsets.UTF_8)
         val publicKeyBytes = publicKey?.toByteArray(Charsets.UTF_8) ?: EMPTY_BYTES
         try {

--- a/service/src/main/java/cleveres/tricky/cleverestech/ServerManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ServerManager.kt
@@ -282,7 +282,7 @@ object ServerManager {
         }
     }
 
-    private fun validateServer(server: ServerConfig) {
+    internal fun validateServer(server: ServerConfig) {
         require(validServerId.matches(server.id)) { "Invalid server ID" }
         require(server.name.isNotBlank() && server.name.length <= 128) { "Invalid server name" }
         require(server.name.none { it.isISOControl() }) { "Invalid server name" }
@@ -290,7 +290,7 @@ object ServerManager {
         require(server.priority in -1_000_000..1_000_000) { "Invalid priority" }
         require(server.refreshIntervalHours in 1..24 * 30) { "Invalid refresh interval" }
         require((server.contentPassword?.length ?: 0) <= 1024) { "Content password is too long" }
-        require((server.contentPublicKey?.length ?: 0) <= 16 * 1024) { "Public key is too long" }
+        require(FusedCboxBackend.isPublicKeyWithinLimit(server.contentPublicKey)) { "Public key is too long" }
         require(server.authData.toString().length <= 64 * 1024) { "Authentication data is too large" }
         require(server.lastStatus.length <= 128 && server.lastStatus.none { it.isISOControl() }) {
             "Invalid server status"

--- a/service/src/test/java/cleveres/tricky/cleverestech/ServerPublicKeyValidationTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ServerPublicKeyValidationTest.kt
@@ -1,0 +1,48 @@
+package cleveres.tricky.cleverestech
+
+import org.json.JSONObject
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.charset.StandardCharsets
+
+class ServerPublicKeyValidationTest {
+    @Test
+    fun `server validation and fused transport share the UTF-8 byte limit`() {
+        val asciiBoundary = "A".repeat(16 * 1024)
+        assertTrue(FusedCboxBackend.isPublicKeyWithinLimit(asciiBoundary))
+        ServerManager.validateServer(server(asciiBoundary))
+
+        val multiByteOverLimit = "\u0800".repeat(6_000)
+        assertTrue(multiByteOverLimit.length < 16 * 1024)
+        assertTrue(multiByteOverLimit.toByteArray(StandardCharsets.UTF_8).size > 16 * 1024)
+        assertThrows(IllegalArgumentException::class.java) {
+            ServerManager.validateServer(server(multiByteOverLimit))
+        }
+    }
+
+    @Test
+    fun `public key validation rejects one UTF-8 byte over the transport frame bound`() {
+        val overLimit = "A".repeat(16 * 1024 + 1)
+
+        assertFalse(FusedCboxBackend.isPublicKeyWithinLimit(overLimit))
+        assertThrows(IllegalArgumentException::class.java) {
+            ServerManager.validateServer(server(overLimit))
+        }
+    }
+
+    private fun server(contentPublicKey: String) =
+        ServerManager.ServerConfig(
+            id = "validation-test",
+            name = "Validation test",
+            url = "https://example.com/keybox.cbox",
+            priority = 0,
+            enabled = true,
+            authType = "NONE",
+            authData = JSONObject(),
+            autoRefresh = false,
+            refreshIntervalHours = 24,
+            contentPublicKey = contentPublicKey,
+        )
+}


### PR DESCRIPTION
## Root causes

- `action.sh` checked a diagnostic path and later reopened it with `dd`, so a regular file could be replaced by a symlink between validation and consumption.
- Server configuration bounded `contentPublicKey` by Kotlin UTF-16 length while the fused/native CBOX transport bounded the encoded UTF-8 byte sequence, allowing persisted configurations that the backend always rejected.

## Fix

- Route diagnostic snapshots through the native WebUI bridge.
- Pin the source root with a directory descriptor, open every relative component with `O_NOFOLLOW`, and read at most 1 MiB from the same final file descriptor.
- Keep the 128-file collection cap and descriptor-relative atomic report destinations.
- Share one UTF-8 public-key byte-limit predicate across server validation, local CBOX unlock, recovery, and the fused transport boundary.

## Regression coverage

- Rust tests cover pinned source-root replacement, intermediate/final symlink rejection, path traversal rejection, and the 1 MiB prefix bound.
- Kotlin tests cover the exact ASCII boundary plus a multibyte value that previously passed configuration validation but exceeded the transport frame.
- The installer security test asserts that production collection no longer reopens `report_file` with path-based `dd`.

## Local checks

- `bash module/install-tests/action_bugreport_security.test.sh`
- `bash module/install-tests/verify_extract_security.test.sh`
- Bash syntax for all module template scripts
- `git diff --check`

Gradle and Rust toolchains were unavailable in the local sandbox; exact-head GitHub Actions are required before merge.