### PR TITLE
Stream keybox source probe without false positives

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
@@ -84,17 +84,24 @@ internal suspend fun retryDeferredKeyboxRefresh(
     return isActive()
 }
 
-private fun directoryHasConfiguredKeyboxSource(root: File): Boolean {
+private fun directoryHasConfiguredKeyboxSource(
+    root: File,
+    allowCbox: Boolean,
+): Boolean {
     if (!Files.isDirectory(root.toPath(), LinkOption.NOFOLLOW_LINKS)) return false
-    return root.listFiles()?.any { file ->
-        Files.isRegularFile(file.toPath(), LinkOption.NOFOLLOW_LINKS) &&
-            (file.name.endsWith(".xml", ignoreCase = true) || file.name.endsWith(".cbox", ignoreCase = true))
-    } == true
+    return Files.newDirectoryStream(root.toPath()).use { entries ->
+        entries.any { entry ->
+            if (!Files.isRegularFile(entry, LinkOption.NOFOLLOW_LINKS)) return@any false
+            val filename = entry.fileName.toString()
+            filename.endsWith(".xml", ignoreCase = true) ||
+                (allowCbox && filename.endsWith(".cbox", ignoreCase = true))
+        }
+    }
 }
 
 internal fun hasConfiguredKeyboxSource(configDir: File): Boolean =
-    directoryHasConfiguredKeyboxSource(configDir) ||
-        directoryHasConfiguredKeyboxSource(File(configDir, "keyboxes"))
+    directoryHasConfiguredKeyboxSource(configDir, allowCbox = false) ||
+        directoryHasConfiguredKeyboxSource(File(configDir, "keyboxes"), allowCbox = true)
 
 fun main(args: Array<String>) {
     Logger.i("Welcome to Service!")

--- a/service/src/test/java/cleveres/tricky/cleverestech/MainStartupContractTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/MainStartupContractTest.kt
@@ -21,6 +21,8 @@ class MainStartupContractTest {
             } finally {
                 outside.delete()
             }
+            File(root, "root.cbox").writeText("placeholder")
+            assertFalse(hasConfiguredKeyboxSource(root))
             File(root, "keybox.xml").writeText("placeholder")
             assertTrue(hasConfiguredKeyboxSource(root))
         } finally {


### PR DESCRIPTION
## Summary
- scan configured Keybox source directories with `DirectoryStream` and early exit instead of allocating `File[]` for every entry
- match runtime scope semantics: XML in the config root, XML/CBOX in `configDir/keyboxes`
- add regression coverage for root `.cbox` rejection and runtime-directory `.cbox` discovery

## Audit finding
The previous helper used `File.listFiles()`, which materialized every directory entry during a periodic boot retry probe. It also treated root-scope `.cbox` files as retry sources even though `StoredKeyboxInventory` only permits XML at the config root. The new implementation is bounded by early exit and aligned with the actual runtime inventory.

## Validation
- `:service:testDebugUnitTest --tests cleveres.tricky.cleverestech.MainStartupContractTest` passed
- `git diff --check` passed
- PR #1056 exact-head Build, Security Regression and Native Hardening were green before merge

No `update.json` change is included before the final V2.6.4 release artifact exists.