### PR TITLE
🧪 fix(release): gracefully skip update.json sync when module ZIP is missing

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -134,8 +134,12 @@ jobs:
           release_json=$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json assets)
           zip_name=$(jq -r --arg prefix "CleveresTricky-${RELEASE_TAG}-" '
             [.assets[] | select(.name | startswith($prefix) and endswith(".zip")) | .name]
-            | if length == 1 then .[0] else error("expected exactly one module release ZIP") end
+            | if length == 1 then .[0] elif length == 0 then empty else error("expected exactly one module release ZIP") end
           ' <<<"$release_json")
+          if [[ -z "$zip_name" ]]; then
+            echo "No module release ZIP found for $RELEASE_TAG. Skipping metadata update."
+            exit 0
+          fi
           expected_digest=$(jq -r --arg name "$zip_name" '
             [.assets[] | select(.name == $name) | .digest]
             | if length == 1 then .[0] else error("module release ZIP digest is missing") end


### PR DESCRIPTION
🎯 **What**
Updated the `.github/workflows/release-notes.yml` action to gracefully exit when there is no matching module release ZIP file for a given release, instead of throwing an error.

💡 **Why**
When `jq` evaluates `if length == 1 then .[0] else error(...)` and there are 0 matched elements (e.g., if there's no module release ZIP file published), it forcefully stops the execution throwing an `expected exactly one module release ZIP` error (like reported in the issue) halting the pipeline with exit code 5. We should exit cleanly in this specific case because the user may simply not have published a module ZIP for that specific release and it should not make the CI fail red.

✅ **Verification**
Verified the `release-notes.yml` script logic and ensured `update.json` sync process correctly gracefully skips when the name is empty. Checked with the full `./gradlew test ktlintCheck` tests suite successfully.

✨ **Result**
The `📝 Sync Release Notes` workflow action will now cleanly and successfully handle instances without module ZIPs without breaking the workflow or triggering an error status.

---
*PR created automatically by Jules for task [9229586775414485588](https://jules.google.com/task/9229586775414485588) started by @tryigit*