### PR TITLE
Honor enabled Build Identity on Android 17

### DIFF
--- a/module/template/post-fs-data.sh
+++ b/module/template/post-fs-data.sh
@@ -171,8 +171,10 @@ apply_early_properties() {
       done
     done
     if [ "$identity_conflict" = true ]; then
-      log -t CleveresTricky "Another build-identity provider is active; template properties were skipped in auto mode"
-      return 0
+      # Build Identity is an explicit user choice. A second identity provider may
+      # overwrite these properties later, but CleveresTricky must never silently
+      # turn its own enabled feature into a no-op.
+      log -t CleveresTricky "Another build-identity provider is active; applying the enabled CleveresTricky Build Identity anyway"
     fi
   fi
 

--- a/module/webui-tests/boot-build-identity-contract.test.js
+++ b/module/webui-tests/boot-build-identity-contract.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const postFs = fs.readFileSync(path.join(repoRoot, 'module/template/post-fs-data.sh'), 'utf8');
+
+function requireToken(token, message) {
+  assert.ok(postFs.includes(token), message || `missing boot identity contract: ${token}`);
+}
+
+// Identity is an explicit user feature: both owner markers and the canonical
+// persisted build-vars file must gate the early-boot application path.
+requireToken('[ -f "$CONFIG_DIR/spoof_enabled" ] || return 0');
+requireToken('[ -f "$CONFIG_DIR/spoof_build_identity" ] || return 0');
+requireToken('vars_file="$CONFIG_DIR/spoof_build_vars"');
+requireToken('done < "$vars_file"');
+
+// A competing PIF/Play Integrity identity provider is useful diagnostic
+// information, but must never silently turn an enabled CleveresTricky feature
+// into a no-op. This is the physical-device regression that previously left
+// Build.*, fingerprint and model values untouched even while the UI reported
+// Build Identity as enabled.
+const conflictMatch = postFs.match(
+  /if \[ "\$identity_conflict" = true \]; then([\s\S]*?)\n\s*fi\n\s*fi\n\n\s*CT_FINGERPRINT=/,
+);
+assert.ok(conflictMatch, 'boot identity conflict branch must remain explicit and adjacent to identity application');
+assert.doesNotMatch(
+  conflictMatch[1],
+  /\breturn\s+0\b/,
+  'an enabled Build Identity must not be skipped just because another identity provider is installed',
+);
+assert.match(
+  conflictMatch[1],
+  /applying the enabled CleveresTricky Build Identity anyway/,
+  'provider conflicts must be logged while honoring the enabled feature',
+);
+
+// The saved Identity Manager fields must reach the properties Android Build
+// snapshots before Zygote starts. Keep this list exhaustive for the fields the
+// persisted template exposes to applications.
+for (const mapping of [
+  ['FINGERPRINT', 'ro.build.fingerprint'],
+  ['BRAND', 'ro.product.brand'],
+  ['DEVICE', 'ro.product.device'],
+  ['PRODUCT', 'ro.product.name'],
+  ['MANUFACTURER', 'ro.product.manufacturer'],
+  ['MODEL', 'ro.product.model'],
+  ['BUILD_ID', 'ro.build.id'],
+  ['RELEASE', 'ro.build.version.release'],
+  ['RELEASE', 'ro.build.version.release_or_codename'],
+  ['INCREMENTAL', 'ro.build.version.incremental'],
+  ['TYPE', 'ro.build.type'],
+  ['TAGS', 'ro.build.tags'],
+  ['SECURITY_PATCH', 'ro.build.version.security_patch'],
+]) {
+  const [field, property] = mapping;
+  requireToken(`apply_prop ${property} "$CT_${field}"`, `${field} must be applied to ${property}`);
+}
+
+requireToken('resetprop -n "$1" "$2"', 'boot identity must use KernelSU/APatch-safe resetprop -n');
+requireToken('apply_early_properties', 'post-fs-data must execute the early property application owner');
+
+console.log('Build Identity boot contract honors the enabled feature and maps every persisted Build field before Zygote.');


### PR DESCRIPTION
## Summary

Fix the physical-device regression where CleveresTricky reports Identity Engine + Build Identity as enabled, persists the selected Pixel identity, but third-party applications still observe the stock OEM `Build.*` identity.

## Root cause

`post-fs-data.sh` treated `boot_props_mode=auto` as permission to silently skip all persisted build-property application whenever another PIF/Play Integrity identity-provider module was detected. The UI and diagnostics still reported Build Identity as enabled, so enabled state and effective app-visible state diverged.

## Fix

- Keep conflict detection for diagnostics, but never turn an explicitly enabled CleveresTricky Build Identity into a no-op.
- Continue applying the persisted `spoof_build_vars` mapping before Zygote using KernelSU/APatch-safe `resetprop -n`.
- Add a deterministic host regression guard that requires the complete persisted Build field -> Android property mapping and forbids a provider-conflict branch from returning before property application.
- Validate on current `master`, including the post-#1006 Android 17 package-enumeration compatibility fallback.

## Exact-head validation

Head: `cfe00b2080eb6df312a21ba831f103a3a18a4e45`

- Security Regression #1068: PASS
  - Dependency Security & Unit Tests: PASS
  - Android 17 / API 37 / 16 KB Platform Contracts: PASS
- Build #3504: PASS
  - Shellcheck / module policy: PASS
  - Native WebUI behavior tests, including Build Identity boot contract: PASS
  - Unit tests: PASS
  - Module artifact/layout/checksum/native-hardening validation: PASS
- Native Hardening #650: PASS
- PR review threads: none open/actionable

The stale failed API37 check attached to merged PR #1006 is superseded by this exact-head Android 17 run, which passes the current package-enumeration implementation.

No physical-device reboot is required as a merge gate; the supplied physical-device failure is now represented by deterministic boot-contract coverage plus the real Android 17 emulator platform suite.