### PR TITLE
chore(release): update update.json to live V2.6.8 build 3500

### DIFF
--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
-  "version": "V2.6.8 (3497-7c8f2e17-release)",
-  "versionCode": 3497,
-  "zipUrl": "https://github.com/tryigit/CleveresTricky/releases/download/V2.6.8/CleveresTricky-V2.6.8-3497-7c8f2e17-release.zip",
+  "version": "V2.6.8 (3500-c8a64a7c-release)",
+  "versionCode": 3500,
+  "zipUrl": "https://github.com/tryigit/CleveresTricky/releases/download/V2.6.8/CleveresTricky-V2.6.8-3500-c8a64a7c-release.zip",
   "changelog": "https://raw.githubusercontent.com/tryigit/CleveresTricky/refs/heads/master/CHANGELOG.md"
 }


### PR DESCRIPTION
## Summary
- Synchronizes \update.json\ with the live \V2.6.8\ release artifact (\ersionCode: 3500\, \CleveresTricky-V2.6.8-3500-c8a64a7c-release.zip\).