### PR TITLE
🧹 Remove unused import in WebServerSaveValidationTest

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerSaveValidationTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerSaveValidationTest.kt
@@ -12,7 +12,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
-import java.io.InputStream
 
 class WebServerSaveValidationTest {
     @Rule


### PR DESCRIPTION
🎯 What: Removed the unused java.io.InputStream import from WebServerSaveValidationTest.kt.
💡 Why: Unused imports clutter the file, making it harder to read and slightly increasing compilation time. Removing them improves code clarity and maintainability.
✅ Verification: Ran ./gradlew ktlintFormat and ./gradlew :service:testDebugUnitTest. The test suite passes fully, and format checks are green.
✨ Result: Cleaner code in WebServerSaveValidationTest.kt with no functional change.

---
*PR created automatically by Jules for task [2030895034724057113](https://jules.google.com/task/2030895034724057113) started by @tryigit*