### PR TITLE
🧹 [Code Health] Resolve TODO/FIXME/HACK keyword in ConfigTargetStateTest

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/ConfigTargetStateTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ConfigTargetStateTest.kt
@@ -98,11 +98,11 @@ class ConfigTargetStateTest {
         return constructor.newInstance(packages)
     }
 
-    private fun createTargetState(hack: PackageTrie<Boolean>): Any {
+    private fun createTargetState(packages: PackageTrie<Boolean>): Any {
         val clazz = Class.forName("cleveres.tricky.cleverestech.Config\$TargetState")
         val constructor = clazz.getDeclaredConstructor(PackageTrie::class.java)
         constructor.isAccessible = true
-        return constructor.newInstance(hack)
+        return constructor.newInstance(packages)
     }
 
     private fun getFieldFromTargetState(


### PR DESCRIPTION
🎯 **What:** Renamed the parameter `hack` to `packages` in `createTargetState` within `ConfigTargetStateTest.kt`.
💡 **Why:** The parameter name `hack` matches patterns meant to flag HACK comments in code health tools, triggering false positive warnings. Renaming it to `packages` aligns with the type (`PackageTrie`) and the naming used in `createIdentityTargetState`, improving readability and removing the static analysis warning.
✅ **Verification:** Ran `./gradlew :service:testDebugUnitTest` and `./gradlew ktlintCheck` - all passed.
✨ **Result:** Code health tool warning is resolved and code is cleaner without changing functionality.

---
*PR created automatically by Jules for task [5255678614015513462](https://jules.google.com/task/5255678614015513462) started by @tryigit*