### PR TITLE
🧪 test: Add unit test for resetCrlUrlForTesting

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierTest.kt
@@ -129,6 +129,40 @@ class KeyboxVerifierTest {
         }
     }
 
+
+    @Test
+    fun `resetCrlUrlForTesting resets URL and clears cache`() {
+        val crlUrlField = KeyboxVerifier::class.java.getDeclaredField("crlUrl")
+        crlUrlField.isAccessible = true
+
+        val cachedCrlField = KeyboxVerifier::class.java.getDeclaredField("cachedCrl")
+        cachedCrlField.isAccessible = true
+
+        val cachedEtagField = KeyboxVerifier::class.java.getDeclaredField("cachedEtag")
+        cachedEtagField.isAccessible = true
+
+        val lastFetchTimeField = KeyboxVerifier::class.java.getDeclaredField("lastFetchTime")
+        lastFetchTimeField.isAccessible = true
+
+        try {
+            KeyboxVerifier.setCrlUrlForTesting("http://127.0.0.1:1234")
+
+            val dummyHandle = cleveres.tricky.cleverestech.CrlWire.Handle(1L, 1, 1)
+            cachedCrlField.set(KeyboxVerifier, dummyHandle)
+            cachedEtagField.set(KeyboxVerifier, "dummy-etag")
+            lastFetchTimeField.set(KeyboxVerifier, 123456789L)
+
+            KeyboxVerifier.resetCrlUrlForTesting()
+
+            assertEquals(KeyboxVerifier::class.java.getDeclaredField("DEFAULT_CRL_URL").apply { isAccessible = true }.get(null) as String, crlUrlField.get(KeyboxVerifier))
+            assertEquals(null, cachedCrlField.get(KeyboxVerifier))
+            assertEquals(null, cachedEtagField.get(KeyboxVerifier))
+            assertEquals(0L, lastFetchTimeField.get(KeyboxVerifier))
+        } finally {
+            KeyboxVerifier.resetCrlUrlForTesting()
+        }
+    }
+
     @Test
     fun `verify rejects keybox directories above the file limit`() {
         val configDir = Files.createTempDirectory("keybox-verifier-limit").toFile()


### PR DESCRIPTION
🎯 **What:** Added missing unit test for the `resetCrlUrlForTesting` function in `KeyboxVerifier.kt` to fix a testing coverage gap.
📊 **Coverage:** The new test verifies that `resetCrlUrlForTesting()` correctly resets the `crlUrl` to its default value and clears internal cache state variables (`cachedCrl`, `cachedEtag`, `lastFetchTime`).
✨ **Result:** Increased testing coverage and confidence that this utility testing function behaves correctly without unintended side effects on cache state.

---
*PR created automatically by Jules for task [13126858335432084599](https://jules.google.com/task/13126858335432084599) started by @tryigit*