### PR TITLE
Fix PatchLevel Format Bug

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -1362,7 +1362,7 @@ object Config {
             val sample = value.replace("YYYY", "2024").replace("MM", "06").replace("DD", "15")
             return runCatching { sample.convertPatchLevel(false) }.map { value }.getOrNull()
         }
-        return runCatching { value.convertPatchLevel(false) }.onFailure { Logger.w("Ignoring invalid security patch setting") }.getOrNull()
+        return runCatching { value.convertPatchLevel(false) }.map { value }.onFailure { Logger.w("Ignoring invalid security patch setting") }.getOrNull()
     }
 
     private fun parseComponentPatchSetting(value: String): Any? =
@@ -1375,7 +1375,7 @@ object Config {
                 val sample = value.replace("YYYY", "2024").replace("MM", "06").replace("DD", "15")
                 runCatching { sample.convertPatchLevel(false) }.map { value }.getOrNull()
             }
-            else -> runCatching { value.convertPatchLevel(false); value }.getOrNull()
+            else -> runCatching { value.convertPatchLevel(false) }.map { value }.getOrNull()
         }
 
     private fun resolvePatchValue(value: String, long: Boolean): Int {


### PR DESCRIPTION
In `Config.kt`, `parsePatchSetting` incorrectly returned the integer result of `convertPatchLevel`. By mapping back to the original value string upon successful validation, we ensure patch settings remain string-typed, fixing upstream `Config.getPatchLevel` failures with un-dashed inputs like `20231201`.

---
*PR created automatically by Jules for task [319488977915842546](https://jules.google.com/task/319488977915842546) started by @tryigit*