### PR TITLE
refactor: move identity runtime core toward Rust and harden lifecycle

### DIFF
--- a/module/template/post-fs-data.sh
+++ b/module/template/post-fs-data.sh
@@ -11,135 +11,72 @@ if [ -d "$CONFIG_DIR" ] && [ ! -L "$CONFIG_DIR" ]; then
   chcon u:object_r:system_file:s0 "$CONFIG_DIR" 2>/dev/null
 fi
 
-policy_feature_enabled() {
+boot_policy_feature_enabled() {
   feature=$1
-  state="$CONFIG_DIR/policy_state_v2.json"
+  state="$CONFIG_DIR/boot_policy_state"
 
-  # No v2 state means legacy marker compatibility remains authoritative.
+  # Upgrades may have v2 policy before the managed service has emitted its first
+  # projection. In that case fail closed instead of treating a profile-derived
+  # legacy marker as global policy. Legacy-only installations keep marker fallback.
   if [ ! -e "$state" ] && [ ! -L "$state" ]; then
+    legacy_state="$CONFIG_DIR/policy_state_v2.json"
+    if [ -e "$legacy_state" ] || [ -L "$legacy_state" ]; then
+      return 1
+    fi
     return 2
   fi
-  if [ -L "$state" ] || [ ! -f "$state" ]; then
-    return 1
-  fi
+  [ -f "$state" ] && [ ! -L "$state" ] || return 1
 
   state_size=$(wc -c < "$state" 2>/dev/null) || return 1
   case "$state_size" in ''|*[!0-9]*) return 1 ;; esac
-  [ "$state_size" -ge 1 ] && [ "$state_size" -le 524288 ] || return 1
+  [ "$state_size" -ge 1 ] && [ "$state_size" -le 128 ] || return 1
 
-  case "$feature" in
-    buildIdentity|regionIdentity|identityRefresh) ;;
+  projection_version=
+  projection_build=
+  projection_region=
+  projection_refresh=
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ "${#line}" -le 32 ] || return 1
+    key=${line%%=*}
+    [ "$key" != "$line" ] || return 1
+    value=${line#*=}
+    case "$value" in 0|1) ;; *)
+      [ "$key" = version ] && [ "$value" = 1 ] || return 1
+      ;;
+    esac
+    case "$key" in
+      version)
+        [ -z "$projection_version" ] || return 1
+        projection_version=$value
+        ;;
+      build)
+        [ -z "$projection_build" ] || return 1
+        projection_build=$value
+        ;;
+      region)
+        [ -z "$projection_region" ] || return 1
+        projection_region=$value
+        ;;
+      refresh)
+        [ -z "$projection_refresh" ] || return 1
+        projection_refresh=$value
+        ;;
+      *) return 1 ;;
+    esac
+  done < "$state"
+
+  [ "$projection_version" = 1 ] || return 1
+  case "$projection_build:$projection_region:$projection_refresh" in
+    [01]:[01]:[01]) ;;
     *) return 1 ;;
   esac
 
-  # policy_state_v2.json can also contain per-profile feature overrides. Only
-  # the top-level `features` object may authorize global early-boot properties.
-  # Scan JSON structure rather than grepping the whole file so a nested profile
-  # override can never resurrect a disabled global feature.
-  awk -v target="$feature" '
-    BEGIN {
-      depth = 0
-      in_string = 0
-      escaped = 0
-      capture_key = 0
-      candidate = 0
-      seek_object = 0
-      in_features = 0
-      object = ""
-      result = -1
-    }
-    {
-      for (i = 1; i <= length($0); i++) {
-        char = substr($0, i, 1)
-        if (in_string) {
-          if (escaped) {
-            escaped = 0
-            if (capture_key) token = token char
-            if (in_features) object = object char
-            continue
-          }
-          if (char == "\\") {
-            escaped = 1
-            if (in_features) object = object char
-            continue
-          }
-          if (char == "\"") {
-            in_string = 0
-            if (capture_key) {
-              capture_key = 0
-              candidate = (depth == 1 && token == "features")
-              token = ""
-            }
-            if (in_features) object = object char
-            continue
-          }
-          if (capture_key) token = token char
-          if (in_features) object = object char
-          continue
-        }
-
-        if (char == "\"") {
-          in_string = 1
-          if (in_features) object = object char
-          else if (depth == 1) {
-            capture_key = 1
-            token = ""
-          }
-          continue
-        }
-
-        if (candidate) {
-          if (char ~ /[[:space:]]/) continue
-          if (char == ":") {
-            seek_object = 1
-            candidate = 0
-            continue
-          }
-          candidate = 0
-        }
-
-        if (seek_object) {
-          if (char ~ /[[:space:]]/) continue
-          if (char == "{" && depth == 1) {
-            depth++
-            in_features = 1
-            object = "{"
-            seek_object = 0
-            continue
-          }
-          result = 1
-          exit
-        }
-
-        if (char == "{") {
-          depth++
-          if (in_features) object = object char
-          continue
-        }
-        if (char == "}") {
-          if (in_features) {
-            object = object char
-            if (depth == 2) {
-              pattern = "\\\"" target "\\\"[[:space:]]*:[[:space:]]*true([[:space:],}]|$)"
-              result = object ~ pattern ? 0 : 1
-              exit
-            }
-          }
-          depth--
-          if (depth < 0) {
-            result = 1
-            exit
-          }
-          continue
-        }
-        if (in_features) object = object char
-      }
-    }
-    END {
-      if (result < 0) result = 1
-      exit result
-    }
-  ' "$state"
+  case "$feature" in
+    buildIdentity) [ "$projection_build" = 1 ] ;;
+    regionIdentity) [ "$projection_region" = 1 ] ;;
+    identityRefresh) [ "$projection_refresh" = 1 ] ;;
+    *) return 1 ;;
+  esac
 }
 
 optional_marker_enabled() {
@@ -147,7 +84,7 @@ optional_marker_enabled() {
   marker=$2
   [ -f "$CONFIG_DIR/$marker" ] && [ ! -L "$CONFIG_DIR/$marker" ] || return 1
 
-  policy_feature_enabled "$feature"
+  boot_policy_feature_enabled "$feature"
   policy_status=$?
   [ "$policy_status" -eq 2 ] && return 0
   [ "$policy_status" -eq 0 ]
@@ -171,8 +108,6 @@ promote_staged_identity() {
     return 0
   fi
 
-  # Identity refresh is optional and belongs to Spoof Engine. Core boot protection
-  # below never depends on either of these files.
   if [ ! -f "$CONFIG_DIR/spoof_enabled" ] || [ -L "$CONFIG_DIR/spoof_enabled" ] ||
     ! optional_marker_enabled identityRefresh random_on_boot; then
     rm -f "$staged_file"
@@ -224,10 +159,6 @@ hide_boot_mode() {
 }
 
 apply_core_boot_properties() {
-  # Core bootloader / verified-boot property protection is intentionally
-  # unconditional. Each property is independent: one vendor/property-service
-  # incompatibility must not prevent the remaining protections or the optional
-  # Build Identity phase from running.
   apply_prop ro.boot.vbmeta.device_state locked || true
   apply_prop ro.boot.verifiedbootstate green || true
   apply_prop ro.boot.flash.locked 1 || true
@@ -242,9 +173,7 @@ apply_core_boot_properties() {
   apply_prop ro.vendor.boot.warranty_bit 0 || true
   apply_prop ro.vendor.warranty_bit 0 || true
   android_sdk=$(getprop ro.build.version.sdk)
-  case "$android_sdk" in
-    ''|*[!0-9]*) android_sdk=0 ;;
-  esac
+  case "$android_sdk" in ''|*[!0-9]*) android_sdk=0 ;; esac
   if [ "$android_sdk" -ge 36 ]; then
     remove_prop sys.oem_unlock_allowed || true
   else
@@ -265,7 +194,6 @@ apply_optional_identity_properties() {
     return 0
   }
 
-  # Everything in this phase belongs to optional identity spoofing.
   [ -f "$CONFIG_DIR/spoof_enabled" ] || return 0
   [ ! -L "$CONFIG_DIR/spoof_enabled" ] || return 0
 
@@ -273,15 +201,10 @@ apply_optional_identity_properties() {
   if [ -f "$CONFIG_DIR/boot_props_mode" ] && [ ! -L "$CONFIG_DIR/boot_props_mode" ]; then
     IFS= read -r boot_mode < "$CONFIG_DIR/boot_props_mode"
   fi
-  case "$boot_mode" in
-    force|disable|auto) ;;
-    *) boot_mode=auto ;;
-  esac
+  case "$boot_mode" in force|disable|auto) ;; *) boot_mode=auto ;; esac
   [ "$boot_mode" != disable ] || return 0
 
   if optional_marker_enabled regionIdentity spoof_region_cn; then
-    # Region Identity and Build Identity are separate child features. A failure in
-    # one region property must never suppress the enabled Build Identity below.
     apply_prop ro.boot.hwc CN || true
     apply_prop gsm.operator.iso-country cn || true
     apply_prop gsm.sim.operator.iso-country cn || true
@@ -293,7 +216,8 @@ apply_optional_identity_properties() {
   vars_file="$CONFIG_DIR/spoof_build_vars"
   [ -f "$vars_file" ] && [ ! -L "$vars_file" ] || return 0
   vars_size=$(wc -c < "$vars_file" 2>/dev/null) || return 0
-  [ "$vars_size" -le 1048576 ] || return 0
+  case "$vars_size" in ''|*[!0-9]*) return 0 ;; esac
+  [ "$vars_size" -ge 1 ] && [ "$vars_size" -le 1048576 ] || return 0
 
   if [ "$boot_mode" = auto ]; then
     identity_conflict=false
@@ -362,9 +286,6 @@ apply_optional_identity_properties() {
   }
   case "$CT_FINGERPRINT" in *[!A-Za-z0-9._:/+-]*) return 0 ;; esac
 
-  # Attempt every persisted Build field independently. This prevents one
-  # vendor-specific property failure from turning the remaining identity into a
-  # no-op, while each individual resetprop failure is still logged above.
   apply_prop ro.build.fingerprint "$CT_FINGERPRINT" || true
   if [ -n "$CT_BRAND" ]; then apply_prop ro.product.brand "$CT_BRAND" || true; fi
   if [ -n "$CT_DEVICE" ]; then apply_prop ro.product.device "$CT_DEVICE" || true; fi
@@ -381,9 +302,7 @@ apply_optional_identity_properties() {
   if [ -n "$CT_TAGS" ]; then apply_prop ro.build.tags "$CT_TAGS" || true; fi
   if [ -n "$CT_SECURITY_PATCH" ]; then
     case "$CT_SECURITY_PATCH" in
-      [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])
-        apply_prop ro.build.version.security_patch "$CT_SECURITY_PATCH" || true
-        ;;
+      [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) apply_prop ro.build.version.security_patch "$CT_SECURITY_PATCH" || true ;;
     esac
   fi
 }
@@ -399,9 +318,6 @@ apply_early_properties() {
 }
 
 if [ "${CLEVERES_TRICKY_IDENTITY_ONLY:-0}" = "1" ]; then
-  # post-mount runs after root-manager system.prop loading. Reassert only the
-  # optional identity phase so a later identity provider cannot silently win the
-  # pre-Zygote property race.
   apply_optional_identity_properties
 else
   promote_staged_identity

--- a/module/webui-tests/boot-build-identity-contract.test.js
+++ b/module/webui-tests/boot-build-identity-contract.test.js
@@ -12,38 +12,23 @@ function requireToken(token, message) {
   assert.ok(postFs.includes(token), message || `missing boot identity contract: ${token}`);
 }
 
-// Identity is still an explicit user feature, but v2 policy is authoritative when
-// it exists. The legacy marker remains the fallback only when no v2 state exists.
 requireToken('[ -f "$CONFIG_DIR/spoof_enabled" ] || return 0');
-requireToken('policy_feature_enabled() {', 'v2 policy gate must remain explicit');
-requireToken('depth == 1 && token == "features"', 'only the top-level features object may authorize global boot identity');
-requireToken('[ "$policy_status" -eq 2 ] && return 0', 'legacy marker fallback must remain available when v2 state is absent');
-requireToken('optional_marker_enabled buildIdentity spoof_build_identity || return 0', 'Build Identity must pass the v2/legacy compatibility gate');
+requireToken('boot_policy_feature_enabled() {', 'boot projection gate must remain explicit');
+requireToken('state="$CONFIG_DIR/boot_policy_state"', 'early boot must consume the derived projection');
+requireToken('[ "$state_size" -ge 1 ] && [ "$state_size" -le 128 ]', 'projection read must stay bounded');
+requireToken('[ "$policy_status" -eq 2 ] && return 0', 'legacy marker fallback is allowed only without v2/projection state');
+requireToken('optional_marker_enabled buildIdentity spoof_build_identity || return 0');
 requireToken('vars_file="$CONFIG_DIR/spoof_build_vars"');
 requireToken('done < "$vars_file"');
