### PR TITLE
🧪 Add tests for KeyboxVerifier.isSafeKeyboxFile

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -512,7 +512,8 @@ object KeyboxVerifier {
             Result(file, file.name, Status.ERROR, "Error: ${error.javaClass.simpleName}", storageId)
         }
 
-    private fun isSafeKeyboxFile(file: File): Boolean =
+    @androidx.annotation.VisibleForTesting
+    internal fun isSafeKeyboxFile(file: File): Boolean =
         Files.isRegularFile(file.toPath(), LinkOption.NOFOLLOW_LINKS) &&
             file.length() in 1..MAX_KEYBOX_XML_BYTES
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierTest.kt
@@ -145,4 +145,64 @@ class KeyboxVerifierTest {
             configDir.deleteRecursively()
         }
     }
+
+    @Test
+    fun `isSafeKeyboxFile returns true for valid file`() {
+        val file = Files.createTempFile("keybox", ".xml").toFile()
+        try {
+            file.writeText("valid content")
+            assertEquals(true, KeyboxVerifier.isSafeKeyboxFile(file))
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun `isSafeKeyboxFile returns false for empty file`() {
+        val file = Files.createTempFile("keybox", ".xml").toFile()
+        try {
+            assertEquals(false, KeyboxVerifier.isSafeKeyboxFile(file))
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun `isSafeKeyboxFile returns false for oversized file`() {
+        val file = Files.createTempFile("keybox", ".xml").toFile()
+        try {
+            val randomAccessFile = java.io.RandomAccessFile(file, "rw")
+            randomAccessFile.setLength(10L * 1024 * 1024 + 1)
+            randomAccessFile.close()
+            assertEquals(false, KeyboxVerifier.isSafeKeyboxFile(file))
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun `isSafeKeyboxFile returns false for directory`() {
+        val dir = Files.createTempDirectory("keybox_dir").toFile()
+        try {
+            assertEquals(false, KeyboxVerifier.isSafeKeyboxFile(dir))
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `isSafeKeyboxFile returns false for symlink`() {
+        val target = Files.createTempFile("target", ".xml").toFile()
+        val link = java.nio.file.Paths.get(target.parent, "symlink.xml")
+        try {
+            target.writeText("valid content")
+            Files.createSymbolicLink(link, target.toPath())
+            assertEquals(false, KeyboxVerifier.isSafeKeyboxFile(link.toFile()))
+        } catch (e: UnsupportedOperationException) {
+            // Symlinks not supported on this OS/filesystem
+        } finally {
+            Files.deleteIfExists(link)
+            target.delete()
+        }
+    }
 }


### PR DESCRIPTION
🎯 What: The testing gap in KeyboxVerifier.isSafeKeyboxFile is addressed by exposing the method for testing.

📊 Coverage: Scenarios tested include valid files, empty files, oversized files, directories, and symlinks.

✨ Result: Increased test coverage and confidence when handling keybox files.

---
*PR created automatically by Jules for task [9114755845735916780](https://jules.google.com/task/9114755845735916780) started by @tryigit*