### PR TITLE
🧹 Remove unused import in KeyboxVerifierCheckFileTest

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierCheckFileTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierCheckFileTest.kt
@@ -11,7 +11,6 @@ import org.junit.Test
 import org.mockito.Mockito
 import java.io.File
 import java.io.IOException
-import java.nio.file.Files
 import java.security.cert.X509Certificate
 import cleveres.tricky.cleverestech.util.KeyboxVerifier.RevocationSource
 


### PR DESCRIPTION
🎯 **What:** Removed unused import `java.nio.file.Files` from `KeyboxVerifierCheckFileTest.kt`.
💡 **Why:** Removing unused imports is a safe cleanup that improves code clarity, reduces noise, and slightly speeds up compilation.
✅ **Verification:** Ran `ktlintCheck` to ensure formatting and `./gradlew :service:testDebugUnitTest` to confirm no behavior was affected and no regressions were introduced. Both passed successfully.
✨ **Result:** A cleaner test file with no unused dependencies.

---
*PR created automatically by Jules for task [10707474826212209830](https://jules.google.com/task/10707474826212209830) started by @tryigit*