### PR TITLE
🧹 Extract magic byte array to constant in UtilsLeafFastPathTest

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/UtilsLeafFastPathTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/UtilsLeafFastPathTest.java
@@ -17,6 +17,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 
 public class UtilsLeafFastPathTest {
+    private static final byte[] DUMMY_ISSUER_BYTES = new byte[] {0x01, 0x02, 0x03, 0x04};
+
     private static X509Certificate fixtureCertificate() throws Exception {
         String pem = TestKeyboxFixtures.INSTANCE.getCertificate();
         return (X509Certificate) CertificateFactory.getInstance("X.509")
@@ -29,13 +31,13 @@ public class UtilsLeafFastPathTest {
 
         KeyMetadata metadata = new KeyMetadata();
         metadata.certificate = expected.getEncoded();
-        metadata.certificateChain = new byte[] {0x01, 0x02, 0x03, 0x04};
+        metadata.certificateChain = DUMMY_ISSUER_BYTES;
 
         X509Certificate leaf = Utils.getLeafCertificate(metadata);
 
         assertNotNull(leaf);
         assertArrayEquals(expected.getEncoded(), leaf.getEncoded());
-        assertArrayEquals(new byte[] {0x01, 0x02, 0x03, 0x04}, metadata.certificateChain);
+        assertArrayEquals(DUMMY_ISSUER_BYTES, metadata.certificateChain);
     }
 
     @Test


### PR DESCRIPTION
🎯 **What:** Extracted the magic byte array {0x01, 0x02, 0x03, 0x04} to a static constant DUMMY_ISSUER_BYTES in UtilsLeafFastPathTest.java.
💡 **Why:** Addresses a code health issue. While the initial report of an 'Unused method parameter' was a false positive for the leafOnlyParserIgnoresUnusedIssuerBytes method, extracting the duplicated dummy array into a well-named constant improves the readability and maintainability of the test file.
✅ **Verification:** Ran the full test suite using ./gradlew :service:testDebugUnitTest, ensuring the test passes and no regressions are introduced.
✨ **Result:** Cleaner test code without magic array duplication.

---
*PR created automatically by Jules for task [2345691608200268857](https://jules.google.com/task/2345691608200268857) started by @tryigit*