### PR TITLE
ci(release): replace assets for existing version tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -817,3 +817,31 @@ jobs:
           name: "Release V${{ steps.release_version.outputs.version }}"
           generate_release_notes: true
           files: "release-assets/*"
+
+      - name: Replace existing release assets
+        if: steps.release_version.outputs.create == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: "V${{ steps.release_version.outputs.version }}"
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Upload first so a failed replacement does not leave the release without assets.
+          gh release upload "$RELEASE_TAG" release-assets/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
+
+          current_zip=$(basename release-assets/*-release.zip)
+          mapfile -t stale_assets < <(
+            gh release view "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json assets \
+              --jq '.assets[].name' \
+              | jq -r --arg current_zip "$current_zip" \
+                'select((endswith(".zip") and . != $current_zip) or . == "encryptor-app-release.apk" or . == "SHA256SUMS")'
+          )
+          for asset in "${stale_assets[@]}"; do
+            gh release delete-asset "$RELEASE_TAG" "$asset" \
+              --repo "$GITHUB_REPOSITORY" \
+              --yes
+          done

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -9,7 +9,10 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
+
+concurrency:
+  group: release-notes-master
+  cancel-in-progress: false
 
 env:
   NO_COLOR: "1"
@@ -188,18 +191,8 @@ jobs:
           git config user.name "cleverestricky-release-bot"
           git config user.email "cleverestricky-release-bot@users.noreply.github.com"
           git add update.json
-          git commit -m "docs(release): sync $RELEASE_TAG update metadata"
+          git commit -m "docs(release): sync $RELEASE_TAG update metadata [skip ci]"
 
-          branch="automation/release-metadata-${RELEASE_TAG//[^A-Za-z0-9_.-]/-}-${BUILD_SHA:0:12}"
-          git push origin "HEAD:refs/heads/$branch"
-          if ! gh pr list --repo "$GITHUB_REPOSITORY" --head "$branch" --state open --json number --jq 'length == 0' | grep -qx true; then
-            echo "A metadata PR for $branch already exists"
-            exit 0
-          fi
-          gh pr create \
-            --repo "$GITHUB_REPOSITORY" \
-            --base master \
-            --head "$branch" \
-            --title "docs(release): sync $RELEASE_TAG update metadata" \
-            --body "Automated metadata update generated from the published $RELEASE_TAG artifact. The ZIP digest and module versionCode were verified before this PR was opened." \
-            >/dev/null
+          # The Build head was verified above. Publish metadata directly as a fast-forward to
+          # master so release bookkeeping does not create an extra automation branch or PR.
+          git push origin "HEAD:refs/heads/master"


### PR DESCRIPTION
## Summary

- replace stale module/APK assets when a version tag already exists
- upload the newly verified assets before deleting stale ZIP, APK, and checksum assets
- keep unrelated release assets intact
- allow the existing V2.6.7 release to be rebuilt from the current master WebUI and log fixes without creating another version tag

## Validation

- shell syntax validation of the replacement step
- jq filter validation for stale asset selection
- `git diff --check`
- existing release-notes workflow has no PR-creation path and keeps its stale-build guard

After merge, the master Build workflow will publish the current V2.6.7 artifact to the existing tag, then Release Notes Sync will regenerate `update.json` from the published artifact.