### PR TITLE
ci: reject noncanonical sources in release update metadata

### DIFF
--- a/.github/workflows/release-source-coherence.yml
+++ b/.github/workflows/release-source-coherence.yml
@@ -1,0 +1,99 @@
+name: Release Source Coherence
+
+on:
+  pull_request:
+    branches: [ "master" ]
+    paths:
+      - "update.json"
+  push:
+    branches: [ "master" ]
+    paths:
+      - "update.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-release-source:
+    name: "🔗 Verify Release Source"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out canonical history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Parse update metadata
+        id: metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+          import re
+          import urllib.parse
+
+          with open("update.json", "r", encoding="utf-8") as handle:
+              metadata = json.load(handle)
+
+          version = str(metadata.get("version", ""))
+          version_code = metadata.get("versionCode")
+          zip_url = str(metadata.get("zipUrl", ""))
+
+          match = re.fullmatch(
+              r"V(?P<version>[0-9]+\.[0-9]+\.[0-9]+) \((?P<code>[0-9]+)-(?P<sha>[0-9a-f]{8,40})-release\)",
+              version,
+          )
+          if match is None:
+              raise SystemExit(f"update.json version has an unsupported release identity: {version!r}")
+
+          code = int(match.group("code"))
+          if not isinstance(version_code, int) or version_code != code:
+              raise SystemExit(
+                  f"versionCode mismatch: field={version_code!r}, embedded={code}"
+              )
+
+          source_sha = match.group("sha")
+          expected_asset = (
+              f"CleveresTricky-V{match.group('version')}-{code}-{source_sha}-release.zip"
+          )
+          asset = os.path.basename(urllib.parse.urlparse(zip_url).path)
+          if asset != expected_asset:
+              raise SystemExit(
+                  f"zipUrl asset mismatch: expected {expected_asset!r}, got {asset!r}"
+              )
+
+          print(f"version_code={code}")
+          print(f"source_sha={source_sha}")
+          print(f"asset={asset}")
+          PY
+
+      - name: Verify source is canonical master history
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ steps.metadata.outputs.source_sha }}
+          VERSION_CODE: ${{ steps.metadata.outputs.version_code }}
+        run: |
+          set -euo pipefail
+
+          full_sha=$(git rev-parse --verify "${SOURCE_SHA}^{commit}") || {
+            echo "::error::update.json references a source commit that is not present in repository history: $SOURCE_SHA"
+            exit 1
+          }
+
+          git fetch --no-tags origin master
+          if ! git merge-base --is-ancestor "$full_sha" origin/master; then
+            echo "::error::update.json source $SOURCE_SHA is not reachable from canonical master history"
+            echo "::error::Do not publish artifacts built from refs/pull/*/merge or other synthetic/diverged refs"
+            exit 1
+          fi
+
+          canonical_count=$(git rev-list --count "$full_sha")
+          if [ "$canonical_count" != "$VERSION_CODE" ]; then
+            echo "::error::versionCode $VERSION_CODE does not match canonical commit count $canonical_count at $SOURCE_SHA"
+            exit 1
+          fi
+
+          echo "Verified release source: $full_sha (versionCode=$VERSION_CODE)"


### PR DESCRIPTION
## Summary

Add a release-source coherence guard for `update.json`.

The installed V2.6.2 build reported in the regression (`versionCode=3109`) maps to `3109-a0589374-release`, while `a0589374` is a synthetic/diverged PR merge commit rather than a commit reachable from canonical `master`. That makes same-version regression analysis non-reproducible from the tagged/mainline source and violates the repository's release-finalization invariant.

This workflow validates future `update.json` changes and can also be run manually. It requires:

- the embedded version code, source SHA, and ZIP filename to agree;
- the referenced source commit to exist in repository history;
- the source commit to be reachable from canonical `master` (rejecting `refs/pull/*/merge` / diverged build refs);
- `versionCode` to equal the canonical `git rev-list --count` at that source commit.

## Scope

This PR intentionally does **not** change Keystore interception, certificate rewriting, keybox behavior, Root of Trust presentation, patch-level presentation, or Play Integrity behavior. It fixes release provenance/traceability so device regressions can be compared against an exact canonical source revision instead of a synthetic merge artifact.

## Evidence

- current `update.json`: `V2.6.2 (3109-a0589374-release)`
- `a0589374e789eb2130fdb14f0f191d9d7b006804` is a synthetic merge commit
- comparing it with the mainline #1004 commit shows divergent history/files
- the V2.6.2 tag itself resolves to the earlier `3094-f17ea02f` release source

## Validation

- branch is based on current `master` (`c6eb651f37b63eb0d2b05801415566f451692a69`)
- diff contains one new workflow file only
- all external Actions are pinned to a full commit SHA
- the workflow is path-gated to `update.json` on PR/push and also supports manual audit

A manual run against the current metadata is expected to fail until the published V2.6.2 artifact/update metadata is reissued from a canonical master commit; that failure is the intended signal.