### PR TITLE
fix: bind keybox file actions to verified snapshots

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/CboxManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CboxManager.kt
@@ -125,8 +125,10 @@ object CboxManager {
         password: String,
         publicKey: String?,
     ): Boolean =
-        KeyboxActivation.coordinateRefresh {
-            unlockLocked(filename, password, publicKey)
+        synchronized(ManagedFileCoordinator.monitor) {
+            KeyboxActivation.coordinateRefresh {
+                unlockLocked(filename, password, publicKey)
+            }
         }
 
     private fun unlockLocked(

--- a/service/src/main/java/cleveres/tricky/cleverestech/ManagedFileCoordinator.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ManagedFileCoordinator.kt
@@ -5,8 +5,9 @@ package cleveres.tricky.cleverestech
  * background maintenance jobs.
  *
  * Reads may still use immutable descriptor-backed snapshots without this monitor. A workflow
- * that validates a snapshot and then mutates its path must hold [monitor] from the final identity
- * check through the mutation and matching runtime refresh.
+ * that validates a snapshot and then mutates its path or publishes state derived from it must hold
+ * [monitor] from the final identity check through the mutation/publication and matching runtime
+ * refresh.
  */
 internal object ManagedFileCoordinator {
     val monitor = Any()

--- a/service/src/main/java/cleveres/tricky/cleverestech/ManagedFileCoordinator.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ManagedFileCoordinator.kt
@@ -1,0 +1,13 @@
+package cleveres.tricky.cleverestech
+
+/**
+ * Process-wide serialization boundary for mutations initiated by the managed WebUI and
+ * background maintenance jobs.
+ *
+ * Reads may still use immutable descriptor-backed snapshots without this monitor. A workflow
+ * that validates a snapshot and then mutates its path must hold [monitor] from the final identity
+ * check through the mutation and matching runtime refresh.
+ */
+internal object ManagedFileCoordinator {
+    val monitor = Any()
+}

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -214,7 +214,7 @@ class WebServer(
 
     private val requestCounts = java.util.concurrent.ConcurrentHashMap<String, RateLimitEntry>()
 
-    private val fileLock = Any()
+    private val fileLock = ManagedFileCoordinator.monitor
 
     private fun updateKeyboxesFromConfiguredRevocationSource(): Boolean =
         crlFetcher?.let { Config.updateKeyBoxesSync(it()) } ?: Config.updateKeyBoxesSync()

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxAutoCleaner.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxAutoCleaner.kt
@@ -2,6 +2,8 @@ package cleveres.tricky.cleverestech.util
 
 import cleveres.tricky.cleverestech.Config
 import cleveres.tricky.cleverestech.Logger
+import cleveres.tricky.cleverestech.ManagedFileCoordinator
+import cleveres.tricky.cleverestech.StoredKeyboxInventory
 import java.io.File
 import java.nio.file.AtomicMoveNotSupportedException
 import java.nio.file.Files
@@ -12,13 +14,16 @@ import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
 object KeyboxAutoCleaner {
+    internal data class CleanupResult(
+        val moved: Int,
+        val cancelled: Boolean,
+    )
+
     private val executorLock = Any()
 
     @Volatile
     private var executor: ScheduledExecutorService? = null
     private val configDir = File("/data/adb/cleverestricky")
-    private val keyboxDir = File(configDir, "keyboxes")
-    private val revokedDir = File(keyboxDir, "revoked")
     private val toggleFile = File(configDir, "auto_keybox_check")
     private val spoofEnabledFile = File(configDir, "spoof_enabled")
 
@@ -66,51 +71,103 @@ object KeyboxAutoCleaner {
 
         Logger.i("AutoCleaner: Starting daily revocation check...")
         val results = KeyboxVerifier.verify(configDir)
-        var revokedCount = 0
-        var cancelled = false
-
-        SecureFile.mkdirs(revokedDir, 448)
-
-        for (res in results) {
-            if (!isEnabledNow()) {
-                cancelled = true
-                break
+        val cleanup =
+            applyVerifiedResults(configDir, results, ::isEnabledNow) {
+                Config.updateKeyBoxesSync()
             }
-            if (res.status == KeyboxVerifier.Status.REVOKED || res.status == KeyboxVerifier.Status.INVALID) {
-                Logger.i("AutoCleaner: Keybox ${res.filename} is ${res.status}. Moving to revoked.")
-                val file = res.file
-                if (file.exists() && File(res.filename).name == res.filename) {
-                    try {
-                        val initialTarget = File(revokedDir, res.filename)
-                        val target =
-                            if (initialTarget.exists()) {
-                                File(revokedDir, "${res.filename}.${System.currentTimeMillis()}.revoked")
-                            } else {
-                                initialTarget
-                            }
-                        try {
-                            Files.move(
-                                file.toPath(),
-                                target.toPath(),
-                                StandardCopyOption.ATOMIC_MOVE,
-                            )
-                        } catch (_: AtomicMoveNotSupportedException) {
-                            Files.move(file.toPath(), target.toPath())
-                        }
-                        revokedCount++
-                    } catch (e: Exception) {
-                        Logger.e("AutoCleaner: Failed to move ${res.filename}", e)
-                    }
-                }
-            }
-        }
-
-        Config.updateKeyBoxesSync()
-        if (!cancelled && revokedCount > 0) notifyUser(revokedCount)
-        if (cancelled) {
+        if (!cleanup.cancelled && cleanup.moved > 0) notifyUser(cleanup.moved)
+        if (cleanup.cancelled) {
             Logger.i("AutoCleaner: Check stopped because automatic cleanup was disabled")
         } else {
-            Logger.i("AutoCleaner: Finished check. Revoked/Invalid files moved: $revokedCount")
+            Logger.i("AutoCleaner: Finished check. Revoked/Invalid files moved: ${cleanup.moved}")
+        }
+    }
+
+    /**
+     * Rebinds every path to the exact descriptor-backed snapshot that produced its verification
+     * result. The shared monitor prevents managed writers from replacing that path between the
+     * final digest comparison, quarantine move, and runtime refresh.
+     */
+    internal fun applyVerifiedResults(
+        configDir: File,
+        results: List<KeyboxVerifier.Result>,
+        isEnabled: () -> Boolean,
+        refresh: () -> Unit,
+    ): CleanupResult =
+        synchronized(ManagedFileCoordinator.monitor) {
+            val revokedDir = File(File(configDir, "keyboxes"), "revoked")
+            SecureFile.mkdirs(revokedDir, 448)
+            var moved = 0
+            var cancelled = false
+
+            for (result in results) {
+                if (!isEnabled()) {
+                    cancelled = true
+                    break
+                }
+                if (result.status != KeyboxVerifier.Status.REVOKED &&
+                    result.status != KeyboxVerifier.Status.INVALID
+                ) {
+                    continue
+                }
+
+                val expectedDigest = result.snapshotSha256
+                if (expectedDigest == null) {
+                    Logger.w("AutoCleaner: Skipping ${result.filename} without a stable verified snapshot")
+                    continue
+                }
+                val scope = result.storageId.substringBefore(':', missingDelimiterValue = "")
+                val source = StoredKeyboxInventory.resolve(configDir, scope, result.filename)
+                if (source == null || source.id != result.storageId) {
+                    Logger.w("AutoCleaner: Skipping changed or missing source ${result.storageId}")
+                    continue
+                }
+
+                try {
+                    val currentDigest = sha256Hex(source.file)
+                    if (currentDigest != expectedDigest) {
+                        Logger.w("AutoCleaner: Skipping replaced keybox source ${result.storageId}")
+                        continue
+                    }
+                    val initialTarget = File(revokedDir, result.filename)
+                    val target =
+                        if (initialTarget.exists()) {
+                            File(revokedDir, "${result.filename}.${System.currentTimeMillis()}.revoked")
+                        } else {
+                            initialTarget
+                        }
+                    try {
+                        Files.move(
+                            source.file.toPath(),
+                            target.toPath(),
+                            StandardCopyOption.ATOMIC_MOVE,
+                        )
+                    } catch (_: AtomicMoveNotSupportedException) {
+                        Files.move(source.file.toPath(), target.toPath())
+                    }
+                    moved++
+                    Logger.i("AutoCleaner: Keybox ${result.filename} is ${result.status}. Moved to revoked.")
+                } catch (error: Exception) {
+                    Logger.e("AutoCleaner: Failed to move ${result.filename}", error)
+                }
+            }
+
+            refresh()
+            CleanupResult(moved, cancelled)
+        }
+
+    private fun sha256Hex(file: File): String {
+        val digest = sha256FileSnapshotBounded(file, 1, StoredKeyboxInventory.MAX_XML_BYTES)
+        return try {
+            buildString(digest.size * 2) {
+                digest.forEach { byte ->
+                    val value = byte.toInt() and 0xff
+                    append(HEX[value ushr 4])
+                    append(HEX[value and 0x0f])
+                }
+            }
+        } finally {
+            digest.fill(0)
         }
     }
 
@@ -149,4 +206,6 @@ object KeyboxAutoCleaner {
     }
 
     private fun isRegularFile(file: File): Boolean = Files.isRegularFile(file.toPath(), LinkOption.NOFOLLOW_LINKS)
+
+    private const val HEX = "0123456789abcdef"
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -28,6 +28,7 @@ object KeyboxVerifier {
         val details: String,
         val storageId: String = "",
         val certificateSerial: String? = null,
+        val snapshotSha256: String? = null,
     )
 
     enum class Status {
@@ -364,15 +365,31 @@ object KeyboxVerifier {
             if (!isSafeKeyboxFile(file)) {
                 return Result(file, file.name, Status.ERROR, "Unsafe or oversized keybox file")
             }
-            val keyboxes = KeyboxLoader.parseFile(scope, filename)
+            val parsed = KeyboxLoader.parseFileSnapshot(scope, filename)
+            val snapshotSha256 = parsed.snapshotSha256?.takeIf(FULL_SHA256_PATTERN::matches)
+            val keyboxes = parsed.keyboxes
             if (keyboxes.isEmpty()) {
-                return Result(file, file.name, Status.INVALID, "No valid keybox found or parse error", storageId)
+                return Result(
+                    file,
+                    file.name,
+                    Status.INVALID,
+                    "No valid keybox found or parse error",
+                    storageId,
+                    snapshotSha256 = snapshotSha256,
+                )
             }
-            // parseFile can discover a Rust backend restart and rebuild backend-owned CRL state.
-            // Resolve the handle only after that recovery boundary so this request never keeps
-            // using the pre-recovery generation on its first manual verification attempt.
+            // parseFileSnapshot can discover a Rust backend restart and rebuild backend-owned CRL
+            // state. Resolve the handle only after that recovery boundary so this request never
+            // keeps using the pre-recovery generation on its first manual verification attempt.
             val crl = crlFetcher()
-                ?: return Result(file, file.name, Status.ERROR, "Failed to initialize CRL index", storageId)
+                ?: return Result(
+                    file,
+                    file.name,
+                    Status.ERROR,
+                    "Failed to initialize CRL index",
+                    storageId,
+                    snapshotSha256 = snapshotSha256,
+                )
             val deviceSerial = keyboxes.asSequence().mapNotNull(CertHack::getDeviceCertificateSerial).firstOrNull()
 
             for (keybox in keyboxes) {
@@ -390,14 +407,50 @@ object KeyboxVerifier {
                             } else {
                                 "unknown"
                             }
-                        return Result(file, file.name, Status.REVOKED, "Certificate with SN $serial is revoked", storageId, deviceSerial)
+                        return Result(
+                            file,
+                            file.name,
+                            Status.REVOKED,
+                            "Certificate with SN $serial is revoked",
+                            storageId,
+                            certificateSerial = deviceSerial,
+                            snapshotSha256 = snapshotSha256,
+                        )
                     }
-                    Status.INVALID -> return Result(file, file.name, Status.INVALID, "Keybox structure is invalid", storageId, deviceSerial)
-                    Status.ERROR -> return Result(file, file.name, Status.ERROR, "Rust CRL backend unavailable", storageId, deviceSerial)
+                    Status.INVALID -> {
+                        return Result(
+                            file,
+                            file.name,
+                            Status.INVALID,
+                            "Keybox structure is invalid",
+                            storageId,
+                            certificateSerial = deviceSerial,
+                            snapshotSha256 = snapshotSha256,
+                        )
+                    }
+                    Status.ERROR -> {
+                        return Result(
+                            file,
+                            file.name,
+                            Status.ERROR,
+                            "Rust CRL backend unavailable",
+                            storageId,
+                            certificateSerial = deviceSerial,
+                            snapshotSha256 = snapshotSha256,
+                        )
+                    }
                     Status.VALID -> Unit
                 }
             }
-            Result(file, file.name, Status.VALID, "Active keybox", storageId, deviceSerial)
+            Result(
+                file,
+                file.name,
+                Status.VALID,
+                "Active keybox",
+                storageId,
+                certificateSerial = deviceSerial,
+                snapshotSha256 = snapshotSha256,
+            )
         } catch (_: RustBackendUnavailableException) {
             Result(file, file.name, Status.ERROR, "Rust backend unavailable", storageId)
         } catch (error: Exception) {
@@ -530,5 +583,6 @@ object KeyboxVerifier {
     }
 
     private val LEGACY_HASH_ALGORITHMS = arrayOf("SHA-1", "SHA-256", "MD5")
+    private val FULL_SHA256_PATTERN = Regex("[0-9a-f]{64}")
     private const val HEX = "0123456789abcdef"
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/CboxManagerConcurrencyTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/CboxManagerConcurrencyTest.kt
@@ -1,0 +1,37 @@
+package cleveres.tricky.cleverestech
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CboxManagerConcurrencyTest {
+    @Test
+    fun `unlock waits for managed file mutation coordinator`() {
+        val attempted = CountDownLatch(1)
+        val finished = CountDownLatch(1)
+        val result = AtomicReference<Boolean>()
+        val worker =
+            Thread {
+                attempted.countDown()
+                try {
+                    result.set(CboxManager.unlock("../invalid.cbox", "password", null))
+                } finally {
+                    finished.countDown()
+                }
+            }
+
+        synchronized(ManagedFileCoordinator.monitor) {
+            worker.start()
+            assertTrue(attempted.await(2, TimeUnit.SECONDS))
+            assertFalse(finished.await(100, TimeUnit.MILLISECONDS))
+        }
+
+        assertTrue(finished.await(2, TimeUnit.SECONDS))
+        worker.join(2_000)
+        assertFalse(worker.isAlive)
+        assertFalse(result.get())
+    }
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxAutoCleanerTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxAutoCleanerTest.kt
@@ -1,0 +1,102 @@
+package cleveres.tricky.cleverestech.util
+
+import cleveres.tricky.cleverestech.ManagedFileCoordinator
+import cleveres.tricky.cleverestech.WebServer
+import java.io.File
+import java.security.MessageDigest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class KeyboxAutoCleanerTest {
+    @get:Rule
+    val temp = TemporaryFolder()
+
+    @Test
+    fun `web server mutations share the cleaner coordination boundary`() {
+        val server = WebServer(0, temp.newFolder("web-server"))
+        val field = WebServer::class.java.getDeclaredField("fileLock").apply { isAccessible = true }
+
+        assertSame(ManagedFileCoordinator.monitor, field.get(server))
+    }
+
+    @Test
+    fun `replacement after verification is not quarantined`() {
+        val root = temp.newFolder("replacement")
+        val source = File(File(root, "keyboxes").apply { mkdirs() }, "candidate.xml")
+        val verified = "verified-revoked-snapshot".toByteArray()
+        source.writeBytes(verified)
+        val result = revokedResult(source, sha256Hex(verified))
+
+        val replacement = "new-valid-snapshot".toByteArray()
+        source.writeBytes(replacement)
+        var refreshes = 0
+        val cleanup =
+            KeyboxAutoCleaner.applyVerifiedResults(root, listOf(result), { true }) {
+                refreshes++
+            }
+
+        assertEquals(0, cleanup.moved)
+        assertFalse(cleanup.cancelled)
+        assertEquals(1, refreshes)
+        assertTrue(source.readBytes().contentEquals(replacement))
+        assertFalse(File(File(root, "keyboxes/revoked"), source.name).exists())
+    }
+
+    @Test
+    fun `matching verified snapshot is quarantined before refresh`() {
+        val root = temp.newFolder("matching")
+        val source = File(File(root, "keyboxes").apply { mkdirs() }, "candidate.xml")
+        val verified = "verified-revoked-snapshot".toByteArray()
+        source.writeBytes(verified)
+        val result = revokedResult(source, sha256Hex(verified))
+        var sourceExistedDuringRefresh = true
+
+        val cleanup =
+            KeyboxAutoCleaner.applyVerifiedResults(root, listOf(result), { true }) {
+                sourceExistedDuringRefresh = source.exists()
+            }
+
+        val quarantined = File(File(root, "keyboxes/revoked"), source.name)
+        assertEquals(1, cleanup.moved)
+        assertFalse(cleanup.cancelled)
+        assertFalse(sourceExistedDuringRefresh)
+        assertFalse(source.exists())
+        assertTrue(quarantined.readBytes().contentEquals(verified))
+    }
+
+    @Test
+    fun `unstable verification result is not eligible for quarantine`() {
+        val root = temp.newFolder("unstable")
+        val source = File(File(root, "keyboxes").apply { mkdirs() }, "candidate.xml")
+        source.writeText("malformed")
+        val result = revokedResult(source, null)
+
+        val cleanup = KeyboxAutoCleaner.applyVerifiedResults(root, listOf(result), { true }) {}
+
+        assertEquals(0, cleanup.moved)
+        assertTrue(source.exists())
+    }
+
+    private fun revokedResult(
+        source: File,
+        digest: String?,
+    ): KeyboxVerifier.Result =
+        KeyboxVerifier.Result(
+            file = source,
+            filename = source.name,
+            status = KeyboxVerifier.Status.REVOKED,
+            details = "revoked",
+            storageId = "keyboxes:${source.name}",
+            snapshotSha256 = digest,
+        )
+
+    private fun sha256Hex(bytes: ByteArray): String =
+        MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { byte ->
+            "%02x".format(byte.toInt() and 0xff)
+        }
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierTest.kt
@@ -86,6 +86,7 @@ class KeyboxVerifierTest {
             val result = KeyboxVerifier.verify(configDir) { emptySet() }.single()
 
             assertEquals(KeyboxVerifier.Status.VALID, result.status)
+            assertEquals("00".repeat(32), result.snapshotSha256)
             assertEquals(KeyboxLoader.FileScope.CONFIG_ROOT, observedScope)
             assertEquals("keybox.xml", observedFilename)
         } finally {


### PR DESCRIPTION
## Summary

- bind automatic keybox quarantine decisions to the descriptor-backed SHA-256 snapshot that was actually parsed and verified
- re-resolve and re-hash the current bounded, nofollow file before moving it; skip missing, replaced, or identity-less results
- serialize the final identity check, quarantine move, and runtime refresh with WebUI upload/delete/restore mutations through one process-wide monitor
- serialize CBOX unlock verification, credential-cache write, and unlocked-state publication through that same monitor
- add regression coverage for post-verification replacement, stable moves, identity-less failures, the shared WebUI boundary, and CBOX unlock coordination

## Bugs

1. `KeyboxAutoCleaner` verified a mutable keybox path, then later reopened and moved that path. A concurrent WebUI upload could atomically replace the same filename between those operations, causing the newly uploaded valid file to be quarantined using the old file's REVOKED/INVALID result.
2. `CboxManager.unlock` performed its final source digest check and then published credential/runtime state without sharing the WebUI file-mutation lock. A concurrent upload could replace the CBOX between those steps, allowing state derived from the old snapshot to be published for the new path.

## Verification

- `git diff --check`
- focused regression tests added for both race classes
- Gradle preflight could not start locally because the sandbox cannot download Gradle 9.7.0 (`Network is unreachable`); repository CI is required for the Kotlin format, lint, and unit-test gates.
