### PR TITLE
🧪 Add tests and implementation for generateLuhn with postfix

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/RandomUtils.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/RandomUtils.kt
@@ -19,17 +19,21 @@ object RandomUtils {
     fun generateLuhn(
         length: Int,
         prefix: String = "",
+        postfix: String = "",
     ): String {
         require(length in 2..MAX_IDENTIFIER_LENGTH) { "Luhn length must be between 2 and $MAX_IDENTIFIER_LENGTH" }
-        require(prefix.length < length) { "Prefix must leave room for a check digit" }
+        val count = length - prefix.length - postfix.length - 1
+        require(count >= 0) { "Length too short" }
         require(prefix.all(Char::isDigit)) { "Prefix must contain only decimal digits" }
+        require(postfix.all(Char::isDigit)) { "Postfix must contain only decimal digits" }
 
-        val rng = secureRandom
         val sb = StringBuilder(length)
         sb.append(prefix)
-        while (sb.length < length - 1) {
-            sb.append(rng.nextInt(10))
+        val body = generateDigits(count)
+        if (body.isNotEmpty()) {
+            sb.append(body)
         }
+        sb.append(postfix)
 
         var sum = 0
         var isSecond = true

--- a/service/src/test/java/cleveres/tricky/cleverestech/RandomUtilsTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/RandomUtilsTest.kt
@@ -57,6 +57,56 @@ class RandomUtilsTest {
     }
 
     @Test
+    fun testGenerateLuhnWithPrefixAndPostfix() {
+        val prefix = "35"
+        val postfix = "123"
+        val length = 15
+        val luhn = RandomUtils.generateLuhn(length, prefix, postfix)
+        assertEquals(length, luhn.length)
+        assertTrue(luhn.startsWith(prefix))
+        assertTrue(luhn.substring(luhn.length - postfix.length - 1, luhn.length - 1) == postfix)
+
+        // Verify Luhn
+        val allDigits = luhn.map { it.toString().toInt() }.toIntArray()
+        var verifySum = 0
+        var doubleIt = false
+        for (i in allDigits.indices.reversed()) {
+            var d = allDigits[i]
+            if (doubleIt) {
+                d *= 2
+                if (d > 9) d -= 9
+            }
+            verifySum += d
+            doubleIt = !doubleIt
+        }
+        assertEquals("Luhn check failed for $luhn", 0, verifySum % 10)
+    }
+
+    @Test
+    fun testGenerateLuhnWithPostfixOnly() {
+        val postfix = "987"
+        val length = 15
+        val luhn = RandomUtils.generateLuhn(length, postfix = postfix)
+        assertEquals(length, luhn.length)
+        assertTrue(luhn.substring(luhn.length - postfix.length - 1, luhn.length - 1) == postfix)
+
+        // Verify Luhn
+        val allDigits = luhn.map { it.toString().toInt() }.toIntArray()
+        var verifySum = 0
+        var doubleIt = false
+        for (i in allDigits.indices.reversed()) {
+            var d = allDigits[i]
+            if (doubleIt) {
+                d *= 2
+                if (d > 9) d -= 9
+            }
+            verifySum += d
+            doubleIt = !doubleIt
+        }
+        assertEquals("Luhn check failed for $luhn", 0, verifySum % 10)
+    }
+
+    @Test
     fun testGenerateRandomSerial() {
         val length = 12
         val serial = RandomUtils.generateRandomSerial(length)
@@ -76,7 +126,9 @@ class RandomUtilsTest {
     fun testRejectsInvalidIdentifierArguments() {
         assertThrows(IllegalArgumentException::class.java) { RandomUtils.generateLuhn(1) }
         assertThrows(IllegalArgumentException::class.java) { RandomUtils.generateLuhn(15, "abc") }
+        assertThrows(IllegalArgumentException::class.java) { RandomUtils.generateLuhn(15, postfix = "abc") }
         assertThrows(IllegalArgumentException::class.java) { RandomUtils.generateLuhn(2, "12") }
+        assertThrows(IllegalArgumentException::class.java) { RandomUtils.generateLuhn(4, "12", "34") }
         assertThrows(IllegalArgumentException::class.java) { RandomUtils.generateDigits(3, "1234") }
         assertThrows(IllegalArgumentException::class.java) { RandomUtils.generateRandomSerial(0) }
     }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was an untested `generateLuhn` function that was missing a `postfix` parameter described in the issue. The code was updated to include this parameter and fully tested.
📊 **Coverage:** What scenarios are now tested:
- Generation of a Luhn algorithm identifier given both a prefix and a postfix.
- Generation of a Luhn algorithm identifier given just a postfix.
- Edge cases involving extremely short combinations and validation argument constraints.
✨ **Result:** The improvement in test coverage resulted in `generateLuhn` now fully supporting the missing `postfix` parameter, calculating accurate string bodies utilizing the centralized `generateDigits` call, and validating its correctness by parsing mathematically via tests. This guarantees correct generation, placement, and checking of prefixes, postfixes, and Luhn checksum digits without arbitrary hardcodes or flakiness.

---
*PR created automatically by Jules for task [12385447401279294663](https://jules.google.com/task/12385447401279294663) started by @tryigit*