### PR TITLE
fix(runtime): keep native interception alive when boot compatibility fails

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
@@ -44,7 +44,6 @@ private fun startWebUiBridge(
     return null
 }
 
-
 private fun hasConfiguredKeyboxSource(configDir: File): Boolean {
     val roots =
         listOf(
@@ -95,7 +94,6 @@ fun main(args: Array<String>) {
         }
 
         while (!NativeBackend.awaitReady(BACKEND_STARTUP_TIMEOUT_MS)) {
-
             if (Thread.currentThread().isInterrupted) {
                 Logger.i("Main: Interrupted while waiting for Rust backend")
                 return@runBlocking
@@ -113,13 +111,65 @@ fun main(args: Array<String>) {
             }
             KernelIdentityManager.initialize(configDir)
             Config.initialize()
-            check(BootLogic.run()) { "Boot property compatibility initialization failed" }
-            CertificatePolicyWatcher.start(configDir)
         } catch (e: Exception) {
-            Logger.e("Failed to initialize Config/BootLogic", e)
+            Logger.e("Failed to initialize core configuration", e)
             Logger.e("Main: Exiting so the module supervisor can retry initialization")
             return@runBlocking
         }
+
+        val startupTasks =
+            listOf(
+                RuntimeStartupTask(
+                    name = "boot property compatibility",
+                    failureMode = RuntimeStartupFailureMode.CONTINUE_AND_RETRY,
+                    attemptBlock = BootLogic::run,
+                    retryDelaysMs = listOf(1_000L, 5_000L, 15_000L, 60_000L, 300_000L),
+                ),
+            )
+        val startupResults = RuntimeStartupPolicy.evaluate(startupTasks)
+        startupResults.forEach { result ->
+            result.failure?.let { failure ->
+                Logger.e("${result.task.name} startup attempt failed", failure)
+            }
+        }
+        if (!RuntimeStartupPolicy.canEnterCoreRuntime(startupResults)) {
+            val unavailable =
+                RuntimeStartupPolicy.fatalFailures(startupResults)
+                    .joinToString { it.task.name }
+            Logger.e("Required startup components are unavailable: $unavailable")
+            Logger.e("Main: Exiting so the module supervisor can retry initialization")
+            return@runBlocking
+        }
+
+        try {
+            CertificatePolicyWatcher.start(configDir)
+        } catch (e: Exception) {
+            Logger.e("Failed to initialize certificate policy watcher", e)
+            Logger.e("Main: Exiting so the module supervisor can retry initialization")
+            return@runBlocking
+        }
+
+        val startupRetryJobs =
+            RuntimeStartupPolicy.retryableFailures(startupResults).map { result ->
+                Logger.w(
+                    "${result.task.name} is unavailable; core Keystore/TEE interception will continue while the startup task retries",
+                )
+                launch(Dispatchers.IO) {
+                    val recovered =
+                        RuntimeStartupPolicy.retryBounded(result.task) { retryResult ->
+                            retryResult.failure?.let { failure ->
+                                Logger.e("${retryResult.task.name} retry attempt failed", failure)
+                            }
+                        }
+                    if (recovered.ready) {
+                        Logger.i("${recovered.task.name} recovered without restarting the native runtime")
+                    } else {
+                        Logger.w(
+                            "${recovered.task.name} remains unavailable; core Keystore/TEE interception remains active",
+                        )
+                    }
+                }
+            }
 
         runCatching { KeyboxDirectoryRefreshWatcher.start(Config.keyboxDirectory) }
             .onFailure { Logger.e("Failed to install conflated keybox watcher; keeping legacy observer", it) }
@@ -303,6 +353,7 @@ fun main(args: Array<String>) {
                 Config.awaitRuntimeController(controllerWaitMs)
             } catch (_: InterruptedException) {
                 Thread.currentThread().interrupt()
+                startupRetryJobs.forEach { it.cancel() }
                 KeyboxDirectoryRefreshWatcher.stop()
                 CertificatePolicyWatcher.stop()
                 SubscriptionVisibilityInterceptor.stop()

--- a/service/src/main/java/cleveres/tricky/cleverestech/RuntimeStartupPolicy.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/RuntimeStartupPolicy.kt
@@ -1,0 +1,87 @@
+package cleveres.tricky.cleverestech
+
+import java.util.concurrent.CancellationException
+import kotlinx.coroutines.delay
+
+internal const val MAX_RUNTIME_STARTUP_RETRY_ATTEMPTS = 8
+internal const val MAX_RUNTIME_STARTUP_RETRY_DELAY_MS = 300_000L
+
+internal enum class RuntimeStartupFailureMode {
+    FATAL,
+    CONTINUE_AND_RETRY,
+}
+
+internal class RuntimeStartupTask(
+    val name: String,
+    val failureMode: RuntimeStartupFailureMode,
+    private val attemptBlock: () -> Boolean,
+    val retryDelaysMs: List<Long> = emptyList(),
+) {
+    init {
+        require(name.isNotBlank()) { "startup task name must not be blank" }
+        when (failureMode) {
+            RuntimeStartupFailureMode.FATAL ->
+                require(retryDelaysMs.isEmpty()) { "fatal startup tasks must not define retries" }
+            RuntimeStartupFailureMode.CONTINUE_AND_RETRY -> {
+                require(retryDelaysMs.isNotEmpty()) { "retryable startup tasks require a retry schedule" }
+                require(retryDelaysMs.size <= MAX_RUNTIME_STARTUP_RETRY_ATTEMPTS) {
+                    "startup retry schedule exceeds the attempt limit"
+                }
+                require(retryDelaysMs.all { it in 1L..MAX_RUNTIME_STARTUP_RETRY_DELAY_MS }) {
+                    "startup retry delay is outside the supported range"
+                }
+            }
+        }
+    }
+
+    fun attempt(): Boolean = attemptBlock()
+}
+
+internal data class RuntimeStartupResult(
+    val task: RuntimeStartupTask,
+    val ready: Boolean,
+    val failure: Exception? = null,
+)
+
+internal object RuntimeStartupPolicy {
+    fun evaluate(tasks: Iterable<RuntimeStartupTask>): List<RuntimeStartupResult> =
+        tasks.map(::attempt)
+
+    fun fatalFailures(results: Iterable<RuntimeStartupResult>): List<RuntimeStartupResult> =
+        results.filter { !it.ready && it.task.failureMode == RuntimeStartupFailureMode.FATAL }
+
+    fun retryableFailures(results: Iterable<RuntimeStartupResult>): List<RuntimeStartupResult> =
+        results.filter {
+            !it.ready && it.task.failureMode == RuntimeStartupFailureMode.CONTINUE_AND_RETRY
+        }
+
+    fun canEnterCoreRuntime(results: Iterable<RuntimeStartupResult>): Boolean =
+        fatalFailures(results).isEmpty()
+
+    suspend fun retryBounded(
+        task: RuntimeStartupTask,
+        wait: suspend (Long) -> Unit = { delay(it) },
+        onAttempt: (RuntimeStartupResult) -> Unit = {},
+    ): RuntimeStartupResult {
+        require(task.failureMode == RuntimeStartupFailureMode.CONTINUE_AND_RETRY) {
+            "only retryable startup tasks can be retried"
+        }
+        var result = RuntimeStartupResult(task = task, ready = false)
+        for (delayMs in task.retryDelaysMs) {
+            wait(delayMs)
+            result = attempt(task)
+            onAttempt(result)
+            if (result.ready) return result
+        }
+        return result
+    }
+
+    private fun attempt(task: RuntimeStartupTask): RuntimeStartupResult =
+        try {
+            RuntimeStartupResult(task = task, ready = task.attempt())
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            RuntimeStartupResult(task = task, ready = false, failure = error)
+        }
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/MainStartupContractTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/MainStartupContractTest.kt
@@ -6,18 +6,6 @@ import org.junit.Test
 
 class MainStartupContractTest {
     @Test
-    fun `boot compatibility failure is routed to supervisor retry`() {
-        val root = locateRoot()
-        val mainSource = File(root, "service/src/main/java/cleveres/tricky/cleverestech/Main.kt").readText()
-        val bootSource = File(root, "service/src/main/java/cleveres/tricky/cleverestech/BootLogic.kt").readText()
-
-        assertTrue(bootSource.contains("fun run(): Boolean"))
-        assertTrue(bootSource.contains("Logger.e(\"BootLogic failed\", e)\n            false"))
-        assertTrue(mainSource.contains("check(BootLogic.run())"))
-        assertTrue(mainSource.contains("Main: Exiting so the module supervisor can retry initialization"))
-    }
-
-    @Test
     fun `web ui adapter registers before backend readiness gate`() {
         val root = locateRoot()
         val source = File(root, "service/src/main/java/cleveres/tricky/cleverestech/Main.kt").readText()

--- a/service/src/test/java/cleveres/tricky/cleverestech/RuntimeStartupPolicyTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/RuntimeStartupPolicyTest.kt
@@ -1,0 +1,176 @@
+package cleveres.tricky.cleverestech
+
+import java.util.concurrent.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class RuntimeStartupPolicyTest {
+    @Test
+    fun `only unavailable fatal tasks block the core runtime`() {
+        val readyFatal = fatalTask("ready") { true }
+        val unavailableRetryable = retryableTask("degraded") { false }
+        val unavailableFatal = fatalTask("required") { false }
+
+        val allowed = RuntimeStartupPolicy.evaluate(listOf(readyFatal, unavailableRetryable))
+        assertTrue(RuntimeStartupPolicy.canEnterCoreRuntime(allowed))
+        assertEquals(listOf("degraded"), RuntimeStartupPolicy.retryableFailures(allowed).map { it.task.name })
+
+        val blocked = RuntimeStartupPolicy.evaluate(listOf(readyFatal, unavailableRetryable, unavailableFatal))
+        assertFalse(RuntimeStartupPolicy.canEnterCoreRuntime(blocked))
+        assertEquals(listOf("required"), RuntimeStartupPolicy.fatalFailures(blocked).map { it.task.name })
+    }
+
+    @Test
+    fun `task exceptions become explicit unavailable state without changing failure policy`() {
+        val cause = IllegalStateException("synthetic")
+        val retryable = retryableTask("degraded") { throw cause }
+        val result = RuntimeStartupPolicy.evaluate(listOf(retryable)).single()
+
+        assertFalse(result.ready)
+        assertSame(cause, result.failure)
+        assertTrue(RuntimeStartupPolicy.canEnterCoreRuntime(listOf(result)))
+        assertEquals(listOf(result), RuntimeStartupPolicy.retryableFailures(listOf(result)))
+    }
+
+    @Test
+    fun `bounded retry stops immediately after recovery`() = runBlocking {
+        var attempts = 0
+        val waits = mutableListOf<Long>()
+        val task =
+            retryableTask(
+                name = "recovering",
+                delays = listOf(10L, 20L, 30L),
+            ) {
+                attempts++
+                attempts == 2
+            }
+
+        val result =
+            RuntimeStartupPolicy.retryBounded(
+                task = task,
+                wait = { waits += it },
+            )
+
+        assertTrue(result.ready)
+        assertEquals(2, attempts)
+        assertEquals(listOf(10L, 20L), waits)
+    }
+
+    @Test
+    fun `bounded retry exhausts a finite schedule without extra attempts`() = runBlocking {
+        var attempts = 0
+        val waits = mutableListOf<Long>()
+        val task =
+            retryableTask(
+                name = "persistent",
+                delays = listOf(10L, 20L, 30L),
+            ) {
+                attempts++
+                false
+            }
+
+        val result =
+            RuntimeStartupPolicy.retryBounded(
+                task = task,
+                wait = { waits += it },
+            )
+
+        assertFalse(result.ready)
+        assertEquals(3, attempts)
+        assertEquals(listOf(10L, 20L, 30L), waits)
+    }
+
+    @Test
+    fun `retry cancellation propagates before another attempt`() {
+        val cancellation = CancellationException("synthetic cancellation")
+        var attempts = 0
+        val task = retryableTask("cancelled") { attempts++ > 0 }
+
+        try {
+            runBlocking {
+                RuntimeStartupPolicy.retryBounded(
+                    task = task,
+                    wait = { throw cancellation },
+                )
+            }
+            fail("cancellation must propagate")
+        } catch (caught: CancellationException) {
+            assertSame(cancellation, caught)
+        }
+        assertEquals(0, attempts)
+    }
+
+    @Test
+    fun `retry schedules are bounded at construction`() {
+        assertInvalidTask {
+            RuntimeStartupTask(
+                name = "missing-schedule",
+                failureMode = RuntimeStartupFailureMode.CONTINUE_AND_RETRY,
+                attemptBlock = { false },
+            )
+        }
+        assertInvalidTask {
+            RuntimeStartupTask(
+                name = "too-many-attempts",
+                failureMode = RuntimeStartupFailureMode.CONTINUE_AND_RETRY,
+                attemptBlock = { false },
+                retryDelaysMs = List(MAX_RUNTIME_STARTUP_RETRY_ATTEMPTS + 1) { 1L },
+            )
+        }
+        assertInvalidTask {
+            RuntimeStartupTask(
+                name = "oversized-delay",
+                failureMode = RuntimeStartupFailureMode.CONTINUE_AND_RETRY,
+                attemptBlock = { false },
+                retryDelaysMs = listOf(MAX_RUNTIME_STARTUP_RETRY_DELAY_MS + 1L),
+            )
+        }
+        assertInvalidTask {
+            RuntimeStartupTask(
+                name = "fatal-with-retry",
+                failureMode = RuntimeStartupFailureMode.FATAL,
+                attemptBlock = { false },
+                retryDelaysMs = listOf(1L),
+            )
+        }
+    }
+
+    private fun fatalTask(
+        name: String,
+        attempt: () -> Boolean,
+    ): RuntimeStartupTask =
+        RuntimeStartupTask(
+            name = name,
+            failureMode = RuntimeStartupFailureMode.FATAL,
+            attemptBlock = attempt,
+        )
+
+    private fun retryableTask(
+        name: String,
+        delays: List<Long> = listOf(1L),
+        attempt: () -> Boolean,
+    ): RuntimeStartupTask =
+        RuntimeStartupTask(
+            name = name,
+            failureMode = RuntimeStartupFailureMode.CONTINUE_AND_RETRY,
+            attemptBlock = attempt,
+            retryDelaysMs = delays,
+        )
+
+    private fun assertInvalidTask(block: () -> Unit) {
+        val thrown =
+            try {
+                block()
+                null
+            } catch (caught: IllegalArgumentException) {
+                caught
+            }
+        assertNotNull(thrown)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the V2.6.1 -> V2.6.2 device regression where CleveresTricky can report an active configuration while the Android native adapter is not alive and the core Keystore interceptor never becomes operational.

Observed on KernelSU with V2.6.2 diagnostics:

```text
native_state=active
native_alive=false
native_failure=none
keystore_interceptor=false
keybox_count=1
identity_engine=false
global_mode=true
```

The resulting attestation path stays genuine, so Key Attestation can still report the real unlocked bootloader/root chain even though the module configuration itself is active.

## Root cause

The V2.6.2 development range changed startup from a non-fatal `BootLogic.run()` call to a fatal `check(BootLogic.run())` gate. `BootLogic` applies app-visible boot/property compatibility through `resetprop` and verifies the resulting property view. That work can fail on a device independently of the Binder/Keystore interception path.

Making the result fatal causes the Android adapter to exit before it reaches the always-on Keystore interceptor controller. The Rust daemon then invalidates the adapter lease, tears down the adapter-bound backend and restarts the adapter with backoff. On a device where the property compatibility failure is persistent this becomes a restart loop: daemon/WebUI reachability can remain while `native_alive=false` and no Keystore interceptor is registered.

`KeystoreInterceptor.kt` is byte-identical between V2.6.1 and the affected head, and the Rust daemon implementation is also unchanged across that boundary. The startup failure classification is the relevant behavioral regression.

## Fix: general startup liveness policy

This PR does not special-case the symptom with another one-off `if`/`check` contract. It introduces a reusable startup policy used by the production entry point:

- startup tasks explicitly declare `FATAL` or `CONTINUE_AND_RETRY` failure semantics;
- only unavailable `FATAL` tasks may block entry into the core runtime;
- degraded retryable tasks remain explicit failures and do not become fake success values;
- task exceptions become explicit unavailable state and retain their cause for logging;
- coroutine cancellation propagates instead of being converted into an ordinary failure;
- retryable tasks must define a finite schedule, capped at 8 attempts with each delay capped at 300 seconds;
- retry loops stop immediately on recovery and never make attempts outside their declared schedule;
- all active startup retry jobs are cancelled during runtime shutdown;
- genuinely core configuration and certificate-policy-watcher initialization failures retain the supervisor-restart path.

Boot-property compatibility is the first `CONTINUE_AND_RETRY` task. Its current schedule is 1s, 5s, 15s, 60s and 300s. If it remains unavailable, the always-on Keystore/TEE controller still starts and continues retrying independently.

## General regression coverage

`RuntimeStartupPolicyTest` exercises the policy with synthetic startup tasks rather than matching BootLogic source strings. It covers:

- ready/failing combinations of fatal and retryable components;
- fatal-only blocking of core-runtime entry;
- exception -> explicit unavailable-state behavior;
- fail -> recover retry sequences;
- permanent failure exhausting exactly the finite schedule;
- cancellation propagation before another attempt;
- invalid empty, oversized-attempt, oversized-delay and fatal-with-retry configurations.

The previous brittle BootLogic-specific source/index test was removed. `MainStartupContractTest` now keeps only the independent architectural contract that the WebUI adapter registers before the backend readiness gate.

## Exact-head CI

Final PR head: `81763c161d6993cd4ea88658ff7c0fa02bd95eca`

- Build #3376: **SUCCESS**
  - Kotlin format/quality: success
  - Android lint: success
  - unit tests: success
  - module artifact build: success
  - module layout/checksums: success
  - native artifact hardening: success
- Security Regression #939: **SUCCESS**
  - Android JVM unit tests: success
- Native Hardening #534: **SUCCESS**

PR test artifact:

```text
CleveresTricky-V2.6.2-3097-4cecf472-release.zip
sha256:f542b32f5c08d69b2ecce80454bd9c588a5aa550e30154f82b95b09864c2895f
```

The artifact filename contains GitHub's PR merge-ref short SHA (`4cecf472`); the workflow itself is attached to the exact PR head `81763c1...`.

Local Gradle preflight could not be run in the current execution environment because a clean checkout cannot resolve `github.com`; the exact final PR-head GitHub workflows above all completed successfully.

## Device validation required before merge/re-release

Install the PR artifact and reboot. Verify at minimum:

```text
native_state=active
native_alive=true
keystore_interceptor=true
keybox_count=1
```

With `identity_engine=false` and `global_mode=true`, core Keystore/TEE interception must remain operational. Re-check Key Attestation on the same device/configuration and confirm the previous genuine/unlocked attestation symptom is gone.

If boot-property compatibility itself still cannot be applied on that device, logs may report a degraded/retry warning, but that must no longer take the core interceptor offline.

Keep this PR draft and do not re-publish V2.6.2 until device validation is confirmed. No version, release asset, changelog, or update metadata changes are included in this PR.