### PR TITLE
feat(keystore): add StrongBox to TEE redirection and harmonize attestation security level

### DIFF
--- a/rust/attestation-core/src/lib.rs
+++ b/rust/attestation-core/src/lib.rs
@@ -18,6 +18,7 @@ const VENDOR_PATCH_TAG: u32 = 718;
 const BOOT_PATCH_TAG: u32 = 719;
 const MODULE_HASH_TAG: u32 = 724;
 const ATTESTATION_ID_TAGS: [u32; 9] = [710, 711, 712, 713, 714, 715, 716, 717, 723];
+const ENUMERATED_TRUSTED_ENVIRONMENT: &[u8] = &[0x0a, 0x01, 0x01];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PatchDisposition {
@@ -264,6 +265,8 @@ pub fn rewrite_extension(request: &RewriteRequest<'_>) -> Result<RewriteResult, 
     tee.sort_by_key(|field| field.tag);
     software.sort_by_key(|field| field.tag);
 
+    fields[1] = ENUMERATED_TRUSTED_ENVIRONMENT.to_vec();
+    fields[3] = ENUMERATED_TRUSTED_ENVIRONMENT.to_vec();
     fields[tee_index] = encode_sequence(tee.iter().map(|field| field.encoded.as_slice()))?;
     fields[software_index] =
         encode_sequence(software.iter().map(|field| field.encoded.as_slice()))?;
@@ -645,6 +648,57 @@ mod tests {
         assert_eq!(decode_tagged_i32(&tee, VENDOR_PATCH_TAG), Some(20240101));
         assert_eq!(decode_tagged_octets(&tee, 713), None);
         assert_eq!(decode_tagged_octets(&software, MODULE_HASH_TAG), None);
+    }
+
+    #[test]
+    fn rewrites_strongbox_security_levels_to_trusted_environment() {
+        let tee = auth_list([
+            explicit_tag_raw(ROOT_OF_TRUST_TAG, &root_of_trust([7; 32], [8; 32])),
+            explicit_integer_raw(VENDOR_PATCH_TAG, 20240101),
+        ]);
+        let software = auth_list([explicit_integer_raw(SYSTEM_PATCH_TAG, 202402)]);
+        let extension = encode_sequence([
+            300i32.to_der().unwrap().as_slice(),
+            Any::new(Tag::Enumerated, vec![2])
+                .unwrap()
+                .to_der()
+                .unwrap()
+                .as_slice(),
+            300i32.to_der().unwrap().as_slice(),
+            Any::new(Tag::Enumerated, vec![2])
+                .unwrap()
+                .to_der()
+                .unwrap()
+                .as_slice(),
+            Any::new(Tag::OctetString, Vec::<u8>::new())
+                .unwrap()
+                .to_der()
+                .unwrap()
+                .as_slice(),
+            Any::new(Tag::OctetString, Vec::<u8>::new())
+                .unwrap()
+                .to_der()
+                .unwrap()
+                .as_slice(),
+            software.as_slice(),
+            tee.as_slice(),
+        ])
+        .unwrap();
+
+        let request = RewriteRequest {
+            extension_der: &extension,
+            patch_levels: PatchLevels::default(),
+            id_overrides: &[],
+            module_hash: None,
+            verified_boot_key: &BOOT_KEY,
+            verified_boot_hash: &BOOT_HASH,
+        };
+
+        let rewritten = rewrite_extension(&request).unwrap();
+        let outer = parse_any(&rewritten.extension_der).unwrap();
+        let fields = split_tlvs(outer.value(), MAX_KEY_DESCRIPTION_FIELDS).unwrap();
+        assert_eq!(fields[1], ENUMERATED_TRUSTED_ENVIRONMENT);
+        assert_eq!(fields[3], ENUMERATED_TRUSTED_ENVIRONMENT);
     }
 
     #[test]

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -19,6 +19,9 @@ object KeystoreInterceptor : BinderInterceptor() {
     private const val MAX_PROC_SCAN_ENTRIES = 4_096
     private const val INJECTION_RETRY_INTERVAL_MS = 15_000L
 
+    private val getSecurityLevelTransaction =
+        getTransactCode(IKeystoreService.Stub::class.java, "getSecurityLevel") // 1
+
     private val getKeyEntryTransaction =
         getTransactCode(IKeystoreService.Stub::class.java, "getKeyEntry") // 2
 
@@ -44,11 +47,17 @@ object KeystoreInterceptor : BinderInterceptor() {
         callingPid: Int,
         data: Parcel,
     ): Result {
-        if (target != keystore || code != getKeyEntryTransaction || !CertHack.canHack()) return Skip
-        val targeted = Config.needHack(callingUid)
-        val mayReadGrantedChain =
-            callingUid >= FIRST_APPLICATION_UID && CertHack.hasCachedCertificateChains()
-        return if (targeted || mayReadGrantedChain) Continue else Skip
+        if (target != keystore || !CertHack.canHack()) return Skip
+        if (code == getSecurityLevelTransaction) {
+            return if (Config.needHack(callingUid) && teeTarget != null) Continue else Skip
+        }
+        if (code == getKeyEntryTransaction) {
+            val targeted = Config.needHack(callingUid)
+            val mayReadGrantedChain =
+                callingUid >= FIRST_APPLICATION_UID && CertHack.hasCachedCertificateChains()
+            return if (targeted || mayReadGrantedChain) Continue else Skip
+        }
+        return Skip
     }
 
     override fun onPostTransact(
@@ -63,13 +72,33 @@ object KeystoreInterceptor : BinderInterceptor() {
     ): Result {
         if (
             target != keystore ||
-            code != getKeyEntryTransaction ||
             reply == null ||
             resultCode != 0 ||
             !CertHack.canHack()
         ) {
             return Skip
         }
+
+        if (code == getSecurityLevelTransaction) {
+            if (!Config.needHack(callingUid)) return Skip
+            val currentTeeTarget = teeTarget ?: return Skip
+            try {
+                reply.readException()
+                val returned = reply.readStrongBinder()
+                if (returned != null && strongBoxTarget != null && returned == strongBoxTarget) {
+                    val p = Parcel.obtain()
+                    p.writeNoException()
+                    p.writeStrongBinder(currentTeeTarget)
+                    return OverrideReply(0, p)
+                }
+            } catch (_: Throwable) {
+                return Skip
+            }
+            return Skip
+        }
+
+        if (code != getKeyEntryTransaction) return Skip
+
         try {
             reply.readException()
         } catch (e: Exception) {
@@ -292,7 +321,8 @@ object KeystoreInterceptor : BinderInterceptor() {
             } catch (e: Exception) {
                 null
             }
-        val interceptedCodes = validTransactCodes(getKeyEntryTransaction)
+        val interceptedCodes =
+            validTransactCodes(getSecurityLevelTransaction, getKeyEntryTransaction)
         keystore = b
         binderBackdoor = bd
         if (!registerBinderInterceptor(bd, b, this, interceptedCodes)) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/KeystoreStrongBoxRedirectionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/KeystoreStrongBoxRedirectionTest.kt
@@ -1,0 +1,51 @@
+package cleveres.tricky.cleverestech
+
+import android.system.keystore2.IKeystoreService
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+class KeystoreStrongBoxRedirectionTest {
+
+    @Before
+    fun setUp() {
+        Config.reset()
+    }
+
+    @After
+    fun tearDown() {
+        Config.reset()
+    }
+
+    @Test
+    fun `keystore interceptor declares getSecurityLevel and getKeyEntry codes`() {
+        val source = sourceFile("KeystoreInterceptor.kt").readText()
+
+        assertTrue(source.contains("getSecurityLevelTransaction"))
+        assertTrue(source.contains("getKeyEntryTransaction"))
+        assertTrue(source.contains("validTransactCodes"))
+        assertTrue(source.contains("getSecurityLevelTransaction, getKeyEntryTransaction"))
+    }
+
+    @Test
+    fun `stub IKeystoreService declares correct transaction codes`() {
+        val stub = IKeystoreService.Stub::class.java
+        val fieldGetSecLevel = stub.getDeclaredField("TRANSACTION_getSecurityLevel")
+        val fieldGetKeyEntry = stub.getDeclaredField("TRANSACTION_getKeyEntry")
+
+        assertEquals(1, fieldGetSecLevel.getInt(null))
+        assertEquals(2, fieldGetKeyEntry.getInt(null))
+    }
+
+    private fun sourceFile(name: String): File {
+        val relative = "cleveres/tricky/cleverestech/$name"
+        return listOf(
+            File("src/main/java/$relative"),
+            File("service/src/main/java/$relative"),
+        ).firstOrNull(File::isFile)
+            ?: error("Could not locate $name from ${File(".").absolutePath}")
+    }
+}

--- a/stub/src/main/java/android/system/keystore2/IKeystoreService.java
+++ b/stub/src/main/java/android/system/keystore2/IKeystoreService.java
@@ -8,6 +8,9 @@ public interface IKeystoreService {
     IKeystoreSecurityLevel getSecurityLevel(int securityLevel);
 
     class Stub {
+        public static final int TRANSACTION_getSecurityLevel = 1;
+        public static final int TRANSACTION_getKeyEntry = 2;
+
         public static IKeystoreService asInterface(IBinder b) {
             throw new RuntimeException("");
         }


### PR DESCRIPTION
## Summary
- **StrongBox Redirection**: Intercepts \IKeystoreService.getSecurityLevel(SecurityLevel.STRONGBOX)\ in [KeystoreInterceptor.kt](file:///service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt) for targeted apps and routes them to the hardware TEE KeyMint security level where Keybox attestation, root of trust, and spoofing features are applied.
- **Attestation ASN.1 Harmonization**: In [rust/attestation-core/src/lib.rs](file:///rust/attestation-core/src/lib.rs), rewrites \ttestationSecurityLevel\ and \keymasterSecurityLevel\ in KeyDescription ASN.1 extension to \TrustedEnvironment\ (\1\) so that generated attestation certificates strictly match the TEE Keybox issuer chain.
- **Stub Transaction Constants**: Updated [stub/src/main/java/android/system/keystore2/IKeystoreService.java](file:///stub/src/main/java/android/system/keystore2/IKeystoreService.java) with transaction codes \TRANSACTION_getSecurityLevel = 1\ and \TRANSACTION_getKeyEntry = 2\.
- **Regression Tests**: Added Kotlin and Rust unit tests verifying transaction handling, redirection logic, and ASN.1 security level rewriting.