### PR TITLE
🧹 Remove redundant CertHack.canHack() check

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -59,12 +59,11 @@ class SecurityLevelInterceptor : BinderInterceptor() {
     ): Result {
         // The native hook only sends POST_TRANSACT after PRE_TRANSACT returned Continue.
         // Target scope was therefore already resolved above; do not repeat Config.needHack()
-        // on the latency-sensitive generateKey reply path.
+        // or CertHack.canHack() on the latency-sensitive generateKey reply path.
         if (
             code != generateKeyTransaction ||
             reply == null ||
-            resultCode != 0 ||
-            !CertHack.canHack()
+            resultCode != 0
         ) {
             return Skip
         }


### PR DESCRIPTION
🎯 **What:** Removed the redundant `CertHack.canHack()` check in `SecurityLevelInterceptor.onPostTransact`.
💡 **Why:** The comment above explicitly says: "The native hook only sends POST_TRANSACT after PRE_TRANSACT returned Continue." Since `onPreTransact` already ensures `CertHack.canHack()` is true, there is no need to repeat it in `onPostTransact`, reducing redundant latency-sensitive operations.
✅ **Verification:** Ran `./gradlew :service:testDebugUnitTest`. The tests passed successfully (ignoring the pre-existing `WebServerUXTest.testMobileAndSettingContracts` failure). Code review was requested and the single minor logging regression was addressed before commit.
✨ **Result:** Improved maintainability and reduced redundant operations on a latency-sensitive path.

---
*PR created automatically by Jules for task [14127527375579471946](https://jules.google.com/task/14127527375579471946) started by @tryigit*