### PR TITLE
Reconcile live Identity transitions after policy mutations with pre-capture and off-lock apply

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/IdentityCoordinator.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/IdentityCoordinator.kt
@@ -100,7 +100,11 @@ internal object IdentityCoordinator {
         root: File,
         before: JSONObject,
         after: JSONObject,
-    ): TransitionOutcome {
+        capture: (File, Boolean, Boolean) -> Result<IdentityRuntimeSnapshot.Snapshot> =
+            IdentityRuntimeSnapshot::capture,
+        restoreRuntime: (File, Boolean, Boolean) -> IdentityRuntimeApplier.Result = IdentityRuntimeApplier::restore,
+        applyRuntime: (File) -> IdentityRuntimeApplier.Result = IdentityRuntimeApplier::apply,
+    ): Result<TransitionOutcome> = runCatching {
         val previous = topLevel(before)
         val current = topLevel(after)
         val enableBuild = !previous.build && current.build
@@ -108,29 +112,30 @@ internal object IdentityCoordinator {
         val disableBuild = previous.build && !current.build
         val disableRegion = previous.region && !current.region
         if (!enableBuild && !enableRegion && !disableBuild && !disableRegion) {
-            return TransitionOutcome(rollbackPrepared = true, restore = null, apply = null)
+            return@runCatching TransitionOutcome(rollbackPrepared = true, restore = null, apply = null)
         }
 
         val rollbackPrepared =
             if (enableBuild || enableRegion) {
-                IdentityRuntimeSnapshot.capture(root, enableBuild, enableRegion).isSuccess
+                capture(root, enableBuild, enableRegion).getOrThrow()
+                true
             } else {
                 true
             }
         val restore =
             if (disableBuild || disableRegion) {
-                IdentityRuntimeApplier.restore(root, disableBuild, disableRegion)
+                restoreRuntime(root, disableBuild, disableRegion)
             } else {
                 null
             }
         val apply =
             if (current.build || current.region) {
-                IdentityRuntimeApplier.apply(root)
+                applyRuntime(root)
             } else {
                 null
             }
         lastRuntime = apply ?: restore
-        return TransitionOutcome(rollbackPrepared, restore, apply)
+        TransitionOutcome(rollbackPrepared, restore, apply)
     }
 
     fun diagnosticsJson(): JSONObject =

--- a/service/src/main/java/cleveres/tricky/cleverestech/PolicyApi.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/PolicyApi.kt
@@ -62,6 +62,10 @@ internal object PolicyApi {
             synchronizeCompatibility = { state ->
                 LegacyIdentityMarkers.syncFromPolicyState(Config.getConfigRoot(), state)
             },
+            captureBefore = { JSONObject(PolicyState.stateJson().toString()) },
+            reconcileRuntime = { previousState, resultingState ->
+                IdentityCoordinator.reconcilePolicyTransition(Config.getConfigRoot(), previousState, resultingState)
+            },
         ).fold(
             onSuccess = { result ->
                 if (result.compatibilitySync == CompatibilitySyncStatus.PENDING) {
@@ -163,6 +167,20 @@ internal object PolicyApi {
                 "compatibilityWarning",
                 "Policy is saved, but early-boot compatibility markers are not synchronized. Retry before reboot by reloading this view.",
             )
+        }
+        result.runtimeTransition?.let { transition ->
+            response.put("runtimeTransition", transition.toJson())
+        }
+        result.runtimeTransitionError?.let { error ->
+            response.put(
+                "runtimeTransition",
+                JSONObject().put("rebootRequired", true).put("error", "snapshot_unavailable"),
+            )
+            response.put(
+                "runtimeWarning",
+                "Policy is saved, but live Identity changes were not applied because the rollback snapshot failed. Reboot is required.",
+            )
+            Logger.e("Policy state saved but live Identity transition could not be prepared", error)
         }
         return response
     }

--- a/service/src/main/java/cleveres/tricky/cleverestech/PolicyMutationCoordinator.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/PolicyMutationCoordinator.kt
@@ -15,6 +15,8 @@ internal data class PolicyMutationResult(
     val compatibilitySync: CompatibilitySyncStatus,
     val compatibilityError: Throwable? = null,
     val previousState: JSONObject? = null,
+    val runtimeTransition: IdentityCoordinator.TransitionOutcome? = null,
+    val runtimeTransitionError: Throwable? = null,
 )
 
 /**
@@ -23,34 +25,57 @@ internal data class PolicyMutationResult(
  * out of order relative to the V2 state that produced them.
  */
 internal object PolicyMutationCoordinator {
+    /* Serializes complete policy-to-runtime transitions without holding PolicyState's monitor over I/O. */
+    private val transitionLock = Any()
+
     fun mutate(
         preflight: () -> Unit,
         mutation: () -> Result<JSONObject>,
         synchronizeCompatibility: (JSONObject) -> Result<Unit>,
         captureBefore: (() -> JSONObject)? = null,
+        reconcileRuntime:
+            ((previous: JSONObject, resulting: JSONObject) -> Result<IdentityCoordinator.TransitionOutcome>)? = null,
     ): Result<PolicyMutationResult> =
-        synchronized(PolicyState) {
-            val previous =
-                try {
-                    captureBefore?.invoke()
-                } catch (error: Throwable) {
-                    return@synchronized Result.failure(error)
-                }
-            try {
-                preflight()
-            } catch (error: Throwable) {
-                return@synchronized Result.failure(CompatibilityPreflightException(error))
-            }
+        synchronized(transitionLock) {
+            val committed =
+                synchronized(PolicyState) {
+                    val previous =
+                        try {
+                            captureBefore?.invoke()
+                        } catch (error: Throwable) {
+                            return@synchronized Result.failure(error)
+                        }
+                    try {
+                        preflight()
+                    } catch (error: Throwable) {
+                        return@synchronized Result.failure(CompatibilityPreflightException(error))
+                    }
 
-            runCatching { mutation().getOrThrow() }.map { state ->
-                val compatibilityResult = runCatching { synchronizeCompatibility(state).getOrThrow() }
-                PolicyMutationResult(
-                    state = state,
-                    compatibilitySync =
-                        if (compatibilityResult.isSuccess) CompatibilitySyncStatus.OK else CompatibilitySyncStatus.PENDING,
-                    compatibilityError = compatibilityResult.exceptionOrNull(),
-                    previousState = previous,
-                )
+                    runCatching { mutation().getOrThrow() }.map { state ->
+                        val compatibilityResult = runCatching { synchronizeCompatibility(state).getOrThrow() }
+                        PolicyMutationResult(
+                            state = state,
+                            compatibilitySync =
+                                if (compatibilityResult.isSuccess) {
+                                    CompatibilitySyncStatus.OK
+                                } else {
+                                    CompatibilitySyncStatus.PENDING
+                                },
+                            compatibilityError = compatibilityResult.exceptionOrNull(),
+                            previousState = previous,
+                        )
+                    }
+                }
+            committed.map { result ->
+                val previous = result.previousState
+                if (previous == null || reconcileRuntime == null) {
+                    result
+                } else {
+                    reconcileRuntime(previous, result.state).fold(
+                        onSuccess = { transition -> result.copy(runtimeTransition = transition) },
+                        onFailure = { error -> result.copy(runtimeTransitionError = error) },
+                    )
+                }
             }
         }
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/PolicyMutationCoordinatorTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/PolicyMutationCoordinatorTest.kt
@@ -246,4 +246,169 @@ class PolicyMutationCoordinatorTest {
         assertTrue(result.exceptionOrNull() is CompatibilityPreflightException)
         assertFalse(mutated)
     }
+
+    @Test
+    fun `enable transition captures its group before applying live identity`() {
+        val calls = mutableListOf<String>()
+        val result =
+            IdentityCoordinator.reconcilePolicyTransition(
+                root = java.io.File("."),
+                before = policyState(build = false, region = false),
+                after = policyState(build = true, region = false),
+                capture = { _, build, region ->
+                    calls += "capture:$build:$region"
+                    Result.success(snapshot())
+                },
+                applyRuntime = {
+                    calls += "apply"
+                    runtimeResult()
+                },
+            )
+
+        assertTrue(result.isSuccess)
+        assertEquals(listOf("capture:true:false", "apply"), calls)
+    }
+
+    @Test
+    fun `region enable captures only the region group before applying live identity`() {
+        val calls = mutableListOf<String>()
+        val result =
+            IdentityCoordinator.reconcilePolicyTransition(
+                root = java.io.File("."),
+                before = policyState(build = false, region = false),
+                after = policyState(build = false, region = true),
+                capture = { _, build, region ->
+                    calls += "capture:$build:$region"
+                    Result.success(snapshot())
+                },
+                applyRuntime = {
+                    calls += "apply"
+                    runtimeResult()
+                },
+            )
+
+        assertTrue(result.isSuccess)
+        assertEquals(listOf("capture:false:true", "apply"), calls)
+    }
+
+    @Test
+    fun `disable transition restores only its group`() {
+        val calls = mutableListOf<String>()
+        val result =
+            IdentityCoordinator.reconcilePolicyTransition(
+                root = java.io.File("."),
+                before = policyState(build = true, region = true),
+                after = policyState(build = false, region = true),
+                restoreRuntime = { _, build, region ->
+                    calls += "restore:$build:$region"
+                    runtimeResult()
+                },
+                applyRuntime = {
+                    calls += "apply"
+                    runtimeResult()
+                },
+            )
+
+        assertTrue(result.isSuccess)
+        assertEquals(listOf("restore:true:false", "apply"), calls)
+    }
+
+    @Test
+    fun `snapshot capture failure skips live apply and preserves committed compatibility response`() {
+        var liveApplyCalled = false
+        val result =
+            PolicyMutationCoordinator.mutate(
+                preflight = {},
+                captureBefore = { policyState(build = false, region = false) },
+                mutation = { Result.success(policyState(build = true, region = false)) },
+                synchronizeCompatibility = { Result.success(Unit) },
+                reconcileRuntime = { before, after ->
+                    IdentityCoordinator.reconcilePolicyTransition(
+                        java.io.File("."),
+                        before,
+                        after,
+                        capture = { _, _, _ -> Result.failure(IOException("snapshot failed")) },
+                        applyRuntime = {
+                            liveApplyCalled = true
+                            runtimeResult()
+                        },
+                    )
+                },
+            )
+
+        assertTrue(result.isSuccess)
+        assertFalse(liveApplyCalled)
+        val response = PolicyApi.mutationResponse(result.getOrThrow())
+        assertEquals("ok", response.getString("compatibilitySync"))
+        assertTrue(response.getJSONObject("runtimeTransition").getBoolean("rebootRequired"))
+        assertTrue(response.getString("runtimeWarning").contains("Policy is saved"))
+    }
+
+    @Test
+    fun `compatibility refresh failure after persistence does not turn committed mutation into failure`() {
+        val result =
+            PolicyMutationCoordinator.mutate(
+                preflight = {},
+                captureBefore = { policyState(build = false, region = false) },
+                mutation = { Result.success(policyState(build = true, region = false)) },
+                synchronizeCompatibility = { Result.failure(IOException("presentation refresh failed")) },
+                reconcileRuntime = { _, _ ->
+                    Result.success(IdentityCoordinator.TransitionOutcome(true, null, null))
+                },
+            )
+
+        assertTrue(result.isSuccess)
+        val response = PolicyApi.mutationResponse(result.getOrThrow())
+        assertTrue(response.getJSONObject("features").getBoolean("buildIdentity"))
+        assertEquals("pending", response.getString("compatibilitySync"))
+    }
+
+    @Test
+    fun `runtime reconciliation does not retain the policy monitor`() {
+        val runtimeEntered = CountDownLatch(1)
+        val releaseRuntime = CountDownLatch(1)
+        val policyMonitorAvailable = CountDownLatch(1)
+        val executor = Executors.newFixedThreadPool(2)
+
+        try {
+            val mutation =
+                executor.submit<Result<PolicyMutationResult>> {
+                    PolicyMutationCoordinator.mutate(
+                        preflight = {},
+                        captureBefore = { policyState(build = false, region = false) },
+                        mutation = { Result.success(policyState(build = true, region = false)) },
+                        synchronizeCompatibility = { Result.success(Unit) },
+                        reconcileRuntime = { _, _ ->
+                            runtimeEntered.countDown()
+                            releaseRuntime.await(2, TimeUnit.SECONDS)
+                            Result.success(IdentityCoordinator.TransitionOutcome(true, null, null))
+                        },
+                    )
+                }
+            assertTrue(runtimeEntered.await(2, TimeUnit.SECONDS))
+
+            executor.submit {
+                synchronized(PolicyState) { policyMonitorAvailable.countDown() }
+            }
+            assertTrue(
+                "runtime I/O must run outside the PolicyState monitor",
+                policyMonitorAvailable.await(2, TimeUnit.SECONDS),
+            )
+
+            releaseRuntime.countDown()
+            assertTrue(mutation.get(2, TimeUnit.SECONDS).isSuccess)
+        } finally {
+            releaseRuntime.countDown()
+            executor.shutdownNow()
+        }
+    }
+
+    private fun policyState(build: Boolean, region: Boolean): JSONObject =
+        JSONObject().put("features", JSONObject().put("buildIdentity", build).put("regionIdentity", region))
+
+    private fun runtimeResult(): IdentityRuntimeApplier.Result =
+        IdentityRuntimeApplier.Result(true, false, false, "test")
+
+    private fun snapshot(): IdentityRuntimeSnapshot.Snapshot =
+        IdentityRuntimeSnapshot.Snapshot("00000000-0000-0000-0000-000000000000", true, false, emptyMap())
 }


### PR DESCRIPTION
### Motivation

- Ensure `PolicyApi` captures canonical state before a policy mutation and performs live Identity transitions only after canonical persistence succeeds. 
- Prevent live runtime changes from running under the `PolicyState` monitor to avoid blocking other policy operations and to ensure snapshot capture failures fail closed. 
- Provide observable results for runtime transitions in the mutation response so callers see reboot-required/snapshot-failure conditions without reverting the committed policy state.

### Description

- Add `captureBefore` and `reconcileRuntime` integration points to `PolicyMutationCoordinator.mutate` and wire them from `PolicyApi.mutatePolicy` so the canonical state is snapped before mutation and the live reconciliation is invoked after commit. 
- Change `PolicyMutationCoordinator` to acquire a separate `transitionLock` and perform the runtime reconciliation outside the `PolicyState` synchronized block, preserving commit ordering while avoiding holding the policy monitor during I/O. 
- Extend `PolicyMutationResult` with `runtimeTransition` and `runtimeTransitionError` fields and include runtime outcome/warning information in `PolicyApi.mutationResponse`. 
- Make `IdentityCoordinator.reconcilePolicyTransition` return a `Result<TransitionOutcome>` and call the runtime snapshot capture via an injected `capture` function so capture failures can be reported and prevent subsequent live apply/restore; plumb `restore`/`apply` hooks for testability. 
- Add regression tests in `PolicyMutationCoordinatorTest` that exercise: top-level build/region enable capture-and-apply ordering, group-selective restore on disable, snapshot-capture failure path that skips live apply while preserving committed response, that compatibility refresh failures do not convert a committed mutation to a failure, and that runtime reconciliation does not retain the `PolicyState` monitor.

### Testing

- Added unit/regression tests in `service/src/test/java/cleveres/tricky/cleverestech/PolicyMutationCoordinatorTest.kt` covering the four requested scenarios and an additional concurrency check; these tests are present but were not executed to completion in this environment. 
- Attempted to run the service unit tests with `./gradlew :service:testDebugUnitTest --tests 'cleveres.tricky.cleverestech.PolicyMutationCoordinatorTest'`, but the Gradle configuration failed early because the Android SDK location was not available in the environment (missing `ANDROID_HOME`/`local.properties`), so the JVM unit tests could not be run here. 
- Performed local verification checks including `git diff --check` and staged-diff checks; no diff-check issues were reported locally.