### PR TITLE
🧹 Remove unused LinkOption import

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierLoadPersistedCrlTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierLoadPersistedCrlTest.kt
@@ -2,7 +2,6 @@ package cleveres.tricky.cleverestech.util
 
 import java.io.File
 import java.nio.file.Files
-import java.nio.file.LinkOption
 import org.junit.After
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals


### PR DESCRIPTION
🎯 **What:** Removed unused `java.nio.file.LinkOption` import from `KeyboxVerifierLoadPersistedCrlTest.kt`.
💡 **Why:** Removes dead code and improves code clarity.
✅ **Verification:** Ran `./gradlew ktlintCheck` and `./gradlew :service:testDebugUnitTest`. All tests passed.
✨ **Result:** Cleaner code without changing functionality.

---
*PR created automatically by Jules for task [18442460319701127098](https://jules.google.com/task/18442460319701127098) started by @tryigit*