### PR TITLE
🧹 [Code Health] Remove unused imports in KeyboxVerifierUnsafeUrlTest

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierUnsafeUrlTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierUnsafeUrlTest.kt
@@ -4,9 +4,7 @@ import cleveres.tricky.cleverestech.CrlBackend
 import cleveres.tricky.cleverestech.CrlWire
 import cleveres.tricky.cleverestech.Logger
 import java.net.ServerSocket
-import java.util.concurrent.atomic.AtomicInteger
 import org.junit.After
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test


### PR DESCRIPTION
🎯 **What:** Removed unused imports `AtomicInteger` and `assertEquals` from `KeyboxVerifierUnsafeUrlTest.kt`.
💡 **Why:** To improve code clarity and maintainability by cleaning up dead code in the imports section.
✅ **Verification:** Ran `./gradlew ktlintCheck` and `./gradlew test` to ensure code format is correct and no existing functionality was broken.
✨ **Result:** A cleaner test file with no unused imports.

---
*PR created automatically by Jules for task [4808407555253270987](https://jules.google.com/task/4808407555253270987) started by @tryigit*