### PR TITLE
Fix keybox deletion and startup readiness resource bounds

### DIFF
--- a/module/src/main/cpp/binder_interceptor.cpp
+++ b/module/src/main/cpp/binder_interceptor.cpp
@@ -228,6 +228,18 @@ private:
   using RwLock = std::shared_mutex;
   using WriteGuard = std::unique_lock<RwLock>;
   using ReadGuard = std::shared_lock<RwLock>;
+  static constexpr size_t kMaxInterceptorRegistrations = 512;
+
+  void pruneDeadItemsLocked() {
+    for (auto it = items.begin(); it != items.end();) {
+      if (it->first.promote() == nullptr) {
+        it = items.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+
   RwLock lock;
   std::unordered_map<wp<IBinder>, InterceptItem, WpIBinderHash, WpIBinderEqual>
       items{};
@@ -770,9 +782,15 @@ status_t BinderInterceptor::onTransact(uint32_t code,
     sp<IBinder> replaced_interceptor;
     {
       WriteGuard wg{lock};
+      pruneDeadItemsLocked();
       wp<IBinder> t = target;
-      auto [it, inserted] = items.try_emplace(t);
-      if (inserted) {
+      auto it = items.find(t);
+      if (it == items.end()) {
+        if (items.size() >= kMaxInterceptorRegistrations) {
+          LOGW("Interceptor registration limit reached");
+          return BAD_VALUE;
+        }
+        it = items.emplace(t, InterceptItem{}).first;
         it->second.target = t;
       } else if (it->second.interceptor != nullptr &&
                  it->second.interceptor != interceptor) {

--- a/module/template/webroot/index.html
+++ b/module/template/webroot/index.html
@@ -653,7 +653,35 @@ return element.innerHTML;
         }
         async function fetchAuth(url, options = {}) {
 if (!window.CleveresBridge) throw new Error('Native WebUI bridge is unavailable');
-return window.CleveresBridge.fetch(url, options);
+const startupRetryDelaysMs = [250, 500, 1000, 2000, 4000, 8000, 16000];
+for (let attempt = 0; ; attempt++) {
+    const response = await window.CleveresBridge.fetch(url, options);
+    if (response.status !== 503 || attempt >= startupRetryDelaysMs.length || typeof response.clone !== 'function') return response;
+    let message = '';
+    try { message = (await response.clone().text()).trim(); } catch (_) { return response; }
+    if (message !== 'Native WebUI runtime is starting; retry shortly') return response;
+    if (options.signal && options.signal.aborted) throw new DOMException('The request was aborted', 'AbortError');
+    await new Promise((resolve, reject) => {
+        let settled = false;
+        const onAbort = () => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            if (options.signal) options.signal.removeEventListener('abort', onAbort);
+            reject(new DOMException('The request was aborted', 'AbortError'));
+        };
+        const timer = setTimeout(() => {
+            if (settled) return;
+            settled = true;
+            if (options.signal) options.signal.removeEventListener('abort', onAbort);
+            resolve();
+        }, startupRetryDelaysMs[attempt]);
+        if (options.signal) {
+            options.signal.addEventListener('abort', onAbort, { once: true });
+            if (options.signal.aborted) onAbort();
+        }
+    });
+}
         }
         async function downloadBlob(blob, filename) {
 if (!window.CleveresBridge) throw new Error('Native WebUI bridge is unavailable');

--- a/module/template/webroot/ux.js
+++ b/module/template/webroot/ux.js
@@ -3120,6 +3120,12 @@
         updateControls(pages);
     }
 
+    function normalizeKeyboxScope(value) {
+        if (value === 'root') return 'root';
+        if (value === 'keyboxes' || value === 'managed') return 'keyboxes';
+        return '';
+    }
+
     async function refreshInventory(options = {}) {
         if (typeof global.fetchAuth !== 'function' || (options.signal && options.signal.aborted)) return;
         const previousController = inventoryController;
@@ -3141,9 +3147,9 @@
                 ? data.slice(0, 4096).map(item => ({
                     id: String(item?.id ?? '').slice(0, 128),
                     filename: String(item?.filename ?? '').slice(0, 256),
-                    scope: item?.scope === 'root' ? 'root' : 'managed',
+                    scope: item?.scope === 'root' || item?.scope === 'keyboxes' || item?.scope === 'managed' ? item.scope : '',
                     certificate_serial: String(item?.certificate_serial ?? '').slice(0, 256)
-                })).filter(item => item.id && item.filename)
+                })).filter(item => item.id && item.filename && item.scope)
                 : [];
             const ids = new Set(inventory.map(item => item.id));
             selected = new Set(Array.from(selected).filter(id => ids.has(id)));
@@ -3173,9 +3179,11 @@
         return enqueueKeyboxMutation(async () => {
             try {
                 if (typeof global.confirm === 'function' && !global.confirm(t('deleteConfirm'))) return;
+                const scope = normalizeKeyboxScope(item.scope);
+                if (!scope) return;
                 const body = new URLSearchParams();
                 body.set('filename', item.filename);
-                body.set('scope', item.scope);
+                body.set('scope', scope);
                 const response = await global.fetchAuth('/api/delete_keybox', { method: 'POST', body });
                 if (!response.ok) {
                     if (typeof global.notify === 'function') global.notify('Error: ' + await response.text(), 'error');
@@ -3197,11 +3205,14 @@
         bulkDeleteBusy = true;
         return enqueueKeyboxMutation(async () => {
             try {
-                const items = inventory.filter(item => selected.has(item.id));
+                const items = inventory
+                    .filter(item => selected.has(item.id))
+                    .map(item => ({ item, scope: normalizeKeyboxScope(item.scope) }))
+                    .filter(entry => entry.scope);
                 if (!items.length) return;
                 if (typeof global.confirm === 'function' && !global.confirm(t('bulkConfirm', { count: items.length }))) return;
                 const body = new URLSearchParams();
-                body.set('items', JSON.stringify(items.map(item => ({ filename: item.filename, scope: item.scope }))));
+                body.set('items', JSON.stringify(items.map(({ item, scope }) => ({ filename: item.filename, scope }))));
                 const response = await global.fetchAuth('/api/delete_keyboxes', { method: 'POST', body });
                 let payload = null;
                 try { payload = await response.clone().json(); } catch (_) {}

--- a/module/webui-tests/keybox-delete-serialization.test.js
+++ b/module/webui-tests/keybox-delete-serialization.test.js
@@ -3,26 +3,39 @@ const fs = require('node:fs');
 const vm = require('node:vm');
 
 const source = fs.readFileSync('module/template/webroot/ux.js', 'utf8');
-const start = source.indexOf('    async function deleteOne(item)');
+const scopeStart = source.indexOf('    function normalizeKeyboxScope(value) {');
+const start = source.indexOf('    async function deleteOne(item)', scopeStart);
 const end = source.indexOf('    async function reloadAll()', start);
+const scopeImplementation = source.slice(scopeStart, start);
+const refreshStart = source.indexOf('    async function refreshInventory(options = {})');
+const refreshEnd = source.indexOf('    function enqueueKeyboxMutation(task)', refreshStart);
+assert.ok(scopeStart >= 0 && start > scopeStart, 'Keybox scope normalizer is missing');
 assert.ok(start >= 0 && end > start, 'Keybox delete implementation is missing');
+assert.ok(refreshStart >= 0 && refreshEnd > refreshStart, 'Keybox inventory refresh implementation is missing');
 const implementation = source.slice(start, end);
+const refreshImplementation = source.slice(refreshStart, refreshEnd);
 assert.match(implementation, /deletingIds\.has\(item\.id\)/);
 assert.match(implementation, /if \(bulkDeleteBusy\) return/);
 assert.match(implementation, /bulkDeleteBusy = true/);
 assert.match(implementation, /bulkDeleteBusy = false/);
 
-const item = { id: 'one', filename: 'one.xml', scope: 'managed' };
+const item = { id: 'keyboxes:one.xml', filename: 'one.xml', scope: 'keyboxes' };
 const calls = [];
 let releaseDelete;
 const context = {
   console,
   URLSearchParams,
+  AbortController,
   confirm: () => true,
   notify() {},
   render() {},
   fetchAuth(path, options) {
     calls.push({ path, options });
+    if (path === '/api/keybox_inventory') {
+      return Promise.resolve({ ok: true, async text() { return ''; }, clone() { return this; }, async json() {
+        return [{ id: 'keyboxes:one.xml', filename: 'one.xml', scope: 'keyboxes', certificate_serial: '' }];
+      } });
+    }
     if (calls.length === 1) {
       return new Promise(resolve => {
         releaseDelete = () => resolve({ ok: true, async text() { return ''; }, clone() { return this; }, async json() { return { deleted: 1 }; } });
@@ -38,18 +51,25 @@ vm.runInContext(`
   let deletingIds = new Set();
   let bulkDeleteBusy = false;
   let keyboxMutationQueue = Promise.resolve();
+  let inventoryController = null;
+  let loading = false;
+  let inventory = [];
+  function statusLabel() {}
   function enqueueKeyboxMutation(task) {
     const operation = keyboxMutationQueue.catch(() => {}).then(task);
     keyboxMutationQueue = operation.catch(() => {});
     return operation;
   }
   let selected = new Set();
-  let inventory = [];
   async function reloadAll() {}
   function t(key) { return key; }
+  ${scopeImplementation}
+  ${refreshImplementation}
   ${implementation}
   this.deleteOne = deleteOne;
   this.bulkDelete = bulkDelete;
+  this.refreshInventory = refreshInventory;
+  this.getInventory = () => inventory;
   this.setItem = value => { inventory = [value]; selected = new Set([value.id]); };
 `, context, { filename: 'ux.js#keybox-delete' });
 
@@ -68,6 +88,9 @@ vm.runInContext(`
   assert.equal(calls.length, 2, 'duplicate bulk-delete clicks must issue only one additional request');
   await Promise.all([firstBulk, duplicateBulk]);
   assert.equal(calls[1].path, '/api/delete_keyboxes');
+  assert.equal(new URLSearchParams(calls[0].options.body).get('scope'), 'keyboxes');
+  await context.refreshInventory();
+  assert.equal(context.getInventory()[0].scope, 'keyboxes', 'managed inventory scope must remain the backend API value');
   console.log('Keybox delete serialization regression checks passed');
 })().catch(error => {
   console.error(error);

--- a/module/webui-tests/startup-readiness-retry.test.js
+++ b/module/webui-tests/startup-readiness-retry.test.js
@@ -1,0 +1,79 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+const source = fs.readFileSync('module/template/webroot/index.html', 'utf8');
+const start = source.indexOf('        async function fetchAuth(url, options = {})');
+const end = source.indexOf('        async function downloadBlob(blob, filename)', start);
+assert.ok(start >= 0 && end > start, 'fetchAuth implementation is missing');
+const implementation = source.slice(start, end);
+assert.match(implementation, /Native WebUI bridge is unavailable/);
+
+const startupMessage = 'Native WebUI runtime is starting; retry shortly';
+let calls = 0;
+const options = { method: 'GET' };
+const startupResponse = {
+  status: 503,
+  ok: false,
+  async text() { return startupMessage; },
+  clone() { return this; }
+};
+const readyResponse = { status: 200, ok: true };
+const context = {
+  console,
+  DOMException,
+  setTimeout(callback) { callback(); return 1; },
+  clearTimeout() {},
+  getAuthUrl(path) { return path; },
+  window: {
+    CleveresBridge: {
+      fetch(path, receivedOptions) {
+        calls += 1;
+        assert.equal(path, '/api/config');
+        assert.equal(receivedOptions, options);
+        return Promise.resolve(calls === 1 ? startupResponse : readyResponse);
+      }
+    }
+  }
+};
+vm.createContext(context);
+vm.runInContext(`${implementation}\nthis.fetchAuth = fetchAuth;`, context, { filename: 'index.html#startup-readiness' });
+
+(async () => {
+  const response = await context.fetchAuth('/api/config', options);
+  assert.equal(response.status, 200, 'startup 503 must be retried until the bridge becomes ready');
+  assert.equal(calls, 2, 'startup retry must be bounded and issue one replacement request');
+
+  let normal503Calls = 0;
+  context.window.CleveresBridge.fetch = () => {
+    normal503Calls += 1;
+    return Promise.resolve({
+      status: 503,
+      ok: false,
+      async text() { return 'Rust backend unavailable'; },
+      clone() { return this; }
+    });
+  };
+  const normal503 = await context.fetchAuth('/api/config', options);
+  assert.equal(normal503.status, 503, 'non-startup 503 must remain visible to the caller');
+  assert.equal(normal503Calls, 1, 'non-startup 503 must not create a retry loop');
+
+  let abortTimer;
+  const abortController = new AbortController();
+  context.setTimeout = callback => { abortTimer = callback; return 2; };
+  context.window.CleveresBridge.fetch = () => Promise.resolve({
+    status: 503,
+    ok: false,
+    async text() { return startupMessage; },
+    clone() { return this; }
+  });
+  const aborted = context.fetchAuth('/api/config', { signal: abortController.signal });
+  await new Promise(resolve => setImmediate(resolve));
+  assert.ok(abortTimer, 'startup retry must install a cancellable timer');
+  abortController.abort();
+  await assert.rejects(aborted, error => error && error.name === 'AbortError');
+  console.log('Startup readiness retry regression checks passed');
+})().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/service/src/main/java/cleveres/tricky/cleverestech/CronAutoIdentity.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CronAutoIdentity.kt
@@ -50,7 +50,7 @@ internal object CronAutoIdentity {
             if (configDir?.absoluteFile != root.absoluteFile) {
                 observer?.stopWatching()
                 observer = null
-                stopExecutorLocked()
+                stopWorkerLocked()
                 configDir = root
             }
             if (observer == null) {
@@ -83,7 +83,7 @@ internal object CronAutoIdentity {
         synchronized(lock) {
             observer?.stopWatching()
             observer = null
-            stopExecutorLocked()
+            shutdownExecutorLocked()
             configDir = null
         }
     }
@@ -93,7 +93,7 @@ internal object CronAutoIdentity {
             val root = configDir ?: return
             val decision = currentDecision(root)
             if (!decision.shouldRun) {
-                stopExecutorLocked()
+                stopWorkerLocked()
                 return
             }
             ensureExecutorLocked()
@@ -144,14 +144,18 @@ internal object CronAutoIdentity {
         scheduled = current.schedule({ runCheck(root, generation) }, boundedDelay, TimeUnit.MILLISECONDS)
     }
 
-    private fun stopExecutorLocked() {
+    private fun stopWorkerLocked() {
         workerGeneration++
         scheduled?.cancel(true)
         scheduled = null
-        executor?.shutdownNow()
-        executor = null
         inFlight = false
         nextRunMs = 0L
+    }
+
+    private fun shutdownExecutorLocked() {
+        stopWorkerLocked()
+        executor?.shutdownNow()
+        executor = null
     }
 
     private fun ownsWork(
@@ -174,7 +178,7 @@ internal object CronAutoIdentity {
                 scheduled = null
                 val current = currentDecision(root)
                 if (!current.shouldRun) {
-                    stopExecutorLocked()
+                    stopWorkerLocked()
                     return
                 }
                 inFlight = true
@@ -196,7 +200,7 @@ internal object CronAutoIdentity {
             inFlight = false
             val current = currentDecision(root)
             if (!current.shouldRun) {
-                stopExecutorLocked()
+                stopWorkerLocked()
                 return
             }
             if (result.isSuccess) {
@@ -231,12 +235,14 @@ internal object CronAutoIdentity {
         synchronized(lock) {
             observer?.stopWatching()
             observer = null
-            stopExecutorLocked()
+            shutdownExecutorLocked()
             configDir = root
         }
     }
 
     @VisibleForTesting
     internal fun isRunningForTesting(): Boolean =
-        synchronized(lock) { executor?.let { !it.isShutdown } == true }
+        synchronized(lock) {
+            executor?.let { !it.isShutdown && (scheduled != null || inFlight) } == true
+        }
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/DrmInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/DrmInterceptor.kt
@@ -6,8 +6,49 @@ import android.os.ServiceManager
 import android.os.SystemClock
 import cleveres.tricky.cleverestech.binder.BinderInterceptor
 import java.io.File
-import java.util.concurrent.ConcurrentHashMap
+import java.util.LinkedHashMap
 import java.util.concurrent.TimeUnit
+
+/**
+ * Small insertion-ordered PID history used only while the DRM reconciliation lock is held.
+ * Failed injection attempts can observe a new service PID on every restart, so this state must not
+ * grow with the lifetime of the Android service process.
+ */
+internal class BoundedPidHistory<V>(
+    private val capacity: Int,
+) {
+    private val entries = LinkedHashMap<Int, V>()
+
+    init {
+        require(capacity > 0) { "PID history capacity must be positive" }
+    }
+
+    val size: Int
+        get() = entries.size
+
+    operator fun get(pid: Int): V? = entries[pid]
+
+    fun containsKey(pid: Int): Boolean = entries.containsKey(pid)
+
+    fun put(pid: Int, value: V) {
+        entries.remove(pid)
+        entries[pid] = value
+        if (entries.size > capacity) {
+            entries.entries.iterator().let { iterator ->
+                iterator.next()
+                iterator.remove()
+            }
+        }
+    }
+
+    fun remove(pid: Int) {
+        entries.remove(pid)
+    }
+
+    fun clear() {
+        entries.clear()
+    }
+}
 
 /**
  * Privacy-only hook for the modern stable-AIDL DRM HAL.
@@ -47,6 +88,7 @@ object DrmInterceptor {
     private const val MAX_PID_OUTPUT_BYTES = 32
     private const val MAX_FACTORY_SERVICES = 16
     private const val MAX_PLUGIN_BINDERS = 256
+    private const val MAX_TRACKED_INJECTION_PIDS = 64
 
     private data class FactoryRegistration(
         val name: String,
@@ -65,8 +107,8 @@ object DrmInterceptor {
 
     private val factories = LinkedHashMap<String, FactoryRegistration>()
     private val plugins = LinkedHashMap<IBinder, PluginRegistration>()
-    private val injectedPids = HashSet<Int>()
-    private val lastInjectionAttempt = ConcurrentHashMap<Int, Long>()
+    private val injectedPids = BoundedPidHistory<Unit>(MAX_TRACKED_INJECTION_PIDS)
+    private val lastInjectionAttempt = BoundedPidHistory<Long>(MAX_TRACKED_INJECTION_PIDS)
     private val pluginInterceptor = PluginInterceptor()
 
     @Volatile
@@ -289,9 +331,9 @@ object DrmInterceptor {
         if (previous != null && now - previous in 0 until INJECTION_RETRY_INTERVAL_MS) {
             return InjectionResult.DEFERRED
         }
-        lastInjectionAttempt[pid] = now
+        lastInjectionAttempt.put(pid, now)
 
-        val symbol = if (injectedPids.contains(pid)) "resume" else "entry"
+        val symbol = if (injectedPids.containsKey(pid)) "resume" else "entry"
         val modulePath = getModuleDir()
         return try {
             val process =
@@ -312,7 +354,7 @@ object DrmInterceptor {
                 Logger.w("DRM privacy: injector failed for pid=$pid (exit=${process.exitValue()})")
                 InjectionResult.FAILED
             } else {
-                injectedPids.add(pid)
+                injectedPids.put(pid, Unit)
                 Logger.i("DRM privacy: native Binder hook activated for DRM HAL pid=$pid")
                 InjectionResult.SUCCESS
             }

--- a/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Main.kt
@@ -3,14 +3,15 @@ package cleveres.tricky.cleverestech
 import cleveres.tricky.cleverestech.keystore.CertHack
 import cleveres.tricky.cleverestech.util.KeyboxAutoCleaner
 import cleveres.tricky.cleverestech.util.SecureFile
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.util.concurrent.CountDownLatch
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import java.io.File
-import java.nio.file.Files
-import java.nio.file.LinkOption
 
 private const val CONFIG_DIR_MODE = 448
 private const val BACKEND_STARTUP_TIMEOUT_MS = 30_000L
@@ -22,8 +23,9 @@ private val DEFERRED_KEYBOX_REFRESH_DELAYS_MS = longArrayOf(1_000L, 5_000L, 15_0
 private fun startWebUiBridge(
     configDir: File,
     isTampered: Boolean,
+    startupReady: CountDownLatch,
 ): WebUiBridge? {
-    val bridge = WebUiBridge(WebServer(0, configDir, isTampered), configDir)
+    val bridge = WebUiBridge(WebServer(0, configDir, isTampered), configDir, startupReady)
     var retryDelayMs = WEB_UI_START_INITIAL_DELAY_MS
     repeat(WEB_UI_START_ATTEMPTS) { attempt ->
         try {
@@ -124,7 +126,8 @@ fun main(args: Array<String>) {
             return@runBlocking
         }
 
-        val webUiBridge = startWebUiBridge(configDir, isTampered)
+        val webUiReady = CountDownLatch(1)
+        val webUiBridge = startWebUiBridge(configDir, isTampered, webUiReady)
         if (webUiBridge == null) {
             Logger.e("Main: Native WebUI adapter could not register; exiting for supervisor retry")
             return@runBlocking
@@ -197,6 +200,10 @@ fun main(args: Array<String>) {
             Logger.e("Main: Exiting so the module supervisor can retry initialization")
             return@runBlocking
         }
+
+        // The transport may register early so the host WebUI can connect during boot, but API
+        // requests must wait until backend, configuration, and required watchers are operational.
+        webUiReady.countDown()
 
         val startupRetryJobs =
             RuntimeStartupPolicy.retryableFailures(startupResults).map { result ->

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -21,9 +21,15 @@ import java.nio.file.LinkOption
 import java.security.MessageDigest
 import java.security.SecureRandom
 import java.util.Base64
+import java.util.Collections
 import java.util.UUID
+import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.FutureTask
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
@@ -189,6 +195,81 @@ internal fun parseTotalCpuTicks(stat: CharSequence): Long? {
 }
 
 private const val LOOPBACK_TEST_HOST = "127.0.0.1"
+internal const val MAX_HTTP_WORKERS = 8
+internal const val MAX_HTTP_QUEUE_CAPACITY = 16
+
+/**
+ * NanoHTTPD 2.3.1's default runner creates one daemon thread per accepted socket.
+ * Keep both thread stacks and retained ClientHandlers bounded because the WebUI is
+ * loopback-only but still reachable by other apps on the same device.
+ */
+internal class BoundedHttpAsyncRunner(
+    workerCount: Int = MAX_HTTP_WORKERS,
+    queueCapacity: Int = MAX_HTTP_QUEUE_CAPACITY,
+) : NanoHTTPD.AsyncRunner {
+    private val stopped = AtomicBoolean(false)
+    private val nextThreadId = AtomicInteger(0)
+    private val running = Collections.synchronizedList(mutableListOf<NanoHTTPD.ClientHandler>())
+    private val executor =
+        ThreadPoolExecutor(
+            workerCount,
+            workerCount,
+            0L,
+            TimeUnit.MILLISECONDS,
+            ArrayBlockingQueue(queueCapacity),
+            { runnable ->
+                Thread(runnable, "CleveresTricky-HTTP-${nextThreadId.incrementAndGet()}").apply {
+                    isDaemon = true
+                }
+            },
+            ThreadPoolExecutor.AbortPolicy(),
+        )
+
+    init {
+        require(workerCount > 0) { "HTTP worker count must be positive" }
+        require(queueCapacity > 0) { "HTTP queue capacity must be positive" }
+    }
+
+    override fun exec(handler: NanoHTTPD.ClientHandler) {
+        val accepted =
+            synchronized(running) {
+                if (stopped.get()) {
+                    false
+                } else {
+                    running.add(handler)
+                    try {
+                        executor.execute(handler)
+                        true
+                    } catch (_: RejectedExecutionException) {
+                        running.remove(handler)
+                        false
+                    }
+                }
+            }
+        if (!accepted) handler.close()
+    }
+
+    override fun closed(handler: NanoHTTPD.ClientHandler) {
+        synchronized(running) { running.remove(handler) }
+    }
+
+    override fun closeAll() {
+        val snapshot =
+            synchronized(running) {
+                if (!stopped.compareAndSet(false, true)) return
+                running.toList()
+            }
+        snapshot.forEach { it.close() }
+        executor.shutdownNow()
+        synchronized(running) { running.clear() }
+    }
+
+    internal fun runningCountForTest(): Int = synchronized(running) { running.size }
+
+    internal fun workerCountForTest(): Int = executor.maximumPoolSize
+
+    internal fun queueCapacityForTest(): Int = executor.queue.size + executor.queue.remainingCapacity()
+}
 
 class WebServer(
     requestedPort: Int,
@@ -206,6 +287,7 @@ class WebServer(
     },
 ) : NanoHTTPD(LOOPBACK_TEST_HOST, requestedPort) {
     init {
+        setAsyncRunner(BoundedHttpAsyncRunner())
         cleveres.tricky.cleverestech.util.LoggerConfig.disableNanoHttpdLogging()
     }
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebUiBridge.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebUiBridge.kt
@@ -21,11 +21,15 @@ import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.security.SecureRandom
 import java.util.Base64
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.system.exitProcess
 
 class WebUiBridge(
     private val server: WebServer,
     configDir: File,
+    private val startupReady: CountDownLatch = CountDownLatch(0),
+    private val startupWaitMs: Long = STARTUP_WAIT_MS,
 ) {
     private val bridgeDir = File(configDir, "webui_bridge")
     private val stagingDir = File(bridgeDir, "staging")
@@ -130,6 +134,12 @@ class WebUiBridge(
 
     internal fun processRequestBytes(requestBytes: ByteArray): ByteArray {
         require(requestBytes.size in 1..MAX_REQUEST_BYTES)
+        if (!awaitStartupReady()) {
+            return encodeErrorResponse(
+                NanoHTTPD.Response.Status.SERVICE_UNAVAILABLE,
+                "Native WebUI runtime is starting; retry shortly",
+            )
+        }
         var uploadFile: File? = null
         return try {
             val request = JSONObject(decodeUtf8Strict(requestBytes))
@@ -153,6 +163,14 @@ class WebUiBridge(
             uploadFile?.let(::deleteRegularFile)
         }
     }
+
+    private fun awaitStartupReady(): Boolean =
+        try {
+            startupReady.await(startupWaitMs, TimeUnit.MILLISECONDS)
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+            false
+        }
 
     private fun decodeUtf8Strict(requestBytes: ByteArray): String =
         Charsets.UTF_8
@@ -530,7 +548,7 @@ class WebUiBridge(
         private const val MAX_CLEANUP_FILES = 1024
         private const val MAX_EMPTY_READS = 16
         private const val STALE_AGE_MS = 10 * 60 * 1000L
-
+        private const val STARTUP_WAIT_MS = 5_000L
         private const val SOCKET_NAME = "cleverestrickyd.v1"
         private const val IPC_VERSION = 1
         private const val HEADER_BYTES = 16

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxAutoCleaner.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/KeyboxAutoCleaner.kt
@@ -9,8 +9,10 @@ import java.nio.file.AtomicMoveNotSupportedException
 import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.nio.file.StandardCopyOption
-import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.ThreadFactory
 import java.util.concurrent.TimeUnit
 
 object KeyboxAutoCleaner {
@@ -23,6 +25,7 @@ object KeyboxAutoCleaner {
 
     @Volatile
     private var executor: ScheduledExecutorService? = null
+    private var scheduledCheck: ScheduledFuture<*>? = null
     private val configDir = File("/data/adb/cleverestricky")
     private val toggleFile = File(configDir, "auto_keybox_check")
     private val spoofEnabledFile = File(configDir, "spoof_enabled")
@@ -35,20 +38,14 @@ object KeyboxAutoCleaner {
         synchronized(executorLock) {
             val current = executor
             if (!enabled) {
-                current?.shutdownNow()
-                executor = null
+                scheduledCheck?.cancel(true)
+                scheduledCheck = null
                 return
             }
-            if (current != null && !current.isShutdown) return
+            val activeExecutor = current?.takeUnless { it.isShutdown } ?: createExecutor().also { executor = it }
+            if (scheduledCheck?.isDone == false) return
 
-            val created =
-                Executors.newSingleThreadScheduledExecutor { runnable ->
-                    Thread(runnable, "CleveresTricky-KeyboxCheck").apply {
-                        isDaemon = true
-                        priority = Thread.MIN_PRIORITY
-                    }
-                }
-            created.scheduleWithFixedDelay(
+            scheduledCheck = activeExecutor.scheduleWithFixedDelay(
                 {
                     try {
                         runCheck()
@@ -60,9 +57,23 @@ object KeyboxAutoCleaner {
                 1440,
                 TimeUnit.MINUTES,
             )
-            executor = created
         }
     }
+
+    private fun createExecutor(): ScheduledExecutorService =
+        ScheduledThreadPoolExecutor(
+            1,
+            ThreadFactory { runnable ->
+                Thread(runnable, "CleveresTricky-KeyboxCheck").apply {
+                    isDaemon = true
+                    priority = Thread.MIN_PRIORITY
+                }
+            },
+        ).apply {
+            setKeepAliveTime(30, TimeUnit.SECONDS)
+            allowCoreThreadTimeOut(true)
+            setRemoveOnCancelPolicy(true)
+        }
 
     private fun isEnabledNow(): Boolean = Config.isSpoofEnabled && isRegularFile(spoofEnabledFile) && isRegularFile(toggleFile)
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/CronAutoIdentityTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/CronAutoIdentityTest.kt
@@ -4,6 +4,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -26,6 +27,29 @@ class CronAutoIdentityTest {
         CronAutoIdentity.stop()
         root.deleteRecursively()
         Config.reset()
+    }
+
+    @Test
+    fun `rapid disable and reenable reuses one scheduler`() {
+        val executorField = CronAutoIdentity::class.java.getDeclaredField("executor").apply { isAccessible = true }
+        File(root, CronAutoIdentity.TOGGLE_FILE).writeText("")
+        PolicyState.installStateForTesting(state(buildIdentity = true).toString())
+
+        try {
+            CronAutoIdentity.refreshEnabled()
+            val first = executorField.get(CronAutoIdentity)
+
+            Files.delete(File(root, CronAutoIdentity.TOGGLE_FILE).toPath())
+            CronAutoIdentity.refreshEnabled()
+            assertFalse(CronAutoIdentity.isRunningForTesting())
+
+            File(root, CronAutoIdentity.TOGGLE_FILE).writeText("")
+            CronAutoIdentity.refreshEnabled()
+            val second = executorField.get(CronAutoIdentity)
+            assertSame(first, second)
+        } finally {
+            CronAutoIdentity.stop()
+        }
     }
 
     @Test

--- a/service/src/test/java/cleveres/tricky/cleverestech/DrmInjectionHistoryTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/DrmInjectionHistoryTest.kt
@@ -1,0 +1,25 @@
+package cleveres.tricky.cleverestech
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DrmInjectionHistoryTest {
+    @Test
+    fun `injection history evicts oldest pid while refreshing recent entries`() {
+        val history = BoundedPidHistory<Long>(3)
+        history.put(101, 1L)
+        history.put(102, 2L)
+        history.put(103, 3L)
+        history.put(101, 4L)
+        history.put(104, 5L)
+
+        assertEquals(3, history.size)
+        assertFalse(history.containsKey(102))
+        assertTrue(history.containsKey(101))
+        assertEquals(4L, history[101])
+        assertTrue(history.containsKey(103))
+        assertTrue(history.containsKey(104))
+    }
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/MainStartupContractTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/MainStartupContractTest.kt
@@ -145,11 +145,13 @@ class MainStartupContractTest {
         val root = locateRoot()
         val source = File(root, "service/src/main/java/cleveres/tricky/cleverestech/Main.kt").readText()
         val entry = source.indexOf("fun main(args: Array<String>)")
-        val registration = source.indexOf("startWebUiBridge(configDir, isTampered)", entry)
+        val registration = source.indexOf("startWebUiBridge(configDir, isTampered, webUiReady)", entry)
         val backendWait = source.indexOf("NativeBackend.awaitReady(BACKEND_STARTUP_TIMEOUT_MS)", entry)
+        val gateRelease = source.indexOf("webUiReady.countDown()", backendWait)
         assertTrue(entry >= 0)
         assertTrue(registration > entry)
         assertTrue(backendWait > registration)
+        assertTrue(gateRelease > backendWait)
     }
 
     private fun locateRoot(): File {

--- a/service/src/test/java/cleveres/tricky/cleverestech/NativeBinderResourceContractTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/NativeBinderResourceContractTest.kt
@@ -1,0 +1,24 @@
+package cleveres.tricky.cleverestech
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeBinderResourceContractTest {
+    @Test
+    fun `native interceptor registry has a bounded dead-target cleanup path`() {
+        val source = nativeSource().readText()
+
+        assertTrue(source.contains("kMaxInterceptorRegistrations"))
+        assertTrue(source.contains("pruneDeadItemsLocked"))
+        assertTrue(source.contains("items.size() >= kMaxInterceptorRegistrations"))
+        assertTrue(source.contains("target == nullptr"))
+    }
+
+    private fun nativeSource(): File =
+        listOf(
+            File("module/src/main/cpp/binder_interceptor.cpp"),
+            File("../module/src/main/cpp/binder_interceptor.cpp"),
+        ).firstOrNull(File::isFile)
+            ?: error("Could not locate binder_interceptor.cpp from ${File(".").absolutePath}")
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/RuntimeWiringContractTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/RuntimeWiringContractTest.kt
@@ -96,12 +96,15 @@ class RuntimeWiringContractTest {
         val root = locateRoot()
         val source = mainSource(root)
         val entry = source.indexOf("fun main(args: Array<String>)")
-        val registration = source.indexOf("startWebUiBridge(configDir, isTampered)", entry)
+        val registration = source.indexOf("startWebUiBridge(configDir, isTampered, webUiReady)", entry)
         val backendWait = source.indexOf("NativeBackend.awaitReady(BACKEND_STARTUP_TIMEOUT_MS)", entry)
 
         assertTrue(entry >= 0)
         assertTrue(registration > entry)
         assertTrue(backendWait > registration)
+        assertTrue(source.contains("val webUiReady = CountDownLatch(1)"))
+        assertTrue(source.contains("startWebUiBridge(configDir, isTampered, webUiReady)"))
+        assertTrue(source.contains("webUiReady.countDown()"))
     }
 
     @Test

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerAsyncRunnerTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerAsyncRunnerTest.kt
@@ -1,0 +1,147 @@
+package cleveres.tricky.cleverestech
+
+import fi.iki.elonen.NanoHTTPD
+import java.io.ByteArrayInputStream
+import java.net.Socket
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class WebServerAsyncRunnerTest {
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private var server: WebServer? = null
+
+    @After
+    fun tearDown() {
+        server?.stop()
+    }
+
+    @Test
+    fun `web server installs bounded async runner`() {
+        server = WebServer(0, tempFolder.newFolder("config"))
+
+        val field = NanoHTTPD::class.java.getDeclaredField("asyncRunner").apply { isAccessible = true }
+        val runner = field.get(server)
+
+        assertTrue(runner is BoundedHttpAsyncRunner)
+        assertEquals(MAX_HTTP_WORKERS, (runner as BoundedHttpAsyncRunner).workerCountForTest())
+        assertEquals(MAX_HTTP_QUEUE_CAPACITY, runner.queueCapacityForTest())
+    }
+
+    @Test
+    fun `accepted idle sockets stay within bounded client cap`() {
+        server = WebServer(0, tempFolder.newFolder("config"))
+        server!!.start()
+        val sockets = ArrayList<Socket>()
+        try {
+            repeat(MAX_HTTP_WORKERS + MAX_HTTP_QUEUE_CAPACITY + 8) {
+                runCatching {
+                    sockets += Socket().apply {
+                        connect(java.net.InetSocketAddress("127.0.0.1", server!!.listeningPort), 1_000)
+                    }
+                }
+            }
+
+            val field = NanoHTTPD::class.java.getDeclaredField("asyncRunner").apply { isAccessible = true }
+            val runner = field.get(server) as BoundedHttpAsyncRunner
+            repeat(20) {
+                if (runner.runningCountForTest() >= MAX_HTTP_WORKERS + MAX_HTTP_QUEUE_CAPACITY) return@repeat
+                Thread.sleep(10)
+            }
+            assertTrue(runner.runningCountForTest() <= MAX_HTTP_WORKERS + MAX_HTTP_QUEUE_CAPACITY)
+        } finally {
+            sockets.forEach { runCatching { it.close() } }
+        }
+    }
+
+    @Test
+    fun `queue full closes new client without growing retained handlers`() {
+        server = WebServer(0, tempFolder.newFolder("config"))
+        val runner = BoundedHttpAsyncRunner(workerCount = 2, queueCapacity = 1)
+        val owner = HandlerOwner()
+        val release = CountDownLatch(1)
+        val started = CountDownLatch(2)
+        val handlers = arrayOfNulls<NanoHTTPD.ClientHandler>(4)
+
+        for (index in handlers.indices) {
+            lateinit var handler: NanoHTTPD.ClientHandler
+            handler = owner.newBlockingHandler(index < 3, started, release) { runner.closed(handler) }
+            handlers[index] = handler
+        }
+        val concreteHandlers = handlers.requireNoNulls()
+
+        concreteHandlers.take(3).forEach(runner::exec)
+
+        assertTrue(started.await(1, TimeUnit.SECONDS))
+        assertEquals(3, runner.runningCountForTest())
+
+        runner.exec(concreteHandlers[3])
+
+        assertTrue(owner.closedHandlers.await(1, TimeUnit.SECONDS))
+        assertEquals(3, runner.runningCountForTest())
+
+        runner.closeAll()
+        concreteHandlers.forEach { handler ->
+            assertTrue(owner.closedSignals[handler]!!.await(1, TimeUnit.SECONDS))
+        }
+        assertEquals(0, runner.runningCountForTest())
+    }
+
+    private class HandlerOwner : NanoHTTPD("127.0.0.1", 0) {
+        val closedHandlers = CountDownLatch(1)
+        val closedSignals = mutableMapOf<NanoHTTPD.ClientHandler, CountDownLatch>()
+
+        override fun serve(session: IHTTPSession): Response =
+            newFixedLengthResponse(Response.Status.OK, "text/plain", "ok")
+
+        fun newBlockingHandler(
+            releaseOnClose: Boolean,
+            started: CountDownLatch,
+            release: CountDownLatch,
+            onClosed: () -> Unit,
+        ): NanoHTTPD.ClientHandler {
+            val signal = CountDownLatch(1)
+            val handler = BlockingClientHandler(ByteArrayInputStream(ByteArray(0)), Socket(), releaseOnClose, started, release, onClosed, signal)
+            closedSignals[handler] = signal
+            return handler
+        }
+
+        private inner class BlockingClientHandler(
+            input: ByteArrayInputStream,
+            socket: Socket,
+            private val releaseOnClose: Boolean,
+            private val started: CountDownLatch,
+            private val release: CountDownLatch,
+            private val onClosed: () -> Unit,
+            private val closedSignal: CountDownLatch,
+        ) : ClientHandler(input, socket) {
+            override fun run() {
+                try {
+                    started.countDown()
+                    try {
+                        release.await()
+                    } catch (_: InterruptedException) {
+                        Thread.currentThread().interrupt()
+                    }
+                } finally {
+                    onClosed()
+                    closedSignal.countDown()
+                }
+            }
+
+            override fun close() {
+                closedHandlers.countDown()
+                if (releaseOnClose) release.countDown()
+                closedSignal.countDown()
+                super.close()
+            }
+        }
+    }
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerRateLimitTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerRateLimitTest.kt
@@ -73,6 +73,8 @@ class WebServerRateLimitTest {
                 } catch (e: Exception) {
                     fail("Request $i failed with exception: ${e.message}")
                     return
+                } finally {
+                    conn.disconnect()
                 }
 
             if (i <= limit) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebUiBridgeTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebUiBridgeTest.kt
@@ -15,6 +15,7 @@ import org.junit.rules.TemporaryFolder
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.util.Base64
+import java.util.concurrent.CountDownLatch
 
 class WebUiBridgeTest {
     @get:Rule
@@ -46,6 +47,22 @@ class WebUiBridgeTest {
         assertTrue(JSONObject(body).has("files"))
         assertFalse(File(configDir, "webui_bridge/requests").exists())
         assertFalse(File(configDir, "webui_bridge/responses").exists())
+    }
+
+    @Test
+    fun `native request waits for bounded startup readiness and recovers`() {
+        val startupReady = CountDownLatch(1)
+        bridge = WebUiBridge(WebServer(0, configDir), configDir, startupReady, 100)
+        val startedAt = System.nanoTime()
+
+        val unavailable = submit("/api/config")
+
+        assertEquals(503, unavailable.getInt("status"))
+        assertTrue(System.nanoTime() - startedAt < 1_000_000_000L)
+
+        startupReady.countDown()
+        val ready = submit("/api/config")
+        assertEquals(200, ready.getInt("status"))
     }
 
     @Test

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxAutoCleanerTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/KeyboxAutoCleanerTest.kt
@@ -25,6 +25,23 @@ class KeyboxAutoCleanerTest {
     }
 
     @Test
+    fun `rapid toggle reuses one executor instead of accumulating workers`() {
+        val field = KeyboxAutoCleaner::class.java.getDeclaredField("executor").apply { isAccessible = true }
+        try {
+            KeyboxAutoCleaner.setEnabled(false)
+            KeyboxAutoCleaner.setEnabled(true)
+            val first = field.get(KeyboxAutoCleaner)
+            KeyboxAutoCleaner.setEnabled(false)
+            KeyboxAutoCleaner.setEnabled(true)
+            val second = field.get(KeyboxAutoCleaner)
+
+            assertSame(first, second)
+        } finally {
+            KeyboxAutoCleaner.setEnabled(false)
+        }
+    }
+
+    @Test
     fun `replacement after verification is not quarantined`() {
         val root = temp.newFolder("replacement")
         val source = File(File(root, "keyboxes").apply { mkdirs() }, "candidate.xml")


### PR DESCRIPTION
## Özet

Bu PR, production’da bildirilen iki WebUI sorununu ve repo-geneli adversarial CPU/RAM bulgularını tek değişiklik kümesinde düzeltir.

## Kök neden düzeltmeleri

- Keybox delete artık backend’in canonical `root`/`keyboxes` scope sözleşmesini kullanıyor. Eski `managed` inventory aliası uyumluluk için `keyboxes` olarak canonicalize ediliyor; unknown scope’lar reddediliyor.
- WebUI transport’u backend/core runtime hazır olmadan request forward etmiyor. `CountDownLatch` gate timeout’lu 503 döndürüyor; browser `fetchAuth` yalnız exact startup-gate mesajında bounded exponential retry yapıyor, normal backend 503’ü gizlemiyor ve abort’u destekliyor.
- NanoHTTPD’nin socket başına thread açan default runner’ı 8 worker + 16 bounded queue + queue-full close + stop cleanup ile değiştirildi.
- DRM injection PID geçmişi 64 kayıtla sınırlandı.
- KeyboxAutoCleaner ve CronAutoIdentity toggle’larında scheduler executor churn kapatıldı.
- Native Binder interceptor registry’sine 512 kayıt cap’i ve dead weak-target pruning eklendi.

## Test ve doğrulama

- 46 WebUI test dosyası sequential: 0 failure.
- Gradle service/stub full test: 655 test, 0 failure, `BUILD SUCCESSFUL`.
- Rust `cargo fmt --all -- --check`, workspace clippy `-D warnings` ve workspace testleri başarılı.
- `:module:zipRelease` ve `:encryptor:assembleRelease` başarılı.
- CDP 360px tüm sayfalar: root/body 360/360, overflow yok; accessibility `missingNames=[]`, `smallTargets=[]`.
- İki farklı post-fix audit turu tamamlandı: sistematik reviewer ve saldırgan/fresh-eyes; ikisi de sıfır yeni bulgu verdi.

Published V2.6.5 tag, release asset’leri, SHA256SUMS ve `update.json` değiştirilmedi. Fiziksel Android cihaz/ADB hedefi olmadığı için gerçek cihaz VmRSS/thread/FD zaman serisi alınamadı; `80.12 MB` aggregate VmRSS tek başına leak kanıtı değildir.