+assert.doesNotMatch(postFs, /awk -v target=|policy_state_v2\.json.*awk|depth == 1 && token == "features"/, 'shell must not parse policy JSON');
 
-// A competing PIF/Play Integrity identity provider is useful diagnostic
-// information, but must never silently turn an enabled CleveresTricky feature
-// into a no-op. This is the physical-device regression that previously left
-// Build.*, fingerprint and model values untouched even while the UI reported
-// Build Identity as enabled.
 const conflictMatch = postFs.match(
   /if \[ "\$identity_conflict" = true \]; then([\s\S]*?)\n\s*fi\n\s*fi\n\n\s*CT_FINGERPRINT=/,
 );
 assert.ok(conflictMatch, 'boot identity conflict branch must remain explicit and adjacent to identity application');
-assert.doesNotMatch(
-  conflictMatch[1],
-  /\breturn\s+0\b/,
-  'an enabled Build Identity must not be skipped just because another identity provider is installed',
-);
-assert.match(
-  conflictMatch[1],
-  /reasserting the enabled CleveresTricky Build Identity/,
-  'provider conflicts must be logged while honoring the enabled feature',
-);
+assert.doesNotMatch(conflictMatch[1], /\breturn\s+0\b/);
+assert.match(conflictMatch[1], /reasserting the enabled CleveresTricky Build Identity/);
 
-// Core verified-boot protection and optional identity are separate phases. One
-// unsupported Android/vendor property must never short-circuit Build Identity.
 requireToken('apply_core_boot_properties');
 requireToken('apply_optional_identity_properties');
 const earlyOwner = postFs.match(/apply_early_properties\(\) \{([\s\S]*?)\n\}/);
@@ -51,9 +36,6 @@ assert.ok(earlyOwner, 'early property owner must remain explicit');
 assert.match(earlyOwner[1], /apply_core_boot_properties/);
 assert.match(earlyOwner[1], /apply_optional_identity_properties/);
 
