### PR TITLE
fix: bind Auto Identity patch level to matching bulletin row

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/AutoIdentityManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/AutoIdentityManager.kt
@@ -366,9 +366,13 @@ object AutoIdentityManager {
         if (token.isEmpty()) return null
         val index = html.indexOf(token, ignoreCase = true)
         if (index < 0) return null
-        val start = (index - 1200).coerceAtLeast(0)
-        val end = (index + token.length + 1200).coerceAtMost(html.length)
-        return Regex("""20\d{2}-\d{2}-\d{2}""").find(html.substring(start, end))?.value
+
+        val rowStart = html.lastIndexOf("<tr", startIndex = index, ignoreCase = true)
+        val rowEnd = html.indexOf("</tr>", startIndex = index, ignoreCase = true)
+        if (rowStart < 0 || rowEnd < index) return null
+
+        val row = html.substring(rowStart, rowEnd + "</tr>".length)
+        return normalizePatch(row)
     }
 
     private fun normalizePatch(value: String): String? =

--- a/service/src/test/java/cleveres/tricky/cleverestech/AutoIdentityManagerTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/AutoIdentityManagerTest.kt
@@ -79,6 +79,34 @@ class AutoIdentityManagerTest {
     }
 
     @Test
+    fun `security patch lookup stays inside the matching bulletin row`() {
+        val bulletin =
+            """
+            <table>
+              <tr><td>2607</td><td>2026-07-05</td></tr>
+              <tr><td>2608</td><td>2026-08-05</td></tr>
+            </table>
+            """.trimIndent()
+
+        assertEquals(
+            "2026-08-05",
+            AutoIdentityManager.findSecurityPatchInBulletin(bulletin, "canary-2608"),
+        )
+    }
+
+    @Test
+    fun `security patch lookup does not borrow a nearby date outside the matching row`() {
+        val bulletin =
+            """
+            <div>2026-07-05</div>
+            <p>canary-2608</p>
+            <div>2026-08-05</div>
+            """.trimIndent()
+
+        assertEquals(null, AutoIdentityManager.findSecurityPatchInBulletin(bulletin, "canary-2608"))
+    }
+
+    @Test
     fun `security patch falls back to canary month when bulletin has no match`() {
         assertEquals("2026-08-05", AutoIdentityManager.estimateSecurityPatch("canary-2608"))
         assertEquals("2026-08-05", AutoIdentityManager.estimateSecurityPatch("canary-202608"))


### PR DESCRIPTION
## Summary
- bind Pixel security-patch extraction to the `<tr>` containing the matched canary token
- fail closed when the token is not associated with a bulletin table row instead of borrowing a nearby date
- add regressions for adjacent bulletin rows and unrelated nearby dates

## Why
The previous ±1200-character search returned the first date in the window, so an earlier bulletin row could supply the wrong patch level for the selected canary build.

## Validation
- regression tests added in `AutoIdentityManagerTest`
- CI must be green before merge