### PR TITLE
🧪 fix(ci): Handle multiple matching release artifacts and delete remnants

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -132,14 +132,23 @@ jobs:
           fi
 
           release_json=$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json assets)
-          zip_name=$(jq -r --arg prefix "CleveresTricky-${RELEASE_TAG}-" '
-            [.assets[] | select(.name | startswith($prefix) and endswith(".zip")) | .name]
-            | if length == 1 then .[0] elif length == 0 then empty else error("expected exactly one module release ZIP") end
+
+          mapfile -t matching_zips < <(jq -r --arg prefix "CleveresTricky-${RELEASE_TAG}-" '
+            [.assets[] | select(.name | startswith($prefix) and endswith(".zip"))]
+            | sort_by(.createdAt) | reverse | .[].name
           ' <<<"$release_json")
-          if [[ -z "$zip_name" ]]; then
+
+          if [[ ${#matching_zips[@]} -eq 0 ]]; then
             echo "No module release ZIP found for $RELEASE_TAG. Skipping metadata update."
             exit 0
           fi
+
+          zip_name="${matching_zips[0]}"
+
+          for remnant in "${matching_zips[@]:1}"; do
+            echo "Deleting remnant asset: $remnant"
+            gh release delete-asset "$RELEASE_TAG" "$remnant" --repo "$GITHUB_REPOSITORY" --yes || true
+          done
           expected_digest=$(jq -r --arg name "$zip_name" '
             [.assets[] | select(.name == $name) | .digest]
             | if length == 1 then .[0] else error("module release ZIP digest is missing") end


### PR DESCRIPTION
🎯 **What**
Updates the release-notes workflow to gracefully handle multiple module release ZIPs.

💡 **Why**
When multiple artifact runs result in duplicate matching ZIPs attached to a GitHub Release (e.g., from an aborted and re-run build), `release-notes.yml` failed with a jq error: `expected exactly one module release ZIP`. This PR updates the logic to sort the matching assets by creation time, selects the newest one as the canonical artifact, and uses `gh release delete-asset` to delete the older remnant ZIPs, as requested.

✅ **Verification**
Verified via local script tests and test suites.

✨ **Result**
The `release-notes.yml` workflow will now correctly proceed even if multiple zip artifacts exist, cleaning up the old remnants automatically.

---
*PR created automatically by Jules for task [3597340444197750519](https://jules.google.com/task/3597340444197750519) started by @tryigit*