-// The saved Identity Manager fields must reach the properties Android Build
-// snapshots before Zygote starts. Keep this list exhaustive for the fields the
-// persisted template exposes to applications.
 for (const mapping of [
   ['FINGERPRINT', 'ro.build.fingerprint'],
   ['BRAND', 'ro.product.brand'],
@@ -73,17 +55,8 @@ for (const mapping of [
   requireToken(`apply_prop ${property} "$CT_${field}"`, `${field} must be applied to ${property}`);
 }
 
-requireToken('resetprop -n "$1" "$2"', 'boot identity must use KernelSU/APatch-safe resetprop -n');
-requireToken('apply_early_properties', 'post-fs-data must execute the early property application owner');
-assert.match(
-  postMount,
-  /CLEVERES_TRICKY_IDENTITY_ONLY=1/,
-  'post-mount must select identity-only reapplication after root-manager property loading',
-);
-assert.match(
-  postMount,
-  /\. "\$MODDIR\/post-fs-data\.sh"/,
-  'post-mount must reuse the same validated Build Identity owner instead of duplicating property mapping',
-);
+requireToken('resetprop -n "$1" "$2"');
+assert.match(postMount, /CLEVERES_TRICKY_IDENTITY_ONLY=1/);
+assert.match(postMount, /\. "\$MODDIR\/post-fs-data\.sh"/);
 
-console.log('Build Identity boot contract is policy-authoritative, failure-isolated, exhaustive and reasserted after root-manager property loading.');
+console.log('Build Identity boot contract uses a bounded projection and preserves the exhaustive property owner.');

--- a/module/webui-tests/identity-policy-authority.test.js
+++ b/module/webui-tests/identity-policy-authority.test.js
@@ -7,89 +7,46 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const script = path.resolve('module/template/post-fs-data.sh');
-assert.ok(fs.existsSync(script), 'post-fs-data.sh is missing');
-
 const scriptText = fs.readFileSync(script, 'utf8');
-const gateStart = scriptText.indexOf('policy_feature_enabled() {');
+const gateStart = scriptText.indexOf('boot_policy_feature_enabled() {');
 const gateEnd = scriptText.indexOf('\npromote_staged_identity() {', gateStart);
-assert.ok(gateStart >= 0 && gateEnd > gateStart, 'boot policy gate functions are missing');
+assert.ok(gateStart >= 0 && gateEnd > gateStart, 'boot projection gate functions are missing');
 const gateSource = scriptText.slice(gateStart, gateEnd);
 
-function runCase(policy, expectedEnabled) {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ct-policy-identity-'));
+function runCase({ projection = null, v2 = false, symlink = false, expected }) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ct-boot-projection-'));
     const config = path.join(root, 'config');
     fs.mkdirSync(config);
     fs.writeFileSync(path.join(config, 'spoof_build_identity'), '');
-    if (policy !== null) {
-        const text = typeof policy === 'string' ? policy : JSON.stringify(policy);
-        fs.writeFileSync(path.join(config, 'policy_state_v2.json'), text);
+    if (v2) fs.writeFileSync(path.join(config, 'policy_state_v2.json'), '{}');
+    if (projection !== null) {
+        const target = path.join(config, 'projection-target');
+        if (symlink) {
+            fs.writeFileSync(target, projection);
+            fs.symlinkSync(target, path.join(config, 'boot_policy_state'));
+        } else {
+            fs.writeFileSync(path.join(config, 'boot_policy_state'), projection);
+        }
     }
 
-    const result = spawnSync(
-        '/bin/sh',
-        ['-c', `${gateSource}\noptional_marker_enabled buildIdentity spoof_build_identity`],
-        {
-            encoding: 'utf8',
-            env: {
-                ...process.env,
-                CONFIG_DIR: config,
-                CLEVERES_TRICKY_CONFIG_DIR: config
-            }
-        }
-    );
-    assert.equal(
-        result.status,
-        expectedEnabled ? 0 : 1,
-        result.stderr || result.stdout || `unexpected policy gate status ${result.status}`
-    );
+    const result = spawnSync('/bin/sh', ['-c', `${gateSource}\noptional_marker_enabled buildIdentity spoof_build_identity`], {
+        encoding: 'utf8',
+        env: { ...process.env, CONFIG_DIR: config, CLEVERES_TRICKY_CONFIG_DIR: config }
+    });
+    assert.equal(result.status, expected ? 0 : 1, result.stderr || result.stdout || `status=${result.status}`);
     fs.rmSync(root, { recursive: true, force: true });
 }
 
-const basePolicy = enabled => ({
-    version: 2,
-    features: {
-        buildIdentity: enabled,
-        attestationIdentity: false,
-        telephonyIdentity: false,
-        regionIdentity: false,
-        identityRefresh: false,
-        securityPatch: false
-    },
-    securityPatch: {
-        automaticThresholdMonths: 6,
-        system: { mode: 'automatic' },
-        vendor: { mode: 'automatic' },
-        boot: { mode: 'automatic' }
-    },
-    profiles: [],
-    activeProfile: null
-});
+const enabled = 'version=1\nbuild=1\nregion=0\nrefresh=0\n';
+const disabled = 'version=1\nbuild=0\nregion=0\nrefresh=0\n';
+runCase({ projection: enabled, v2: true, expected: true });
+runCase({ projection: disabled, v2: true, expected: false });
+runCase({ projection: null, v2: false, expected: true });
+runCase({ projection: null, v2: true, expected: false });
+runCase({ projection: 'version=1\nbuild=1\nregion=0\nrefresh=0\nextra=1\n', v2: true, expected: false });
+runCase({ projection: 'version=1\nbuild=2\nregion=0\nrefresh=0\n', v2: true, expected: false });
+runCase({ projection: enabled, v2: true, symlink: true, expected: false });
 
-runCase(basePolicy(false), false);
-runCase(basePolicy(true), true);
-runCase(null, true);
-runCase('{not valid json', false);
-
-const nestedOverride = {
-    ...basePolicy(false),
-    profiles: [{
-        name: 'App Override',
-        enabled: true,
-        applications: ['com.example.app'],
-        features: { buildIdentity: true }
-    }]
-};
-runCase(nestedOverride, false);
-
-const nestedDisable = {
-    ...basePolicy(true),
-    profiles: [{
-        name: 'App Override',
-        enabled: true,
-        applications: ['com.example.app'],
-        features: { buildIdentity: false }
-    }]
-};
-runCase(nestedDisable, true);
-
-console.log('v2 policy authority for early Build Identity passed');
+assert.doesNotMatch(scriptText, /awk -v target=.*buildIdentity|depth == 1 && token == "features"/, 'shell must not parse v2 JSON');
+assert.match(scriptText, /state_size.*-le 128/, 'projection read must remain bounded');
+console.log('boot identity projection is bounded, v2-authoritative and legacy-compatible');

--- a/module/webui-tests/profile-auto-identity.test.js
+++ b/module/webui-tests/profile-auto-identity.test.js
@@ -18,8 +18,8 @@ const configOwner = fs.readFileSync(
   path.join(repoRoot, 'service/src/main/java/cleveres/tricky/cleverestech/Config.kt'),
   'utf8',
 );
-const cronOwner = fs.readFileSync(
-  path.join(repoRoot, 'service/src/main/java/cleveres/tricky/cleverestech/CronAutoIdentity.kt'),
+const coordinatorOwner = fs.readFileSync(
+  path.join(repoRoot, 'service/src/main/java/cleveres/tricky/cleverestech/IdentityCoordinator.kt'),
   'utf8',
 );
 const profileStore = fs.readFileSync(
@@ -58,14 +58,19 @@ assert.match(
   'UID Build resolution must use the isolated snapshot only inside profile Auto Identity scope',
 );
 assert.match(
-  cronOwner,
-  /if \(decision\.profileScoped\) \{[\s\S]*?ProfileAutoIdentityStore\.save\(root, resolved\)\.getOrThrow\(\)/,
-  'profile-scoped refresh must persist its own snapshot',
+  coordinatorOwner,
+  /if \(persistProfile\) ProfileAutoIdentityStore\.save\(root, resolved\)\.getOrThrow\(\)/,
+  'profile-scoped refresh must persist its own snapshot through the Identity coordinator',
 );
 assert.match(
-  cronOwner,
-  /if \(!decision\.globalLiveApply\) \{[\s\S]*?global identity storage and Build properties were left unchanged[\s\S]*?return[\s\S]*?AutoIdentityPersistence\.save\(root, resolved\)\.getOrThrow\(\)/,
-  'profile-only refresh must return before global identity persistence',
+  coordinatorOwner,
+  /if \(persistGlobal\) AutoIdentityPersistence\.save\(root, resolved\)\.getOrThrow\(\)/,
+  'global persistence must remain explicitly separate from profile persistence',
+);
+assert.match(
+  coordinatorOwner,
+  /liveApplyGlobal && persistGlobal && PolicyState\.isTopLevelFeatureEnabled\(PolicyState\.Feature\.BUILD_IDENTITY\)/,
+  'profile-only refresh must never trigger global live Build Identity apply',
 );
 assert.doesNotMatch(
   profileStore,

--- a/service/src/androidTest/java/cleveres/tricky/cleverestech/WebUiFeatureMatrixInstrumentationTest.kt
+++ b/service/src/androidTest/java/cleveres/tricky/cleverestech/WebUiFeatureMatrixInstrumentationTest.kt
@@ -385,6 +385,7 @@ class WebUiFeatureMatrixInstrumentationTest {
                 FeatureCase("POST", "/api/reset_environment"),
                 FeatureCase("POST", "/api/reload"),
                 FeatureCase("GET", "/api/logs"),
+                FeatureCase("GET", "/api/identity_diagnostics"),
                 FeatureCase("POST", "/api/backup"),
                 FeatureCase("GET", "/api/language", allowedStatuses = setOf(200, 404)),
                 FeatureCase("GET", "/api/resource_usage"),

--- a/service/src/main/java/cleveres/tricky/cleverestech/BootPolicyProjection.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/BootPolicyProjection.kt
@@ -1,0 +1,81 @@
+package cleveres.tricky.cleverestech
+
+import org.json.JSONObject
+import java.io.File
+
+/**
+ * Minimal early-boot policy projection.
+ *
+ * post-fs-data must not parse the full policy JSON: profiles can contain feature overrides and the
+ * shell runs before the managed service is available. This projection contains only top-level
+ * features that are allowed to affect device-wide pre-Zygote properties.
+ */
+internal object BootPolicyProjection {
+    const val FILE_NAME = "boot_policy_state"
+    private const val FORMAT_VERSION = 1
+    private const val MAX_BYTES = 128L
+
+    data class State(
+        val buildIdentity: Boolean,
+        val regionIdentity: Boolean,
+        val identityRefresh: Boolean,
+    )
+
+    fun preflight(root: File) {
+        SafeConfigStore.preflight(root, FILE_NAME)
+    }
+
+    fun desired(state: JSONObject): State {
+        val features = state.optJSONObject("features") ?: JSONObject()
+        return State(
+            buildIdentity = features.optBoolean("buildIdentity", false),
+            regionIdentity = features.optBoolean("regionIdentity", false),
+            identityRefresh = features.optBoolean("identityRefresh", false),
+        )
+    }
+
+    fun isSynchronized(
+        root: File,
+        state: JSONObject,
+    ): Boolean = read(root) == desired(state)
+
+    fun write(
+        root: File,
+        state: JSONObject,
+    ) {
+        val desired = desired(state)
+        val text =
+            buildString {
+                append("version=").append(FORMAT_VERSION).append('\n')
+                append("build=").append(if (desired.buildIdentity) 1 else 0).append('\n')
+                append("region=").append(if (desired.regionIdentity) 1 else 0).append('\n')
+                append("refresh=").append(if (desired.identityRefresh) 1 else 0).append('\n')
+            }
+        SafeConfigStore.writeText(root, FILE_NAME, text, MAX_BYTES)
+    }
+
+    fun read(root: File): State? {
+        val text = SafeConfigStore.readText(root, FILE_NAME, MAX_BYTES, minBytes = 1) ?: return null
+        val values = LinkedHashMap<String, String>()
+        text.lineSequence().forEach { line ->
+            if (line.isEmpty()) return@forEach
+            val separator = line.indexOf('=')
+            if (separator <= 0 || separator == line.lastIndex) return null
+            val key = line.substring(0, separator)
+            val value = line.substring(separator + 1)
+            if (key !in setOf("version", "build", "region", "refresh") || values.put(key, value) != null) return null
+        }
+        if (values.size != 4 || values["version"] != FORMAT_VERSION.toString()) return null
+        fun flag(name: String): Boolean? =
+            when (values[name]) {
+                "0" -> false
+                "1" -> true
+                else -> null
+            }
+        return State(
+            buildIdentity = flag("build") ?: return null,
+            regionIdentity = flag("region") ?: return null,
+            identityRefresh = flag("refresh") ?: return null,
+        )
+    }
+}

--- a/service/src/main/java/cleveres/tricky/cleverestech/CronAutoIdentity.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CronAutoIdentity.kt
@@ -2,23 +2,27 @@ package cleveres.tricky.cleverestech
 
 import android.os.FileObserver
 import androidx.annotation.VisibleForTesting
+import org.json.JSONObject
 import java.io.File
-import java.nio.file.Files
-import java.nio.file.LinkOption
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 
-/**
- * Optional daily Auto Identity refresh.
- *
- * Global mode requires both the explicit cron marker and global Build Identity. Profiles can opt
- * in independently through their identityRefresh override while Build Identity is effective for
- * that profile. Profile-only work refreshes the shared identity data but never applies global
- * resetprop changes, so apps outside that profile do not inherit device-wide Build properties.
- */
+/** Daily Auto Identity scheduler with cancellation-safe one-shot rescheduling and bounded backoff. */
 internal object CronAutoIdentity {
     const val TOGGLE_FILE = "cron_auto_identity"
+    private const val INITIAL_DELAY_MS = 60_000L
+    private const val SUCCESS_DELAY_MS = 24L * 60L * 60L * 1000L
+    private val failureBackoffMs =
+        longArrayOf(
+            5L * 60L * 1000L,
+            15L * 60L * 1000L,
+            30L * 60L * 1000L,
+            60L * 60L * 1000L,
+            3L * 60L * 60L * 1000L,
+            6L * 60L * 60L * 1000L,
+        )
 
     private val lock = Any()
 
@@ -31,9 +35,17 @@ internal object CronAutoIdentity {
     @Volatile
     private var observer: FileObserver? = null
 
+    private var scheduled: ScheduledFuture<*>? = null
     private var workerGeneration = 0L
+    private var inFlight = false
+    private var nextRunMs = 0L
+    private var lastAttemptMs = 0L
+    private var lastSuccessMs = 0L
+    private var lastError: String? = null
+    private var failureCount = 0
 
     fun start(root: File) {
+        IdentityCoordinator.initialize(root)
         synchronized(lock) {
             if (configDir?.absoluteFile != root.absoluteFile) {
                 observer?.stopWatching()
@@ -53,6 +65,16 @@ internal object CronAutoIdentity {
         refreshEnabled()
     }
 
+    fun setEnabled(
+        root: File,
+        enabled: Boolean,
+    ) {
+        SafeConfigStore.setMarker(root, TOGGLE_FILE, enabled)
+        if (configDir?.absoluteFile == root.absoluteFile) refreshEnabled()
+    }
+
+    fun isEnabled(root: File): Boolean = runCatching { SafeConfigStore.markerEnabled(root, TOGGLE_FILE) }.getOrDefault(false)
+
     fun onPolicyChanged() {
         if (configDir != null) refreshEnabled()
     }
@@ -70,45 +92,66 @@ internal object CronAutoIdentity {
         synchronized(lock) {
             val root = configDir ?: return
             val decision = currentDecision(root)
-            val current = executor
             if (!decision.shouldRun) {
-                if (current != null) stopExecutorLocked()
+                stopExecutorLocked()
                 return
             }
-            if (current != null && !current.isShutdown) return
-
-            val generation = ++workerGeneration
-            val created =
-                Executors.newSingleThreadScheduledExecutor { runnable ->
-                    Thread(runnable, "CleveresTricky-AutoIdentity").apply {
-                        isDaemon = true
-                        priority = Thread.MIN_PRIORITY
-                    }
-                }
-            executor = created
-            created.scheduleWithFixedDelay(
-                { runCheck(root, generation) },
-                1,
-                1440,
-                TimeUnit.MINUTES,
-            )
-            Logger.i(
-                when {
-                    decision.globalLiveApply && decision.profileScoped ->
-                        "Cron Auto Identity enabled for global and profile scopes; next refresh is scheduled"
-                    decision.globalLiveApply ->
-                        "Cron Auto Identity enabled; next refresh is scheduled"
-                    else ->
-                        "Profile Auto Identity enabled; next refresh is scheduled"
-                },
-            )
+            ensureExecutorLocked()
+            if (!inFlight && scheduled == null) {
+                scheduleLocked(root, workerGeneration, INITIAL_DELAY_MS)
+            }
         }
+    }
+
+    fun statusJson(): JSONObject =
+        synchronized(lock) {
+            val root = configDir
+            val decision = root?.let(::currentDecision)
+            JSONObject()
+                .put("enabled", decision?.shouldRun == true)
+                .put("global", decision?.globalLiveApply == true)
+                .put("profile", decision?.profileScoped == true)
+                .put("running", executor?.isShutdown == false)
+                .put("inFlight", inFlight)
+                .put("nextRunMs", nextRunMs)
+                .put("lastAttemptMs", lastAttemptMs)
+                .put("lastSuccessMs", lastSuccessMs)
+                .put("lastError", lastError ?: JSONObject.NULL)
+                .put("failureCount", failureCount)
+        }
+
+    private fun ensureExecutorLocked() {
+        val current = executor
+        if (current != null && !current.isShutdown) return
+        workerGeneration++
+        executor =
+            Executors.newSingleThreadScheduledExecutor { runnable ->
+                Thread(runnable, "CleveresTricky-AutoIdentity").apply {
+                    isDaemon = true
+                    priority = Thread.MIN_PRIORITY
+                }
+            }
+    }
+
+    private fun scheduleLocked(
+        root: File,
+        generation: Long,
+        delayMs: Long,
+    ) {
+        val current = executor ?: return
+        val boundedDelay = delayMs.coerceAtLeast(1_000L)
+        nextRunMs = System.currentTimeMillis() + boundedDelay
+        scheduled = current.schedule({ runCheck(root, generation) }, boundedDelay, TimeUnit.MILLISECONDS)
     }
 
     private fun stopExecutorLocked() {
         workerGeneration++
+        scheduled?.cancel(true)
+        scheduled = null
         executor?.shutdownNow()
         executor = null
+        inFlight = false
+        nextRunMs = 0L
     }
 
     private fun ownsWork(
@@ -116,78 +159,72 @@ internal object CronAutoIdentity {
         generation: Long,
     ): Boolean =
         synchronized(lock) {
-            val current = executor
             generation == workerGeneration &&
                 configDir?.absoluteFile == root.absoluteFile &&
-                current != null &&
-                !current.isShutdown
+                executor?.isShutdown == false
         }
 
     private fun runCheck(
         root: File,
         generation: Long,
     ) {
-        if (!ownsWork(root, generation) || !currentDecision(root).shouldRun) {
-            refreshEnabled()
-            return
-        }
-        try {
-            Logger.i("Cron Auto Identity: fetching a fresh identity")
-            val resolved = AutoIdentityManager.fetchLatest()
-            if (!ownsWork(root, generation) || !currentDecision(root).shouldRun) {
-                Logger.i("Cron Auto Identity: fetched identity discarded because the worker was disabled or replaced")
-                refreshEnabled()
+        val decision =
+            synchronized(lock) {
+                if (!ownsWorkLocked(root, generation)) return
+                scheduled = null
+                val current = currentDecision(root)
+                if (!current.shouldRun) {
+                    stopExecutorLocked()
+                    return
+                }
+                inFlight = true
+                lastAttemptMs = System.currentTimeMillis()
+                nextRunMs = 0L
+                current
+            }
+
+        val result =
+            IdentityCoordinator.refresh(
+                root = root,
+                persistGlobal = decision.globalLiveApply,
+                persistProfile = decision.profileScoped,
+                liveApplyGlobal = decision.globalLiveApply,
+            )
+
+        synchronized(lock) {
+            if (!ownsWorkLocked(root, generation)) return
+            inFlight = false
+            val current = currentDecision(root)
+            if (!current.shouldRun) {
+                stopExecutorLocked()
                 return
             }
-            val decision = currentDecision(root)
-            if (!decision.shouldRun) {
-                Logger.i("Cron Auto Identity: fetched identity discarded because Auto Identity was disabled")
-                refreshEnabled()
-                return
-            }
-            if (decision.profileScoped) {
-                ProfileAutoIdentityStore.save(root, resolved).getOrThrow()
-            }
-            if (!ownsWork(root, generation)) {
-                Logger.i("Cron Auto Identity: profile snapshot saved but follow-up work skipped because the worker was replaced")
-                return
-            }
-            if (!decision.globalLiveApply) {
-                Logger.i("Cron Auto Identity: profile-scoped identity refreshed; global identity storage and Build properties were left unchanged")
-                return
-            }
-            if (!currentDecision(root).globalLiveApply) {
-                Logger.i("Cron Auto Identity: global identity save skipped because global Auto Identity was disabled")
-                refreshEnabled()
-                return
-            }
-            AutoIdentityPersistence.save(root, resolved).getOrThrow()
-            if (!ownsWork(root, generation) || !currentDecision(root).globalLiveApply) {
-                Logger.i("Cron Auto Identity: global identity refreshed but live apply skipped because the worker or policy changed")
-                refreshEnabled()
-                return
-            }
-            val applied = IdentityRuntimeApplier.apply(root)
-            if (applied.applied) {
-                Logger.i("Cron Auto Identity: refreshed and applied Build Identity without reboot")
-            } else if (applied.rebootRequired) {
-                Logger.w("Cron Auto Identity: identity refreshed; reboot is required on this environment (${applied.reason})")
+            if (result.isSuccess) {
+                failureCount = 0
+                lastError = null
+                lastSuccessMs = System.currentTimeMillis()
+                scheduleLocked(root, generation, SUCCESS_DELAY_MS)
+                Logger.i("Auto Identity refresh completed; next run is scheduled in 24 hours")
             } else {
-                Logger.i("Cron Auto Identity: identity refreshed; live apply skipped (${applied.reason})")
+                failureCount = (failureCount + 1).coerceAtMost(Int.MAX_VALUE)
+                lastError = result.exceptionOrNull()?.javaClass?.simpleName ?: "UnknownFailure"
+                val delay = failureBackoffMs[minOf(failureCount - 1, failureBackoffMs.lastIndex)]
+                scheduleLocked(root, generation, delay)
+                Logger.w("Auto Identity refresh deferred after failure; bounded retry is scheduled")
             }
-        } catch (error: InterruptedException) {
-            Thread.currentThread().interrupt()
-            Logger.i("Cron Auto Identity refresh interrupted because the worker was stopped")
-        } catch (error: Throwable) {
-            Logger.e("Cron Auto Identity refresh failed", error)
         }
     }
 
-    private fun currentDecision(root: File): AutoIdentityPolicy.Decision =
-        AutoIdentityPolicy.evaluate(isRegularMarker(File(root, TOGGLE_FILE)))
+    private fun ownsWorkLocked(
+        root: File,
+        generation: Long,
+    ): Boolean =
+        generation == workerGeneration &&
+            configDir?.absoluteFile == root.absoluteFile &&
+            executor?.isShutdown == false
 
-    private fun isRegularMarker(file: File): Boolean =
-        Files.isRegularFile(file.toPath(), LinkOption.NOFOLLOW_LINKS) && !Files.isSymbolicLink(file.toPath())
+    private fun currentDecision(root: File): AutoIdentityPolicy.Decision =
+        AutoIdentityPolicy.evaluate(isEnabled(root))
 
     @VisibleForTesting
     internal fun configureForTesting(root: File) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/IdentityCoordinator.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/IdentityCoordinator.kt
@@ -1,0 +1,175 @@
+package cleveres.tricky.cleverestech
+
+import org.json.JSONObject
+import java.io.File
+import java.util.concurrent.CompletableFuture
+
+/** Single owner for Identity fetch, persistence, live apply/rollback and diagnostics. */
+internal object IdentityCoordinator {
+    data class RefreshOutcome(
+        val identity: AutoIdentityManager.Result,
+        val runtime: IdentityRuntimeApplier.Result?,
+        val globalPersisted: Boolean,
+        val profilePersisted: Boolean,
+    )
+
+    data class TransitionOutcome(
+        val rollbackPrepared: Boolean,
+        val restore: IdentityRuntimeApplier.Result?,
+        val apply: IdentityRuntimeApplier.Result?,
+    ) {
+        val rebootRequired: Boolean
+            get() = restore?.rebootRequired == true || apply?.rebootRequired == true
+
+        fun toJson(): JSONObject =
+            JSONObject()
+                .put("rollbackPrepared", rollbackPrepared)
+                .put("rebootRequired", rebootRequired)
+                .put("restore", restore?.toJson() ?: JSONObject.NULL)
+                .put("apply", apply?.toJson() ?: JSONObject.NULL)
+    }
+
+    private data class TopLevelIdentity(
+        val build: Boolean,
+        val region: Boolean,
+    )
+
+    private val fetchLock = Any()
+    private var fetchFlight: CompletableFuture<AutoIdentityManager.Result>? = null
+
+    @Volatile
+    private var lastAttemptMs = 0L
+
+    @Volatile
+    private var lastSuccessMs = 0L
+
+    @Volatile
+    private var lastError: String? = null
+
+    @Volatile
+    private var lastScope = "none"
+
+    @Volatile
+    private var lastRuntime: IdentityRuntimeApplier.Result? = null
+
+    fun initialize(root: File) {
+        runCatching { IdentityRuntimeSnapshot.read(root) }
+            .onFailure {
+                Logger.w("Discarding unreadable live Identity rollback metadata")
+                runCatching { IdentityRuntimeSnapshot.clear(root) }
+            }
+    }
+
+    fun refresh(
+        root: File,
+        persistGlobal: Boolean,
+        persistProfile: Boolean,
+        liveApplyGlobal: Boolean,
+        fetcher: () -> AutoIdentityManager.Result = { AutoIdentityManager.fetchLatest() },
+    ): Result<RefreshOutcome> {
+        require(persistGlobal || persistProfile) { "Identity refresh has no persistence scope" }
+        lastAttemptMs = System.currentTimeMillis()
+        lastScope =
+            when {
+                persistGlobal && persistProfile -> "global+profile"
+                persistGlobal -> "global"
+                else -> "profile"
+            }
+        return runCatching {
+            val resolved = fetchShared(fetcher)
+            if (persistProfile) ProfileAutoIdentityStore.save(root, resolved).getOrThrow()
+            if (persistGlobal) AutoIdentityPersistence.save(root, resolved).getOrThrow()
+            val runtime =
+                if (liveApplyGlobal && persistGlobal && PolicyState.isTopLevelFeatureEnabled(PolicyState.Feature.BUILD_IDENTITY)) {
+                    IdentityRuntimeApplier.apply(root)
+                } else {
+                    null
+                }
+            lastRuntime = runtime
+            lastSuccessMs = System.currentTimeMillis()
+            lastError = null
+            RefreshOutcome(resolved, runtime, persistGlobal, persistProfile)
+        }.onFailure { error ->
+            lastError = error.javaClass.simpleName
+            Logger.e("Identity refresh failed", error)
+        }
+    }
+
+    fun reconcilePolicyTransition(
+        root: File,
+        before: JSONObject,
+        after: JSONObject,
+    ): TransitionOutcome {
+        val previous = topLevel(before)
+        val current = topLevel(after)
+        val enableBuild = !previous.build && current.build
+        val enableRegion = !previous.region && current.region
+        val disableBuild = previous.build && !current.build
+        val disableRegion = previous.region && !current.region
+        if (!enableBuild && !enableRegion && !disableBuild && !disableRegion) {
+            return TransitionOutcome(rollbackPrepared = true, restore = null, apply = null)
+        }
+
+        val rollbackPrepared =
+            if (enableBuild || enableRegion) {
+                IdentityRuntimeSnapshot.capture(root, enableBuild, enableRegion).isSuccess
+            } else {
+                true
+            }
+        val restore =
+            if (disableBuild || disableRegion) {
+                IdentityRuntimeApplier.restore(root, disableBuild, disableRegion)
+            } else {
+                null
+            }
+        val apply =
+            if (current.build || current.region) {
+                IdentityRuntimeApplier.apply(root)
+            } else {
+                null
+            }
+        lastRuntime = apply ?: restore
+        return TransitionOutcome(rollbackPrepared, restore, apply)
+    }
+
+    fun diagnosticsJson(): JSONObject =
+        JSONObject()
+            .put("lastAttemptMs", lastAttemptMs)
+            .put("lastSuccessMs", lastSuccessMs)
+            .put("lastError", lastError ?: JSONObject.NULL)
+            .put("lastScope", lastScope)
+            .put("fetchInFlight", synchronized(fetchLock) { fetchFlight?.isDone == false })
+            .put("lastRuntime", lastRuntime?.toJson() ?: JSONObject.NULL)
+
+    private fun fetchShared(fetcher: () -> AutoIdentityManager.Result): AutoIdentityManager.Result {
+        var owner = false
+        val flight =
+            synchronized(fetchLock) {
+                fetchFlight?.takeIf { !it.isDone }
+                    ?: CompletableFuture<AutoIdentityManager.Result>().also {
+                        fetchFlight = it
+                        owner = true
+                    }
+            }
+        if (owner) {
+            try {
+                flight.complete(fetcher())
+            } catch (error: Throwable) {
+                flight.completeExceptionally(error)
+            } finally {
+                synchronized(fetchLock) {
+                    if (fetchFlight === flight) fetchFlight = null
+                }
+            }
+        }
+        return flight.get()
+    }
+
+    private fun topLevel(state: JSONObject): TopLevelIdentity {
+        val features = state.optJSONObject("features") ?: JSONObject()
+        return TopLevelIdentity(
+            build = features.optBoolean("buildIdentity", false),
+            region = features.optBoolean("regionIdentity", false),
+        )
+    }
+}

--- a/service/src/main/java/cleveres/tricky/cleverestech/IdentityCoordinator.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/IdentityCoordinator.kt
@@ -3,6 +3,7 @@ package cleveres.tricky.cleverestech
 import org.json.JSONObject
 import java.io.File
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
 
 /** Single owner for Identity fetch, persistence, live apply/rollback and diagnostics. */
 internal object IdentityCoordinator {
@@ -162,7 +163,11 @@ internal object IdentityCoordinator {
                 }
             }
         }
-        return flight.get()
+        return try {
+            flight.get()
+        } catch (error: ExecutionException) {
+            throw error.cause ?: error
+        }
     }
 
     private fun topLevel(state: JSONObject): TopLevelIdentity {

--- a/service/src/main/java/cleveres/tricky/cleverestech/IdentityRuntimeApplier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/IdentityRuntimeApplier.kt
@@ -1,18 +1,30 @@
 package cleveres.tricky.cleverestech
 
+import org.json.JSONObject
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.util.concurrent.TimeUnit
 
-/** Applies only the optional Build Identity property phase from post-fs-data.sh. */
+/** Applies and restores only optional device-wide Identity properties. */
 internal object IdentityRuntimeApplier {
     data class Result(
         val applied: Boolean,
         val rebootRequired: Boolean,
         val processRestartRecommended: Boolean,
         val reason: String,
-    )
+        val buildApplied: Boolean = false,
+        val regionApplied: Boolean = false,
+    ) {
+        fun toJson(): JSONObject =
+            JSONObject()
+                .put("applied", applied)
+                .put("rebootRequired", rebootRequired)
+                .put("processRestartRecommended", processRestartRecommended)
+                .put("reason", reason)
+                .put("buildApplied", buildApplied)
+                .put("regionApplied", regionApplied)
+    }
 
     private val moduleRoots =
         listOf(
@@ -20,68 +32,149 @@ internal object IdentityRuntimeApplier {
             File("/data/adb/ksu/modules/cleverestricky"),
             File("/data/adb/ap/modules/cleverestricky"),
         )
+    private val expectedRegion =
+        linkedMapOf(
+            "ro.boot.hwc" to "CN",
+            "gsm.operator.iso-country" to "cn",
+            "gsm.sim.operator.iso-country" to "cn",
+            "ro.boot.hwlevel" to "MP",
+            "persist.radio.skhwc_matchres" to "MATCH",
+        )
 
     fun apply(configDir: File): Result {
-        if (!PolicyState.isTopLevelFeatureEnabled(PolicyState.Feature.BUILD_IDENTITY)) {
-            return Result(false, false, false, "disabled")
-        }
+        val build = PolicyState.isTopLevelFeatureEnabled(PolicyState.Feature.BUILD_IDENTITY)
+        val region = PolicyState.isTopLevelFeatureEnabled(PolicyState.Feature.REGION_IDENTITY)
+        if (!build && !region) return Result(false, false, false, "disabled")
+
         val expectedFingerprint = Config.getBuildIdentity()["FINGERPRINT"].orEmpty()
-        if (expectedFingerprint.isBlank()) return Result(false, false, false, "not_configured")
-
-        val script =
-            moduleRoots
-                .asSequence()
-                .map { File(it, "post-fs-data.sh") }
-                .firstOrNull { file ->
-                    val path = file.toPath()
-                    Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS) && !Files.isSymbolicLink(path)
-                } ?: return Result(false, true, false, "script_unavailable")
-
-        if (!commandSucceeds(arrayOf("/system/bin/sh", "-c", "command -v resetprop >/dev/null 2>&1"), 3)) {
-            return Result(false, true, false, "resetprop_unavailable")
-        }
+        val buildConfigured = !build || expectedFingerprint.isNotBlank()
+        val script = findScript() ?: return Result(false, true, false, "script_unavailable")
 
         val process =
-            ProcessBuilder("/system/bin/sh", script.absolutePath)
-                .redirectOutput(File("/dev/null"))
-                .redirectError(File("/dev/null"))
-                .apply {
-                    environment()["CLEVERES_TRICKY_IDENTITY_ONLY"] = "1"
-                    environment()["CLEVERES_TRICKY_CONFIG_DIR"] = configDir.absolutePath
-                }.start()
+            try {
+                ProcessBuilder("/system/bin/sh", script.absolutePath)
+                    .redirectOutput(File("/dev/null"))
+                    .redirectError(File("/dev/null"))
+                    .apply {
+                        environment()["CLEVERES_TRICKY_IDENTITY_ONLY"] = "1"
+                        environment()["CLEVERES_TRICKY_CONFIG_DIR"] = configDir.absolutePath
+                    }.start()
+            } catch (error: Exception) {
+                Logger.w("Live Identity shell is unavailable: ${error.javaClass.simpleName}")
+                return Result(false, true, false, "shell_unavailable")
+            }
         val finished = process.waitFor(10, TimeUnit.SECONDS)
         if (!finished) {
             process.destroyForcibly()
             process.waitFor(1, TimeUnit.SECONDS)
-            Logger.e("Live Build Identity apply timed out")
+            Logger.e("Live Identity apply timed out")
             return Result(false, true, false, "timeout")
         }
         if (process.exitValue() != 0) {
-            Logger.e("Live Build Identity apply failed with exit=${process.exitValue()}")
+            Logger.e("Live Identity apply failed with exit=${process.exitValue()}")
             return Result(false, true, false, "apply_failed")
         }
 
-        val actualFingerprint = systemPropertiesGet("ro.build.fingerprint", "").orEmpty()
-        if (actualFingerprint != expectedFingerprint) {
-            Logger.w("Live Build Identity verification did not observe the configured fingerprint")
-            return Result(false, true, false, "verification_failed")
+        val buildApplied =
+            build && buildConfigured && systemPropertiesGet("ro.build.fingerprint", "").orEmpty() == expectedFingerprint
+        val regionApplied =
+            region && expectedRegion.all { (property, expected) -> systemPropertiesGet(property, "").orEmpty() == expected }
+        if (build && !buildConfigured) {
+            Logger.w("Build Identity is enabled, but no configured fingerprint is available")
+        }
+        if ((build && buildConfigured && !buildApplied) || (region && !regionApplied)) {
+            Logger.w("Live Identity verification did not observe every requested property")
+            return Result(
+                applied = false,
+                rebootRequired = true,
+                processRestartRecommended = buildApplied || regionApplied,
+                reason = "verification_failed",
+                buildApplied = buildApplied,
+                regionApplied = regionApplied,
+            )
+        }
+        if (build && !buildConfigured) {
+            return Result(
+                applied = region && regionApplied,
+                rebootRequired = false,
+                processRestartRecommended = regionApplied,
+                reason = "build_not_configured",
+                buildApplied = false,
+                regionApplied = regionApplied,
+            )
         }
 
-        Logger.i("Build Identity properties applied live; existing app processes may need restart")
-        return Result(true, false, true, "applied")
+        Logger.i("Identity properties applied live; existing app processes may need restart")
+        return Result(true, false, true, "applied", buildApplied, regionApplied)
     }
 
-    private fun commandSucceeds(
-        command: Array<String>,
-        timeoutSeconds: Long,
+    fun restore(
+        configDir: File,
+        restoreBuild: Boolean,
+        restoreRegion: Boolean,
+    ): Result {
+        if (!restoreBuild && !restoreRegion) return Result(false, false, false, "nothing_to_restore")
+        val snapshot =
+            runCatching { IdentityRuntimeSnapshot.read(configDir) }.getOrElse {
+                Logger.w("Live Identity rollback snapshot cannot be read")
+                return Result(false, true, false, "snapshot_unavailable")
+            } ?: return Result(false, true, false, "snapshot_unavailable")
+        if ((restoreBuild && !snapshot.buildCaptured) || (restoreRegion && !snapshot.regionCaptured)) {
+            return Result(false, true, false, "snapshot_incomplete")
+        }
+
+        val properties = LinkedHashSet<String>()
+        if (restoreBuild) properties.addAll(IdentityRuntimeSnapshot.buildProperties)
+        if (restoreRegion) properties.addAll(IdentityRuntimeSnapshot.regionProperties)
+        var commandFailed = false
+        properties.forEach { property ->
+            val value = snapshot.values[property]
+            if (value == null || !setProperty(property, value)) commandFailed = true
+        }
+        val verified =
+            properties.all { property ->
+                snapshot.values[property]?.let { expected ->
+                    systemPropertiesGet(property, "").orEmpty() == expected
+                } == true
+            }
+        if (commandFailed || !verified) {
+            Logger.w("Live Identity rollback was incomplete; reboot is required")
+            return Result(false, true, false, if (commandFailed) "restore_failed" else "restore_verification_failed")
+        }
+
+        runCatching { IdentityRuntimeSnapshot.release(configDir, restoreBuild, restoreRegion) }
+            .onFailure { Logger.w("Restored Identity properties but could not release rollback snapshot") }
+        Logger.i("Identity properties restored live; existing app processes may need restart")
+        return Result(
+            applied = true,
+            rebootRequired = false,
+            processRestartRecommended = true,
+            reason = "restored",
+            buildApplied = restoreBuild,
+            regionApplied = restoreRegion,
+        )
+    }
+
+    private fun findScript(): File? =
+        moduleRoots
+            .asSequence()
+            .map { File(it, "post-fs-data.sh") }
+            .firstOrNull { file ->
+                val path = file.toPath()
+                Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS) && !Files.isSymbolicLink(path)
+            }
+
+    private fun setProperty(
+        property: String,
+        value: String,
     ): Boolean =
         try {
             val process =
-                ProcessBuilder(*command)
+                ProcessBuilder("resetprop", "-n", property, value)
                     .redirectOutput(File("/dev/null"))
                     .redirectError(File("/dev/null"))
                     .start()
-            val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
+            val finished = process.waitFor(2, TimeUnit.SECONDS)
             if (!finished) {
                 process.destroyForcibly()
                 process.waitFor(1, TimeUnit.SECONDS)
@@ -89,8 +182,7 @@ internal object IdentityRuntimeApplier {
             } else {
                 process.exitValue() == 0
             }
-        } catch (error: Exception) {
-            Logger.d { "Live Build Identity prerequisite check failed: ${error.javaClass.simpleName}" }
+        } catch (_: Exception) {
             false
         }
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/IdentityRuntimeSnapshot.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/IdentityRuntimeSnapshot.kt
@@ -1,0 +1,124 @@
+package cleveres.tricky.cleverestech
+
+import org.json.JSONObject
+import java.io.File
+
+/** Captures genuine app-visible properties before a runtime Identity enable transition. */
+internal object IdentityRuntimeSnapshot {
+    const val FILE_NAME = "identity_runtime_original"
+    private const val FORMAT_VERSION = 1
+    private const val MAX_BYTES = 16L * 1024L
+
+    val buildProperties =
+        listOf(
+            "ro.build.fingerprint",
+            "ro.product.brand",
+            "ro.product.device",
+            "ro.product.name",
+            "ro.product.manufacturer",
+            "ro.product.model",
+            "ro.build.id",
+            "ro.build.version.release",
+            "ro.build.version.release_or_codename",
+            "ro.build.version.incremental",
+            "ro.build.type",
+            "ro.build.tags",
+            "ro.build.version.security_patch",
+        )
+    val regionProperties =
+        listOf(
+            "ro.boot.hwc",
+            "gsm.operator.iso-country",
+            "gsm.sim.operator.iso-country",
+            "ro.boot.hwlevel",
+            "persist.radio.skhwc_matchres",
+        )
+    private val allowedProperties = (buildProperties + regionProperties).toSet()
+
+    data class Snapshot(
+        val buildCaptured: Boolean,
+        val regionCaptured: Boolean,
+        val values: Map<String, String>,
+    )
+
+    @Synchronized
+    fun capture(
+        root: File,
+        build: Boolean,
+        region: Boolean,
+    ): Result<Snapshot> =
+        runCatching {
+            require(build || region) { "No runtime Identity group requested" }
+            val existing = read(root)
+            if (existing != null && (!build || existing.buildCaptured) && (!region || existing.regionCaptured)) {
+                return@runCatching existing
+            }
+
+            val values = LinkedHashMap<String, String>()
+            existing?.values?.let(values::putAll)
+            var buildCaptured = existing?.buildCaptured == true
+            var regionCaptured = existing?.regionCaptured == true
+            if (build && !buildCaptured) {
+                captureGroup(buildProperties, values)
+                buildCaptured = true
+            }
+            if (region && !regionCaptured) {
+                captureGroup(regionProperties, values)
+                regionCaptured = true
+            }
+
+            val json = JSONObject()
+                .put("version", FORMAT_VERSION)
+                .put("build", buildCaptured)
+                .put("region", regionCaptured)
+                .put("values", JSONObject(values as Map<*, *>))
+            SafeConfigStore.writeText(root, FILE_NAME, json.toString(), MAX_BYTES)
+            Snapshot(buildCaptured, regionCaptured, values.toMap())
+        }.onFailure { error ->
+            Logger.w("Live Identity rollback snapshot is unavailable: ${error.javaClass.simpleName}")
+        }
+
+    @Synchronized
+    fun read(root: File): Snapshot? {
+        val text = SafeConfigStore.readText(root, FILE_NAME, MAX_BYTES, minBytes = 1) ?: return null
+        val json = JSONObject(text)
+        require(json.length() == 4 && json.getInt("version") == FORMAT_VERSION) { "Invalid runtime Identity snapshot" }
+        val build = json.getBoolean("build")
+        val region = json.getBoolean("region")
+        val objectValues = json.getJSONObject("values")
+        val values = LinkedHashMap<String, String>()
+        val keys = objectValues.keys()
+        while (keys.hasNext()) {
+            val key = keys.next()
+            require(key in allowedProperties) { "Unexpected runtime Identity property" }
+            val value = objectValues.getString(key)
+            require(value.isNotEmpty() && value.length <= 512 && value.none { it.code < 0x20 || it.code == 0x7f }) {
+                "Invalid runtime Identity property value"
+            }
+            values[key] = value
+        }
+        if (build) require(values.keys.containsAll(buildProperties)) { "Incomplete Build rollback snapshot" }
+        if (region) require(values.keys.containsAll(regionProperties)) { "Incomplete region rollback snapshot" }
+        return Snapshot(build, region, values)
+    }
+
+    @Synchronized
+    fun clear(root: File) {
+        SafeConfigStore.delete(root, FILE_NAME)
+    }
+
+    private fun captureGroup(
+        properties: List<String>,
+        destination: MutableMap<String, String>,
+    ) {
+        val captured = LinkedHashMap<String, String>()
+        properties.forEach { property ->
+            val value = systemPropertiesGet(property, "").orEmpty()
+            require(value.isNotEmpty() && value.length <= 512 && value.none { it.code < 0x20 || it.code == 0x7f }) {
+                "Property $property cannot be safely restored without reboot"
+            }
+            captured[property] = value
+        }
+        destination.putAll(captured)
+    }
+}

--- a/service/src/main/java/cleveres/tricky/cleverestech/IdentityRuntimeSnapshot.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/IdentityRuntimeSnapshot.kt
@@ -67,13 +67,9 @@ internal object IdentityRuntimeSnapshot {
                 regionCaptured = true
             }
 
-            val json = JSONObject()
-                .put("version", FORMAT_VERSION)
-                .put("build", buildCaptured)
-                .put("region", regionCaptured)
-                .put("values", JSONObject(values as Map<*, *>))
-            SafeConfigStore.writeText(root, FILE_NAME, json.toString(), MAX_BYTES)
-            Snapshot(buildCaptured, regionCaptured, values.toMap())
+            val snapshot = Snapshot(buildCaptured, regionCaptured, values.toMap())
+            write(root, snapshot)
+            snapshot
         }.onFailure { error ->
             Logger.w("Live Identity rollback snapshot is unavailable: ${error.javaClass.simpleName}")
         }
@@ -92,19 +88,54 @@ internal object IdentityRuntimeSnapshot {
             val key = keys.next()
             require(key in allowedProperties) { "Unexpected runtime Identity property" }
             val value = objectValues.getString(key)
-            require(value.isNotEmpty() && value.length <= 512 && value.none { it.code < 0x20 || it.code == 0x7f }) {
-                "Invalid runtime Identity property value"
-            }
+            require(validValue(value)) { "Invalid runtime Identity property value" }
             values[key] = value
         }
         if (build) require(values.keys.containsAll(buildProperties)) { "Incomplete Build rollback snapshot" }
         if (region) require(values.keys.containsAll(regionProperties)) { "Incomplete region rollback snapshot" }
+        require(build || region) { "Empty runtime Identity snapshot" }
         return Snapshot(build, region, values)
+    }
+
+    @Synchronized
+    fun release(
+        root: File,
+        build: Boolean,
+        region: Boolean,
+    ) {
+        if (!build && !region) return
+        val current = read(root) ?: return
+        val keepBuild = current.buildCaptured && !build
+        val keepRegion = current.regionCaptured && !region
+        if (!keepBuild && !keepRegion) {
+            SafeConfigStore.delete(root, FILE_NAME)
+            return
+        }
+        val keepKeys = LinkedHashSet<String>()
+        if (keepBuild) keepKeys.addAll(buildProperties)
+        if (keepRegion) keepKeys.addAll(regionProperties)
+        val keptValues = current.values.filterKeys { it in keepKeys }
+        write(root, Snapshot(keepBuild, keepRegion, keptValues))
     }
 
     @Synchronized
     fun clear(root: File) {
         SafeConfigStore.delete(root, FILE_NAME)
+    }
+
+    private fun write(
+        root: File,
+        snapshot: Snapshot,
+    ) {
+        val objectValues = JSONObject()
+        snapshot.values.toSortedMap().forEach { (key, value) -> objectValues.put(key, value) }
+        val json =
+            JSONObject()
+                .put("version", FORMAT_VERSION)
+                .put("build", snapshot.buildCaptured)
+                .put("region", snapshot.regionCaptured)
+                .put("values", objectValues)
+        SafeConfigStore.writeText(root, FILE_NAME, json.toString(), MAX_BYTES)
     }
 
     private fun captureGroup(
@@ -114,11 +145,12 @@ internal object IdentityRuntimeSnapshot {
         val captured = LinkedHashMap<String, String>()
         properties.forEach { property ->
             val value = systemPropertiesGet(property, "").orEmpty()
-            require(value.isNotEmpty() && value.length <= 512 && value.none { it.code < 0x20 || it.code == 0x7f }) {
-                "Property $property cannot be safely restored without reboot"
-            }
+            require(validValue(value)) { "Property $property cannot be safely restored without reboot" }
             captured[property] = value
         }
         destination.putAll(captured)
     }
+
+    private fun validValue(value: String): Boolean =
+        value.isNotEmpty() && value.length <= 512 && value.none { it.code < 0x20 || it.code == 0x7f }
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/IdentityRuntimeSnapshot.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/IdentityRuntimeSnapshot.kt
@@ -1,5 +1,6 @@
 package cleveres.tricky.cleverestech
 
+import cleveres.tricky.cleverestech.util.readUtf8FileSnapshotBounded
 import org.json.JSONObject
 import java.io.File
 
@@ -8,6 +9,7 @@ internal object IdentityRuntimeSnapshot {
     const val FILE_NAME = "identity_runtime_original"
     private const val FORMAT_VERSION = 1
     private const val MAX_BYTES = 16L * 1024L
+    private val bootIdPattern = Regex("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
 
     val buildProperties =
         listOf(
@@ -36,6 +38,7 @@ internal object IdentityRuntimeSnapshot {
     private val allowedProperties = (buildProperties + regionProperties).toSet()
 
     data class Snapshot(
+        val bootId: String,
         val buildCaptured: Boolean,
         val regionCaptured: Boolean,
         val values: Map<String, String>,
@@ -49,6 +52,7 @@ internal object IdentityRuntimeSnapshot {
     ): Result<Snapshot> =
         runCatching {
             require(build || region) { "No runtime Identity group requested" }
+            val bootId = currentBootId()
             val existing = read(root)
             if (existing != null && (!build || existing.buildCaptured) && (!region || existing.regionCaptured)) {
                 return@runCatching existing
@@ -67,7 +71,7 @@ internal object IdentityRuntimeSnapshot {
                 regionCaptured = true
             }
 
-            val snapshot = Snapshot(buildCaptured, regionCaptured, values.toMap())
+            val snapshot = Snapshot(bootId, buildCaptured, regionCaptured, values.toMap())
             write(root, snapshot)
             snapshot
         }.onFailure { error ->
@@ -78,7 +82,13 @@ internal object IdentityRuntimeSnapshot {
     fun read(root: File): Snapshot? {
         val text = SafeConfigStore.readText(root, FILE_NAME, MAX_BYTES, minBytes = 1) ?: return null
         val json = JSONObject(text)
-        require(json.length() == 4 && json.getInt("version") == FORMAT_VERSION) { "Invalid runtime Identity snapshot" }
+        require(json.length() == 5 && json.getInt("version") == FORMAT_VERSION) { "Invalid runtime Identity snapshot" }
+        val storedBootId = json.getString("bootId")
+        require(bootIdPattern.matches(storedBootId)) { "Invalid runtime Identity boot ID" }
+        if (storedBootId != currentBootId()) {
+            SafeConfigStore.delete(root, FILE_NAME)
+            return null
+        }
         val build = json.getBoolean("build")
         val region = json.getBoolean("region")
         val objectValues = json.getJSONObject("values")
@@ -94,7 +104,7 @@ internal object IdentityRuntimeSnapshot {
         if (build) require(values.keys.containsAll(buildProperties)) { "Incomplete Build rollback snapshot" }
         if (region) require(values.keys.containsAll(regionProperties)) { "Incomplete region rollback snapshot" }
         require(build || region) { "Empty runtime Identity snapshot" }
-        return Snapshot(build, region, values)
+        return Snapshot(storedBootId, build, region, values)
     }
 
     @Synchronized
@@ -115,7 +125,7 @@ internal object IdentityRuntimeSnapshot {
         if (keepBuild) keepKeys.addAll(buildProperties)
         if (keepRegion) keepKeys.addAll(regionProperties)
         val keptValues = current.values.filterKeys { it in keepKeys }
-        write(root, Snapshot(keepBuild, keepRegion, keptValues))
+        write(root, Snapshot(current.bootId, keepBuild, keepRegion, keptValues))
     }
 
     @Synchronized
@@ -132,6 +142,7 @@ internal object IdentityRuntimeSnapshot {
         val json =
             JSONObject()
                 .put("version", FORMAT_VERSION)
+                .put("bootId", snapshot.bootId)
                 .put("build", snapshot.buildCaptured)
                 .put("region", snapshot.regionCaptured)
                 .put("values", objectValues)
@@ -149,6 +160,12 @@ internal object IdentityRuntimeSnapshot {
             captured[property] = value
         }
         destination.putAll(captured)
+    }
+
+    private fun currentBootId(): String {
+        val value = readUtf8FileSnapshotBounded(File("/proc/sys/kernel/random/boot_id"), 1, 64).trim()
+        require(bootIdPattern.matches(value)) { "Invalid current boot ID" }
+        return value.lowercase()
     }
 
     private fun validValue(value: String): Boolean =

--- a/service/src/main/java/cleveres/tricky/cleverestech/LegacyIdentityMarkers.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/LegacyIdentityMarkers.kt
@@ -33,26 +33,32 @@ internal object LegacyIdentityMarkers {
 
     fun preflight(root: File) {
         allowedNames.forEach { validatePath(File(root, it)) }
+        BootPolicyProjection.preflight(root)
     }
 
     fun isSynchronized(root: File, state: JSONObject): Result<Boolean> = runCatching {
         if (!state.optString("source").equals("v2", true)) return@runCatching true
-        plan(root, desiredState(state)).isEmpty()
+        plan(root, desiredState(state)).isEmpty() && BootPolicyProjection.isSynchronized(root, state)
     }
 
     fun syncFromPolicyState(root: File, state: JSONObject): Result<Unit> = runCatching {
         if (!state.optString("source").equals("v2", true)) return@runCatching
         apply(plan(root, desiredState(state)))
+        // The early-boot projection is deliberately written after marker changes. Enabling remains
+        // fail-closed until the projection exists, while disabling is already blocked by marker
+        // removal even if this final write fails. A later policy read retries reconciliation.
+        BootPolicyProjection.write(root, state)
     }
 
     fun plan(root: File, desired: DesiredState): List<Operation> {
-        val expected = linkedMapOf(
-            ENGINE to desired.engine,
-            BUILD to desired.build,
-            TELEPHONY to desired.telephony,
-            REGION to desired.region,
-            REFRESH to desired.refresh,
-        )
+        val expected =
+            linkedMapOf(
+                ENGINE to desired.engine,
+                BUILD to desired.build,
+                TELEPHONY to desired.telephony,
+                REGION to desired.region,
+                REFRESH to desired.refresh,
+            )
         return expected.mapNotNull { (name, enabled) ->
             val file = File(root, name)
             if (validatePath(file) != enabled) Operation(name, file, enabled) else null
@@ -110,9 +116,9 @@ internal object LegacyIdentityMarkers {
         listOf("buildIdentity", "attestationIdentity", "telephonyIdentity", "regionIdentity", "identityRefresh")
             .forEach { key -> resolved[key] = features.optBoolean(key, false) }
 
-        // JSON null is the canonical representation of "no active profile". Do not
-        // coerce JSONObject.NULL through optString(): Android org.json renders that
-        // sentinel as the literal string "null", which is also a valid profile name.
+        // Compatibility markers still follow the active profile because managed runtime
+        // interceptors consume them. The separate BootPolicyProjection intentionally does not:
+        // only top-level policy may authorize device-wide pre-Zygote properties.
         val activeProfile =
             if (state.has("activeProfile") && !state.isNull("activeProfile")) {
                 (state.opt("activeProfile") as? String)?.trim().orEmpty()
@@ -123,6 +129,7 @@ internal object LegacyIdentityMarkers {
         if (activeProfile.isNotEmpty() && profiles != null) {
             for (i in 0 until profiles.length()) {
                 val profile = profiles.optJSONObject(i) ?: continue
+                if (!profile.optBoolean("enabled", true)) continue
                 if (!profile.optString("name").equals(activeProfile, true)) continue
                 val overrides = profile.optJSONObject("features") ?: break
                 resolved.keys.forEach { key ->

--- a/service/src/main/java/cleveres/tricky/cleverestech/PolicyApi.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/PolicyApi.kt
@@ -10,6 +10,7 @@ internal object PolicyApi {
             "/api/policy_state",
             "/api/effective_state",
             "/api/profile_v2",
+            "/api/identity_diagnostics",
         )
 
     fun serve(session: NanoHTTPD.IHTTPSession): NanoHTTPD.Response? {
@@ -44,6 +45,9 @@ internal object PolicyApi {
                 },
                 onFailure = { text(NanoHTTPD.Response.Status.BAD_REQUEST, "Invalid profile request") },
             )
+        }
+        if (uri == "/api/identity_diagnostics" && method == NanoHTTPD.Method.GET) {
+            return json(NanoHTTPD.Response.Status.OK, IdentityCoordinator.diagnosticsJson())
         }
         return null
     }

--- a/service/src/main/java/cleveres/tricky/cleverestech/PolicyMutationCoordinator.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/PolicyMutationCoordinator.kt
@@ -14,6 +14,7 @@ internal data class PolicyMutationResult(
     val state: JSONObject,
     val compatibilitySync: CompatibilitySyncStatus,
     val compatibilityError: Throwable? = null,
+    val previousState: JSONObject? = null,
 )
 
 /**
@@ -26,8 +27,15 @@ internal object PolicyMutationCoordinator {
         preflight: () -> Unit,
         mutation: () -> Result<JSONObject>,
         synchronizeCompatibility: (JSONObject) -> Result<Unit>,
+        captureBefore: (() -> JSONObject)? = null,
     ): Result<PolicyMutationResult> =
         synchronized(PolicyState) {
+            val previous =
+                try {
+                    captureBefore?.invoke()
+                } catch (error: Throwable) {
+                    return@synchronized Result.failure(error)
+                }
             try {
                 preflight()
             } catch (error: Throwable) {
@@ -41,6 +49,7 @@ internal object PolicyMutationCoordinator {
                     compatibilitySync =
                         if (compatibilityResult.isSuccess) CompatibilitySyncStatus.OK else CompatibilitySyncStatus.PENDING,
                     compatibilityError = compatibilityResult.exceptionOrNull(),
+                    previousState = previous,
                 )
             }
         }

--- a/service/src/main/java/cleveres/tricky/cleverestech/ProfileAutoIdentityStore.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ProfileAutoIdentityStore.kt
@@ -1,23 +1,16 @@
 package cleveres.tricky.cleverestech
 
-import cleveres.tricky.cleverestech.util.SecureFile
-import cleveres.tricky.cleverestech.util.readUtf8FileSnapshotBounded
+import org.json.JSONObject
 import java.io.File
-import java.nio.file.Files
-import java.nio.file.LinkOption
 
-/**
- * Persisted app-scoped Auto Identity snapshot.
- *
- * The profile scheduler owns this file. Global/manual Auto Identity continues to own
- * spoof_build_vars, so a profile-only refresh cannot alter the next device-wide boot identity.
- */
+/** Persisted app-scoped Auto Identity snapshot, isolated from global spoof_build_vars. */
 internal object ProfileAutoIdentityStore {
     const val FILE_NAME = "profile_auto_identity_vars"
+    private const val FORMAT_VERSION = 2
     private const val MAX_BYTES = 64L * 1024L
     private const val MAX_ENTRIES = 32
     private val allowedKeys =
-        setOf(
+        listOf(
             "BRAND",
             "DEVICE",
             "PRODUCT",
@@ -31,63 +24,104 @@ internal object ProfileAutoIdentityStore {
             "TAGS",
             "SECURITY_PATCH",
         )
+    private val allowedKeySet = allowedKeys.toSet()
+
+    private data class Snapshot(
+        val generation: Long,
+        val updatedAtMs: Long,
+        val values: Map<String, String>,
+    )
 
     @Volatile
-    private var values: Map<String, String> = emptyMap()
+    private var snapshot = Snapshot(0, 0, emptyMap())
 
-    fun get(key: String): String? = values[key]
+    fun get(key: String): String? = snapshot.values[key]
 
+    fun generation(): Long = snapshot.generation
+
+    fun updatedAtMs(): Long = snapshot.updatedAtMs
+
+    fun diagnosticsJson(): JSONObject =
+        JSONObject()
+            .put("generation", snapshot.generation)
+            .put("updatedAtMs", snapshot.updatedAtMs)
+            .put("ready", snapshot.values.isNotEmpty())
+
+    @Synchronized
     fun save(
         configDir: File,
         result: AutoIdentityManager.Result,
+        nowMs: Long = System.currentTimeMillis(),
     ): Result<Unit> =
         runCatching {
-            requireSafeRoot(configDir)
+            require(nowMs >= 0) { "Invalid Profile Auto Identity timestamp" }
             val updates = canonicalEntries(result)
             validateEntries(updates)
-            val file = File(configDir, FILE_NAME)
-            requireSafeFile(file)
-            val content = updates.entries.joinToString("\n", postfix = "\n") { (key, value) -> "$key=$value" }
-            require(content.toByteArray(Charsets.UTF_8).size <= MAX_BYTES) {
-                "Profile Auto Identity snapshot is too large"
-            }
-            SecureFile.writeText(file, content)
-            values = updates.toMap()
-            Logger.i("Profile Auto Identity snapshot updated (${updates.size} Build fields)")
+            val currentGeneration = snapshot.generation
+            require(currentGeneration < Long.MAX_VALUE) { "Profile Auto Identity generation exhausted" }
+            val nextGeneration = currentGeneration + 1
+            val content =
+                buildString {
+                    append("version=").append(FORMAT_VERSION).append('\n')
+                    append("generation=").append(nextGeneration).append('\n')
+                    append("updated_at_ms=").append(nowMs).append('\n')
+                    allowedKeys.forEach { key -> append(key).append('=').append(updates.getValue(key)).append('\n') }
+                }
+            SafeConfigStore.writeText(configDir, FILE_NAME, content, MAX_BYTES)
+            snapshot = Snapshot(nextGeneration, nowMs, updates.toMap())
+            Logger.i("Profile Auto Identity snapshot updated (generation=$nextGeneration)")
         }.onFailure { error ->
             Logger.e("Failed to persist Profile Auto Identity snapshot", error)
         }
 
+    @Synchronized
     fun load(configDir: File): Result<Unit> =
         runCatching {
-            requireSafeRoot(configDir)
-            val file = File(configDir, FILE_NAME)
-            val path = file.toPath()
-            if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
-                values = emptyMap()
+            val text = SafeConfigStore.readText(configDir, FILE_NAME, MAX_BYTES)
+            if (text == null) {
+                snapshot = Snapshot(0, 0, emptyMap())
                 return@runCatching
             }
-            requireSafeFile(file)
-            val parsed = LinkedHashMap<String, String>()
-            readUtf8FileSnapshotBounded(file, 0, MAX_BYTES).lineSequence().forEach { line ->
-                val trimmed = line.trim()
-                if (trimmed.isEmpty() || trimmed.startsWith("#")) return@forEach
-                val separator = trimmed.indexOf('=')
-                require(separator in 1 until trimmed.lastIndex) { "Invalid Profile Auto Identity entry" }
-                val key = trimmed.substring(0, separator).trim()
-                val value = trimmed.substring(separator + 1).trim()
-                require(key in allowedKeys) { "Unsupported Profile Auto Identity field" }
-                require(Config.isValidBuildVarEntry(key, value)) { "Invalid Profile Auto Identity field" }
-                require(!parsed.containsKey(key)) { "Duplicate Profile Auto Identity field" }
-                require(parsed.size < MAX_ENTRIES) { "Too many Profile Auto Identity fields" }
-                parsed[key] = value
-            }
-            validateEntries(parsed)
-            values = parsed.toMap()
+            val parsed = parse(text)
+            snapshot = parsed
         }.onFailure { error ->
-            values = emptyMap()
+            snapshot = Snapshot(0, 0, emptyMap())
             Logger.e("Failed to load Profile Auto Identity snapshot; profile Auto Identity is unavailable", error)
         }
+
+    private fun parse(text: String): Snapshot {
+        val raw = LinkedHashMap<String, String>()
+        text.lineSequence().forEach { line ->
+            val trimmed = line.trim()
+            if (trimmed.isEmpty() || trimmed.startsWith("#")) return@forEach
+            val separator = trimmed.indexOf('=')
+            require(separator in 1 until trimmed.lastIndex) { "Invalid Profile Auto Identity entry" }
+            val key = trimmed.substring(0, separator).trim()
+            val value = trimmed.substring(separator + 1).trim()
+            require(raw.put(key, value) == null) { "Duplicate Profile Auto Identity field" }
+            require(raw.size <= MAX_ENTRIES) { "Too many Profile Auto Identity fields" }
+        }
+
+        val isVersioned = raw.containsKey("version")
+        val generation: Long
+        val updatedAtMs: Long
+        if (isVersioned) {
+            require(raw.remove("version") == FORMAT_VERSION.toString()) { "Unsupported Profile Auto Identity version" }
+            generation = raw.remove("generation")?.toLongOrNull()?.takeIf { it > 0 } ?: error("Invalid Profile Auto Identity generation")
+            updatedAtMs = raw.remove("updated_at_ms")?.toLongOrNull()?.takeIf { it >= 0 } ?: error("Invalid Profile Auto Identity timestamp")
+        } else {
+            // v1 shipped as only canonical Build key/value lines. Keep it readable for upgrades;
+            // the next refresh writes v2 with an explicit generation.
+            generation = 1
+            updatedAtMs = 0
+        }
+
+        require(raw.keys == allowedKeySet) { "Profile Auto Identity snapshot is incomplete" }
+        validateEntries(raw)
+        val ordered = LinkedHashMap<String, String>()
+        allowedKeys.forEach { key -> ordered[key] = raw.getValue(key) }
+        return Snapshot(generation, updatedAtMs, ordered)
+    }
 
     private fun canonicalEntries(result: AutoIdentityManager.Result): LinkedHashMap<String, String> {
         val entries = LinkedHashMap(result.buildVars())
@@ -96,39 +130,20 @@ internal object ProfileAutoIdentityStore {
             require(release.isNotEmpty()) { "Auto Identity fingerprint does not contain an Android release" }
             entries["RELEASE"] = release
         }
-        return entries
+        val ordered = LinkedHashMap<String, String>()
+        allowedKeys.forEach { key -> entries[key]?.let { ordered[key] = it } }
+        return ordered
     }
 
     private fun validateEntries(entries: Map<String, String>) {
-        require(entries.keys.containsAll(allowedKeys) && entries.size == allowedKeys.size) {
-            "Profile Auto Identity snapshot is incomplete"
-        }
-        require(entries.size <= MAX_ENTRIES) { "Too many Profile Auto Identity fields" }
+        require(entries.keys == allowedKeySet) { "Profile Auto Identity snapshot is incomplete" }
         entries.forEach { (key, value) ->
-            require(key in allowedKeys) { "Unsupported Profile Auto Identity field" }
             require(Config.isValidBuildVarEntry(key, value)) { "Invalid Profile Auto Identity field" }
-        }
-    }
-
-    private fun requireSafeRoot(configDir: File) {
-        val path = configDir.toPath()
-        require(Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS) && !Files.isSymbolicLink(path)) {
-            "Profile Auto Identity configuration root is unsafe"
-        }
-    }
-
-    private fun requireSafeFile(file: File) {
-        val path = file.toPath()
-        require(!Files.isSymbolicLink(path)) { "Profile Auto Identity snapshot must not be a symbolic link" }
-        if (Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
-            require(Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
-                "Profile Auto Identity snapshot must be a regular file"
-            }
         }
     }
 
     @androidx.annotation.VisibleForTesting
     internal fun resetForTesting() {
-        values = emptyMap()
+        snapshot = Snapshot(0, 0, emptyMap())
     }
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/RuntimeDiagnostics.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/RuntimeDiagnostics.kt
@@ -82,7 +82,7 @@ internal object RuntimeDiagnostics {
                             output.write(buffer, 0, count)
                             total += count
                         }
-                        output.toString(Charsets.UTF_8)
+                        String(output.toByteArray(), Charsets.UTF_8)
                     } finally {
                         buffer.fill(0)
                         output.reset()

--- a/service/src/main/java/cleveres/tricky/cleverestech/RuntimeDiagnostics.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/RuntimeDiagnostics.kt
@@ -1,0 +1,121 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.keystore.CertHack
+import org.json.JSONObject
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.IOException
+import java.util.concurrent.FutureTask
+import java.util.concurrent.TimeUnit
+
+internal object RuntimeDiagnostics {
+    private const val MAX_LOG_BYTES = 1024 * 1024
+    private const val MAX_LOG_LINES = 2500
+    private const val MAX_NATIVE_LOG_BYTES = 512L * 1024L
+    private val cleveresMarkers =
+        listOf(
+            "CleveresTricky",
+            "cleverestricky",
+            "cleverestrickyd",
+            "cleverestricky_backend",
+        )
+
+    fun healthJson(root: File): JSONObject {
+        val policy = PolicyState.stateJson()
+        val features = policy.optJSONObject("features") ?: JSONObject()
+        val rollbackAvailable = runCatching { IdentityRuntimeSnapshot.read(root) != null }.getOrDefault(false)
+        return JSONObject()
+            .put("policySource", policy.optString("source", "unknown"))
+            .put("buildIdentity", features.optBoolean("buildIdentity", false))
+            .put("regionIdentity", features.optBoolean("regionIdentity", false))
+            .put("securityPatch", features.optBoolean("securityPatch", false))
+            .put("cronAutoIdentity", CronAutoIdentity.statusJson())
+            .put("identityCoordinator", IdentityCoordinator.diagnosticsJson())
+            .put("profileAutoIdentity", ProfileAutoIdentityStore.diagnosticsJson())
+            .put("rollbackAvailable", rollbackAvailable)
+            .put("keyboxCount", CertHack.getKeyboxSourceCount())
+            .put("keystoreInterceptor", KeystoreInterceptor.isRunning())
+            .put("telephonyInterceptor", TelephonyInterceptor.isRunning())
+    }
+
+    fun cleveresLogs(root: File): String {
+        val logcat = readProcessOutput(arrayOf("logcat", "-d", "-t", "2000"))
+        val filtered =
+            logcat
+                .lineSequence()
+                .filter { line -> cleveresMarkers.any(line::contains) }
+                .takeLastBounded(MAX_LOG_LINES)
+                .joinToString("\n")
+        val native =
+            runCatching { SafeConfigStore.readText(root, "native_runtime.log", MAX_NATIVE_LOG_BYTES) }
+                .getOrNull()
+                .orEmpty()
+                .lineSequence()
+                .takeLastBounded(1000)
+                .joinToString("\n")
+        val combined =
+            buildString {
+                if (filtered.isNotBlank()) append(filtered.trim())
+                if (native.isNotBlank()) {
+                    if (isNotEmpty()) append("\n\n")
+                    append("--- native runtime ---\n")
+                    append(native.trim())
+                }
+            }
+        return if (combined.toByteArray(Charsets.UTF_8).size <= MAX_LOG_BYTES) {
+            combined
+        } else {
+            combined.takeLast(MAX_LOG_BYTES)
+        }
+    }
+
+    private fun readProcessOutput(command: Array<String>): String {
+        val process = ProcessBuilder(*command).redirectErrorStream(true).start()
+        val reader =
+            FutureTask<String> {
+                process.inputStream.use { input ->
+                    val output = ByteArrayOutputStream()
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    try {
+                        var total = 0
+                        while (true) {
+                            val count = input.read(buffer)
+                            if (count < 0) break
+                            if (count == 0) continue
+                            if (count > MAX_LOG_BYTES - total) throw IOException("Log output exceeds bound")
+                            output.write(buffer, 0, count)
+                            total += count
+                        }
+                        output.toString(Charsets.UTF_8)
+                    } finally {
+                        buffer.fill(0)
+                        output.reset()
+                    }
+                }
+            }
+        Thread(reader, "CleveresTricky-LogReader").apply {
+            isDaemon = true
+            start()
+        }
+        return try {
+            if (!process.waitFor(10, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                process.waitFor(1, TimeUnit.SECONDS)
+                throw IOException("logcat timed out")
+            }
+            reader.get(2, TimeUnit.SECONDS)
+        } finally {
+            if (process.isAlive) process.destroyForcibly()
+            if (!reader.isDone) reader.cancel(true)
+        }
+    }
+
+    private fun Sequence<String>.takeLastBounded(limit: Int): List<String> {
+        val buffer = ArrayDeque<String>(limit)
+        for (line in this) {
+            if (buffer.size == limit) buffer.removeFirst()
+            buffer.addLast(line)
+        }
+        return buffer.toList()
+    }
+}

--- a/service/src/main/java/cleveres/tricky/cleverestech/RuntimeDiagnostics.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/RuntimeDiagnostics.kt
@@ -62,11 +62,7 @@ internal object RuntimeDiagnostics {
                     append(native.trim())
                 }
             }
-        return if (combined.toByteArray(Charsets.UTF_8).size <= MAX_LOG_BYTES) {
-            combined
-        } else {
-            combined.takeLast(MAX_LOG_BYTES)
-        }
+        return boundUtf8Tail(combined, MAX_LOG_BYTES)
     }
 
     private fun readProcessOutput(command: Array<String>): String {
@@ -108,6 +104,24 @@ internal object RuntimeDiagnostics {
             if (process.isAlive) process.destroyForcibly()
             if (!reader.isDone) reader.cancel(true)
         }
+    }
+
+    private fun boundUtf8Tail(
+        text: String,
+        maxBytes: Int,
+    ): String {
+        val lines = text.lineSequence().toList()
+        val selected = ArrayDeque<String>()
+        var totalBytes = 0
+        for (index in lines.indices.reversed()) {
+            val line = lines[index]
+            val lineBytes = line.toByteArray(Charsets.UTF_8).size
+            val separatorBytes = if (selected.isEmpty()) 0 else 1
+            if (lineBytes > maxBytes - totalBytes - separatorBytes) break
+            selected.addFirst(line)
+            totalBytes += lineBytes + separatorBytes
+        }
+        return selected.joinToString("\n")
     }
 
     private fun Sequence<String>.takeLastBounded(limit: Int): List<String> {

--- a/service/src/main/java/cleveres/tricky/cleverestech/SafeConfigStore.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SafeConfigStore.kt
@@ -1,0 +1,100 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.util.SecureFile
+import cleveres.tricky.cleverestech.util.readUtf8FileSnapshotBounded
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.LinkOption
+
+/**
+ * Small common owner for root-only module state.
+ *
+ * Callers supply a simple file name and an explicit byte bound. The helper rejects symbolic links,
+ * non-regular files, unsafe roots, and unbounded reads before delegating atomic writes to SecureFile.
+ */
+internal object SafeConfigStore {
+    private const val ROOT_ONLY_FILE_MODE = 384
+    private val safeName = Regex("[A-Za-z0-9][A-Za-z0-9_.-]{0,127}")
+
+    fun preflight(
+        root: File,
+        name: String,
+    ): File {
+        requireSafeRoot(root)
+        require(safeName.matches(name)) { "Unsafe config file name" }
+        val file = File(root, name)
+        val path = file.toPath()
+        if (Files.isSymbolicLink(path)) throw IOException("Config file must not be a symbolic link: $name")
+        if (Files.exists(path, LinkOption.NOFOLLOW_LINKS) && !Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
+            throw IOException("Config file must be regular: $name")
+        }
+        return file
+    }
+
+    fun readText(
+        root: File,
+        name: String,
+        maxBytes: Long,
+        minBytes: Long = 0,
+    ): String? {
+        require(maxBytes >= 0 && minBytes in 0..maxBytes)
+        val file = preflight(root, name)
+        if (!Files.exists(file.toPath(), LinkOption.NOFOLLOW_LINKS)) return null
+        return readUtf8FileSnapshotBounded(file, minBytes, maxBytes)
+    }
+
+    fun writeText(
+        root: File,
+        name: String,
+        content: String,
+        maxBytes: Long,
+    ) {
+        require(maxBytes >= 0)
+        val bytes = content.toByteArray(Charsets.UTF_8)
+        try {
+            require(bytes.size.toLong() <= maxBytes) { "Config content exceeds the $maxBytes-byte limit" }
+            val file = preflight(root, name)
+            SecureFile.writeText(file, content)
+            preflight(root, name)
+        } finally {
+            bytes.fill(0)
+        }
+    }
+
+    fun markerEnabled(
+        root: File,
+        name: String,
+    ): Boolean {
+        val file = preflight(root, name)
+        return Files.isRegularFile(file.toPath(), LinkOption.NOFOLLOW_LINKS)
+    }
+
+    fun setMarker(
+        root: File,
+        name: String,
+        enabled: Boolean,
+    ) {
+        val file = preflight(root, name)
+        if (enabled) {
+            SecureFile.touch(file, ROOT_ONLY_FILE_MODE)
+        } else {
+            Files.deleteIfExists(file.toPath())
+        }
+    }
+
+    fun delete(
+        root: File,
+        name: String,
+    ) {
+        val file = preflight(root, name)
+        Files.deleteIfExists(file.toPath())
+    }
+
+    private fun requireSafeRoot(root: File) {
+        val path = root.toPath()
+        if (Files.isSymbolicLink(path) || !Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+            throw IOException("Config root is unsafe")
+        }
+    }
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/BootPolicyProjectionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/BootPolicyProjectionTest.kt
@@ -1,0 +1,90 @@
+package cleveres.tricky.cleverestech
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+
+class BootPolicyProjectionTest {
+    private lateinit var root: File
+
+    @Before
+    fun setUp() {
+        root = Files.createTempDirectory("boot-policy-projection-test").toFile()
+    }
+
+    @After
+    fun tearDown() {
+        root.deleteRecursively()
+    }
+
+    @Test
+    fun `projection persists only top level boot features`() {
+        val state =
+            JSONObject()
+                .put(
+                    "features",
+                    JSONObject()
+                        .put("buildIdentity", false)
+                        .put("regionIdentity", true)
+                        .put("identityRefresh", false),
+                ).put(
+                    "profiles",
+                    JSONArray().put(
+                        JSONObject()
+                            .put("name", "Active")
+                            .put("enabled", true)
+                            .put("features", JSONObject().put("buildIdentity", true).put("identityRefresh", true)),
+                    ),
+                ).put("activeProfile", "Active")
+
+        BootPolicyProjection.write(root, state)
+
+        assertEquals(
+            BootPolicyProjection.State(buildIdentity = false, regionIdentity = true, identityRefresh = false),
+            BootPolicyProjection.read(root),
+        )
+        val text = File(root, BootPolicyProjection.FILE_NAME).readText()
+        assertEquals("version=1\nbuild=0\nregion=1\nrefresh=0\n", text)
+        assertFalse(text.contains("Active"))
+    }
+
+    @Test
+    fun `malformed or linked projection fails closed`() {
+        val file = File(root, BootPolicyProjection.FILE_NAME)
+        file.writeText("version=1\nbuild=2\nregion=0\nrefresh=0\n")
+        assertNull(BootPolicyProjection.read(root))
+
+        file.delete()
+        val outside = File(root.parentFile, "projection-${System.nanoTime()}")
+        outside.writeText("version=1\nbuild=1\nregion=0\nrefresh=0\n")
+        try {
+            Files.createSymbolicLink(file.toPath(), outside.toPath())
+        } catch (_: UnsupportedOperationException) {
+            outside.delete()
+            return
+        }
+        assertTrue(runCatching { BootPolicyProjection.read(root) }.isFailure)
+        outside.delete()
+    }
+
+    @Test
+    fun `synchronization detects stale projection`() {
+        val state = JSONObject().put("features", JSONObject().put("buildIdentity", true))
+        BootPolicyProjection.write(root, state)
+        assertTrue(BootPolicyProjection.isSynchronized(root, state))
+        assertFalse(
+            BootPolicyProjection.isSynchronized(
+                root,
+                JSONObject().put("features", JSONObject().put("buildIdentity", false)),
+            ),
+        )
+    }
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/ProfileAutoIdentityVersioningTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ProfileAutoIdentityVersioningTest.kt
@@ -1,0 +1,80 @@
+package cleveres.tricky.cleverestech
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+
+class ProfileAutoIdentityVersioningTest {
+    private lateinit var root: File
+
+    @Before
+    fun setUp() {
+        Config.reset()
+        root = Files.createTempDirectory("profile-auto-version-test").toFile()
+        Config.setRootForTesting(root)
+    }
+
+    @After
+    fun tearDown() {
+        root.deleteRecursively()
+        Config.reset()
+    }
+
+    @Test
+    fun `successful saves advance persisted generation`() {
+        assertTrue(ProfileAutoIdentityStore.save(root, result("one"), nowMs = 10).isSuccess)
+        assertEquals(1, ProfileAutoIdentityStore.generation())
+        assertTrue(ProfileAutoIdentityStore.save(root, result("two"), nowMs = 20).isSuccess)
+        assertEquals(2, ProfileAutoIdentityStore.generation())
+        assertEquals(20, ProfileAutoIdentityStore.updatedAtMs())
+
+        ProfileAutoIdentityStore.resetForTesting()
+        assertTrue(ProfileAutoIdentityStore.load(root).isSuccess)
+        assertEquals(2, ProfileAutoIdentityStore.generation())
+        assertEquals("Pixel two", ProfileAutoIdentityStore.get("MODEL"))
+    }
+
+    @Test
+    fun `legacy unversioned snapshot loads and upgrades on next save`() {
+        File(root, ProfileAutoIdentityStore.FILE_NAME).writeText(
+            """
+            BRAND=google
+            DEVICE=tokay
+            PRODUCT=tokay_beta
+            MANUFACTURER=Google
+            MODEL=Pixel Legacy
+            FINGERPRINT=google/tokay_beta/tokay:17/LEGACY/1:user/release-keys
+            RELEASE=17
+            BUILD_ID=LEGACY
+            INCREMENTAL=1
+            TYPE=user
+            TAGS=release-keys
+            SECURITY_PATCH=2026-08-05
+            """.trimIndent() + "\n",
+        )
+        assertTrue(ProfileAutoIdentityStore.load(root).isSuccess)
+        assertEquals(1, ProfileAutoIdentityStore.generation())
+        assertEquals(0, ProfileAutoIdentityStore.updatedAtMs())
+
+        assertTrue(ProfileAutoIdentityStore.save(root, result("new"), nowMs = 30).isSuccess)
+        val text = File(root, ProfileAutoIdentityStore.FILE_NAME).readText()
+        assertTrue(text.startsWith("version=2\ngeneration=2\nupdated_at_ms=30\n"))
+    }
+
+    private fun result(suffix: String): AutoIdentityManager.Result =
+        AutoIdentityManager.Result(
+            model = "Pixel $suffix",
+            product = "tokay_beta",
+            device = "tokay",
+            fingerprint = "google/tokay_beta/tokay:17/BP31.260801.001/$suffix:user/release-keys",
+            buildId = "BP31.260801.001",
+            incremental = suffix,
+            release = "17",
+            securityPatch = "2026-08-05",
+            securityPatchEstimated = false,
+        )
+}


### PR DESCRIPTION
Refactor Identity into a single coordinator, separate global/profile persistence, add rollback/boot-aware snapshots, bounded scheduler/backoff, typed diagnostics API, safe config/projection boundaries, and move privileged/stateful work toward the existing Rust secure-fs/backend boundary. Follow-up work will keep framework-only lifecycle in Kotlin and portable/security-sensitive parsing/state logic in Rust.