### PR TITLE
🧪 Fix log vanishing on refresh and suppress harmless error logs

### DIFF
--- a/module/template/webroot/bridge.js
+++ b/module/template/webroot/bridge.js
@@ -1173,7 +1173,7 @@
     }
 
     const cleveresLogsCommand =
-        `{ logcat -d -t 2000 2>/dev/null | grep -E 'CleveresTricky|cleverestricky|cleverestrickyd|cleverestricky_backend' || true; ` +
+        `{ logcat -d -t 2000 2>/dev/null | grep -E ' (CleveresTricky|cleverestricky|cleverestrickyd|cleverestricky_backend) *:' || true; ` +
         `if [ -f '${nativeRuntimeLog}' ] && [ ! -L '${nativeRuntimeLog}' ]; then printf '\n--- native runtime ---\n'; tail -n 1000 '${nativeRuntimeLog}' 2>/dev/null; fi; } | tail -n 2500 | tail -c 1048576`;
 
     async function loadCleveresLogs() {

--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -642,7 +642,7 @@ object Config {
                     storedKeyboxCache.clear()
                     KeyboxActivation.commitAndPublish(emptyList())
                 }
-                Logger.e("failed to update keyboxes", error)
+                Logger.i("failed to update keyboxes: ${error.message}")
                 if (allowRecovery &&
                     (error is RustBackendUnavailableException || error is RustBackendStateException || NativeBackend.consumeBackendStateReset())
                 ) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/InstalledPackagesCompat.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/InstalledPackagesCompat.kt
@@ -32,10 +32,10 @@ internal object InstalledPackagesCompat {
         try {
             getInstalledPackageNamesViaBinder(packageManager, userId)
         } catch (error: LinkageError) {
-            Logger.w("Hidden PackageManager package enumeration is unavailable; using bounded cmd fallback")
+            Logger.i("Hidden PackageManager package enumeration is unavailable; using bounded cmd fallback")
             getInstalledPackageNamesViaCommand(userId)
         } catch (error: SecurityException) {
-            Logger.w("Hidden PackageManager package enumeration was denied; using bounded cmd fallback")
+            Logger.i("Hidden PackageManager package enumeration was denied; using bounded cmd fallback")
             getInstalledPackageNamesViaCommand(userId)
         }
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeyboxLoader.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeyboxLoader.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 /** Transient transport or protocol failure at the unprivileged Rust backend boundary. */
 internal class RustBackendUnavailableException(
     cause: Throwable? = null,
-) : IOException("Rust backend is unavailable", cause)
+) : IOException("Rust backend is unavailable. (transient)", cause)
 
 /**
  * One managed boundary for keybox material. XML is parsed and private keys are normalized and

--- a/service/src/main/java/cleveres/tricky/cleverestech/NativeBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/NativeBackend.kt
@@ -253,7 +253,7 @@ object NativeBackend {
                     continue
                 }
                 synchronized(this) { closeSocket() }
-                Logger.w("Rust backend operation $opcode failed: ${error.javaClass.simpleName}")
+                Logger.i("Rust backend operation $opcode failed: ${error.javaClass.simpleName}")
                 if (propagateTransportFailure) throw RustBackendUnavailableException(error)
                 return null
             }

--- a/service/src/main/java/cleveres/tricky/cleverestech/NativeBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/NativeBackend.kt
@@ -253,7 +253,7 @@ object NativeBackend {
                     continue
                 }
                 synchronized(this) { closeSocket() }
-                Logger.e("Rust backend operation $opcode failed: ${error.javaClass.simpleName}")
+                Logger.w("Rust backend operation $opcode failed: ${error.javaClass.simpleName}")
                 if (propagateTransportFailure) throw RustBackendUnavailableException(error)
                 return null
             }

--- a/service/src/main/java/cleveres/tricky/cleverestech/RuntimeDiagnostics.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/RuntimeDiagnostics.kt
@@ -12,13 +12,7 @@ internal object RuntimeDiagnostics {
     private const val MAX_LOG_BYTES = 1024 * 1024
     private const val MAX_LOG_LINES = 2500
     private const val MAX_NATIVE_LOG_BYTES = 512L * 1024L
-    private val cleveresMarkers =
-        listOf(
-            "CleveresTricky",
-            "cleverestricky",
-            "cleverestrickyd",
-            "cleverestricky_backend",
-        )
+    private val cleveresMarkerRegex = Regex(" (CleveresTricky|cleverestricky|cleverestrickyd|cleverestricky_backend) *:")
 
     fun healthJson(root: File): JSONObject {
         val policy = PolicyState.stateJson()
@@ -43,7 +37,7 @@ internal object RuntimeDiagnostics {
         val filtered =
             logcat
                 .lineSequence()
-                .filter { line -> cleveresMarkers.any(line::contains) }
+                .filter { line -> cleveresMarkerRegex.containsMatchIn(line) }
                 .takeLastBounded(MAX_LOG_LINES)
                 .joinToString("\n")
         val native =

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -2095,7 +2095,7 @@ class WebServer(
                     when (type) {
                         "errors" -> arrayOf("logcat", "-d", "-t", "1000", "*:E")
                         "system" -> arrayOf("logcat", "-d", "-t", "1000")
-                        else -> arrayOf("logcat", "-d", "-t", "1000", "-s", "cleverestricky:V")
+                        else -> arrayOf("logcat", "-d", "-t", "1000", "-s", "cleverestricky:V", "CleveresTricky:V")
                     }
                 val logs = readCommandOutput(cmd)
                 secureResponse(Response.Status.OK, "text/plain", logs.ifBlank { "No logs found." })


### PR DESCRIPTION
🎯 **What**
This PR fixes an issue where logs vanish after refreshing, filters out non-CleveresTricky logs that just happen to contain the phrase "CleveresTricky", and downgrades harmless fallback warnings to info logs to reduce user confusion.

💡 **Why**
- Logs vanished because `WebServer.kt` was only pulling `cleverestricky:V` and missing the daemon logs `CleveresTricky:V`.
- WebUI fallback JS script and Kotlin `RuntimeDiagnostics` fetched logs that simply contained the string "CleveresTricky" rather than using proper tag matching regex, picking up extraneous logs from apps like flutter or hyper_launcher.
- Normal linkage fallback failures during package enumeration outputted scary warnings.
- Backend failures outputted scary error logs which are now downgraded to warning/info.

✅ **Verification**
Ran all tests successfully with `./gradlew test ktlintCheck` and `npx playwright test`.

✨ **Result**
Harmless warnings are downgraded to info. Refreshing logs works without vanishing and only the correct CleveresTricky-tagged logs appear.

---
*PR created automatically by Jules for task [1412558883314534748](https://jules.google.com/task/1412558883314534748) started by @tryigit*