### PR TITLE
Make Android 17 Build Identity app-visible deterministically

### DIFF
--- a/module/template/post-fs-data.sh
+++ b/module/template/post-fs-data.sh
@@ -1,5 +1,5 @@
 #!/system/bin/sh
-CONFIG_DIR="/data/adb/cleverestricky"
+CONFIG_DIR="${CLEVERES_TRICKY_CONFIG_DIR:-/data/adb/cleverestricky}"
 CONFIG_ROOT_SAFE=false
 
 if [ -d "$CONFIG_DIR" ] && [ ! -L "$CONFIG_DIR" ]; then
@@ -60,67 +60,70 @@ promote_staged_identity() {
   fi
 }
 
-apply_early_properties() {
-  [ "$CONFIG_ROOT_SAFE" = true ] || return 0
-  command -v resetprop >/dev/null 2>&1 || {
-    log -t CleveresTricky "resetprop is unavailable; boot property protection was skipped"
-    return 0
+apply_prop() {
+  resetprop -n "$1" "$2" >/dev/null 2>&1 || {
+    log -t CleveresTricky "Failed to apply an app-visible boot property: $1"
+    return 1
   }
+}
 
-  apply_prop() {
-    resetprop -n "$1" "$2" >/dev/null 2>&1 || {
-      log -t CleveresTricky "Failed to apply an app-visible boot property"
-      return 1
-    }
+remove_prop() {
+  resetprop --delete "$1" >/dev/null 2>&1 || {
+    log -t CleveresTricky "Failed to remove a legacy boot property: $1"
+    return 1
   }
+}
 
-  remove_prop() {
-    resetprop --delete "$1" >/dev/null 2>&1 || {
-      log -t CleveresTricky "Failed to remove a legacy boot property"
-      return 1
-    }
-  }
+hide_boot_mode() {
+  current_value=$(getprop "$1")
+  case "$current_value" in
+    *recovery*|*RECOVERY*) apply_prop "$1" unknown || return 1 ;;
+  esac
+}
 
-  hide_boot_mode() {
-    current_value=$(getprop "$1")
-    case "$current_value" in
-      *recovery*|*RECOVERY*) apply_prop "$1" unknown || return 1 ;;
-    esac
-  }
-
-  # Core bootloader / verified-boot property protection. This is intentionally
-  # unconditional: Spoof Engine controls identity only, and legacy
-  # hide_sensitive_props / boot_props_mode files cannot disable this path.
-  apply_prop ro.boot.vbmeta.device_state locked || return 0
-  apply_prop ro.boot.verifiedbootstate green || return 0
-  apply_prop ro.boot.flash.locked 1 || return 0
-  apply_prop ro.boot.warranty_bit 0 || return 0
-  apply_prop ro.warranty_bit 0 || return 0
-  apply_prop ro.debuggable 0 || return 0
-  apply_prop ro.force.debuggable 0 || return 0
-  apply_prop ro.secure 1 || return 0
-  apply_prop ro.adb.secure 1 || return 0
-  apply_prop ro.build.type user || return 0
-  apply_prop ro.build.tags release-keys || return 0
-  apply_prop ro.vendor.boot.warranty_bit 0 || return 0
-  apply_prop ro.vendor.warranty_bit 0 || return 0
+apply_core_boot_properties() {
+  # Core bootloader / verified-boot property protection is intentionally
+  # unconditional. Each property is independent: one vendor/property-service
+  # incompatibility must not prevent the remaining protections or the optional
+  # Build Identity phase from running.
+  apply_prop ro.boot.vbmeta.device_state locked || true
+  apply_prop ro.boot.verifiedbootstate green || true
+  apply_prop ro.boot.flash.locked 1 || true
+  apply_prop ro.boot.warranty_bit 0 || true
+  apply_prop ro.warranty_bit 0 || true
+  apply_prop ro.debuggable 0 || true
+  apply_prop ro.force.debuggable 0 || true
+  apply_prop ro.secure 1 || true
+  apply_prop ro.adb.secure 1 || true
+  apply_prop ro.build.type user || true
+  apply_prop ro.build.tags release-keys || true
+  apply_prop ro.vendor.boot.warranty_bit 0 || true
+  apply_prop ro.vendor.warranty_bit 0 || true
   android_sdk=$(getprop ro.build.version.sdk)
   case "$android_sdk" in
     ''|*[!0-9]*) android_sdk=0 ;;
   esac
   if [ "$android_sdk" -ge 36 ]; then
-    remove_prop sys.oem_unlock_allowed || return 0
+    remove_prop sys.oem_unlock_allowed || true
   else
-    apply_prop sys.oem_unlock_allowed 0 || return 0
+    apply_prop sys.oem_unlock_allowed 0 || true
   fi
-  apply_prop ro.secureboot.lockstate locked || return 0
-  apply_prop ro.boot.realmebootstate green || return 0
-  apply_prop ro.boot.realme.lockstate 1 || return 0
-  hide_boot_mode ro.bootmode || return 0
-  hide_boot_mode ro.boot.bootmode || return 0
-  hide_boot_mode vendor.boot.bootmode || return 0
+  apply_prop ro.secureboot.lockstate locked || true
+  apply_prop ro.boot.realmebootstate green || true
+  apply_prop ro.boot.realme.lockstate 1 || true
+  hide_boot_mode ro.bootmode || true
+  hide_boot_mode ro.boot.bootmode || true
+  hide_boot_mode vendor.boot.bootmode || true
+}
 
