### PR TITLE
chore(release): update update.json to live V2.6.8 build 3504

### DIFF
--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
-  "version": "V2.6.8 (3502-5fced1b1-release)",
-  "versionCode": 3502,
-  "zipUrl": "https://github.com/tryigit/CleveresTricky/releases/download/V2.6.8/CleveresTricky-V2.6.8-3502-5fced1b1-release.zip",
+  "version": "V2.6.8 (3504-c43c5991-release)",
+  "versionCode": 3504,
+  "zipUrl": "https://github.com/tryigit/CleveresTricky/releases/download/V2.6.8/CleveresTricky-V2.6.8-3504-c43c5991-release.zip",
   "changelog": "https://raw.githubusercontent.com/tryigit/CleveresTricky/refs/heads/master/CHANGELOG.md"
 }


### PR DESCRIPTION
## Summary
- Synchronizes \update.json\ with live \V2.6.8\ release artifact (\ersionCode: 3504\, \CleveresTricky-V2.6.8-3504-c43c5991-release.zip\).