### PR TITLE
🧪 [ci] fix release notes sync failing on signed commit requirement

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -201,11 +201,23 @@ jobs:
           fi
           mv "$tmp" update.json
 
-          git config user.name "cleverestricky-release-bot"
-          git config user.email "cleverestricky-release-bot@users.noreply.github.com"
-          git add update.json
-          git commit -m "docs(release): sync $RELEASE_TAG update metadata [skip ci]"
+          file_sha=$(git rev-parse HEAD:update.json)
+          b64_content=$(base64 -w 0 update.json)
+          commit_msg="docs(release): sync $RELEASE_TAG update metadata [skip ci]"
 
-          # The Build head was verified above. Publish metadata directly as a fast-forward to
-          # master so release bookkeeping does not create an extra automation branch or PR.
-          git push origin "HEAD:refs/heads/master"
+          payload_file="$RUNNER_TEMP/commit_payload.json"
+          jq -n \
+            --arg msg "$commit_msg" \
+            --arg content "$b64_content" \
+            --arg sha "$file_sha" \
+            --arg branch "master" \
+            '{ message: $msg, content: $content, sha: $sha, branch: $branch }' > "$payload_file"
+
+          # Publish metadata directly to master via GitHub API to ensure the commit is
+          # signed and accepted by branch protection rules.
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/"$GITHUB_REPOSITORY"/contents/update.json \
+            --input "$payload_file"


### PR DESCRIPTION
🎯 **What**
Modify `.github/workflows/release-notes.yml` to replace the standard `git commit` and `git push` logic in the final step with GitHub API calls using `gh api`.

💡 **Why**
The standard `git commit` generated unsigned commits. Branch protection rules on the `master` branch require verified commit signatures. Using `gh api` generates signed commits via the GitHub bot natively which will be accepted by branch protection rules.

✅ **Verification**
Verified locally using `gh api` and verified `.github/workflows/release-notes.yml` using diff to ensure modifications were made accurately. Also, ran tests `gradlew test` and `ktlintCheck` on native modules and `encryptor-app` successfully to confirm no regressions are made in other modules.

✨ **Result**
Release notes syncing via the workflow will no longer be rejected by branch protection requiring signed commits.

---
*PR created automatically by Jules for task [3194430936918186621](https://jules.google.com/task/3194430936918186621) started by @tryigit*