### PR TITLE
chore(release): finalize V2.6.8 release metadata and update.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## V2.6.8
 
-- **WebUI Visual Improvements:** The Global Mode active state is now displayed with the correct color. Spacing issues in the Core Protection descriptions have been fixed, and duplicate clear buttons in App Search have been removed.
-- **Mobile WebUI Improvements:** The Stored Keyboxes section is now displayed more cleanly on smaller screens, and a loading indicator is shown while content is being loaded when the WebUI starts.
+- **WebUI Visual & Mobile Improvements:** The Global Mode active state is displayed with the correct color, obsolete status indicators have been cleaned up, dropdown select arrows are modernized, and text selection styling now matches the dark theme. Spacing in Core Protection descriptions and button text alignment have been polished.
+- **Mobile Usability & Layout:** The Stored Keyboxes section is displayed cleanly on smaller screens, and a loading indicator is shown while content is being loaded when the WebUI starts.
 - **Log Display Fixes:** Logs no longer disappear after being refreshed. Only logs actually belonging to CleveresTricky are displayed, and normal return states no longer generate unnecessary error warnings.
 - **Keybox and Background Stability:** Improved resilience against temporary connection issues during Keybox updates and background service operations.
 - **Camera Privacy Stability:** Improved application responsiveness and state transitions while applying camera visibility and privacy rules.

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
-  "version": "V2.6.7 (3481-b22f53b3-release)",
-  "versionCode": 3481,
-  "zipUrl": "https://github.com/tryigit/CleveresTricky/releases/download/V2.6.7/CleveresTricky-V2.6.7-3481-b22f53b3-release.zip",
+  "version": "V2.6.8 (3497-7c8f2e17-release)",
+  "versionCode": 3497,
+  "zipUrl": "https://github.com/tryigit/CleveresTricky/releases/download/V2.6.8/CleveresTricky-V2.6.8-3497-7c8f2e17-release.zip",
   "changelog": "https://raw.githubusercontent.com/tryigit/CleveresTricky/refs/heads/master/CHANGELOG.md"
 }


### PR DESCRIPTION
## Summary
- Finalizes \update.json\ with the live published \V2.6.8\ release artifact metadata (\ersionCode: 3497\, \CleveresTricky-V2.6.8-3497-7c8f2e17-release.zip\).
- Polishes \CHANGELOG.md\ to capture the late WebUI visual, mobile usability, and status indicator improvements.