### PR TITLE
fix(webui): mark reboot-required identity settings

### DIFF
--- a/module/template/webroot/bridge.js
+++ b/module/template/webroot/bridge.js
@@ -1119,31 +1119,6 @@
         continueIdentitySaveWrapper(0);
     }
 
-    function installIdentityPolicyTransitionWatcher() {
-        const document = global.document;
-        if (!document || !document.documentElement || document.documentElement.dataset.ctIdentityTransitionWatcher) return;
-        document.documentElement.dataset.ctIdentityTransitionWatcher = '1';
-        document.addEventListener('change', event => {
-            const target = event.target;
-            if (!target || target.type !== 'checkbox') return;
-            const feature = target.dataset && target.dataset.policyFeature;
-            const isBuildOrRegion = feature === 'buildIdentity' || feature === 'regionIdentity';
-            const isMaster = typeof target.id === 'string' && /_identity_master$/.test(target.id);
-            if (!isBuildOrRegion && !isMaster) return;
-            const previous = latestPolicyState && latestPolicyState.features ? latestPolicyState.features : {};
-            const previouslyRuntimeVisible = Boolean(previous.buildIdentity || previous.regionIdentity);
-            global.setTimeout(async () => {
-                try {
-                    const state = await readPolicyState();
-                    const enabled = Boolean(state.features && (state.features.buildIdentity || state.features.regionIdentity));
-                    if (enabled) notifyLiveIdentityResult(await applyIdentityLive(state));
-                    else if (previouslyRuntimeVisible) notifyExtension('Disabling an already applied Build/region identity may require a reboot to restore original properties.', 'error');
-                } catch (_) {
-                }
-            }, 500);
-        }, true);
-    }
-
     function installAutoIdentityOwner() {
         const current = global.applyAutoIdentity;
         if (typeof current !== 'function' || current.ctAutoIdentityOwner) return false;
@@ -1230,7 +1205,6 @@
         installCronAutoIdentity().catch(() => {});
         const logsReady = installLogsOwner() || (typeof global.fetchLogs === 'function' && global.fetchLogs.ctCleveresLogs === true);
         installIdentitySaveWrapper();
-        installIdentityPolicyTransitionWatcher();
         const autoIdentityReady = installAutoIdentityOwner() || (typeof global.applyAutoIdentity === 'function' && global.applyAutoIdentity.ctAutoIdentityOwner === true);
 
         const identityPanel = document.querySelector('#spoof .panel');

--- a/module/template/webroot/policy.js
+++ b/module/template/webroot/policy.js
@@ -55,6 +55,7 @@ let templates = [];
 let selectedProfileIndex = -1;
 let saving = false;
 let savedBuildIdentity = Object.freeze({});
+const REBOOT_POLICY_FEATURES = new Set(['buildIdentity', 'regionIdentity', 'identityRefresh']);
 
 function onReady(fn) {
   // policy.js is loaded at the end of <body>, before the legacy inline bootstrap.
@@ -83,9 +84,12 @@ function policyCompatibilityWarning(state) {
 }
 
 function notifyPolicyMutation(successMessage, state) {
+  const message = successMessage || 'Saved';
   const warning = policyCompatibilityWarning(state);
-  if (warning) notify(`${successMessage || 'Saved'}. Warning: ${warning}`);
-  else notify(successMessage || 'Saved');
+  const runtimeWarning = state && state.runtimeWarning;
+  if (runtimeWarning) notify(`${message}. Warning: ${runtimeWarning}`, 'warning');
+  else if (warning) notify(`${message}. Warning: ${warning}`);
+  else notify(message);
 }
 
 function refreshPresentation() {
@@ -156,16 +160,40 @@ function stateForSave(source) {
   };
 }
 
+function transitionRequiresReboot(transition, feature) {
+  if (!transition || typeof transition !== 'object') return true;
+  if (transition.rebootRequired !== true) return false;
+  const appliedKey = feature === 'buildIdentity' ? 'buildApplied' : 'regionApplied';
+  return ![transition.restore, transition.apply].some(result => result && result[appliedKey] === true);
+}
+
+function reconcilePolicyPendingReboot(previous, next) {
+  const previousFeatures = previous && previous.features ? previous.features : {};
+  const nextFeatures = next && next.features ? next.features : {};
+  REBOOT_POLICY_FEATURES.forEach(feature => {
+    const before = Boolean(previousFeatures[feature]);
+    const after = Boolean(nextFeatures[feature]);
+    if (before === after) return;
+    if (feature === 'identityRefresh' || transitionRequiresReboot(next.runtimeTransition, feature)) {
+      markPendingReboot(`feature:${feature}`);
+    } else {
+      clearPendingReboot(`feature:${feature}`);
+    }
+  });
+}
+
 async function savePolicy(mutator, successMessage) {
   if (!policyState || saving) return;
   saving = true;
   document.documentElement.classList.add('ct-saving');
   try {
+    const previous = safeClone(policyState);
     const next = safeClone(policyState);
     mutator(next);
     const body = new URLSearchParams();
     body.set('data', JSON.stringify(stateForSave(next)));
     policyState = await request('/api/policy_state', {method:'POST', body});
+    reconcilePolicyPendingReboot(previous, policyState);
     renderAll();
     notifyPolicyMutation(successMessage, policyState);
   } catch (error) {
@@ -340,9 +368,16 @@ function markIdentityActionGroups() {
 function getPendingRebootSettings() {
   try {
     const raw = typeof sessionStorage !== 'undefined' && sessionStorage.getItem('ct_pending_reboot');
-    return raw ? new Set(JSON.parse(raw)) : new Set();
+    const parsed = raw ? JSON.parse(raw) : [];
+    return new Set(Array.isArray(parsed) ? parsed.filter(value => typeof value === 'string') : []);
   } catch (e) {
     return new Set();
+  }
+}
+
+function writePendingRebootSettings(pending) {
+  if (typeof sessionStorage !== 'undefined') {
+    sessionStorage.setItem('ct_pending_reboot', JSON.stringify([...pending]));
   }
 }
 
@@ -350,9 +385,15 @@ function markPendingReboot(setting) {
   try {
     const pending = getPendingRebootSettings();
     pending.add(setting);
-    if (typeof sessionStorage !== 'undefined') {
-      sessionStorage.setItem('ct_pending_reboot', JSON.stringify([...pending]));
-    }
+    writePendingRebootSettings(pending);
+  } catch (e) {}
+}
+
+function clearPendingReboot(setting) {
+  try {
+    const pending = getPendingRebootSettings();
+    pending.delete(setting);
+    writePendingRebootSettings(pending);
   } catch (e) {}
 }
 
@@ -373,17 +414,25 @@ function helpMarkup(text) {
   return `<details class="ct-help"><summary>What does this do?</summary><p>${escapeHtml(text)}</p></details>`;
 }
 
+function policyFeatureFromMarkup(extra) {
+  const match = String(extra || '').match(/data-policy-feature="([^"]+)"/);
+  return match ? match[1] : '';
+}
+
 function switchMarkup(id, checked, extra) {
-  let isPending = false;
-  if (id && id.includes('global_identity')) {
-    isPending = isPendingReboot('global_identity_mode') || Boolean(legacyConfig && legacyConfig.global_identity_mode);
-  }
   const extraAttr = extra || '';
+  const feature = policyFeatureFromMarkup(extraAttr);
+  const pendingKey = feature ? `feature:${feature}` : '';
+  const isPending = Boolean(
+    (pendingKey && isPendingReboot(pendingKey)) ||
+    (id && id.includes('global_identity') && (isPendingReboot('global_identity_mode') || Boolean(legacyConfig && legacyConfig.global_identity_mode))),
+  );
+  const pendingAttr = isPending ? 'data-pending-reboot="true"' : '';
   if (extraAttr.includes('class="')) {
-    return `<input id="${id}" type="checkbox" ${extraAttr.replace('class="', `class="${isPending ? 'pending-reboot ' : ''}`)} ${checked ? 'checked' : ''}>`;
+    return `<input id="${id}" type="checkbox" ${extraAttr.replace('class="', `class="${isPending ? 'pending-reboot ' : ''}`)} ${pendingAttr} ${checked ? 'checked' : ''}>`;
   }
   if (isPending) {
-    return `<input id="${id}" type="checkbox" class="ct-switch pending-reboot" ${extraAttr} ${checked ? 'checked' : ''}>`;
+    return `<input id="${id}" type="checkbox" class="ct-switch pending-reboot" ${extraAttr} ${pendingAttr} ${checked ? 'checked' : ''}>`;
   }
   return `<input id="${id}" type="checkbox" class="ct-switch" ${extraAttr} ${checked ? 'checked' : ''}>`;
 }
@@ -517,22 +566,22 @@ function bindFeatureCenter(panel, prefix) {
 }
 
 async function setLegacyToggle(setting, enabled) {
+  let updated = false;
   try {
     const body = new URLSearchParams();
     body.set('setting',setting);
     body.set('value',String(Boolean(enabled)));
     await request('/api/toggle',{method:'POST',body});
+    updated = true;
     await loadLegacyConfig();
-    renderFeatureCenter();
-    renderIdentityControls();
-    refreshPresentation();
   } catch (error) {
     notify(error.message || 'Could not update setting','error');
     await loadLegacyConfig();
-    renderFeatureCenter();
-    renderIdentityControls();
-    refreshPresentation();
   }
+  renderFeatureCenter();
+  renderIdentityControls();
+  refreshPresentation();
+  return updated;
 }
 
 function installFeatureCenter() {
@@ -585,7 +634,13 @@ function bindIdentityControls(panel, prefix) {
       markPendingReboot('global_identity_mode');
       globalIdentityToggle.classList.add('pending-reboot');
       notify('Global Identity toggled. A device reboot is required for system properties to take full effect.', 'warning');
-      setLegacyToggle('global_identity_mode', globalIdentityToggle.checked);
+      setLegacyToggle('global_identity_mode', globalIdentityToggle.checked).then(updated => {
+        if (!updated) {
+          clearPendingReboot('global_identity_mode');
+          renderFeatureCenter();
+          renderIdentityControls();
+        }
+      });
     };
   }
   if (cameraToggle) cameraToggle.onchange = () => setLegacyToggle('camera_visibility',cameraToggle.checked);
@@ -1216,6 +1271,10 @@ function installIdentityManagerState() {
     const wrappedApply = async function() {
       const result = await originalApply.apply(this,arguments);
       const refreshError = await refreshSavedBuildIdentityBestEffort();
+      if (policyState && policyState.features && policyState.features.buildIdentity) {
+        markPendingReboot('feature:buildIdentity');
+        renderFeatureCenter();
+      }
       if (refreshError) {
         notify('Identity was applied. Warning: the saved identity view could not be refreshed. Reload to retry.');
       }
@@ -1283,8 +1342,15 @@ function installAutoIdentityOverride() {
       }
       if (await refreshSavedBuildIdentityBestEffort()) refreshFailed = true;
       const success = `Identity ready: ${data.model || data.device || 'Pixel'} · ${data.build_id || data.buildId || 'current build'}`;
+      const rebootPending = Boolean(policyState && policyState.features && policyState.features.buildIdentity);
+      if (rebootPending) {
+        markPendingReboot('feature:buildIdentity');
+        renderFeatureCenter();
+      }
       if (refreshFailed) {
         notify(`${success}. Warning: the Identity Manager view could not be fully refreshed. Reload to retry.`);
+      } else if (rebootPending) {
+        notify(`${success}. Reboot required for Build Identity to take effect.`, 'warning');
       } else {
         notify(success);
       }

--- a/module/webui-tests/bridge.test.js
+++ b/module/webui-tests/bridge.test.js
@@ -4,6 +4,7 @@ const path = require('path');
 const vm = require('vm');
 
 const webroot = 'module/template/webroot';
+const bridgeSource = fs.readFileSync(path.join(webroot, 'bridge.js'), 'utf8');
 const uxSource = fs.readFileSync(path.join(webroot, 'ux.js'), 'utf8');
 const policySource = fs.readFileSync(path.join(webroot, 'policy.js'), 'utf8');
 const indexSource = fs.readFileSync(path.join(webroot, 'index.html'), 'utf8');
@@ -52,6 +53,7 @@ assert.match(policySource, /CPU very low per UID decision; RAM low with a bounde
 assert.match(policySource, /function installTabNavigationOwner\(\)/);
 assert.match(policySource, /event\.stopImmediatePropagation\(\)/);
 assert.ok(!policySource.includes('bindCommunityExternally'), 'Policy must not own the community link');
+assert.ok(!bridgeSource.includes('installIdentityPolicyTransitionWatcher'), 'Policy saves already reconcile live Identity transitions; bridge must not apply them a second time from change events');
 assert.ok(!policySource.includes('watchCommunityBriefly'), 'Policy must not poll/watch for the community card');
 assert.ok(!policySource.includes('ctPolicyExternal'), 'Policy must not attach a second community click handler');
 assert.ok(!policySource.includes('global.switchTab = wrapped'), 'Policy must not monkey-patch the global tab router');

--- a/module/webui-tests/reboot-pending-policy.test.js
+++ b/module/webui-tests/reboot-pending-policy.test.js
@@ -1,0 +1,124 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+const source = fs.readFileSync('module/template/webroot/policy.js', 'utf8');
+const instrumented = source.replace(
+    'onReady(initialize);',
+    'global.__policyTest = { switchMarkup, markPendingReboot, clearPendingReboot, reconcilePolicyPendingReboot, notifyPolicyMutation };\nonReady(() => {});',
+);
+
+function createPolicyHarness(initialStorage = {}) {
+    const storage = new Map(Object.entries(initialStorage));
+    const messages = [];
+    const context = {
+        CleveresBridge: { fetch() { throw new Error('network should not be used'); } },
+        document: {
+            body: undefined,
+            addEventListener() {},
+        },
+        sessionStorage: {
+            getItem(key) { return storage.has(key) ? storage.get(key) : null; },
+            setItem(key, value) { storage.set(key, value); },
+        },
+        console,
+        JSON,
+        Set,
+        Array,
+        Promise,
+        notify(message, type) { messages.push({ message, type }); },
+    };
+    context.window = context;
+    vm.runInNewContext(instrumented, context, { filename: 'policy.js' });
+    return { api: context.__policyTest, storage, messages };
+}
+
+function pending(storage) {
+    const raw = storage.get('ct_pending_reboot');
+    return raw ? JSON.parse(raw) : [];
+}
+
+const initial = createPolicyHarness();
+assert.doesNotMatch(
+    initial.api.switchMarkup('ct_dash_identity_build', true, 'data-policy-feature="buildIdentity"'),
+    /pending-reboot/,
+    'a reboot marker must not appear before a policy transition requires it',
+);
+
+initial.api.reconcilePolicyPendingReboot(
+    { features: { buildIdentity: false, regionIdentity: false, identityRefresh: false } },
+    {
+        features: { buildIdentity: true, regionIdentity: false, identityRefresh: false },
+        runtimeTransition: { rebootRequired: true, apply: { buildApplied: false, regionApplied: false } },
+    },
+);
+assert.deepStrictEqual(pending(initial.storage), ['feature:buildIdentity']);
+assert.match(
+    initial.api.switchMarkup('ct_dash_identity_build', true, 'data-policy-feature="buildIdentity"'),
+    /class="ct-switch pending-reboot"/,
+    'Build Identity must render yellow when the backend reports a reboot requirement',
+);
+assert.match(
+    initial.api.switchMarkup('ct_dash_identity_build', true, 'data-policy-feature="buildIdentity"'),
+    /data-pending-reboot="true"/,
+);
+
+initial.api.reconcilePolicyPendingReboot(
+    { features: { buildIdentity: true, regionIdentity: false, identityRefresh: false } },
+    {
+        features: { buildIdentity: false, regionIdentity: false, identityRefresh: false },
+        runtimeTransition: { rebootRequired: false, restore: { buildApplied: true, regionApplied: false } },
+    },
+);
+assert.deepStrictEqual(pending(initial.storage), []);
+assert.doesNotMatch(
+    initial.api.switchMarkup('ct_dash_identity_build', false, 'data-policy-feature="buildIdentity"'),
+    /pending-reboot/,
+    'a successfully restored Build Identity must clear its pending marker',
+);
+
+const region = createPolicyHarness();
+region.api.reconcilePolicyPendingReboot(
+    { features: { buildIdentity: false, regionIdentity: false, identityRefresh: false } },
+    {
+        features: { buildIdentity: false, regionIdentity: true, identityRefresh: false },
+        runtimeTransition: { rebootRequired: true, apply: { buildApplied: true, regionApplied: false } },
+    },
+);
+assert.match(
+    region.api.switchMarkup('ct_dash_identity_region', true, 'data-policy-feature="regionIdentity"'),
+    /pending-reboot/,
+    'Region Identity must render yellow when only the region transition needs a reboot',
+);
+assert.doesNotMatch(
+    region.api.switchMarkup('ct_dash_identity_build', true, 'data-policy-feature="buildIdentity"'),
+    /pending-reboot/,
+    'Build Identity must not be marked when the backend confirmed it was applied',
+);
+
+const refresh = createPolicyHarness();
+refresh.api.reconcilePolicyPendingReboot(
+    { features: { buildIdentity: false, regionIdentity: false, identityRefresh: false } },
+    {
+        features: { buildIdentity: false, regionIdentity: false, identityRefresh: true },
+        runtimeTransition: undefined,
+    },
+);
+assert.match(
+    refresh.api.switchMarkup('ct_dash_identity_refresh', true, 'data-policy-feature="identityRefresh"'),
+    /pending-reboot/,
+    'Identity Refresh must render yellow because it only takes effect on the next boot',
+);
+
+const warning = createPolicyHarness();
+warning.api.notifyPolicyMutation('Identity enabled', { runtimeWarning: 'Reboot is required.' });
+assert.deepStrictEqual(warning.messages, [{ message: 'Identity enabled. Warning: Reboot is required.', type: 'warning' }]);
+
+const malformed = createPolicyHarness({ ct_pending_reboot: '{"unexpected":true}' });
+assert.doesNotMatch(
+    malformed.api.switchMarkup('ct_dash_identity_build', true, 'data-policy-feature="buildIdentity"'),
+    /pending-reboot/,
+    'malformed pending storage must fail closed without marking controls',
+);
+
+console.log('Policy reboot-pending indicator regression checks passed');


### PR DESCRIPTION
This pull request introduces a robust mechanism for tracking and displaying when a device reboot is required after policy changes related to identity features. The main changes remove the previous event-driven approach from `bridge.js` and instead centralize all pending reboot logic in `policy.js`, ensuring that the UI accurately reflects the need for a reboot and that this state is managed consistently. A new test suite validates these behaviors.

**Pending reboot tracking and UI feedback:**

* Added logic to reconcile policy state transitions and mark or clear pending reboot requirements for identity-related features (`buildIdentity`, `regionIdentity`, `identityRefresh`). This state is stored in `sessionStorage` and reflected in the UI by highlighting affected controls and adding a `data-pending-reboot` attribute. [[1]](diffhunk://#diff-6cb1e258fa0fefaec236eace85cb8a7b72749049a7623c8b8cfb2f1de0ba1fb2R58) [[2]](diffhunk://#diff-6cb1e258fa0fefaec236eace85cb8a7b72749049a7623c8b8cfb2f1de0ba1fb2R163-R196) [[3]](diffhunk://#diff-6cb1e258fa0fefaec236eace85cb8a7b72749049a7623c8b8cfb2f1de0ba1fb2L343-R396) [[4]](diffhunk://#diff-6cb1e258fa0fefaec236eace85cb8a7b72749049a7623c8b8cfb2f1de0ba1fb2L376-R435)
* Updated notification logic to display runtime warnings (such as "Reboot is required") when relevant, improving user awareness of pending actions.

**Codebase simplification and correctness:**

* Removed the `installIdentityPolicyTransitionWatcher` from `bridge.js`, as policy state reconciliation now handles all live identity transitions, preventing duplicate or conflicting state changes. [[1]](diffhunk://#diff-8bffc47041be116f3367a530ade428a1c6e5991043185c85b83248088c032520L1122-L1146) [[2]](diffhunk://#diff-8bffc47041be116f3367a530ade428a1c6e5991043185c85b83248088c032520L1233) [[3]](diffhunk://#diff-bb8eb1c2033b7de1c0cb9e586cc93b4837bbe64a943ce59eb08d9db20a5918d5R56)
* Improved the handling of legacy toggles and their pending reboot state, ensuring that UI indicators are only shown when appropriate and cleared if the toggle fails. [[1]](diffhunk://#diff-6cb1e258fa0fefaec236eace85cb8a7b72749049a7623c8b8cfb2f1de0ba1fb2R569-R584) [[2]](diffhunk://#diff-6cb1e258fa0fefaec236eace85cb8a7b72749049a7623c8b8cfb2f1de0ba1fb2L588-R643)

**Testing:**

* Added a comprehensive test suite (`reboot-pending-policy.test.js`) that validates pending reboot state tracking, UI rendering, and notification behaviors for all supported identity features and edge cases.

**Identity feature application:**

* Ensured that applying or overriding identity features marks the correct pending reboot state and triggers UI updates and notifications as needed. [[1]](diffhunk://#diff-6cb1e258fa0fefaec236eace85cb8a7b72749049a7623c8b8cfb2f1de0ba1fb2R1274-R1277) [[2]](diffhunk://#diff-6cb1e258fa0fefaec236eace85cb8a7b72749049a7623c8b8cfb2f1de0ba1fb2R1345-R1353)

These changes collectively make pending reboot requirements more reliable, visible, and user-friendly, while simplifying the codebase and preventing redundant or conflicting logic.