-  # Everything below this point is optional identity spoofing.
+apply_optional_identity_properties() {
+  [ "$CONFIG_ROOT_SAFE" = true ] || return 0
+  command -v resetprop >/dev/null 2>&1 || {
+    log -t CleveresTricky "resetprop is unavailable; identity properties were skipped"
+    return 0
+  }
+
+  # Everything in this phase belongs to optional identity spoofing.
   [ -f "$CONFIG_DIR/spoof_enabled" ] || return 0
   [ ! -L "$CONFIG_DIR/spoof_enabled" ] || return 0
 
@@ -135,11 +138,13 @@ apply_early_properties() {
   [ "$boot_mode" != disable ] || return 0
 
   if [ -f "$CONFIG_DIR/spoof_region_cn" ] && [ ! -L "$CONFIG_DIR/spoof_region_cn" ]; then
-    apply_prop ro.boot.hwc CN || return 0
-    apply_prop gsm.operator.iso-country cn || return 0
-    apply_prop gsm.sim.operator.iso-country cn || return 0
-    apply_prop ro.boot.hwlevel MP || return 0
-    apply_prop persist.radio.skhwc_matchres MATCH || return 0
+    # Region Identity and Build Identity are separate child features. A failure in
+    # one region property must never suppress the enabled Build Identity below.
+    apply_prop ro.boot.hwc CN || true
+    apply_prop gsm.operator.iso-country cn || true
+    apply_prop gsm.sim.operator.iso-country cn || true
+    apply_prop ro.boot.hwlevel MP || true
+    apply_prop persist.radio.skhwc_matchres MATCH || true
   fi
 
   [ -f "$CONFIG_DIR/spoof_build_identity" ] || return 0
@@ -171,10 +176,7 @@ apply_early_properties() {
       done
     done
     if [ "$identity_conflict" = true ]; then
-      # Build Identity is an explicit user choice. A second identity provider may
-      # overwrite these properties later, but CleveresTricky must never silently
-      # turn its own enabled feature into a no-op.
-      log -t CleveresTricky "Another build-identity provider is active; applying the enabled CleveresTricky Build Identity anyway"
+      log -t CleveresTricky "Another build-identity provider is active; reasserting the enabled CleveresTricky Build Identity"
     fi
   fi
 
@@ -219,28 +221,48 @@ apply_early_properties() {
   }
   case "$CT_FINGERPRINT" in *[!A-Za-z0-9._:/+-]*) return 0 ;; esac
 
-  apply_prop ro.build.fingerprint "$CT_FINGERPRINT" || return 0
-  if [ -n "$CT_BRAND" ]; then apply_prop ro.product.brand "$CT_BRAND"; fi
-  if [ -n "$CT_DEVICE" ]; then apply_prop ro.product.device "$CT_DEVICE"; fi
-  if [ -n "$CT_PRODUCT" ]; then apply_prop ro.product.name "$CT_PRODUCT"; fi
-  if [ -n "$CT_MANUFACTURER" ]; then apply_prop ro.product.manufacturer "$CT_MANUFACTURER"; fi
-  if [ -n "$CT_MODEL" ]; then apply_prop ro.product.model "$CT_MODEL"; fi
-  if [ -n "$CT_BUILD_ID" ]; then apply_prop ro.build.id "$CT_BUILD_ID"; fi
+  # Attempt every persisted Build field independently. This prevents one
+  # vendor-specific property failure from turning the remaining identity into a
+  # no-op, while each individual resetprop failure is still logged above.
+  apply_prop ro.build.fingerprint "$CT_FINGERPRINT" || true
+  if [ -n "$CT_BRAND" ]; then apply_prop ro.product.brand "$CT_BRAND" || true; fi
+  if [ -n "$CT_DEVICE" ]; then apply_prop ro.product.device "$CT_DEVICE" || true; fi
+  if [ -n "$CT_PRODUCT" ]; then apply_prop ro.product.name "$CT_PRODUCT" || true; fi
+  if [ -n "$CT_MANUFACTURER" ]; then apply_prop ro.product.manufacturer "$CT_MANUFACTURER" || true; fi
+  if [ -n "$CT_MODEL" ]; then apply_prop ro.product.model "$CT_MODEL" || true; fi
+  if [ -n "$CT_BUILD_ID" ]; then apply_prop ro.build.id "$CT_BUILD_ID" || true; fi
   if [ -n "$CT_RELEASE" ]; then
-    apply_prop ro.build.version.release "$CT_RELEASE"
-    apply_prop ro.build.version.release_or_codename "$CT_RELEASE"
+    apply_prop ro.build.version.release "$CT_RELEASE" || true
+    apply_prop ro.build.version.release_or_codename "$CT_RELEASE" || true
   fi
-  if [ -n "$CT_INCREMENTAL" ]; then apply_prop ro.build.version.incremental "$CT_INCREMENTAL"; fi
-  if [ -n "$CT_TYPE" ]; then apply_prop ro.build.type "$CT_TYPE"; fi
-  if [ -n "$CT_TAGS" ]; then apply_prop ro.build.tags "$CT_TAGS"; fi
+  if [ -n "$CT_INCREMENTAL" ]; then apply_prop ro.build.version.incremental "$CT_INCREMENTAL" || true; fi
+  if [ -n "$CT_TYPE" ]; then apply_prop ro.build.type "$CT_TYPE" || true; fi
+  if [ -n "$CT_TAGS" ]; then apply_prop ro.build.tags "$CT_TAGS" || true; fi
   if [ -n "$CT_SECURITY_PATCH" ]; then
     case "$CT_SECURITY_PATCH" in
       [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])
-        apply_prop ro.build.version.security_patch "$CT_SECURITY_PATCH"
+        apply_prop ro.build.version.security_patch "$CT_SECURITY_PATCH" || true
         ;;
     esac
   fi
 }
 
