### PR TITLE
🧹 [Code Health] Refactor test dummy instantiations of NanoHTTPD.IHTTPSession into reusable mock

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/MockIHTTPSession.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/MockIHTTPSession.kt
@@ -1,0 +1,48 @@
+package cleveres.tricky.cleverestech
+
+import fi.iki.elonen.NanoHTTPD
+import fi.iki.elonen.NanoHTTPD.Method
+import fi.iki.elonen.NanoHTTPD.CookieHandler
+import java.io.InputStream
+
+open class MockIHTTPSession(
+    private val uri: String = "/",
+    private val method: Method = Method.GET,
+    private val headers: Map<String, String> = mapOf("host" to "localhost"),
+    private val parms: Map<String, String> = emptyMap(),
+    private val parameters: Map<String, List<String>> = emptyMap(),
+    private val inputStream: InputStream? = null,
+    private val queryParameterString: String = "",
+    private val remoteIpAddress: String = "127.0.0.1",
+    private val remoteHostName: String = "localhost"
+) : NanoHTTPD.IHTTPSession {
+
+    override fun execute() {}
+
+    override fun getCookies(): CookieHandler? = null
+
+    @Deprecated("Deprecated by NanoHTTPD")
+    override fun getHeaders(): Map<String, String> = headers
+
+    override fun getInputStream(): InputStream? = inputStream
+
+    override fun getMethod(): Method = method
+
+    @Deprecated("Use getParameters")
+    override fun getParms(): Map<String, String> = parms
+
+    override fun getParameters(): Map<String, List<String>> = parameters
+
+    @Deprecated("Deprecated by NanoHTTPD")
+    override fun getQueryParameterString(): String = queryParameterString
+
+    override fun getUri(): String = uri
+
+    override fun parseBody(files: MutableMap<String, String>?) {}
+
+    @Deprecated("Deprecated by NanoHTTPD")
+    override fun getRemoteIpAddress(): String = remoteIpAddress
+
+    @Deprecated("Deprecated by NanoHTTPD")
+    override fun getRemoteHostName(): String = remoteHostName
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerCsrfTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerCsrfTest.kt
@@ -12,42 +12,17 @@ class WebServerCsrfTest {
         host: String,
         origin: String,
     ): NanoHTTPD.IHTTPSession {
-        return object : NanoHTTPD.IHTTPSession {
-            override fun execute() {}
-
-            override fun getCookies() = null
-
-            @Deprecated("Deprecated by NanoHTTPD")
-            override fun getHeaders() =
-                mapOf(
-                    "host" to host,
-                    "origin" to origin,
-                    "content-length" to "0",
-                )
-
-            override fun getInputStream() = null
-
-            override fun getMethod() = NanoHTTPD.Method.POST
-
-            @Deprecated("Use getParameters")
-
-            override fun getParms() = mapOf("token" to server.token)
-
-            @Deprecated("Deprecated by NanoHTTPD")
-            override fun getQueryParameterString() = ""
-
-            override fun getUri() = "/api/config"
-
-            override fun parseBody(files: Map<String, String>?) {}
-
-            @Deprecated("Deprecated by NanoHTTPD")
-            override fun getRemoteIpAddress() = "127.0.0.1"
-
-            @Deprecated("Deprecated by NanoHTTPD")
-            override fun getRemoteHostName() = "localhost"
-
-            override fun getParameters(): Map<String, List<String>> = mapOf("token" to listOf("testtoken"))
-        }
+        return MockIHTTPSession(
+            uri = "/api/config",
+            method = NanoHTTPD.Method.POST,
+            headers = mapOf(
+                "host" to host,
+                "origin" to origin,
+                "content-length" to "0",
+            ),
+            parms = mapOf("token" to server.token),
+            parameters = mapOf("token" to listOf("testtoken"))
+        )
     }
 
     @Test

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerPolicySecurityTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerPolicySecurityTest.kt
@@ -13,36 +13,11 @@ class WebServerPolicySecurityTest {
         uri: String,
         contentLength: String = "0",
     ): NanoHTTPD.IHTTPSession =
-        object : NanoHTTPD.IHTTPSession {
-            override fun execute() {}
-
-            override fun getCookies() = null
-
-            @Deprecated("Deprecated by NanoHTTPD")
-            override fun getHeaders() = mapOf("host" to "localhost", "content-length" to contentLength)
-
-            override fun getInputStream(): InputStream? = null
-
-            override fun getMethod() = method
-
-            @Deprecated("Use getParameters")
-            override fun getParms(): Map<String, String> = emptyMap()
-
-            override fun getParameters(): Map<String, List<String>> = emptyMap()
-
-            @Deprecated("Deprecated by NanoHTTPD")
-            override fun getQueryParameterString() = ""
-
-            override fun getUri() = uri
-
-            override fun parseBody(files: MutableMap<String, String>?) {}
-
-            @Deprecated("Deprecated by NanoHTTPD")
-            override fun getRemoteIpAddress() = "127.0.0.1"
-
-            @Deprecated("Deprecated by NanoHTTPD")
-            override fun getRemoteHostName() = "localhost"
-        }
+        MockIHTTPSession(
+            uri = uri,
+            method = method,
+            headers = mapOf("host" to "localhost", "content-length" to contentLength)
+        )
 
     @Test
     fun `policy route retains common tamper protection on native bridge`() {

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerSaveValidationTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerSaveValidationTest.kt
@@ -66,42 +66,16 @@ class WebServerSaveValidationTest {
         filename: String,
         content: String,
     ): NanoHTTPD.IHTTPSession {
-        return object : NanoHTTPD.IHTTPSession {
-            override fun execute() {}
-
-            override fun getCookies() = null
-
-            @Deprecated("Deprecated by NanoHTTPD")
-            override fun getHeaders() = mapOf("content-length" to "100", "host" to "localhost")
-
-            override fun getInputStream(): InputStream? = null
-
-            override fun getMethod() = NanoHTTPD.Method.POST
-
-            @Deprecated("Use getParameters")
-
-            override fun getParms() =
-                mapOf(
-                    "token" to webServer.token,
-                    "filename" to filename,
-                    "content" to content,
-                )
-
-            override fun getParameters(): Map<String, List<String>> = emptyMap<String, List<String>>()
-
-            @Deprecated("Deprecated by NanoHTTPD")
-            override fun getQueryParameterString() = ""
-
-            override fun getUri() = "/api/save"
-
-            override fun parseBody(files: MutableMap<String, String>?) {}
-
-            @Deprecated("Deprecated by NanoHTTPD")
-            override fun getRemoteIpAddress() = "127.0.0.1"
-
-            @Deprecated("Deprecated by NanoHTTPD")
-            override fun getRemoteHostName() = "localhost"
-        }
+        return MockIHTTPSession(
+            uri = "/api/save",
+            method = NanoHTTPD.Method.POST,
+            headers = mapOf("content-length" to "100", "host" to "localhost"),
+            parms = mapOf(
+                "token" to webServer.token,
+                "filename" to filename,
+                "content" to content,
+            )
+        )
     }
 
     @Test

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerStoredXssTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerStoredXssTest.kt
@@ -66,38 +66,11 @@ class WebServerStoredXssTest {
         val maliciousContent = "com.example <svg/onload=alert(1)> null"
         File(configDir, "app_config").writeText(maliciousContent)
 
-        val session =
-            object : NanoHTTPD.IHTTPSession {
-                override fun execute() {}
-
-                override fun getCookies() = null
-
-                @Deprecated("Deprecated by NanoHTTPD")
-                override fun getHeaders() = mapOf("host" to "localhost")
-
-                override fun getInputStream(): InputStream? = null
-
-                override fun getMethod() = NanoHTTPD.Method.GET
-
-                @Deprecated("Use getParameters")
-
-                override fun getParms() = mapOf("token" to webServer.token)
-
-                override fun getParameters(): Map<String, List<String>> = emptyMap<String, List<String>>()
-
-                @Deprecated("Deprecated by NanoHTTPD")
-                override fun getQueryParameterString() = ""
-
-                override fun getUri() = "/api/app_config_structured"
-
-                override fun parseBody(files: MutableMap<String, String>?) {}
-
-                @Deprecated("Deprecated by NanoHTTPD")
-                override fun getRemoteIpAddress() = "127.0.0.1"
-
-                @Deprecated("Deprecated by NanoHTTPD")
-                override fun getRemoteHostName() = "localhost"
-            }
+        val session = MockIHTTPSession(
+            uri = "/api/app_config_structured",
+            method = NanoHTTPD.Method.GET,
+            parms = mapOf("token" to webServer.token)
+        )
 
         val response = webServer.serve(session)
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerXssTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerXssTest.kt
@@ -65,38 +65,12 @@ class WebServerXssTest {
         val xssPayload = "<svg/onload=alert(1)>"
         val jsonPayload = "[{\"package\": \"$xssPayload\", \"template\": \"null\", \"keybox\": \"null\"}]"
 
-        val session =
-            object : NanoHTTPD.IHTTPSession {
-                override fun execute() {}
-
-                override fun getCookies() = null
-
-                @Deprecated("Deprecated by NanoHTTPD")
-                override fun getHeaders() = mapOf("content-length" to jsonPayload.length.toString(), "host" to "localhost")
-
-                override fun getInputStream(): InputStream? = null
-
-                override fun getMethod() = NanoHTTPD.Method.POST
-
-                @Deprecated("Use getParameters")
-
-                override fun getParms() = mapOf("token" to webServer.token, "data" to jsonPayload)
-
-                override fun getParameters(): Map<String, List<String>> = emptyMap<String, List<String>>()
-
-                @Deprecated("Deprecated by NanoHTTPD")
-                override fun getQueryParameterString() = ""
-
-                override fun getUri() = "/api/app_config_structured"
-
-                override fun parseBody(files: MutableMap<String, String>?) {}
-
-                @Deprecated("Deprecated by NanoHTTPD")
-                override fun getRemoteIpAddress() = "127.0.0.1"
-
-                @Deprecated("Deprecated by NanoHTTPD")
-                override fun getRemoteHostName() = "localhost"
-            }
+        val session = MockIHTTPSession(
+            uri = "/api/app_config_structured",
+            method = NanoHTTPD.Method.POST,
+            headers = mapOf("content-length" to jsonPayload.length.toString(), "host" to "localhost"),
+            parms = mapOf("token" to webServer.token, "data" to jsonPayload)
+        )
 
         val response = webServer.serve(session)
 
@@ -117,38 +91,12 @@ class WebServerXssTest {
 
         val jsonPayload = "[{\"package\": \"$validPkg\", \"template\": \"pixel8pro\", \"keybox\": \"null\"}, {\"package\": \"$wildcardPkg\", \"template\": \"null\", \"keybox\": \"null\", \"privacy\": \"isolate\"}]"
 
-        val session =
-            object : NanoHTTPD.IHTTPSession {
-                override fun execute() {}
-
-                override fun getCookies() = null
-
-                @Deprecated("Deprecated by NanoHTTPD")
-                override fun getHeaders() = mapOf("content-length" to jsonPayload.length.toString(), "host" to "localhost")
-
-                override fun getInputStream(): InputStream? = null
-
-                override fun getMethod() = NanoHTTPD.Method.POST
-
-                @Deprecated("Use getParameters")
-
-                override fun getParms() = mapOf("token" to webServer.token, "data" to jsonPayload)
-
-                override fun getParameters(): Map<String, List<String>> = emptyMap<String, List<String>>()
-
-                @Deprecated("Deprecated by NanoHTTPD")
-                override fun getQueryParameterString() = ""
-
-                override fun getUri() = "/api/app_config_structured"
-
-                override fun parseBody(files: MutableMap<String, String>?) {}
-
-                @Deprecated("Deprecated by NanoHTTPD")
-                override fun getRemoteIpAddress() = "127.0.0.1"
-
-                @Deprecated("Deprecated by NanoHTTPD")
-                override fun getRemoteHostName() = "localhost"
-            }
+        val session = MockIHTTPSession(
+            uri = "/api/app_config_structured",
+            method = NanoHTTPD.Method.POST,
+            headers = mapOf("content-length" to jsonPayload.length.toString(), "host" to "localhost"),
+            parms = mapOf("token" to webServer.token, "data" to jsonPayload)
+        )
 
         val response = webServer.serve(session)
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced repeated anonymous instances of `NanoHTTPD.IHTTPSession` across multiple test classes with a reusable, configurable mock class `MockIHTTPSession`.

💡 **Why:** How this improves maintainability
The interface `NanoHTTPD.IHTTPSession` has numerous deprecated methods, leading to cluttered test code with repetitive suppression tags and boilerplate. Providing a single mock object implementation drastically cleans up the test files, avoids repeating defaults like empty iterators/maps, and consolidates the suppression logic.

✅ **Verification:** How you confirmed the change is safe
Ran `./gradlew :service:testDebugUnitTest` on the modified modules to verify that `MockIHTTPSession` successfully serves the requirements of these tests without modifying application logic. (Also ensured test assets like revisions in unmodified UI tests remained strictly untouched).

✨ **Result:** The improvement achieved
Refactored `WebServerStoredXssTest.kt`, `WebServerCsrfTest.kt`, `WebServerPolicySecurityTest.kt`, `WebServerXssTest.kt`, and `WebServerSaveValidationTest.kt`. Each is now more readable, relying on the clean `MockIHTTPSession`.

---
*PR created automatically by Jules for task [13329650042180770030](https://jules.google.com/task/13329650042180770030) started by @tryigit*