### PR TITLE
Fix KeyboxVerifier Negative Decimal check

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxVerifier.kt
@@ -122,6 +122,17 @@ object KeyboxVerifier {
     }
 
     @androidx.annotation.VisibleForTesting
+    internal fun isDecimal(str: String): Boolean {
+        if (str.isEmpty()) return false
+        val start = if (str[0] == '-') 1 else 0
+        if (start >= str.length) return false
+        if (str.length - start > 1 && str[start] == '0') return false
+        for (i in start until str.length) {
+            if (str[i] !in '0'..'9') return false
+        }
+        return true
+    }
+
     internal fun isHex(str: String): Boolean {
         if (str.isEmpty()) return false
         for (i in 0 until str.length) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierIsDecimalTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxVerifierIsDecimalTest.kt
@@ -1,0 +1,46 @@
+package cleveres.tricky.cleverestech.util
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KeyboxVerifierIsDecimalTest {
+
+    @Test
+    fun `isDecimal returns true for valid positive numbers`() {
+        assertTrue(KeyboxVerifier.isDecimal("0"))
+        assertTrue(KeyboxVerifier.isDecimal("1"))
+        assertTrue(KeyboxVerifier.isDecimal("1234567890"))
+    }
+
+    @Test
+    fun `isDecimal returns true for valid negative numbers`() {
+        assertTrue(KeyboxVerifier.isDecimal("-1"))
+        assertTrue(KeyboxVerifier.isDecimal("-10"))
+        assertTrue(KeyboxVerifier.isDecimal("-1234567890"))
+    }
+
+    @Test
+    fun `isDecimal returns false for empty strings`() {
+        assertFalse(KeyboxVerifier.isDecimal(""))
+    }
+
+    @Test
+    fun `isDecimal returns false for strings with invalid characters`() {
+        assertFalse(KeyboxVerifier.isDecimal("a"))
+        assertFalse(KeyboxVerifier.isDecimal("123a456"))
+        assertFalse(KeyboxVerifier.isDecimal(" "))
+        assertFalse(KeyboxVerifier.isDecimal("123 456"))
+        assertFalse(KeyboxVerifier.isDecimal("!@#$"))
+        assertFalse(KeyboxVerifier.isDecimal("-"))
+        assertFalse(KeyboxVerifier.isDecimal("--1"))
+    }
+
+    @Test
+    fun `isDecimal returns false for numbers with leading zeros except zero`() {
+        assertFalse(KeyboxVerifier.isDecimal("01"))
+        assertFalse(KeyboxVerifier.isDecimal("-01"))
+        assertFalse(KeyboxVerifier.isDecimal("00"))
+        assertTrue(KeyboxVerifier.isDecimal("-0"))
+    }
+}


### PR DESCRIPTION
This PR adds `isDecimal` validation to `KeyboxVerifier` and corresponding tests to handle negative decimal serial numbers correctly, addressing the missing check.

---
*PR created automatically by Jules for task [5586467402469539040](https://jules.google.com/task/5586467402469539040) started by @tryigit*