### PR TITLE
🧹 [Remove unused imports in DeviceKeyManagerInitializeTest]

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/util/DeviceKeyManagerInitializeTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/DeviceKeyManagerInitializeTest.kt
@@ -6,7 +6,6 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import org.mockito.MockedStatic
@@ -16,12 +15,9 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.`when`
 import java.io.File
-import java.io.IOException
-import java.nio.file.Files
 import java.nio.file.Path
 import java.security.KeyStore
 import javax.crypto.spec.SecretKeySpec
-import kotlin.io.path.createFile
 import kotlin.io.path.createTempDirectory
 
 class DeviceKeyManagerInitializeTest {


### PR DESCRIPTION
🎯 **What:** Removed unused imports in DeviceKeyManagerInitializeTest.kt.
💡 **Why:** To improve code clarity and maintainability by removing unnecessary lines.
✅ **Verification:** Ran ./gradlew ktlintCheck and ./gradlew :service:testDebugUnitTest to ensure formatting is correct and tests pass.
✨ **Result:** Cleaned up code without affecting functionality.

---
*PR created automatically by Jules for task [9021394736153661003](https://jules.google.com/task/9021394736153661003) started by @tryigit*