### PR TITLE
🧪 [testing improvement description] add tests for disableNanoHttpdLogging

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/util/LoggerConfigTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/LoggerConfigTest.kt
@@ -1,0 +1,39 @@
+package cleveres.tricky.cleverestech.util
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.logging.Level
+import java.util.logging.Logger
+
+class LoggerConfigTest {
+
+    private val nanoLoggerName = "fi.iki.elonen.NanoHTTPD"
+    private var originalLevel: Level? = null
+
+    @Before
+    fun setUp() {
+        val logger = Logger.getLogger(nanoLoggerName)
+        originalLevel = logger.level
+    }
+
+    @After
+    fun tearDown() {
+        val logger = Logger.getLogger(nanoLoggerName)
+        logger.level = originalLevel
+    }
+
+    @Test
+    fun disableNanoHttpdLogging_setsLevelToOff() {
+        // Arrange
+        val logger = Logger.getLogger(nanoLoggerName)
+        logger.level = Level.ALL // Set to something other than OFF
+
+        // Act
+        LoggerConfig.disableNanoHttpdLogging()
+
+        // Assert
+        assertEquals(Level.OFF, logger.level)
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed for `LoggerConfig.disableNanoHttpdLogging()`.
📊 **Coverage:** Tests that the NanoHTTPD logger's level is explicitly set to `Level.OFF` when the method is invoked, using `@Before` and `@After` to restore the previous state to avoid polluting global state.
✨ **Result:** `disableNanoHttpdLogging` is now covered by unit tests and ensures no cross-test pollution occurs.

---
*PR created automatically by Jules for task [7482417571123660648](https://jules.google.com/task/7482417571123660648) started by @tryigit*