### PR TITLE
fix(webui): remove redundant dashboard status grid and polish select dropdown arrows

### DIFF
--- a/module/template/webroot/index.html
+++ b/module/template/webroot/index.html
@@ -201,11 +201,31 @@
             min-height: 44px;
             min-width: 44px;
         }
-        input[type="text"]:focus, input[type="tel"]:focus, input[type="password"]:focus, input[type="search"]:focus, input[type="number"]:focus, textarea:focus, select:focus {
+        select {
+            appearance: none;
+            -webkit-appearance: none;
+            -moz-appearance: none;
+            background-color: var(--input-bg);
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%238e8e93' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-position: right 14px center;
+            background-size: 16px 16px;
+            padding-right: 40px !important;
+            cursor: pointer;
+        }
+        select::-ms-expand { display: none; }
+        input[type="text"]:focus, input[type="tel"]:focus, input[type="password"]:focus, input[type="search"]:focus, input[type="number"]:focus, textarea:focus {
             border-color: var(--accent);
             outline: none;
             box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.3);
             background: #323236;
+        }
+        select:focus {
+            border-color: var(--accent);
+            outline: none;
+            box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.3);
+            background-color: #323236;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%230a84ff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
         }
         button {
             background: var(--panel-elevated);
@@ -304,46 +324,6 @@
         #info { overflow-x: hidden; }
         #info .responsive-table { table-layout: fixed; }
         #info .responsive-table td { overflow-wrap: anywhere; }
-        .status-grid {
-            display: grid;
-            grid-template-columns: repeat(4, minmax(0, 1fr));
-            gap: 12px;
-            margin-bottom: 18px;
-            width: 100%;
-            box-sizing: border-box;
-        }
-        .status-card {
-            min-width: 0;
-            padding: 16px;
-            border: 1px solid var(--border);
-            border-radius: 14px;
-            background: var(--panel);
-            box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
-            box-sizing: border-box;
-        }
-        .status-label {
-            color: var(--text-muted);
-            font-size: 0.7rem;
-            font-weight: 600;
-            letter-spacing: 0.06em;
-            line-height: 1.35;
-            text-transform: uppercase;
-        }
-        .status-value {
-            display: inline-block;
-            margin-top: 10px;
-            padding: 5px 8px;
-            border: 1px solid var(--border);
-            border-radius: 8px;
-            color: var(--text) !important;
-            background: var(--panel-elevated) !important;
-            font-size: 0.76rem;
-            font-weight: 700;
-            letter-spacing: 0.03em;
-        }
-        #status_rkp.status-value { color: var(--success) !important; background: var(--success-soft) !important; border-color: rgba(48, 209, 88, 0.3); }
-        #status_global.status-value, #status_drm.status-value { border-color: rgba(255, 69, 58, 0.3); }
-        #status_global.status-value.active, #status_drm.status-value.active { border-color: rgba(48, 209, 88, 0.3); }
         .log-toolbar { display: grid; grid-template-columns: minmax(0, 1fr) repeat(3, minmax(124px, auto)); gap: 10px; align-items: stretch; margin-bottom: 10px; width: 100%; box-sizing: border-box; }
         .log-toolbar > * { min-width: 0; }
         .log-toolbar select, .log-toolbar button { width: 100%; min-width: 0; margin: 0; min-height: 44px; }
@@ -353,7 +333,6 @@
         @media screen and (max-width: 900px) {
             body { grid-template-columns: minmax(180px, 210px) minmax(0, 1fr); }
             .content { padding-left: 14px; padding-right: 14px; }
-            .status-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
         }
         @media screen and (max-width: 700px) {
             body {
@@ -431,9 +410,6 @@
                 overflow-x: hidden;
             }
             .panel { padding: 18px 16px; border-radius: 14px; margin-bottom: 16px; }
-            .status-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
-            .status-card { padding: 12px; }
-            .status-label { font-size: 0.66rem; }
             .grid-2 { grid-template-columns: 1fr; gap: 14px; }
             .row { flex-wrap: wrap; gap: 10px; }
             .row > label, .row > span, .row > h3 { flex: 1 1 100%; min-width: 0; line-height: 1.4; }
@@ -510,24 +486,6 @@
         <div class="panel panel-hero">
 <h3>Core Protection</h3>
 <div class="scope-note" style="margin-top:10px;"><strong style="color:var(--success);">Always active.</strong> Bootloader/verified-boot property compatibility and Keystore/TEE certificate protection are core module behavior. They have no on/off switch and continue working when Identity Engine is disabled. Hardware bootloader and root-of-trust state are not physically changed.</div>
-        </div>
-        <div class="status-grid" aria-label="Protection status">
-            <div class="status-card">
-                <div class="status-label">Identity Engine</div>
-                <div id="status_engine" class="status-value">OFF</div>
-            </div>
-            <div class="status-card">
-                <div class="status-label">Global Mode</div>
-                <div id="status_global" class="status-value">INACTIVE</div>
-            </div>
-            <div class="status-card">
-                <div class="status-label">RKP Protection</div>
-                <div id="status_rkp" class="status-value">ALWAYS ON</div>
-            </div>
-            <div class="status-card">
-                <div class="status-label">DRM Fix</div>
-                <div id="status_drm" class="status-value">INACTIVE</div>
-            </div>
         </div>
 
         <div class="panel panel-config">

--- a/module/template/webroot/policy.js
+++ b/module/template/webroot/policy.js
@@ -347,11 +347,13 @@ function makePage(id, afterId) {
 function removeLegacySurfaces() {
   const dashboard = document.getElementById('dashboard');
   if (dashboard) {
+    const statusGrid = dashboard.querySelector('.status-grid');
+    if (statusGrid) statusGrid.remove();
     const statusEngine = document.getElementById('status_engine');
     const statusGlobal = document.getElementById('status_global');
     if (statusEngine && statusGlobal) {
       const strip = statusEngine.parentElement && statusEngine.parentElement.parentElement;
-      if (strip && !strip.classList.contains('status-grid') && strip.contains(statusGlobal) && strip.parentElement === dashboard) strip.remove();
+      if (strip && strip.contains(statusGlobal) && strip.parentElement === dashboard) strip.remove();
     }
     [...dashboard.querySelectorAll('.panel')].forEach(panel => {
       const title = (panel.querySelector('h3')?.textContent || '').trim();

--- a/module/template/webroot/ux.js
+++ b/module/template/webroot/ux.js
@@ -1615,6 +1615,7 @@
             #ct_keyboxhub_hint .ct-keyboxhub-action:hover { background:rgba(255,255,255,.07); }
             html[dir="rtl"] body { direction: rtl; }
             html[dir="rtl"] input, html[dir="rtl"] select, html[dir="rtl"] textarea, html[dir="rtl"] pre, html[dir="rtl"] code, html[dir="rtl"] .mono { direction: ltr; text-align: left; }
+            html[dir="rtl"] select { background-position: left 14px center !important; padding-left: 40px !important; padding-right: 14px !important; }
             html[dir="rtl"] input[type="checkbox"].toggle { direction: ltr; }
             @media (max-width: 520px) {
                 .ct-verify-header, .ct-diagnostics-header { flex-direction: column; align-items: stretch; gap: 10px; margin-bottom: 10px !important; }

--- a/module/webui-tests/all-pages-responsive.test.js
+++ b/module/webui-tests/all-pages-responsive.test.js
@@ -90,5 +90,20 @@ assert.doesNotMatch(
   /#tab_donate\s*\{[^}]*background:\s*transparent\s*!important/s,
   'Donate tab must not force transparent background',
 );
+assert.match(
+  indexSource,
+  /select\s*\{[^}]*appearance:\s*none/s,
+  'select elements must use appearance: none with custom chevron arrow',
+);
+assert.match(
+  indexSource,
+  /select\s*\{[^}]*background-position:\s*right 14px center/s,
+  'select elements must position down chevron with right margin',
+);
+assert.doesNotMatch(
+  indexSource,
+  /<div class="status-grid"/,
+  'Dashboard must not contain obsolete status-grid',
+);
 
 console.log('All-pages responsive and accessible-control regression checks passed');

--- a/module/webui-tests/canonical-entrypoint.test.js
+++ b/module/webui-tests/canonical-entrypoint.test.js
@@ -104,7 +104,7 @@ function testCanonicalInitialStateAndRuntimeSurface() {
     assert.doesNotMatch(bridgeSource, /(?:ux-core|zip-import|ux-base|ux-patch)\.js/i, 'bridge must not load retired UX bundles');
 
     assert.match(html, /\.panel-hero\s*\{/i, 'direct-open dashboard must expose the modern hero surface');
-    assert.match(html, /\.status-grid\s*\{/i, 'direct-open dashboard must expose the modern status grid');
+    assert.doesNotMatch(html, /class=["'][^"']*\bstatus-grid\b/i, 'direct-open dashboard must not contain obsolete status-grid');
     const mobileStart = html.lastIndexOf('@media screen and (max-width: 700px)');
     assert.ok(mobileStart >= 0, 'canonical index must keep a mobile-specific layout contract');
     const mobileBlock = html.slice(mobileStart);

--- a/module/webui-tests/rkp-retirement.test.js
+++ b/module/webui-tests/rkp-retirement.test.js
@@ -7,7 +7,7 @@ const html = fs.readFileSync(path.join(__dirname, '../template/webroot/index.htm
 
 test('retired RKP passthrough is presented as always-on protection', () => {
   assert.match(html, /RKP Protection/);
-  assert.match(html, /ALWAYS ON/);
+  assert.match(html, /Always on/i);
   assert.doesNotMatch(html, /RKP Bypass/);
 
   const settings = html.match(/const WEB_UI_SETTINGS = \[([^\]]+)\]/)?.[1] || '';

--- a/module/webui-tests/webui-runtime-contract.test.js
+++ b/module/webui-tests/webui-runtime-contract.test.js
@@ -254,28 +254,18 @@ function makeCleanupSurface(classNames = [], textContent = '') {
     };
 }
 
-async function testLegacyCleanupPreservesCanonicalStatusGrid() {
+async function testLegacyCleanupRemovesStatusGrid() {
     const canonical = loadPolicyRuntime();
     const dashboard = makeCleanupSurface();
     const statusGrid = makeCleanupSurface(['status-grid']);
-    const engineCard = makeCleanupSurface();
-    const globalCard = makeCleanupSurface();
-    const statusEngine = makeCleanupSurface();
-    const statusGlobal = makeCleanupSurface();
     statusGrid.parentElement = dashboard;
-    statusGrid.children = [engineCard, globalCard];
-    statusGrid.containsNode = statusGlobal;
-    engineCard.parentElement = statusGrid;
-    globalCard.parentElement = statusGrid;
-    statusEngine.parentElement = engineCard;
-    statusGlobal.parentElement = globalCard;
+    dashboard.querySelector = sel => (sel === '.status-grid' ? statusGrid : null);
+    dashboard.querySelectorAll = () => [];
     canonical.document.getElementById = id => ({
-        dashboard,
-        status_engine: statusEngine,
-        status_global: statusGlobal
+        dashboard
     }[id] || null);
     canonical.hooks.removeLegacySurfaces();
-    assert.strictEqual(statusGrid.removed, false, 'legacy cleanup must preserve the canonical status-grid');
+    assert.strictEqual(statusGrid.removed, true, 'legacy cleanup must remove status-grid if present');
 
     const legacy = loadPolicyRuntime();
     const legacyDashboard = makeCleanupSurface();
@@ -382,7 +372,7 @@ async function testAutoIdentityBackendFailureStillFails() {
     await testCanonicalSaveWarningIsNotReportedAsFailure();
     await testSaveUsesCanonicalReadbackInsteadOfStaleUiState();
     await testPolicyNormalizationRejectsMalformedAndOversizedState();
-    await testLegacyCleanupPreservesCanonicalStatusGrid();
+    await testLegacyCleanupRemovesStatusGrid();
     await testApplyIdentitySurvivesPresentationRefreshFailure();
     await testAutoIdentitySurvivesPresentationRefreshFailure();
     await testAutoIdentityBackendFailureStillFails();


### PR DESCRIPTION
## Summary
- Removes the obsolete static 4-card status grid (\status-grid\) from the Dashboard tab, keeping the modern, comprehensive Feature Center as the single source of truth for runtime protections and switches.
- Modernizes \<select>\ dropdown menus across the WebUI with \ppearance: none\, sleek SVG chevron down arrows, consistent 14px padding offset from edges, and full RTL layout support.
- Updates regression tests in \ll-pages-responsive.test.js\, \canonical-entrypoint.test.js\, \kp-retirement.test.js\, and \webui-runtime-contract.test.js\.