### PR TITLE
fix(webui): center diagnostics copy button text and add theme-matching selection styling

### DIFF
--- a/module/template/webroot/index.html
+++ b/module/template/webroot/index.html
@@ -32,6 +32,14 @@
             --content-width: 1240px;
         }
         * { box-sizing: border-box; }
+        ::selection {
+            background-color: rgba(10, 132, 255, 0.4);
+            color: #ffffff;
+        }
+        ::-moz-selection {
+            background-color: rgba(10, 132, 255, 0.4);
+            color: #ffffff;
+        }
         html {
             color-scheme: dark;
             background: var(--bg);
@@ -237,6 +245,10 @@
             font-family: inherit;
             font-weight: 600;
             font-size: 0.92rem;
+            text-align: center;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
             transition: all 0.18s cubic-bezier(0.16, 1, 0.3, 1);
             text-transform: none;
             letter-spacing: -0.01em;

--- a/module/template/webroot/ux.js
+++ b/module/template/webroot/ux.js
@@ -1594,6 +1594,7 @@
             #ct_debug_panel .row > label { flex: 1 1 auto !important; min-width: 0 !important; padding-right: 14px !important; }
             #ct_debug_panel .row > input[type="checkbox"] { flex: 0 0 48px !important; width: 48px !important; min-width: 48px !important; max-width: 48px !important; height: 28px !important; min-height: 28px !important; max-height: 28px !important; margin: 0 !important; }
             #ct_diagnostics_panel .row, #ct_drm_dashboard_panel .row { margin-bottom: 0; }
+            #ct_diagnostics_copy { white-space: nowrap !important; text-align: center !important; justify-content: center !important; }
             #ct_effective_apps_host > .panel { margin-top: 0; }
             #ct_effective_apps_host { margin-top: 20px; }
             #cleveresCommunityCard { box-sizing: border-box; margin: 20px 0 24px !important; width: 100%; }
@@ -2100,7 +2101,7 @@
         const panel = document.createElement('div');
         panel.id = 'ct_diagnostics_panel';
         panel.className = 'panel';
-        panel.innerHTML = '<h3>Support Diagnostics</h3><div class="row ct-diagnostics-header"><div id="ct_diagnostics_hint" class="res-desc" style="flex:1;padding-right:14px">Copy a bounded support snapshot without logs, package names, keybox names, identity values, credentials, or key material.</div><button id="ct_diagnostics_copy" type="button" aria-label="Copy Diagnostics">Copy Diagnostics</button></div>';
+        panel.innerHTML = '<h3>Support Diagnostics</h3><div class="row ct-diagnostics-header"><div id="ct_diagnostics_hint" class="res-desc" style="flex:1;padding-right:14px">Copy a bounded support snapshot without logs, package names, keybox names, identity values, credentials, or key material.</div><button id="ct_diagnostics_copy" type="button" aria-label="Copy Diagnostics" style="text-align:center;justify-content:center;white-space:nowrap;">Copy Diagnostics</button></div>';
         info.appendChild(panel);
         panel.querySelector('button').addEventListener('click', event => copyDiagnosticsSnapshot(event.currentTarget));
     }

--- a/module/webui-tests/all-pages-responsive.test.js
+++ b/module/webui-tests/all-pages-responsive.test.js
@@ -105,5 +105,20 @@ assert.doesNotMatch(
   /<div class="status-grid"/,
   'Dashboard must not contain obsolete status-grid',
 );
+assert.match(
+  indexSource,
+  /::selection\s*\{[^}]*background-color:\s*rgba\(10,\s*132,\s*255/s,
+  'theme selection styling must use accent color',
+);
+assert.match(
+  indexSource,
+  /button\s*\{[^}]*text-align:\s*center/s,
+  'buttons must center text alignment',
+);
+assert.match(
+  uxSource,
+  /#ct_diagnostics_copy\s*\{[^}]*text-align:\s*center/s,
+  'diagnostics copy button must explicitly center text',
+);
 
 console.log('All-pages responsive and accessible-control regression checks passed');


### PR DESCRIPTION
## Summary
- Ensures \#ct_diagnostics_copy\ (and all buttons globally) use explicit \	ext-align: center\, \display: inline-flex\, \lign-items: center\, and \justify-content: center\ with \white-space: nowrap\ to eliminate any right-shifted/off-center button text.
- Adds dark theme-matched \::selection\ and \::-moz-selection\ styles with the semi-transparent accent color (\gba(10, 132, 255, 0.4)\) and white text.
- Adds regression unit tests in \ll-pages-responsive.test.js\.