### PR TITLE
fix: align CBOX author wire bounds

### DIFF
--- a/rust/backend/src/main.rs
+++ b/rust/backend/src/main.rs
@@ -44,7 +44,8 @@ const MAX_BACKUP_REQUEST_BYTES: usize = 2 + MAX_PASSWORD_BYTES + MAX_BACKUP_BYTE
 const MAX_BACKEND_FRAME_BYTES: usize = MAX_BACKUP_REQUEST_BYTES;
 const MAX_BACKUP_RESPONSE_BYTES: usize = MAX_BACKUP_BYTES + 64;
 const MAX_KEYBOX_RESPONSE_BYTES: usize = keybox_wire::MAX_KEYBOX_RESPONSE_BYTES;
-const MAX_CBOX_AUTHOR_BYTES: usize = 1024;
+const MAX_CBOX_AUTHOR_UTF16_UNITS: usize = 1024;
+const MAX_CBOX_AUTHOR_BYTES: usize = 4 * MAX_CBOX_AUTHOR_UTF16_UNITS;
 const CBOX_RESPONSE_PREFIX_BYTES: usize = 7;
 const MAX_CBOX_RESPONSE_BYTES: usize =
     CBOX_RESPONSE_PREFIX_BYTES + MAX_CBOX_AUTHOR_BYTES + MAX_KEYBOX_RESPONSE_BYTES;
@@ -876,6 +877,26 @@ mod tests {
         assert!(!wire
             .windows(19)
             .any(|window| window == b"AndroidAttestation"));
+    }
+
+    #[test]
+    fn cbox_response_accepts_multibyte_author_within_producer_contract() {
+        let author = "é".repeat(MAX_CBOX_AUTHOR_UTF16_UNITS);
+        assert_eq!(author.encode_utf16().count(), MAX_CBOX_AUTHOR_UTF16_UNITS);
+        assert!(author.len() > 1024);
+
+        let response = encode_cbox_response(author.as_bytes(), false, b"wire").unwrap();
+        let author_len = u16::from_be_bytes(response[0..2].try_into().unwrap()) as usize;
+
+        assert_eq!(author_len, author.len());
+        assert_eq!(&response[7..7 + author_len], author.as_bytes());
+    }
+
+    #[test]
+    fn cbox_response_rejects_author_over_byte_bound() {
+        let author = vec![b'a'; MAX_CBOX_AUTHOR_BYTES + 1];
+
+        assert!(encode_cbox_response(&author, false, b"wire").is_err());
     }
 
     #[test]

--- a/service/src/main/java/cleveres/tricky/cleverestech/FusedCboxBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/FusedCboxBackend.kt
@@ -149,7 +149,8 @@ internal object FusedCboxBackend {
         }
     }
 
