### PR TITLE
🧹 Remove unused imports in WebServer.kt

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -16,8 +16,6 @@ import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
-import java.nio.ByteBuffer
-import java.nio.charset.CodingErrorAction
 import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.security.MessageDigest


### PR DESCRIPTION
🎯 **What:** Removed `java.nio.ByteBuffer` and `java.nio.charset.CodingErrorAction` from `WebServer.kt`.
💡 **Why:** Improves code clarity and maintainability by removing dead code.
✅ **Verification:** Ran `ktlintFormat`, `ktlintCheck`, and `testDebugUnitTest` in the `service` module. All passed.
✨ **Result:** Cleaner imports in `WebServer.kt` without affecting functionality.

---
*PR created automatically by Jules for task [1427286037340492844](https://jules.google.com/task/1427286037340492844) started by @tryigit*