### PR TITLE
fix: honor complete CBOX wire contract

### DIFF
--- a/module/template/webroot/index.html
+++ b/module/template/webroot/index.html
@@ -978,7 +978,6 @@ try {
 
         async function unlockCbox(filename, controlId) {
 const pwd = document.getElementById('pwd_' + controlId).value;
-if (!pwd.trim()) { notify('Password required', 'error'); return; }
 const pk = document.getElementById('pk_' + controlId).value;
 try {
     const formData = new FormData();

--- a/module/template/webroot/index.html
+++ b/module/template/webroot/index.html
@@ -1117,8 +1117,9 @@ try {
 const file = input instanceof File ? input : (input && input.files ? input.files[0] : null);
 if (file) {
     const lowerName = file.name.toLowerCase();
-    if ((!lowerName.endsWith('.xml') && !lowerName.endsWith('.cbox')) || file.size <= 0 || file.size > 10 * 1024 * 1024) {
-        notify('Select a non-empty XML or CBOX file up to 10 MB', 'error');
+    const maxFileBytes = lowerName.endsWith('.cbox') ? 10 * 1024 * 1024 + 36 : 10 * 1024 * 1024;
+    if ((!lowerName.endsWith('.xml') && !lowerName.endsWith('.cbox')) || file.size <= 0 || file.size > maxFileBytes) {
+        notify('Select a non-empty XML or CBOX file within its supported size limit', 'error');
         if (!(input instanceof File)) input.value = '';
         resetDropZone();
         return;

--- a/module/template/webroot/ux.js
+++ b/module/template/webroot/ux.js
@@ -2071,8 +2071,9 @@
 
     const MAX_SUPPORTED_FILES = 64;
     const MAX_ARCHIVE_ENTRIES = 256;
-    const MAX_FILE_BYTES = 10 * 1024 * 1024;
-    const MAX_COMPRESSED_FILE_BYTES = MAX_FILE_BYTES + 64 * 1024;
+    const MAX_XML_BYTES = 10 * 1024 * 1024;
+    const MAX_CBOX_BYTES = MAX_XML_BYTES + 36;
+    const MAX_COMPRESSED_FILE_BYTES = MAX_CBOX_BYTES + 64 * 1024;
     const MAX_NAME_BYTES = 4096;
     const MAX_CENTRAL_DIRECTORY_BYTES = 64 * 1024 * 1024;
     const STORAGE_KEY = 'cleverestricky.language.v1';
@@ -2252,6 +2253,10 @@
         return lower.endsWith('.xml') || lower.endsWith('.cbox');
     }
 
+    function fileLimitForName(name) {
+        return name.toLowerCase().endsWith('.cbox') ? MAX_CBOX_BYTES : MAX_XML_BYTES;
+    }
+
     function safeBasename(name) {
         let base = name.replace(/\\/g, '/').split('/').pop() || 'keybox.xml';
         base = base.replace(/[\u0000-\u001f\u007f]/g, '_').trim();
@@ -2343,7 +2348,7 @@
                 if (method !== 0 && method !== 8) fail('compression');
                 const name = decodeName(central.subarray(cursor + 46, cursor + 46 + nameLength), (flags & 0x0800) !== 0);
                 if (!name.endsWith('/') && isSupportedName(name)) {
-                    if (uncompressedSize <= 0 || uncompressedSize > MAX_FILE_BYTES || compressedSize <= 0 || compressedSize > MAX_COMPRESSED_FILE_BYTES) fail('fileLimit');
+                    if (uncompressedSize <= 0 || uncompressedSize > fileLimitForName(name) || compressedSize <= 0 || compressedSize > MAX_COMPRESSED_FILE_BYTES) fail('fileLimit');
                     entries.push({ name, flags, method, crc, compressedSize, uncompressedSize, localOffset });
                     if (entries.length > MAX_SUPPORTED_FILES) fail('fileCountLimit');
                 }
@@ -2390,7 +2395,7 @@
                 const result = await reader.read();
                 if (result.done) break;
                 const chunk = result.value instanceof Uint8Array ? result.value : new Uint8Array(result.value);
-                if (chunk.length > expectedSize - total || total + chunk.length > MAX_FILE_BYTES) fail('fileLimit');
+                if (chunk.length > expectedSize - total) fail('fileLimit');
                 chunks.push(chunk);
                 total += chunk.length;
             }
@@ -2674,7 +2679,7 @@
     }
 
     global.CleveresZipImport = Object.freeze({
-        limits: Object.freeze({ MAX_SUPPORTED_FILES, MAX_ARCHIVE_ENTRIES, MAX_FILE_BYTES }),
+        limits: Object.freeze({ MAX_SUPPORTED_FILES, MAX_ARCHIVE_ENTRIES, MAX_XML_BYTES, MAX_CBOX_BYTES }),
         parseZipFile,
         extractEntry,
         allocateUploadNames,

--- a/module/webui-tests/runtime-layout.test.js
+++ b/module/webui-tests/runtime-layout.test.js
@@ -8,9 +8,11 @@ assert.deepStrictEqual(runtimeScripts, ['bridge.js', 'policy.js', 'ux.js'], 'Web
 const ux = fs.readFileSync(`${root}/ux.js`, 'utf8');
 const index = fs.readFileSync(`${root}/index.html`, 'utf8');
 assert.ok(ux.includes('const MAX_SUPPORTED_FILES = 64;'), 'module ZIP import must respect the 64 active XML source runtime limit');
-assert.ok(ux.includes('const MAX_FILE_BYTES = 10 * 1024 * 1024;'), 'per-keybox ZIP limit must remain 10 MiB');
+assert.ok(ux.includes('const MAX_XML_BYTES = 10 * 1024 * 1024;'), 'XML ZIP limit must remain 10 MiB');
+assert.ok(ux.includes('const MAX_CBOX_BYTES = MAX_XML_BYTES + 36;'), 'CBOX ZIP limit must include the envelope header');
 assert.ok(ux.includes('I understand that every supported XML/CBOX file in this ZIP will be imported individually.'), 'ZIP confirmation copy is missing');
 assert.ok(index.includes('accept=".xml,.cbox,.zip"'), 'keybox picker must accept ZIP');
+assert.ok(index.includes("lowerName.endsWith('.cbox') ? 10 * 1024 * 1024 + 36 : 10 * 1024 * 1024"), 'direct CBOX upload must include the envelope header');
 assert.ok(!fs.existsSync(`${root}/ux-core.js`) && !fs.existsSync(`${root}/zip-import.js`), 'feature-specific runtime JS must not be reintroduced');
 
 console.log('WebUI ZIP runtime layout checks passed');

--- a/module/webui-tests/runtime-layout.test.js
+++ b/module/webui-tests/runtime-layout.test.js
@@ -13,6 +13,8 @@ assert.ok(ux.includes('const MAX_CBOX_BYTES = MAX_XML_BYTES + 36;'), 'CBOX ZIP l
 assert.ok(ux.includes('I understand that every supported XML/CBOX file in this ZIP will be imported individually.'), 'ZIP confirmation copy is missing');
 assert.ok(index.includes('accept=".xml,.cbox,.zip"'), 'keybox picker must accept ZIP');
 assert.ok(index.includes("lowerName.endsWith('.cbox') ? 10 * 1024 * 1024 + 36 : 10 * 1024 * 1024"), 'direct CBOX upload must include the envelope header');
+assert.ok(!index.includes("if (!pwd.trim())"), 'legacy empty-password CBOX unlock must reach the backend');
+assert.ok(index.includes("formData.append('password', pwd)"), 'CBOX unlock must submit the exact password value');
 assert.ok(!fs.existsSync(`${root}/ux-core.js`) && !fs.existsSync(`${root}/zip-import.js`), 'feature-specific runtime JS must not be reintroduced');
 
 console.log('WebUI ZIP runtime layout checks passed');

--- a/module/webui-tests/zip-import.test.js
+++ b/module/webui-tests/zip-import.test.js
@@ -4,7 +4,8 @@ const vm = require('vm');
 
 const source = fs.readFileSync('module/template/webroot/ux.js', 'utf8');
 assert.ok(source.includes('const MAX_SUPPORTED_FILES = 64;'), 'module ZIP keybox limit must match runtime bound');
-assert.ok(source.includes('const MAX_FILE_BYTES = 10 * 1024 * 1024;'), 'per-keybox limit must remain 10 MiB');
+assert.ok(source.includes('const MAX_XML_BYTES = 10 * 1024 * 1024;'), 'XML limit must remain 10 MiB');
+assert.ok(source.includes('const MAX_CBOX_BYTES = MAX_XML_BYTES + 36;'), 'CBOX limit must include the envelope header');
 assert.ok(!source.includes('MAX_TOTAL_XML_BYTES'), 'ZIP importer must not retain the old aggregate XML cap');
 assert.ok(!source.includes('MAX_ARCHIVE_BYTES'), 'ZIP importer must not retain the old aggregate archive cap');
 assert.ok(source.includes("new global.DecompressionStream('deflate-raw')"), 'deflated ZIP entries must use bounded streaming decompression');
@@ -23,7 +24,8 @@ vm.runInContext(source, context, { filename: 'zip-import.js' });
 const api = context.CleveresZipImport;
 assert.ok(api, 'ZIP importer API must be exposed for regression tests');
 assert.strictEqual(api.limits.MAX_SUPPORTED_FILES, 64);
-assert.strictEqual(api.limits.MAX_FILE_BYTES, 10 * 1024 * 1024);
+assert.strictEqual(api.limits.MAX_XML_BYTES, 10 * 1024 * 1024);
+assert.strictEqual(api.limits.MAX_CBOX_BYTES, 10 * 1024 * 1024 + 36);
 assert.ok(api.limits.MAX_ARCHIVE_ENTRIES >= api.limits.MAX_SUPPORTED_FILES);
 
 function crc32(bytes) {
@@ -92,6 +94,15 @@ function storedZip(name, data, declaredSize = data.length) {
 
   await assert.rejects(
     api.parseZipFile(storedZip('too-large.xml', Buffer.from('x'), 10 * 1024 * 1024 + 1)),
+    error => error && error.code === 'fileLimit'
+  );
+
+  const maxCbox = await api.parseZipFile(
+    storedZip('full-size.cbox', Buffer.from('x'), 10 * 1024 * 1024 + 36)
+  );
+  assert.strictEqual(maxCbox.entries[0].uncompressedSize, 10 * 1024 * 1024 + 36);
+  await assert.rejects(
+    api.parseZipFile(storedZip('too-large.cbox', Buffer.from('x'), 10 * 1024 * 1024 + 37)),
     error => error && error.code === 'fileLimit'
   );
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/CboxManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CboxManager.kt
@@ -136,7 +136,7 @@ object CboxManager {
         password: String,
         publicKey: String?,
     ): Boolean {
-        if (!validFilename.matches(filename) || password.length !in 1..MAX_PASSWORD_CHARS) return false
+        if (!validFilename.matches(filename) || !isUnlockPasswordWithinLimit(password)) return false
         val verificationKey = publicKey?.takeUnless { it.isBlank() }
         if (!FusedCboxBackend.isPublicKeyWithinLimit(verificationKey)) return false
         val file = File(Config.keyboxDirectory, filename)
@@ -204,6 +204,9 @@ object CboxManager {
     fun getLockedFiles(): Set<String> = lockedFiles.toSortedSet()
 
     fun isLocked(filename: String): Boolean = lockedFiles.contains(filename)
+
+    /** New producers require a strong password, but decryption keeps legacy empty-password files readable. */
+    internal fun isUnlockPasswordWithinLimit(password: String): Boolean = password.length <= MAX_PASSWORD_CHARS
 
     @Throws(IOException::class)
     private fun listCboxFiles(directory: File): List<File> {
@@ -419,8 +422,8 @@ object CboxManager {
 
     private const val SHA256_BYTES = 32
     private const val RECOVERY_KEY_BYTES = 32
-    private const val MIN_CBOX_BYTES = 4L + 4L + 16L + 12L + 16L
-    private const val MAX_CBOX_BYTES = 10L * 1024 * 1024 + 36L
+    private val MIN_CBOX_BYTES = CboxWireLimits.MIN_BYTES.toLong()
+    private val MAX_CBOX_BYTES = CboxWireLimits.MAX_BYTES.toLong()
     private const val MAX_CACHE_BYTES = 64L * 1024
     private const val MAX_CBOX_FILES = 64
     private const val MAX_PASSWORD_CHARS = 1024

--- a/service/src/main/java/cleveres/tricky/cleverestech/CboxWireLimits.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CboxWireLimits.kt
@@ -1,0 +1,10 @@
+package cleveres.tricky.cleverestech
+
+/** Managed mirror of the bounded CBOX envelope contract implemented by the Rust crypto cores. */
+internal object CboxWireLimits {
+    const val HEADER_BYTES = 4 + 4 + 16 + 12
+    const val TAG_BYTES = 16
+    const val MAX_CIPHERTEXT_BYTES = 10 * 1024 * 1024
+    const val MIN_BYTES = HEADER_BYTES + TAG_BYTES
+    const val MAX_BYTES = HEADER_BYTES + MAX_CIPHERTEXT_BYTES
+}

--- a/service/src/main/java/cleveres/tricky/cleverestech/FusedCboxBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/FusedCboxBackend.kt
@@ -230,7 +230,7 @@ internal object FusedCboxBackend {
     private const val MAX_PUBLIC_KEY_BYTES = 16 * 1024
     private const val MAX_AUTHOR_UTF16_UNITS = 1024
     private const val MAX_AUTHOR_BYTES = 4 * MAX_AUTHOR_UTF16_UNITS
-    private const val MAX_CBOX_BYTES = 10 * 1024 * 1024 + 36
+    private const val MAX_CBOX_BYTES = CboxWireLimits.MAX_BYTES
     private const val MAX_KEYBOX_WIRE_BYTES = KeyboxWire.MAX_RESPONSE_BYTES
     private const val MAX_CBOX_RESPONSE_BYTES = RESPONSE_PREFIX_BYTES + MAX_AUTHOR_BYTES + MAX_KEYBOX_WIRE_BYTES
     private const val MAX_CBOX_UNLOCK_RESPONSE_BYTES = RECOVERY_KEY_BYTES + MAX_CBOX_RESPONSE_BYTES

--- a/service/src/main/java/cleveres/tricky/cleverestech/ServerManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ServerManager.kt
@@ -532,7 +532,7 @@ object ServerManager {
                 return commitFetchFailure(context, "HTTP_${conn.responseCode}")
             }
 
-            val maxResponseSize = 10 * 1024 * 1024
+            val maxResponseSize = CboxWireLimits.MAX_BYTES
             val contentLength = conn.contentLengthLong
             if (contentLength > maxResponseSize) {
                 return commitFetchFailure(context, "RESPONSE_TOO_LARGE")
@@ -551,7 +551,7 @@ object ServerManager {
                             if (count == 0) continue
                             totalRead += count
                             if (totalRead > maxResponseSize) {
-                                throw SecurityException("Server response exceeds 10MB limit")
+                                throw SecurityException("Server response exceeds the CBOX wire limit")
                             }
                             output.write(chunk, 0, count)
                         }

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -1605,8 +1605,14 @@ class WebServer(
                 val originalName = getParam(session, "filename") ?: "upload.bin"
                 val tmpFile = File(tmpFilePath)
                 val extension = originalName.substringAfterLast('.', "").lowercase()
+                val uploadLimit =
+                    if (extension == "cbox") {
+                        MAX_CBOX_UPLOAD_SIZE
+                    } else {
+                        MAX_KEYBOX_XML_UPLOAD_SIZE
+                    }
                 if (!Files.isRegularFile(tmpFile.toPath(), LinkOption.NOFOLLOW_LINKS) ||
-                    tmpFile.length() !in 1..MAX_KEYBOX_UPLOAD_SIZE
+                    tmpFile.length() !in 1..uploadLimit
                 ) {
                     if (tmpFile.exists()) tmpFile.delete()
                     return secureResponse(Response.Status.BAD_REQUEST, "text/plain", "Invalid upload size")
@@ -1615,7 +1621,7 @@ class WebServer(
                     tmpFile.delete()
                     return secureResponse(Response.Status.BAD_REQUEST, "text/plain", "Invalid upload filename")
                 }
-                val bytes = readFileBytesLimited(tmpFile, MAX_KEYBOX_UPLOAD_SIZE.toInt())
+                val bytes = readFileBytesLimited(tmpFile, uploadLimit.toInt())
                 try {
                     synchronized(fileLock) {
                         val keyboxDir = File(configDir, "keyboxes")
@@ -2095,10 +2101,11 @@ class WebServer(
     }
 
     companion object {
-        private const val MAX_UPLOAD_SIZE = 10 * 1024 * 1024L
+        private val MAX_UPLOAD_SIZE = CboxWireLimits.MAX_BYTES.toLong() + 1024 * 1024L
         private const val MAX_NATIVE_UPLOAD_SIZE = 20 * 1024 * 1024L
         private const val MAX_NATIVE_REQUEST_SIZE = MAX_NATIVE_UPLOAD_SIZE + 1024 * 1024L
-        private const val MAX_KEYBOX_UPLOAD_SIZE = 10 * 1024 * 1024L
+        private const val MAX_KEYBOX_XML_UPLOAD_SIZE = 10 * 1024 * 1024L
+        private val MAX_CBOX_UPLOAD_SIZE = CboxWireLimits.MAX_BYTES.toLong()
         private const val MAX_BODY_SIZE = 5 * 1024 * 1024L
         private const val MAX_CONFIG_FILE_SIZE = 1024 * 1024L
         private const val MAX_IDENTITY_REQUEST_BYTES = 8 * 1024
@@ -2112,7 +2119,8 @@ class WebServer(
         private const val MAX_BACKUP_KEYBOXES = 64
         private const val MAX_LISTED_KEYBOX_FILES = 128
         private const val MAX_BACKUP_CONFIG_ENTRY_BYTES = 1024 * 1024
-        private const val MAX_BACKUP_KEYBOX_ENTRY_BYTES = 10 * 1024 * 1024
+        private const val MAX_BACKUP_XML_ENTRY_BYTES = 10 * 1024 * 1024
+        private const val MAX_BACKUP_CBOX_ENTRY_BYTES = CboxWireLimits.MAX_BYTES
         private const val MAX_BACKUP_UNCOMPRESSED_BYTES = 16 * 1024 * 1024
         private const val MAX_SECURITY_PATCH_RULES = 512
         private const val MAX_DRM_PACKAGE_RULES = 256
@@ -2586,19 +2594,21 @@ class WebServer(
                                 isValidKeyboxBackupPath("keyboxes/${file.name}")
                             }
                         keyboxes.forEach { keybox ->
+                            val backupName = "keyboxes/${keybox.name}"
+                            val entryLimit = backupEntryLimit(backupName)
                             val size = keybox.length()
-                            if (size !in 1..MAX_BACKUP_KEYBOX_ENTRY_BYTES.toLong()) {
+                            if (size !in 1..entryLimit.toLong()) {
                                 throw IOException("Keybox exceeds size limit: ${keybox.name}")
                             }
                             val remaining = MAX_BACKUP_UNCOMPRESSED_BYTES.toLong() - totalBytes
                             if (remaining < 0) throw IOException("Backup exceeds uncompressed size limit")
-                            zos.putNextEntry(ZipEntry("keyboxes/${keybox.name}"))
+                            zos.putNextEntry(ZipEntry(backupName))
                             val copied =
                                 Files.newInputStream(keybox.toPath(), LinkOption.NOFOLLOW_LINKS).use { input ->
                                     BackupIo.copyBounded(
                                         input,
                                         zos,
-                                        MAX_BACKUP_KEYBOX_ENTRY_BYTES.toLong(),
+                                        entryLimit.toLong(),
                                         remaining,
                                     )
                                 }
@@ -2752,7 +2762,11 @@ class WebServer(
         private fun isBackupKeyboxEntry(name: String): Boolean = name == "keybox.xml" || isValidKeyboxBackupPath(name)
 
         private fun backupEntryLimit(name: String): Int =
-            if (isBackupKeyboxEntry(name)) MAX_BACKUP_KEYBOX_ENTRY_BYTES else MAX_BACKUP_CONFIG_ENTRY_BYTES
+            when {
+                name.endsWith(".cbox", ignoreCase = true) -> MAX_BACKUP_CBOX_ENTRY_BYTES
+                isBackupKeyboxEntry(name) -> MAX_BACKUP_XML_ENTRY_BYTES
+                else -> MAX_BACKUP_CONFIG_ENTRY_BYTES
+            }
 
         private fun isValidKeyboxBackupPath(name: String): Boolean {
             if (!name.startsWith("keyboxes/") || name.count { it == '/' } != 1) return false

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/CboxDecryptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/CboxDecryptor.kt
@@ -1,19 +1,15 @@
 package cleveres.tricky.cleverestech.util
 
+import cleveres.tricky.cleverestech.CboxWireLimits
 import java.nio.charset.StandardCharsets
 
 /** Classifies CBOX envelopes before they cross into the unprivileged Rust backend. */
 object CboxDecryptor {
     private const val CBOX_MAGIC = "CBOX"
-    private const val SALT_LENGTH = 16
-    private const val IV_LENGTH = 12
-    private const val GCM_TAG_LENGTH = 16
-    private const val HEADER_BYTES = 4 + Int.SIZE_BYTES + SALT_LENGTH + IV_LENGTH + GCM_TAG_LENGTH
-
     private val magicBytes = CBOX_MAGIC.toByteArray(StandardCharsets.US_ASCII)
 
     fun hasSupportedEnvelopeHeader(bytes: ByteArray): Boolean {
-        if (bytes.size < HEADER_BYTES) return false
+        if (bytes.size < CboxWireLimits.MIN_BYTES || bytes.size > CboxWireLimits.MAX_BYTES) return false
         for (index in magicBytes.indices) {
             if (bytes[index] != magicBytes[index]) return false
         }

--- a/service/src/test/java/cleveres/tricky/cleverestech/CboxManagerValidationTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/CboxManagerValidationTest.kt
@@ -1,0 +1,17 @@
+package cleveres.tricky.cleverestech
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CboxManagerValidationTest {
+    @Test
+    fun `legacy empty password remains decryptable`() {
+        assertTrue(CboxManager.isUnlockPasswordWithinLimit(""))
+    }
+
+    @Test
+    fun `password over backend UTF-16 limit is rejected`() {
+        assertFalse(CboxManager.isUnlockPasswordWithinLimit("a".repeat(1025)))
+    }
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerBackupTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerBackupTest.kt
@@ -119,7 +119,7 @@ class WebServerBackupTest {
         val kbDir = File(configDir, "keyboxes")
         kbDir.mkdirs()
         File(kbDir, "kb1.xml").writeText(TestKeyboxFixtures.validEcKeyboxXml)
-        val cboxBytes = ByteArray(1024 * 1024 + 1)
+        val cboxBytes = ByteArray(CboxWireLimits.MAX_BYTES)
         ByteBuffer.wrap(cboxBytes)
             .put("CBOX".toByteArray(StandardCharsets.US_ASCII))
             .putInt(2)

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerUploadTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerUploadTest.kt
@@ -13,6 +13,7 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.net.HttpURLConnection
 import java.net.URL
+import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
 class WebServerUploadTest {
@@ -192,6 +193,17 @@ class WebServerUploadTest {
 
         assertEquals(200, uploadMultipartKeybox("multipart.xml", content))
         assertArrayEquals(content, File(configDir, "keyboxes/multipart.xml").readBytes())
+    }
+
+    @Test
+    fun `multipart upload accepts full CBOX wire bound`() {
+        val content = ByteArray(CboxWireLimits.MAX_BYTES)
+        ByteBuffer.wrap(content)
+            .put("CBOX".toByteArray(StandardCharsets.US_ASCII))
+            .putInt(2)
+
+        assertEquals(200, uploadMultipartKeybox("full-size.cbox", content))
+        assertEquals(content.size.toLong(), File(configDir, "keyboxes/full-size.cbox").length())
     }
 
     @Test

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/CryptoCompatibilityTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/CryptoCompatibilityTest.kt
@@ -1,5 +1,6 @@
 package cleveres.tricky.cleverestech.util
 
+import cleveres.tricky.cleverestech.CboxWireLimits
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -9,6 +10,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.ByteArrayInputStream
 import java.io.IOException
+import java.nio.charset.StandardCharsets
 import java.util.Base64
 
 class CryptoCompatibilityTest {
@@ -112,6 +114,24 @@ class CryptoCompatibilityTest {
             assertFalse(CboxDecryptor.hasSupportedEnvelopeHeader(unsupported))
         } finally {
             current.fill(0)
+        }
+    }
+
+    @Test
+    fun `CBOX header classifier accepts the full wire bound only`() {
+        val bounded = ByteArray(CboxWireLimits.MAX_BYTES)
+        val oversized = ByteArray(CboxWireLimits.MAX_BYTES + 1)
+        try {
+            "CBOX".toByteArray(StandardCharsets.US_ASCII).copyInto(bounded)
+            bounded[7] = 2
+            "CBOX".toByteArray(StandardCharsets.US_ASCII).copyInto(oversized)
+            oversized[7] = 2
+
+            assertTrue(CboxDecryptor.hasSupportedEnvelopeHeader(bounded))
+            assertFalse(CboxDecryptor.hasSupportedEnvelopeHeader(oversized))
+        } finally {
+            bounded.fill(0)
+            oversized.fill(0)
         }
     }
 


### PR DESCRIPTION
## Summary
- centralize the managed CBOX envelope bounds and accept the complete 10 MiB ciphertext plus 36-byte header across direct/ZIP WebUI imports, service uploads, backups, and remote downloads
- keep XML limits unchanged while giving multipart and compressed-entry framing bounded headroom
- preserve decryption compatibility for legacy CBOX files created with an empty password; new encryption still requires a strong password
- add exact-boundary WebUI, upload, backup/restore, classifier, and password validation regressions

## Verification
- all `module/webui-tests/*.test.js`
- `git diff --check`
- local Gradle execution unavailable because the Gradle 9.7 distribution is not present and network download is blocked; GitHub Actions is the execution gate