-    private fun decode(bytes: ByteArray): Payload? {
+    @VisibleForTesting
+    internal fun decode(bytes: ByteArray): Payload? {
         if (bytes.size < RESPONSE_PREFIX_BYTES) {
             bytes.fill(0)
             return null
@@ -165,6 +166,7 @@ internal object FusedCboxBackend {
             val wireEnd = Math.addExact(authorEnd, wireLength.toInt())
             if (wireEnd != bytes.size || authorLength > MAX_AUTHOR_BYTES || wireLength > MAX_KEYBOX_WIRE_BYTES) return null
             val author = decodeUtf8Strict(bytes, authorStart, authorLength)
+            if (author.length > MAX_AUTHOR_UTF16_UNITS) return null
             keyboxWire = bytes.copyOfRange(authorEnd, wireEnd)
             val document = KeyboxWire.decode(keyboxWire) ?: return null
             keyboxWire = null
@@ -226,7 +228,8 @@ internal object FusedCboxBackend {
     private const val RECOVERY_KEY_BYTES = 32
     private const val MAX_PASSWORD_BYTES = 4 * 1024
     private const val MAX_PUBLIC_KEY_BYTES = 16 * 1024
-    private const val MAX_AUTHOR_BYTES = 1024
+    private const val MAX_AUTHOR_UTF16_UNITS = 1024
+    private const val MAX_AUTHOR_BYTES = 4 * MAX_AUTHOR_UTF16_UNITS
     private const val MAX_CBOX_BYTES = 10 * 1024 * 1024 + 36
     private const val MAX_KEYBOX_WIRE_BYTES = KeyboxWire.MAX_RESPONSE_BYTES
     private const val MAX_CBOX_RESPONSE_BYTES = RESPONSE_PREFIX_BYTES + MAX_AUTHOR_BYTES + MAX_KEYBOX_WIRE_BYTES

--- a/service/src/test/java/cleveres/tricky/cleverestech/FusedCboxBackendTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/FusedCboxBackendTest.kt
@@ -1,0 +1,66 @@
+package cleveres.tricky.cleverestech
+
+import java.io.ByteArrayOutputStream
+import java.io.DataOutputStream
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FusedCboxBackendTest {
+    @Test
+    fun `multibyte author at producer UTF-16 limit decodes`() {
+        val author = "é".repeat(MAX_AUTHOR_UTF16_UNITS)
+        assertTrue(author.toByteArray(Charsets.UTF_8).size > MAX_AUTHOR_UTF16_UNITS)
+        val response = encodeResponse(author)
+
+        val payload = requireNotNull(FusedCboxBackend.decode(response))
+
+        assertEquals(author, payload.author)
+        assertTrue(response.all { it == 0.toByte() })
+    }
+
+    @Test
+    fun `author over producer UTF-16 limit fails closed`() {
+        val response = encodeResponse("a".repeat(MAX_AUTHOR_UTF16_UNITS + 1))
+
+        assertNull(FusedCboxBackend.decode(response))
+        assertTrue(response.all { it == 0.toByte() })
+    }
+
+    private fun encodeResponse(author: String): ByteArray {
+        val authorBytes = author.toByteArray(Charsets.UTF_8)
+        val keyboxWire = encodeKeyboxWire()
+        val output = ByteArrayOutputStream()
+        DataOutputStream(output).use { data ->
+            data.writeShort(authorBytes.size)
+            data.writeInt(keyboxWire.size)
+            data.writeByte(0)
+            data.write(authorBytes)
+            data.write(keyboxWire)
+        }
+        return output.toByteArray()
+    }
+
+    private fun encodeKeyboxWire(): ByteArray {
+        val output = ByteArrayOutputStream()
+        DataOutputStream(output).use { data ->
+            data.writeByte(4)
+            data.writeByte(1)
+            data.writeByte(1)
+            data.writeShort(1)
+            data.write(ByteArray(32) { 0xab.toByte() })
+            data.writeByte(2)
+            data.writeByte(1)
+            data.write(ByteArray(16) { index -> (index + 1).toByte() })
+            data.writeBytes("EC")
+            data.writeInt(1)
+            data.writeByte(0x30)
+        }
+        return output.toByteArray()
+    }
+
+    private companion object {
+        const val MAX_AUTHOR_UTF16_UNITS = 1024
+    }
+}


### PR DESCRIPTION
## Summary

- align the CBOX backend response author budget with the official producer contract: 1,024 UTF-16 units and up to 4,096 UTF-8 bytes
- retain the character-count guard in the managed decoder after strict UTF-8 decoding
- add Rust encoder and Kotlin decoder regression tests for multibyte boundary values and fail-closed over-limit input

## Bug

The official encryptor accepts an author up to 1,024 UTF-16 units and allocates up to 4,096 UTF-8 bytes. The Rust backend and managed response decoder instead capped that same field at 1,024 **bytes**. A valid CBOX such as one authored with 1,024 `é` characters (2,048 UTF-8 bytes) could therefore be created successfully but would always fail to open or recover.

## Verification

- `git diff --check`
- local Cargo/Rust and Gradle execution are unavailable in this sandbox; the PR's Rust, JVM, format, lint, hardening, and security workflows are the execution gates