-promote_staged_identity
-apply_early_properties
+apply_early_properties() {
+  [ "$CONFIG_ROOT_SAFE" = true ] || return 0
+  command -v resetprop >/dev/null 2>&1 || {
+    log -t CleveresTricky "resetprop is unavailable; boot property protection was skipped"
+    return 0
+  }
+  apply_core_boot_properties
+  apply_optional_identity_properties
+}
+
+if [ "${CLEVERES_TRICKY_IDENTITY_ONLY:-0}" = "1" ]; then
+  # post-mount runs after root-manager system.prop loading. Reassert only the
+  # optional identity phase so a later identity provider cannot silently win the
+  # pre-Zygote property race.
+  apply_optional_identity_properties
+else
+  promote_staged_identity
+  apply_early_properties
+fi

--- a/module/template/post-mount.sh
+++ b/module/template/post-mount.sh
@@ -7,4 +7,5 @@ MODDIR=${0%/*}
 # before Android application processes snapshot Build.* values.
 CLEVERES_TRICKY_IDENTITY_ONLY=1
 export CLEVERES_TRICKY_IDENTITY_ONLY
+# shellcheck disable=SC1090
 . "$MODDIR/post-fs-data.sh"

--- a/module/template/post-mount.sh
+++ b/module/template/post-mount.sh
@@ -7,5 +7,5 @@ MODDIR=${0%/*}
 # before Android application processes snapshot Build.* values.
 CLEVERES_TRICKY_IDENTITY_ONLY=1
 export CLEVERES_TRICKY_IDENTITY_ONLY
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 . "$MODDIR/post-fs-data.sh"

--- a/module/template/post-mount.sh
+++ b/module/template/post-mount.sh
@@ -1,0 +1,10 @@
+#!/system/bin/sh
+MODDIR=${0%/*}
+
+# KernelSU/APatch load module system.prop data after regular post-fs-data scripts.
+# Reuse the same validated identity owner after that stage so another provider's
+# property file cannot silently replace an explicitly enabled Build Identity
+# before Android application processes snapshot Build.* values.
+CLEVERES_TRICKY_IDENTITY_ONLY=1
+export CLEVERES_TRICKY_IDENTITY_ONLY
+. "$MODDIR/post-fs-data.sh"

--- a/module/webui-tests/boot-build-identity-contract.test.js
+++ b/module/webui-tests/boot-build-identity-contract.test.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 
 const repoRoot = path.resolve(__dirname, '..', '..');
 const postFs = fs.readFileSync(path.join(repoRoot, 'module/template/post-fs-data.sh'), 'utf8');
+const postMount = fs.readFileSync(path.join(repoRoot, 'module/template/post-mount.sh'), 'utf8');
 
 function requireToken(token, message) {
   assert.ok(postFs.includes(token), message || `missing boot identity contract: ${token}`);
@@ -34,9 +35,18 @@ assert.doesNotMatch(
 );
 assert.match(
   conflictMatch[1],
-  /applying the enabled CleveresTricky Build Identity anyway/,
+  /reasserting the enabled CleveresTricky Build Identity/,
   'provider conflicts must be logged while honoring the enabled feature',
 );
+
+// Core verified-boot protection and optional identity are separate phases. One
+// unsupported Android/vendor property must never short-circuit Build Identity.
+requireToken('apply_core_boot_properties');
+requireToken('apply_optional_identity_properties');
+const earlyOwner = postFs.match(/apply_early_properties\(\) \{([\s\S]*?)\n\}/);
+assert.ok(earlyOwner, 'early property owner must remain explicit');
+assert.match(earlyOwner[1], /apply_core_boot_properties/);
+assert.match(earlyOwner[1], /apply_optional_identity_properties/);
 
 // The saved Identity Manager fields must reach the properties Android Build
 // snapshots before Zygote starts. Keep this list exhaustive for the fields the
@@ -62,5 +72,15 @@ for (const mapping of [
 
 requireToken('resetprop -n "$1" "$2"', 'boot identity must use KernelSU/APatch-safe resetprop -n');
 requireToken('apply_early_properties', 'post-fs-data must execute the early property application owner');
+assert.match(
+  postMount,
+  /CLEVERES_TRICKY_IDENTITY_ONLY=1/,
+  'post-mount must select identity-only reapplication after root-manager property loading',
+);
+assert.match(
+  postMount,
+  /\. "\$MODDIR\/post-fs-data\.sh"/,
+  'post-mount must reuse the same validated Build Identity owner instead of duplicating property mapping',
+);
 
-console.log('Build Identity boot contract honors the enabled feature and maps every persisted Build field before Zygote.');
+console.log('Build Identity boot contract is failure-isolated, exhaustive and reasserted after root-manager property loading.');

--- a/module/webui-tests/boot-build-identity-runtime.test.js
+++ b/module/webui-tests/boot-build-identity-runtime.test.js
@@ -1,0 +1,191 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const postFs = path.join(repoRoot, 'module/template/post-fs-data.sh');
+const postMount = path.join(repoRoot, 'module/template/post-mount.sh');
+
+const pixel = {
+  'ro.build.fingerprint': 'google/husky/husky:14/AP1A.240405.002/11480754:user/release-keys',
+  'ro.product.brand': 'google',
+  'ro.product.device': 'husky',
+  'ro.product.name': 'husky',
+  'ro.product.manufacturer': 'Google',
+  'ro.product.model': 'Pixel 8 Pro',
+  'ro.build.id': 'AP1A.240405.002',
+  'ro.build.version.release': '14',
+  'ro.build.version.release_or_codename': '14',
+  'ro.build.version.incremental': '11480754',
+  'ro.build.version.security_patch': '2024-04-05',
+};
+
+const physical = {
+  'ro.build.fingerprint': 'Xiaomi/popsicle/popsicle:17/CP2A.260605.016/OS4.0.0.23.XPBCNXM:user/release-keys',
+  'ro.product.brand': 'Xiaomi',
+  'ro.product.device': 'popsicle',
+  'ro.product.name': 'popsicle',
+  'ro.product.manufacturer': 'Xiaomi',
+  'ro.product.model': '2509FPN0BC',
+  'ro.build.id': 'CP2A.260605.016',
+  'ro.build.version.release': '17',
+  'ro.build.version.release_or_codename': '17',
+  'ro.build.version.incremental': 'OS4.0.0.23.XPBCNXM',
+  'ro.build.version.security_patch': '2026-06-05',
+  'ro.build.version.sdk': '37',
+};
+
+function writeExecutable(filename, content) {
+  fs.writeFileSync(filename, content, { mode: 0o755 });
+}
+
+function readProps(filename) {
+  return JSON.parse(fs.readFileSync(filename, 'utf8'));
+}
+
+function writeProps(filename, value) {
+  fs.writeFileSync(filename, JSON.stringify(value, null, 2));
+}
+
+function assertIdentity(actual, expected, context) {
+  for (const [key, value] of Object.entries(expected)) {
+    if (key === 'ro.build.version.sdk') continue;
+    assert.equal(actual[key], value, `${context}: ${key}`);
+  }
+}
+
+function execute(script, env) {
+  const result = spawnSync('/bin/sh', [script], {
+    cwd: repoRoot,
+    env,
+    encoding: 'utf8',
+  });
+  assert.equal(
+    result.status,
+    0,
+    `${path.basename(script)} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+}
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ct-build-identity-'));
+try {
+  const configDir = path.join(tempRoot, 'config');
+  const fakeBin = path.join(tempRoot, 'bin');
+  const propDb = path.join(tempRoot, 'properties.json');
+  fs.mkdirSync(configDir);
+  fs.mkdirSync(fakeBin);
+
+  // post-fs-data runs as root on-device. Make only the privileged metadata
+  // commands no-ops here; the production script, marker checks and property
+  // application path are otherwise executed unchanged.
+  for (const command of ['chown', 'chmod', 'chcon', 'log']) {
+    writeExecutable(path.join(fakeBin, command), '#!/bin/sh\nexit 0\n');
+  }
+
+  writeExecutable(
+    path.join(fakeBin, 'getprop'),
+    `#!/usr/bin/env node
+'use strict';
+const fs = require('node:fs');
+const props = JSON.parse(fs.readFileSync(process.env.PROP_DB, 'utf8'));
+process.stdout.write(String(props[process.argv[2]] ?? '') + '\\n');
+`,
+  );
+  writeExecutable(
+    path.join(fakeBin, 'resetprop'),
+    `#!/usr/bin/env node
+'use strict';
+const fs = require('node:fs');
+const db = process.env.PROP_DB;
+const props = JSON.parse(fs.readFileSync(db, 'utf8'));
+let key;
+if (process.argv[2] === '--delete') {
+  key = process.argv[3];
+  if (key === process.env.FAIL_RESETPROP_KEY) process.exit(17);
+  delete props[key];
+} else if (process.argv[2] === '-n') {
+  key = process.argv[3];
+  if (key === process.env.FAIL_RESETPROP_KEY) process.exit(18);
+  props[key] = process.argv[4] ?? '';
+} else {
+  process.exit(19);
+}
+fs.writeFileSync(db, JSON.stringify(props, null, 2));
+`,
+  );
+
+  fs.writeFileSync(path.join(configDir, 'spoof_enabled'), '');
+  fs.writeFileSync(path.join(configDir, 'spoof_build_identity'), '');
+  fs.writeFileSync(path.join(configDir, 'boot_props_mode'), 'auto\n');
+  fs.writeFileSync(
+    path.join(configDir, 'spoof_build_vars'),
+    [
+      `FINGERPRINT=${pixel['ro.build.fingerprint']}`,
+      `BRAND=${pixel['ro.product.brand']}`,
+      `DEVICE=${pixel['ro.product.device']}`,
+      `PRODUCT=${pixel['ro.product.name']}`,
+      `MANUFACTURER=${pixel['ro.product.manufacturer']}`,
+      `MODEL=${pixel['ro.product.model']}`,
+      `BUILD_ID=${pixel['ro.build.id']}`,
+      `RELEASE=${pixel['ro.build.version.release']}`,
+      `INCREMENTAL=${pixel['ro.build.version.incremental']}`,
+      'TYPE=user',
+      'TAGS=release-keys',
+      `SECURITY_PATCH=${pixel['ro.build.version.security_patch']}`,
+      '',
+    ].join('\n'),
+  );
+
+  const env = {
+    ...process.env,
+    PATH: `${fakeBin}:${process.env.PATH}`,
+    PROP_DB: propDb,
+    CLEVERES_TRICKY_CONFIG_DIR: configDir,
+    // Android 16+ removes this legacy property. A failure here used to return
+    // from apply_early_properties() and silently skip Build Identity entirely.
+    FAIL_RESETPROP_KEY: 'sys.oem_unlock_allowed',
+  };
+
+  writeProps(propDb, physical);
+  execute(postFs, env);
+  assertIdentity(
+    readProps(propDb),
+    pixel,
+    'a core boot-property failure must not suppress enabled Build Identity',
+  );
+
+  // KernelSU/APatch can load module system.prop data after regular post-fs-data
+  // scripts. Model a competing identity provider overwriting CT at that point.
+  // post-mount must reassert CT before application processes snapshot Build.*.
+  writeProps(propDb, { ...readProps(propDb), ...physical });
+  assertIdentity(readProps(propDb), physical, 'test setup must model the downstream overwrite');
+  execute(postMount, env);
+  assertIdentity(
+    readProps(propDb),
+    pixel,
+    'post-mount must restore the explicitly enabled CT identity after downstream property loading',
+  );
+
+  // Build Identity remains opt-in. The second-pass owner must not turn the
+  // feature on merely because persisted Pixel values exist.
+  fs.unlinkSync(path.join(configDir, 'spoof_build_identity'));
+  writeProps(propDb, physical);
+  execute(postMount, env);
+  assertIdentity(readProps(propDb), physical, 'disabled Build Identity must preserve the physical property view');
+
+  // Region Identity is an independent child feature. Even a region resetprop
+  // failure must not suppress Build Identity.
+  fs.writeFileSync(path.join(configDir, 'spoof_build_identity'), '');
+  fs.writeFileSync(path.join(configDir, 'spoof_region_cn'), '');
+  writeProps(propDb, physical);
+  execute(postMount, { ...env, FAIL_RESETPROP_KEY: 'ro.boot.hwc' });
+  assertIdentity(readProps(propDb), pixel, 'Region Identity failure must not suppress Build Identity');
+
+  console.log('Build Identity survives Android 17 core-property failures and downstream post-fs property overwrites.');
+} finally {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

Fix the remaining Android 17 Build Identity runtime gap demonstrated on a real KernelSU device: CleveresTricky could report Build Identity enabled and persist a Pixel identity while external applications still observed the physical Xiaomi `Build.*` values.

### Root causes addressed

- `post-fs-data.sh` short-circuited the entire property owner when any earlier core/vendor property mutation failed. On Android 16+ a failed legacy-property delete could therefore silently skip Build Identity.
- KernelSU/APatch load module property data after regular post-fs-data scripts. A downstream identity provider/system.prop could overwrite CleveresTricky again before applications snapshot `Build.*`.
- The previous regression only inspected shell source tokens; it did not execute the production boot script or assert the final property view.

### Fix

- Isolate core boot protection, Region Identity and Build Identity property failures so one unsupported property cannot suppress the remaining enabled features.
- Add `post-mount.sh` which reuses the same validated Build Identity owner in identity-only mode after root-manager property loading/mounting.
- Keep Build Identity opt-in: without `spoof_build_identity`, the second pass leaves physical properties untouched.
- Add an executable boot regression using the real production shell with mock `resetprop/getprop`:
  - Android 17 / SDK 37 property view
  - forced core resetprop failure
  - Pixel Identity application
  - simulated downstream Xiaomi overwrite after post-fs-data
  - post-mount reassertion back to Pixel
  - disabled-feature preservation
  - Region Identity failure isolation

No physical-device checkbox is required for merge; the regression is deterministic and runs in Security Regression on every PR.