### PR TITLE
🧪 Add unit test for configureCacheRoot

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierTest.kt
@@ -9,6 +9,7 @@ import java.security.cert.X509Certificate
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Test
+import java.io.File
 import org.mockito.Mockito
 
 class KeyboxVerifierTest {
@@ -144,5 +145,19 @@ class KeyboxVerifierTest {
         } finally {
             configDir.deleteRecursively()
         }
+    }
+
+    @Test
+    fun `configureCacheRoot sets cacheRoot directory`() {
+        val newCacheDir = File("/test/cache/dir")
+        KeyboxVerifier.configureCacheRoot(newCacheDir)
+
+        val cacheRootField = KeyboxVerifier::class.java.getDeclaredField("cacheRoot")
+        cacheRootField.isAccessible = true
+        val actualCacheRoot = cacheRootField.get(KeyboxVerifier) as File
+
+        assertEquals(newCacheDir, actualCacheRoot)
+
+        KeyboxVerifier.resetCacheRootForTesting()
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Added a unit test for the previously untested `configureCacheRoot` function in `KeyboxVerifier.kt`.
📊 **Coverage:** What scenarios are now tested: The test ensures that setting a new cache root directory behaves as expected and updates the internal field securely via reflection.
✨ **Result:** The improvement in test coverage: Improved test coverage and reliability for foundational utility functions.

---
*PR created automatically by Jules for task [12166444414559293327](https://jules.google.com/task/12166444414559293327) started by @tryigit*