### PR TITLE
🧪 Fix UI alignment in Donate -> Platforms panel

### DIFF
--- a/module/template/webroot/index.html
+++ b/module/template/webroot/index.html
@@ -795,9 +795,9 @@
         <div class="panel">
 <h3>Platforms</h3>
 <div style="display:flex; flex-direction:column; gap:12px;">
-    <div class="row"><span style="font-weight:bold;">Binance User ID</span><span style="font-family:monospace;">114574830 <button onclick="copyToClipboard('114574830','Copied Binance ID',this)" style="padding:8px 16px; font-size:0.85em; margin-left:5px; min-height:44px;">Copy</button></span></div>
-    <div class="row"><span style="font-weight:bold;">PayPal</span><a href="https://www.paypal.me/tryigitx" target="_blank" rel="noopener noreferrer" style="display:inline-flex; align-items:center; justify-content:center; min-height:44px; min-width:44px; color:var(--accent); text-decoration:none;">paypal.me/tryigitx</a></div>
-    <div class="row"><span style="font-weight:bold;">BuyMeACoffee</span><a href="https://buymeacoffee.com/yigitx" target="_blank" rel="noopener noreferrer" style="display:inline-flex; align-items:center; justify-content:center; min-height:44px; min-width:44px; color:var(--accent); text-decoration:none;">buymeacoffee.com/yigitx</a></div>
+    <div class="row"><span style="font-weight:bold;">Binance User ID</span><div style="display:flex; align-items:center; justify-content:flex-end; gap:8px;"><span style="font-family:monospace;">114574830</span><button onclick="copyToClipboard('114574830','Copied Binance ID',this)" style="padding:8px 16px; font-size:0.85em; min-height:44px;">Copy</button></div></div>
+    <div class="row"><span style="font-weight:bold;">PayPal</span><a href="https://www.paypal.me/tryigitx" target="_blank" rel="noopener noreferrer" style="display:inline-flex; align-items:center; justify-content:flex-end; min-height:44px; min-width:44px; color:var(--accent); text-decoration:none; text-align:right;">paypal.me/tryigitx</a></div>
+    <div class="row"><span style="font-weight:bold;">BuyMeACoffee</span><a href="https://buymeacoffee.com/yigitx" target="_blank" rel="noopener noreferrer" style="display:inline-flex; align-items:center; justify-content:flex-end; min-height:44px; min-width:44px; color:var(--accent); text-decoration:none; text-align:right;">buymeacoffee.com/yigitx</a></div>
 </div>
         </div>
         <div class="panel" style="text-align:center;">


### PR DESCRIPTION
🎯 **What**: Aligned the "Platforms" panel in the donate menu to ensure "Copy" buttons and links are neatly right-aligned.
💡 **Why**: The "Copy" button for the Binance User ID and the links for PayPal/BuyMeACoffee were rendering poorly aligned when there were width constraints or different flexbox behaviors on mobile.
✅ **Verification**: Visually verified the layout with Playwright using a mobile viewport, capturing video and screenshot. Additionally, ran `ktlintCheck` and `service:testDebugUnitTest` to make sure string assertions weren't impacted.
✨ **Result**: The values for platforms now wrap to the right and layout cleanly.

---
*PR created automatically by Jules for task [1216905772642298742](https://jules.google.com/task/1216905772642298742) started by @tryigit*