### PR TITLE
fix: validate server authentication headers

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/ServerManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ServerManager.kt
@@ -312,12 +312,7 @@ object ServerManager {
             "BASIC" -> {
                 val username = server.authData.optString("username")
                 val password = server.authData.optString("password")
-                require(username.length <= 1024 && password.length <= 1024) {
-                    "Basic authentication credentials are too long"
-                }
-                require('\r' !in username && '\n' !in username && '\r' !in password && '\n' !in password) {
-                    "Invalid basic authentication credentials"
-                }
+                validateBasicAuthentication(username, password)
             }
             "API_KEY" -> {
                 val header = server.authData.optString("headerName", "X-API-Key")
@@ -355,8 +350,38 @@ object ServerManager {
     ) {
         require(validHeaderName.matches(name)) { "Invalid authentication header name" }
         require(name.lowercase() !in restrictedHeaders) { "Restricted authentication header" }
-        require(value.length <= 8192 && '\r' !in value && '\n' !in value) {
+        require(value.length <= MAX_HEADER_VALUE_CHARS && '\r' !in value && '\n' !in value) {
             "Invalid authentication header value"
+        }
+    }
+
+    private fun validateBasicAuthentication(
+        username: String,
+        password: String,
+    ) {
+        require(
+            username.length <= MAX_BASIC_CREDENTIAL_UTF16_UNITS &&
+                password.length <= MAX_BASIC_CREDENTIAL_UTF16_UNITS,
+        ) {
+            "Basic authentication credentials are too long"
+        }
+        require(
+            ':' !in username &&
+                '\r' !in username &&
+                '\n' !in username &&
+                '\r' !in password &&
+                '\n' !in password,
+        ) {
+            "Invalid basic authentication credentials"
+        }
+
+        val credentialsBytes =
+            username.toByteArray(StandardCharsets.UTF_8).size +
+                1 +
+                password.toByteArray(StandardCharsets.UTF_8).size
+        val encodedChars = ((credentialsBytes + 2) / 3) * 4
+        require(BASIC_AUTH_PREFIX.length + encodedChars <= MAX_HEADER_VALUE_CHARS) {
+            "Basic authentication credentials are too long"
         }
     }
 
@@ -505,9 +530,13 @@ object ServerManager {
                     val user = snapshot.authData.optString("username")
                     val pass = snapshot.authData.optString("password")
                     if (user.isNotEmpty() || pass.isNotEmpty()) {
-                        val auth = Base64.encodeToString("$user:$pass".toByteArray(), Base64.NO_WRAP)
-                        requireSafeHeader("Authorization", "Basic $auth")
-                        conn.setRequestProperty("Authorization", "Basic $auth")
+                        val auth = Base64.encodeToString(
+                            "$user:$pass".toByteArray(StandardCharsets.UTF_8),
+                            Base64.NO_WRAP,
+                        )
+                        val authorization = "$BASIC_AUTH_PREFIX$auth"
+                        requireSafeHeader("Authorization", authorization)
+                        conn.setRequestProperty("Authorization", authorization)
                     }
                 }
                 "API_KEY" -> {
@@ -874,6 +903,9 @@ object ServerManager {
     private const val MAX_REMOTE_KEYBOXES = 64
     private const val MAX_CONFIG_BYTES = 2L * 1024 * 1024
     private const val MAX_CACHE_BYTES = 16L * 1024 * 1024
+    private const val MAX_HEADER_VALUE_CHARS = 8192
+    private const val MAX_BASIC_CREDENTIAL_UTF16_UNITS = 1024
+    private const val BASIC_AUTH_PREFIX = "Basic "
     private val SERVER_CACHE_MAGIC = byteArrayOf('C'.code.toByte(), 'T'.code.toByte(), 'S'.code.toByte(), 'C'.code.toByte(), 2)
     private const val SERVER_CACHE_BINDING_BYTES = 32
     private val SERVER_CACHE_PREFIX_BYTES = SERVER_CACHE_MAGIC.size + SERVER_CACHE_BINDING_BYTES

--- a/service/src/main/java/cleveres/tricky/cleverestech/ServerManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ServerManager.kt
@@ -350,7 +350,10 @@ object ServerManager {
     ) {
         require(validHeaderName.matches(name)) { "Invalid authentication header name" }
         require(name.lowercase() !in restrictedHeaders) { "Restricted authentication header" }
-        require(value.length <= MAX_HEADER_VALUE_CHARS && '\r' !in value && '\n' !in value) {
+        require(
+            value.length <= MAX_HEADER_VALUE_CHARS &&
+                value.all { character -> character >= ' ' && character != '\u007f' },
+        ) {
             "Invalid authentication header value"
         }
     }

--- a/service/src/test/java/cleveres/tricky/cleverestech/ServerBasicAuthenticationValidationTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ServerBasicAuthenticationValidationTest.kt
@@ -1,0 +1,51 @@
+package cleveres.tricky.cleverestech
+
+import org.json.JSONObject
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class ServerBasicAuthenticationValidationTest {
+    @Test
+    fun `multibyte credentials that overflow the authorization header are rejected`() {
+        val username = "\u0800".repeat(1024)
+        val password = "\u0800".repeat(1024)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            ServerManager.validateServer(server(username, password))
+        }
+    }
+
+    @Test
+    fun `username containing the basic authentication separator is rejected`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            ServerManager.validateServer(server("user:name", "password"))
+        }
+    }
+
+    @Test
+    fun `multibyte credentials fitting the encoded header bound are accepted`() {
+        val username = "\u0800".repeat(1022)
+        val password = "\u0800".repeat(1023)
+
+        ServerManager.validateServer(server(username, password))
+    }
+
+    private fun server(
+        username: String,
+        password: String,
+    ) =
+        ServerManager.ServerConfig(
+            id = "basic-validation-test",
+            name = "Basic validation test",
+            url = "https://example.com/keybox.cbox",
+            priority = 0,
+            enabled = true,
+            authType = "BASIC",
+            authData =
+                JSONObject()
+                    .put("username", username)
+                    .put("password", password),
+            autoRefresh = false,
+            refreshIntervalHours = 24,
+        )
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/ServerHeaderValidationTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ServerHeaderValidationTest.kt
@@ -1,0 +1,56 @@
+package cleveres.tricky.cleverestech
+
+import org.json.JSONObject
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class ServerHeaderValidationTest {
+    @Test
+    fun `Android-forbidden control characters are rejected before fetch`() {
+        val configurations =
+            listOf(
+                "BEARER" to JSONObject().put("token", "token\u0000value"),
+                "API_KEY" to
+                    JSONObject()
+                        .put("headerName", "X-API-Key")
+                        .put("key", "key\tvalue"),
+                "CUSTOM" to
+                    JSONObject().put(
+                        "headers",
+                        JSONObject().put("X-Custom", "value\u007f"),
+                    ),
+            )
+
+        configurations.forEach { (authType, authData) ->
+            assertThrows(IllegalArgumentException::class.java) {
+                ServerManager.validateServer(server(authType, authData))
+            }
+        }
+    }
+
+    @Test
+    fun `visible Unicode header values remain supported`() {
+        ServerManager.validateServer(
+            server(
+                "CUSTOM",
+                JSONObject().put("headers", JSONObject().put("X-Custom", "geçerli-🍩")),
+            ),
+        )
+    }
+
+    private fun server(
+        authType: String,
+        authData: JSONObject,
+    ) =
+        ServerManager.ServerConfig(
+            id = "header-validation-test",
+            name = "Header validation test",
+            url = "https://example.com/keybox.cbox",
+            priority = 0,
+            enabled = true,
+            authType = authType,
+            authData = authData,
+            autoRefresh = false,
+            refreshIntervalHours = 24,
+        )
+}


### PR DESCRIPTION
## Summary
- validate BASIC credentials against the final UTF-8/Base64 Authorization header bound before accepting server configuration
- reject `:` in usernames so the configured username/password boundary cannot be reinterpreted
- reject C0 control characters and DEL that Android's HTTP transport refuses in Bearer, API-key, and custom header values
- encode BASIC credentials explicitly as UTF-8 and share the header-limit constants
- add regression coverage for overflow, separator ambiguity, Android-forbidden controls, Unicode compatibility, and the near-boundary valid case

## Bugs
1. Two 1024-unit multibyte BASIC values were accepted, but generated an 8202-character `Authorization` value that the 8192-character request-header guard rejected during every fetch.
2. Header validation only rejected CR/LF, so configurations containing NUL, TAB, other C0 controls, or DEL were accepted and then rejected by Android `HttpURLConnection`.

## Validation
- `git diff --check`
- exact BASIC boundary calculation: 1024/1024 U+0800 credentials produce an 8202-character header; 1022/1023 produce 8190
- regression tests cover all authentication header paths
- exact-head GitHub CI required before merge