### PR TITLE
🧹 Remove unused imports in WebServer.kt

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -16,8 +16,6 @@ import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
-import java.nio.ByteBuffer
-import java.nio.charset.CodingErrorAction
 import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.security.MessageDigest


### PR DESCRIPTION
🎯 **What:** Removed unused imports `java.nio.ByteBuffer` and `java.nio.charset.CodingErrorAction` from `WebServer.kt`.
💡 **Why:** Removing unused imports is a safe cleanup that improves code clarity and maintainability.
✅ **Verification:** Verified by running `./gradlew ktlintCheck` and `./gradlew :service:testDebugUnitTest`, as well as full `./gradlew test ktlintCheck` to ensure no functionality is broken.
✨ **Result:** The code health issue is resolved, with a cleaner import list and preserved behavior.

---
*PR created automatically by Jules for task [14318056500836824499](https://jules.google.com/task/14318056500836824499) started by @tryigit*