### PR TITLE
Stop retrying unused legacy keybox path

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
@@ -84,21 +84,17 @@ internal suspend fun retryDeferredKeyboxRefresh(
     return isActive()
 }
 
-internal fun hasConfiguredKeyboxSource(configDir: File): Boolean {
-    val roots =
-        listOf(
-            configDir,
-            File(configDir, "keyboxes"),
-            File("/data/adb/tricky_store/keybox"),
-        )
-    return roots.any { root ->
-        if (!Files.isDirectory(root.toPath(), LinkOption.NOFOLLOW_LINKS)) return@any false
-        root.listFiles()?.any { file ->
-            Files.isRegularFile(file.toPath(), LinkOption.NOFOLLOW_LINKS) &&
-                (file.name.endsWith(".xml", ignoreCase = true) || file.name.endsWith(".cbox", ignoreCase = true))
-        } == true
-    }
+private fun directoryHasConfiguredKeyboxSource(root: File): Boolean {
+    if (!Files.isDirectory(root.toPath(), LinkOption.NOFOLLOW_LINKS)) return false
+    return root.listFiles()?.any { file ->
+        Files.isRegularFile(file.toPath(), LinkOption.NOFOLLOW_LINKS) &&
+            (file.name.endsWith(".xml", ignoreCase = true) || file.name.endsWith(".cbox", ignoreCase = true))
+    } == true
 }
+
+internal fun hasConfiguredKeyboxSource(configDir: File): Boolean =
+    directoryHasConfiguredKeyboxSource(configDir) ||
+        directoryHasConfiguredKeyboxSource(File(configDir, "keyboxes"))
 
 fun main(args: Array<String>) {
     Logger.i("Welcome to Service!")

--- a/service/src/test/java/cleveres/tricky/cleverestech/MainStartupContractTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/MainStartupContractTest.kt
@@ -29,6 +29,23 @@ class MainStartupContractTest {
     }
 
     @Test
+    fun `configured keybox source probe scans the runtime keybox directory`() {
+        val root = NioFiles.createTempDirectory("cleverestricky-keyboxes-probe").toFile()
+        try {
+            val keyboxes = File(root, "keyboxes")
+            assertTrue(keyboxes.mkdir())
+            File(keyboxes, "encrypted.cbox").writeText("placeholder")
+            File(keyboxes, "ignored.txt").writeText("placeholder")
+            assertTrue(hasConfiguredKeyboxSource(root))
+
+            File(keyboxes, "encrypted.cbox").delete()
+            assertFalse(hasConfiguredKeyboxSource(root))
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
     fun `deferred keybox retry recovers on an early attempt`() = runBlocking {
         val waits = mutableListOf<Long>()
         var attempts = 0


### PR DESCRIPTION
## Summary
- stop boot-time deferred Keybox retries from treating the unused `/data/adb/tricky_store/keybox` path as a live source
- keep the probe aligned with the two runtime source scopes: the config root and `configDir/keyboxes`
- add regression coverage for `.cbox` discovery and unsupported files

## Audit result
The legacy path was referenced only by the deferred retry probe and is not consumed by `StoredKeyboxInventory` or `KeyboxLoader`. If that stale directory existed, the service could retain an unnecessary background retry coroutine forever, waking only at the capped interval. The fix removes that false-positive source and does not alter the active runtime path.

## Validation
- `:service:testDebugUnitTest --tests cleveres.tricky.cleverestech.MainStartupContractTest` passed
- `git diff --check` passed
- full PR #1055 local and exact-head GitHub gates were green before merge

No `update.json` change is included before the final V2.6.4 release artifact exists.