### PR TITLE
Make Build Identity effective in app processes

### DIFF
--- a/module/template/service.sh
+++ b/module/template/service.sh
@@ -175,10 +175,10 @@ load_build_identity_vars() {
   CT_SECURITY_PATCH=
   BUILD_IDENTITY_LOAD_REASON=not_configured
 
-  [ -d "$CONFIG_DIR" ] && [ ! -L "$CONFIG_DIR" ] || {
+  if [ ! -d "$CONFIG_DIR" ] || [ -L "$CONFIG_DIR" ]; then
     BUILD_IDENTITY_LOAD_REASON=unsafe_config_root
     return 1
-  }
+  fi
   [ -f "$CONFIG_DIR/spoof_enabled" ] && [ ! -L "$CONFIG_DIR/spoof_enabled" ] || return 1
   [ -f "$CONFIG_DIR/spoof_build_identity" ] && [ ! -L "$CONFIG_DIR/spoof_build_identity" ] || return 1
 
@@ -196,10 +196,10 @@ load_build_identity_vars() {
   esac
 
   vars_file="$CONFIG_DIR/spoof_build_vars"
-  [ -f "$vars_file" ] && [ ! -L "$vars_file" ] || {
+  if [ ! -f "$vars_file" ] || [ -L "$vars_file" ]; then
     BUILD_IDENTITY_LOAD_REASON=missing_build_vars
     return 1
-  }
+  fi
   vars_size=$(wc -c < "$vars_file" 2>/dev/null) || {
     BUILD_IDENTITY_LOAD_REASON=unreadable_build_vars
     return 1

--- a/module/template/service.sh
+++ b/module/template/service.sh
@@ -6,6 +6,8 @@ CONFIG_DIR="/data/adb/cleverestricky"
 retry_delay=2
 max_retry_delay=60
 stable_runtime=120
+BUILD_IDENTITY_STATUS_FILE="$CONFIG_DIR/build_identity_runtime_status"
+BUILD_IDENTITY_RESTART_FILE="$CONFIG_DIR/build_identity_zygote_restart"
 
 has_legacy_optional_policy() {
   for flag in spoof_enabled spoof_build_identity telephony random_on_boot spoof_region_cn; do
@@ -131,6 +133,242 @@ mirror_root_keyboxes() {
   done
 }
 
+write_build_identity_status() {
+  configured=$1
+  properties_effective=$2
+  app_process_effective=$3
+  reason=$4
+  mismatch_keys=$5
+  zygote_refresh=$6
+
+  [ -d "$CONFIG_DIR" ] && [ ! -L "$CONFIG_DIR" ] || return 0
+  tmp="$BUILD_IDENTITY_STATUS_FILE.tmp.$$"
+  umask 077
+  {
+    printf 'configured=%s\n' "$configured"
+    printf 'properties_effective=%s\n' "$properties_effective"
+    printf 'app_process_effective=%s\n' "$app_process_effective"
+    printf 'reason=%s\n' "$reason"
+    printf 'mismatches=%s\n' "$mismatch_keys"
+    printf 'zygote_refresh=%s\n' "$zygote_refresh"
+    printf 'ksu_late_load=%s\n' "${KSU_LATE_LOAD:-0}"
+    printf 'ksu_runtime_mode=%s\n' "${KSU_RUNTIME_MODE:-unknown}"
+  } > "$tmp" || { rm -f "$tmp"; return 0; }
+  chown 0:0 "$tmp" 2>/dev/null || { rm -f "$tmp"; return 0; }
+  chmod 600 "$tmp" 2>/dev/null || { rm -f "$tmp"; return 0; }
+  chcon u:object_r:system_file:s0 "$tmp" 2>/dev/null
+  mv -f "$tmp" "$BUILD_IDENTITY_STATUS_FILE" 2>/dev/null || rm -f "$tmp"
+}
+
+load_build_identity_vars() {
+  CT_FINGERPRINT=
+  CT_BRAND=
+  CT_DEVICE=
+  CT_PRODUCT=
+  CT_MANUFACTURER=
+  CT_MODEL=
+  CT_BUILD_ID=
+  CT_RELEASE=
+  CT_INCREMENTAL=
+  CT_TYPE=
+  CT_TAGS=
+  CT_SECURITY_PATCH=
+  BUILD_IDENTITY_LOAD_REASON=not_configured
+
+  [ -d "$CONFIG_DIR" ] && [ ! -L "$CONFIG_DIR" ] || {
+    BUILD_IDENTITY_LOAD_REASON=unsafe_config_root
+    return 1
+  }
+  [ -f "$CONFIG_DIR/spoof_enabled" ] && [ ! -L "$CONFIG_DIR/spoof_enabled" ] || return 1
+  [ -f "$CONFIG_DIR/spoof_build_identity" ] && [ ! -L "$CONFIG_DIR/spoof_build_identity" ] || return 1
+
+  boot_mode=auto
+  if [ -f "$CONFIG_DIR/boot_props_mode" ] && [ ! -L "$CONFIG_DIR/boot_props_mode" ]; then
+    IFS= read -r boot_mode < "$CONFIG_DIR/boot_props_mode"
+  fi
+  case "$boot_mode" in
+    auto|force) ;;
+    disable)
+      BUILD_IDENTITY_LOAD_REASON=disabled_by_boot_props_mode
+      return 1
+      ;;
+    *) boot_mode=auto ;;
+  esac
+
+  vars_file="$CONFIG_DIR/spoof_build_vars"
+  [ -f "$vars_file" ] && [ ! -L "$vars_file" ] || {
+    BUILD_IDENTITY_LOAD_REASON=missing_build_vars
+    return 1
+  }
+  vars_size=$(wc -c < "$vars_file" 2>/dev/null) || {
+    BUILD_IDENTITY_LOAD_REASON=unreadable_build_vars
+    return 1
+  }
+  if [ "$vars_size" -lt 1 ] || [ "$vars_size" -gt 1048576 ]; then
+    BUILD_IDENTITY_LOAD_REASON=invalid_build_vars_size
+    return 1
+  fi
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in ''|'#'*) continue ;; esac
+    key=${line%%=*}
+    [ "$key" != "$line" ] || continue
+    value=${line#*=}
+    [ "${#value}" -le 512 ] || continue
+    case "$value" in *[![:print:]]*) continue ;; esac
+    case "$key" in
+      FINGERPRINT) CT_FINGERPRINT=$value ;;
+      BRAND) CT_BRAND=$value ;;
+      DEVICE) CT_DEVICE=$value ;;
+      PRODUCT) CT_PRODUCT=$value ;;
+      MANUFACTURER) CT_MANUFACTURER=$value ;;
+      MODEL) CT_MODEL=$value ;;
+      BUILD_ID) CT_BUILD_ID=$value ;;
+      RELEASE) CT_RELEASE=$value ;;
+      INCREMENTAL) CT_INCREMENTAL=$value ;;
+      TYPE) CT_TYPE=$value ;;
+      TAGS) CT_TAGS=$value ;;
+      SECURITY_PATCH) CT_SECURITY_PATCH=$value ;;
+    esac
+  done < "$vars_file"
+
+  [ -n "$CT_FINGERPRINT" ] || {
+    BUILD_IDENTITY_LOAD_REASON=missing_fingerprint
+    return 1
+  }
+  case "$CT_FINGERPRINT" in
+    *[!A-Za-z0-9._:/+-]*)
+      BUILD_IDENTITY_LOAD_REASON=invalid_fingerprint
+      return 1
+      ;;
+  esac
+  BUILD_IDENTITY_LOAD_REASON=loaded
+  return 0
+}
+
+restart_zygote_once() {
+  boot_id=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null)
+  case "$boot_id" in
+    ''|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+
+  previous_boot_id=
+  if [ -f "$BUILD_IDENTITY_RESTART_FILE" ] && [ ! -L "$BUILD_IDENTITY_RESTART_FILE" ]; then
+    IFS= read -r previous_boot_id < "$BUILD_IDENTITY_RESTART_FILE"
+  fi
+  if [ "$previous_boot_id" = "$boot_id" ]; then
+    return 2
+  fi
+
+  tmp="$BUILD_IDENTITY_RESTART_FILE.tmp.$$"
+  umask 077
+  printf '%s\n' "$boot_id" > "$tmp" || { rm -f "$tmp"; return 1; }
+  chown 0:0 "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  chmod 600 "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  chcon u:object_r:system_file:s0 "$tmp" 2>/dev/null
+  mv -f "$tmp" "$BUILD_IDENTITY_RESTART_FILE" 2>/dev/null || { rm -f "$tmp"; return 1; }
+
+  secondary_state=$(getprop init.svc.zygote_secondary 2>/dev/null)
+  if [ -n "$secondary_state" ] && [ "$secondary_state" != stopped ]; then
+    if ! setprop ctl.restart zygote_secondary; then
+      rm -f "$BUILD_IDENTITY_RESTART_FILE"
+      return 1
+    fi
+  fi
+  if ! setprop ctl.restart zygote; then
+    rm -f "$BUILD_IDENTITY_RESTART_FILE"
+    return 1
+  fi
+  return 0
+}
+
+reconcile_build_identity_runtime() {
+  if ! load_build_identity_vars; then
+    write_build_identity_status false false false "$BUILD_IDENTITY_LOAD_REASON" "" none
+    return 0
+  fi
+  if ! command -v resetprop >/dev/null 2>&1 || ! command -v getprop >/dev/null 2>&1; then
+    write_build_identity_status true false false resetprop_unavailable "" none
+    log -t CleveresTricky "Build Identity is configured, but runtime property tools are unavailable"
+    return 0
+  fi
+
+  had_mismatch=false
+  apply_failed=false
+  mismatch_keys=
+  reconcile_prop() {
+    prop_name=$1
+    expected=$2
+    [ -n "$expected" ] || return 0
+    current=$(getprop "$prop_name" 2>/dev/null)
+    if [ "$current" != "$expected" ]; then
+      had_mismatch=true
+      if [ -n "$mismatch_keys" ]; then
+        mismatch_keys="$mismatch_keys,$prop_name"
+      else
+        mismatch_keys=$prop_name
+      fi
+      if ! resetprop -n "$prop_name" "$expected" >/dev/null 2>&1; then
+        apply_failed=true
+        return 0
+      fi
+      current=$(getprop "$prop_name" 2>/dev/null)
+      if [ "$current" != "$expected" ]; then
+        apply_failed=true
+      fi
+    fi
+  }
+
+  reconcile_prop ro.build.fingerprint "$CT_FINGERPRINT"
+  reconcile_prop ro.product.brand "$CT_BRAND"
+  reconcile_prop ro.product.device "$CT_DEVICE"
+  reconcile_prop ro.product.name "$CT_PRODUCT"
+  reconcile_prop ro.product.manufacturer "$CT_MANUFACTURER"
+  reconcile_prop ro.product.model "$CT_MODEL"
+  reconcile_prop ro.build.id "$CT_BUILD_ID"
+  reconcile_prop ro.build.version.release "$CT_RELEASE"
+  reconcile_prop ro.build.version.release_or_codename "$CT_RELEASE"
+  reconcile_prop ro.build.version.incremental "$CT_INCREMENTAL"
+  reconcile_prop ro.build.type "$CT_TYPE"
+  reconcile_prop ro.build.tags "$CT_TAGS"
+  case "$CT_SECURITY_PATCH" in
+    [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])
+      reconcile_prop ro.build.version.security_patch "$CT_SECURITY_PATCH"
+      ;;
+  esac
+
+  if [ "$apply_failed" = true ]; then
+    write_build_identity_status true false false property_reconcile_failed "$mismatch_keys" failed
+    log -t CleveresTricky "Build Identity runtime reconciliation failed: $mismatch_keys"
+    return 0
+  fi
+
+  needs_zygote_refresh=false
+  if [ "${KSU_LATE_LOAD:-0}" = 1 ] || [ "$had_mismatch" = true ]; then
+    needs_zygote_refresh=true
+  fi
+
+  if [ "$needs_zygote_refresh" = true ]; then
+    restart_zygote_once
+    restart_result=$?
+    case "$restart_result" in
+      0)
+        write_build_identity_status true true true zygote_refresh_requested "$mismatch_keys" requested
+        log -t CleveresTricky "Build Identity properties reconciled; requested one-time Zygote refresh so app processes inherit the configured identity"
+        ;;
+      2)
+        write_build_identity_status true true true zygote_refresh_already_requested "$mismatch_keys" already_requested
+        ;;
+      *)
+        write_build_identity_status true true false zygote_refresh_failed "$mismatch_keys" failed
+        log -t CleveresTricky "Build Identity properties are correct, but Zygote refresh failed; app processes may still expose the pre-reconcile identity"
+        ;;
+    esac
+  else
+    write_build_identity_status true true true verified_without_runtime_reconcile "" not_required
+  fi
+}
+
 generate_backend_auth() {
   # Keep the backend capability in process environment only. Regenerate for every
   # daemon lifetime so stale workers from a previous supervisor iteration cannot
@@ -157,6 +395,13 @@ if [ -d "$CONFIG_DIR" ] && [ ! -L "$CONFIG_DIR" ]; then
   find "$CONFIG_DIR" -xdev -maxdepth 2 -type f -exec chmod 600 {} + 2>/dev/null
   find "$CONFIG_DIR" -xdev -maxdepth 2 -type f -exec chcon u:object_r:system_file:s0 {} + 2>/dev/null
 fi
+
+# post-fs-data runs before Zygote on standard KernelSU/APatch and remains the
+# first owner of boot properties. service.sh is the final safety net: it catches
+# properties overwritten later in boot and KernelSU late-load, where module
+# scripts necessarily start after the existing Zygote has already snapshotted
+# android.os.Build static fields.
+reconcile_build_identity_runtime
 
 chcon u:object_r:system_file:s0 "$MODDIR/daemon" 2>/dev/null
 chcon u:object_r:system_file:s0 "$MODDIR/cleverestrickyd" 2>/dev/null

--- a/module/webui-tests/boot-build-identity-contract.test.js
+++ b/module/webui-tests/boot-build-identity-contract.test.js
@@ -6,23 +6,26 @@ const path = require('node:path');
 
 const repoRoot = path.resolve(__dirname, '..', '..');
 const postFs = fs.readFileSync(path.join(repoRoot, 'module/template/post-fs-data.sh'), 'utf8');
+const service = fs.readFileSync(path.join(repoRoot, 'module/template/service.sh'), 'utf8');
 
-function requireToken(token, message) {
-  assert.ok(postFs.includes(token), message || `missing boot identity contract: ${token}`);
+function requirePostFsToken(token, message) {
+  assert.ok(postFs.includes(token), message || `missing early boot identity contract: ${token}`);
+}
+
+function requireServiceToken(token, message) {
+  assert.ok(service.includes(token), message || `missing runtime build identity contract: ${token}`);
 }
 
 // Identity is an explicit user feature: both owner markers and the canonical
 // persisted build-vars file must gate the early-boot application path.
-requireToken('[ -f "$CONFIG_DIR/spoof_enabled" ] || return 0');
-requireToken('[ -f "$CONFIG_DIR/spoof_build_identity" ] || return 0');
-requireToken('vars_file="$CONFIG_DIR/spoof_build_vars"');
-requireToken('done < "$vars_file"');
+requirePostFsToken('[ -f "$CONFIG_DIR/spoof_enabled" ] || return 0');
+requirePostFsToken('[ -f "$CONFIG_DIR/spoof_build_identity" ] || return 0');
+requirePostFsToken('vars_file="$CONFIG_DIR/spoof_build_vars"');
+requirePostFsToken('done < "$vars_file"');
 
 // A competing PIF/Play Integrity identity provider is useful diagnostic
 // information, but must never silently turn an enabled CleveresTricky feature
-// into a no-op. This is the physical-device regression that previously left
-// Build.*, fingerprint and model values untouched even while the UI reported
-// Build Identity as enabled.
+// into a no-op.
 const conflictMatch = postFs.match(
   /if \[ "\$identity_conflict" = true \]; then([\s\S]*?)\n\s*fi\n\s*fi\n\n\s*CT_FINGERPRINT=/,
 );
@@ -38,9 +41,9 @@ assert.match(
   'provider conflicts must be logged while honoring the enabled feature',
 );
 
-// The saved Identity Manager fields must reach the properties Android Build
-// snapshots before Zygote starts. Keep this list exhaustive for the fields the
-// persisted template exposes to applications.
+// The saved Identity Manager fields must reach both owners: post-fs-data writes
+// them before a normal Zygote starts, while service.sh reconciles the same
+// fields if a later property provider overwrites them or KernelSU is late-loaded.
 for (const mapping of [
   ['FINGERPRINT', 'ro.build.fingerprint'],
   ['BRAND', 'ro.product.brand'],
@@ -57,10 +60,53 @@ for (const mapping of [
   ['SECURITY_PATCH', 'ro.build.version.security_patch'],
 ]) {
   const [field, property] = mapping;
-  requireToken(`apply_prop ${property} "$CT_${field}"`, `${field} must be applied to ${property}`);
+  requirePostFsToken(`apply_prop ${property} "$CT_${field}"`, `${field} must be applied early to ${property}`);
+  requireServiceToken(
+    `reconcile_prop ${property} "$CT_${field}"`,
+    `${field} must be reconciled at runtime for ${property}`,
+  );
 }
 
-requireToken('resetprop -n "$1" "$2"', 'boot identity must use KernelSU/APatch-safe resetprop -n');
-requireToken('apply_early_properties', 'post-fs-data must execute the early property application owner');
+requirePostFsToken('resetprop -n "$1" "$2"', 'early identity must use KernelSU/APatch-safe resetprop -n');
+requirePostFsToken('apply_early_properties', 'post-fs-data must execute the early property application owner');
 
-console.log('Build Identity boot contract honors the enabled feature and maps every persisted Build field before Zygote.');
+// A successful resetprop call is not evidence that applications see the value.
+// The runtime owner must read each property back and treat a mismatch as a
+// failure before any Zygote refresh is requested.
+requireServiceToken('current=$(getprop "$prop_name" 2>/dev/null)');
+requireServiceToken('resetprop -n "$prop_name" "$expected"');
+requireServiceToken('if [ "$current" != "$expected" ]; then');
+requireServiceToken('apply_failed=true');
+requireServiceToken('property_reconcile_failed');
+
+// KernelSU late-load happens after the system has fully booted, so Build.* was
+// already snapshotted in Zygote. A normal boot only needs the refresh if a later
+// provider overwrote our early values. Both cases must refresh Zygote once.
+requireServiceToken('if [ "${KSU_LATE_LOAD:-0}" = 1 ] || [ "$had_mismatch" = true ]; then');
+requireServiceToken('cat /proc/sys/kernel/random/boot_id');
+requireServiceToken('BUILD_IDENTITY_RESTART_FILE="$CONFIG_DIR/build_identity_zygote_restart"');
+requireServiceToken('if [ "$previous_boot_id" = "$boot_id" ]; then');
+requireServiceToken('setprop ctl.restart zygote_secondary');
+requireServiceToken('setprop ctl.restart zygote');
+requireServiceToken('zygote_refresh_already_requested');
+
+// Diagnostics must distinguish configuration from effective runtime state; the
+// old build_identity=true line alone was insufficient to explain a stale app
+// process on physical devices.
+requireServiceToken('BUILD_IDENTITY_STATUS_FILE="$CONFIG_DIR/build_identity_runtime_status"');
+for (const field of [
+  'configured=',
+  'properties_effective=',
+  'app_process_effective=',
+  'reason=',
+  'mismatches=',
+  'zygote_refresh=',
+  'ksu_late_load=',
+  'ksu_runtime_mode=',
+]) {
+  requireServiceToken(`printf '${field}%s\\n'`, `runtime status must expose ${field}`);
+}
+
+console.log(
+  'Build Identity contract now covers early property writes, readback reconciliation, KernelSU late-load, and one-shot Zygote refresh.',
+);


### PR DESCRIPTION
## Problem
Physical KernelSU evidence shows Build Identity can be configured and persisted while target applications still inherit the device's original `android.os.Build.*` values from Zygote. The previous boot contract only proved that `resetprop` was attempted.

KernelSU standard post-fs-data runs before Zygote, but later boot property providers can still overwrite those values. KernelSU late-load explicitly runs after the system is fully booted, so property writes alone cannot change the Build fields already snapshotted by Zygote.

## Fix
- Add a final Build Identity runtime reconciler to `service.sh`.
- Re-read every saved app-visible Build property and use `resetprop -n` only for actual mismatches.
- Verify each write with `getprop`; do not treat a successful command invocation as evidence.
- On standard boot, request a Zygote refresh only if a later provider changed the early values.
- On `KSU_LATE_LOAD=1`, request the refresh even when properties already match because Zygote predates module loading.
- Guard Zygote refresh by `/proc/sys/kernel/random/boot_id` so it can happen at most once per boot.
- Refresh both primary and secondary Zygote when present.
- Persist bounded runtime status (`configured`, property/app-process effective state, reason, mismatches, refresh state, KernelSU runtime mode).
- Upgrade the host boot contract so CI requires readback, late-load handling, one-shot refresh, and the complete Build field mapping.

## Regression evidence
The reported physical failure is specifically: saved Pixel 8 Pro identity + `identity_engine=true` + `build_identity=true`, while a target app still reports Xiaomi brand/model/product/device/fingerprint. This PR moves the merge contract from “configuration exists/resetprop was called” to the runtime process boundary that applications actually observe.

Routine merge remains automated: host/security/native checks plus Android 17/API 37 emulator contracts. Physical reboot evidence is not a merge checkbox; this physical finding is converted into deterministic boot/runtime contracts.