### PR TITLE
🧹 Remove unused import in KeyboxZipReader

### DIFF
--- a/encryptor-app/src/main/java/cleveres/tricky/encryptor/KeyboxZipReader.kt
+++ b/encryptor-app/src/main/java/cleveres/tricky/encryptor/KeyboxZipReader.kt
@@ -1,7 +1,6 @@
 package cleveres.tricky.encryptor
 
 import java.io.BufferedInputStream
-import java.io.FilterInputStream
 import java.io.IOException
 import java.io.InputStream
 import java.util.zip.ZipEntry


### PR DESCRIPTION
🎯 **What:** Removed unused `java.io.FilterInputStream` import.\n💡 **Why:** Improves code cleanliness and maintainability by removing dead code.\n✅ **Verification:** Passed `ktlint` and ran `encryptor-app` unit tests.\n✨ **Result:** A cleaner file.

---
*PR created automatically by Jules for task [625049408852719007](https://jules.google.com/task/625049408852719007) started by @tryigit*