### PR TITLE
🧪 [testing improvement] Add edge case test for getModuleDir

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/UtilTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/UtilTest.kt
@@ -136,6 +136,14 @@ class UtilTest {
     }
 
     @Test
+    fun testGetModuleDir_noCandidatesExist() {
+        // Since we are running on a standard JVM/build environment, the /data/adb/ paths
+        // will not exist, thus testing the edge case where no candidate directory is found.
+        val expectedDefault = "/data/adb/modules/cleverestricky"
+        org.junit.Assert.assertEquals(expectedDefault, getModuleDir())
+    }
+
+    @Test
     fun testUtf8ByteLength_matchesByteArraySize() {
         val samples =
             listOf(


### PR DESCRIPTION
🎯 **What:** Added a test for the fallback logic of `getModuleDir()`.
📊 **Coverage:** Covered the edge case where none of the `/data/adb/*` directories exist.
✨ **Result:** Verified that the default return value is correct in the test suite, increasing test coverage.

---
*PR created automatically by Jules for task [4597571462791891622](https://jules.google.com/task/4597571462791891622) started by @tryigit*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying the default module directory is returned when no candidate directory exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->