### PR TITLE
fix: harden Auto Identity metadata parsing

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/AutoIdentityManager.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/AutoIdentityManager.kt
@@ -239,16 +239,17 @@ object AutoIdentityManager {
     internal fun parseDeviceCandidates(html: String): List<DeviceCandidate> {
         val rows =
             Regex(
-                """<tr\s+id=["']([^"']+)["'][^>]*>(.*?)</tr>""",
+                """<tr\b([^>]*)>(.*?)</tr>""",
                 setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
             )
+        val rowId = Regex("""(?:^|\s)id\s*=\s*["']([^"']+)["']""", RegexOption.IGNORE_CASE)
         val modelCell =
             Regex(
                 """<td[^>]*>\s*(.*?)\s*</td>""",
                 setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
             )
         return rows.findAll(html).mapNotNull { row ->
-            val device = row.groupValues[1].trim()
+            val device = rowId.find(row.groupValues[1])?.groupValues?.get(1)?.trim() ?: return@mapNotNull null
             val rawModel = modelCell.find(row.groupValues[2])?.groupValues?.get(1) ?: return@mapNotNull null
             val model = stripHtml(rawModel)
             if (!VALID_DEVICE.matches(device) || model.isBlank() || model.length > 128) return@mapNotNull null
@@ -316,12 +317,18 @@ object AutoIdentityManager {
     }
 
     private fun canaryDateKey(value: String): Int {
-        val full = Regex("""(?<!\d)(20\d{2})[-_.]?(0[1-9]|1[0-2])[-_.]?([0-2]\d|3[01])(?!\d)""").find(value)
-        if (full != null) {
-            val year = full.groupValues[1].toInt()
-            val month = full.groupValues[2].toInt()
-            val day = full.groupValues[3].toInt()
-            return year * 10_000 + month * 100 + day
+        val fullPattern =
+            Regex("""(?<!\d)(20\d{2})[-_.]?(0[1-9]|1[0-2])[-_.]?(0[1-9]|[12]\d|3[01])(?!\d)""")
+        for (match in fullPattern.findAll(value)) {
+            val date =
+                runCatching {
+                    LocalDate.of(
+                        match.groupValues[1].toInt(),
+                        match.groupValues[2].toInt(),
+                        match.groupValues[3].toInt(),
+                    )
+                }.getOrNull() ?: continue
+            return date.year * 10_000 + date.monthValue * 100 + date.dayOfMonth
         }
         val monthOnly = Regex("""(?<!\d)(20\d{2})[-_.]?(0[1-9]|1[0-2])(?!\d)""").find(value)
         if (monthOnly != null) {
@@ -364,19 +371,24 @@ object AutoIdentityManager {
     ): String? {
         val token = canaryId.removePrefix("canary-").trim()
         if (token.isEmpty()) return null
-        val index = html.indexOf(token, ignoreCase = true)
-        if (index < 0) return null
-
-        val rowStart = html.lastIndexOf("<tr", startIndex = index, ignoreCase = true)
-        val rowEnd = html.indexOf("</tr>", startIndex = index, ignoreCase = true)
-        if (rowStart < 0 || rowEnd < index) return null
-
-        val row = html.substring(rowStart, rowEnd + "</tr>".length)
-        return normalizePatch(row)
+        val rows =
+            Regex(
+                """<tr\b[^>]*>.*?</tr>""",
+                setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
+            )
+        return rows
+            .findAll(html)
+            .map { it.value }
+            .firstOrNull { row -> row.contains(token, ignoreCase = true) }
+            ?.let(::normalizePatch)
     }
 
     private fun normalizePatch(value: String): String? =
-        Regex("""20\d{2}-\d{2}-\d{2}""").find(value)?.value
+        Regex("""20\d{2}-\d{2}-\d{2}""")
+            .findAll(value)
+            .mapNotNull { match -> runCatching { LocalDate.parse(match.value) }.getOrNull() }
+            .firstOrNull()
+            ?.toString()
 
     internal fun estimateSecurityPatch(canaryId: String): String {
         val digits = canaryId.removePrefix("canary-").filter(Char::isDigit)

--- a/service/src/test/java/cleveres/tricky/cleverestech/AutoIdentityManagerTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/AutoIdentityManagerTest.kt
@@ -35,7 +35,8 @@ class AutoIdentityManagerTest {
                           "canary": true,
                           "releaseCandidateName": "BP31.260801.001",
                           "buildId": "12345678",
-                          "releaseTrackVersionName": "Android 17 Canary"
+                          "releaseTrackVersionName": "Android 17 Canary",
+                          "securityPatch": "2026-02-31"
                         }
                       ]
                     }
@@ -79,6 +80,18 @@ class AutoIdentityManagerTest {
     }
 
     @Test
+    fun `invalid canary calendar dates cannot outrank valid builds`() {
+        val valid =
+            """{"id":"canary-20260228","canary":true,"releaseCandidateName":"BP31.260228.001","buildId":"100"}"""
+        val invalid =
+            """{"id":"canary-20260231","canary":true,"releaseCandidateName":"BP31.260231.001","buildId":"999"}"""
+
+        val latest = AutoIdentityManager.findLatestCanary("[$valid,$invalid]")
+
+        assertEquals("canary-20260228", latest?.optString("id"))
+    }
+
+    @Test
     fun `security patch lookup stays inside the matching bulletin row`() {
         val bulletin =
             """
@@ -95,6 +108,20 @@ class AutoIdentityManagerTest {
     }
 
     @Test
+    fun `security patch lookup does not bridge across bulletin rows`() {
+        val bulletin =
+            """
+            <table>
+              <tr><td>2607</td><td>2026-07-05</td></tr>
+              <p>canary-2608</p>
+              <tr><td>2026-08-05</td></tr>
+            </table>
+            """.trimIndent()
+
+        assertEquals(null, AutoIdentityManager.findSecurityPatchInBulletin(bulletin, "canary-2608"))
+    }
+
+    @Test
     fun `security patch lookup does not borrow a nearby date outside the matching row`() {
         val bulletin =
             """
@@ -102,6 +129,13 @@ class AutoIdentityManagerTest {
             <p>canary-2608</p>
             <div>2026-08-05</div>
             """.trimIndent()
+
+        assertEquals(null, AutoIdentityManager.findSecurityPatchInBulletin(bulletin, "canary-2608"))
+    }
+
+    @Test
+    fun `security patch lookup rejects impossible calendar dates`() {
+        val bulletin = """<table><tr><td>2608</td><td>2026-02-31</td></tr></table>"""
 
         assertEquals(null, AutoIdentityManager.findSecurityPatchInBulletin(bulletin, "canary-2608"))
     }
@@ -117,11 +151,12 @@ class AutoIdentityManagerTest {
         val candidates =
             AutoIdentityManager.parseDeviceCandidates(
                 """
-                <tr id="good_device"><td>Pixel Good</td></tr>
-                <tr id="bad/device"><td>Pixel Bad</td></tr>
+                <tr class="pixel-row" data-id="ignored" id = "good_device"><td>Pixel Good</td></tr>
+                <tr class="pixel-row" id="bad/device"><td>Pixel Bad</td></tr>
                 """.trimIndent(),
             )
         assertEquals(1, candidates.size)
+        assertEquals("good_device", candidates.single().device)
         assertTrue(candidates.single().product.endsWith("_beta"))
     }
 }


### PR DESCRIPTION
## Summary
- keep Pixel bulletin patch lookup inside actual `<tr>...</tr>` blocks instead of bridging across neighboring rows
- validate security patch dates semantically with `LocalDate` so impossible dates do not become spoofed patch levels
- reject impossible full calendar dates when ranking canary builds
- accept device-row `id` attributes regardless of attribute order/spacing without confusing `data-id`

## Regression coverage
- invalid explicit `securityPatch` falls through to the valid bulletin patch
- impossible canary date cannot outrank a valid build
- token between bulletin rows cannot borrow either row's date
- impossible bulletin dates are rejected
- beta device rows still parse when `id` is not the first attribute

## Validation
- standalone Kotlin parser checks passed locally with `kotlinc`
- full repository Gradle preflight could not be run in this execution environment because `github.com` DNS resolution is unavailable, so the repository cannot be cloned/materialized for Gradle execution here
- no workflow/build/config files changed; final diff is limited to `AutoIdentityManager.kt` and `AutoIdentityManagerTest.kt`

The PR should only be merged if the CI checks attached to its final head are green.