### PR TITLE
🧹 Remove unused java.io.IOException import

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/CertificateBackendWireTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/CertificateBackendWireTest.kt
@@ -1,6 +1,6 @@
 package cleveres.tricky.cleverestech
 
-import java.io.IOException
+
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse


### PR DESCRIPTION
🎯 What: Removed the unused java.io.IOException import from CertificateBackendWireTest.kt.
💡 Why: Clean up dead code to improve code clarity and maintainability.
✅ Verification: Ran ktlintCheck and testDebugUnitTest to ensure the formatting is correct and tests still pass.
✨ Result: Cleaner code without unused imports.

---
*PR created automatically by Jules for task [1977275116935926702](https://jules.google.com/task/1977275116935926702) started by @tryigit*