### PR TITLE
🧪 Add edge case tests for `convertPatchLevel`

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/UtilTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/UtilTest.kt
@@ -7,8 +7,10 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
+import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import java.time.DateTimeException
 
 @OptIn(ExperimentalStdlibApi::class)
 class UtilTest {
@@ -158,5 +160,55 @@ class UtilTest {
             val actual = sample.utf8ByteLength()
             org.junit.Assert.assertEquals("Length mismatch for: $sample", expected, actual)
         }
+    }
+
+    @Test
+    fun testConvertPatchLevel_validFormats() {
+        org.junit.Assert.assertEquals(202305, "202305".convertPatchLevel(false))
+        org.junit.Assert.assertEquals(20230501, "202305".convertPatchLevel(true))
+
+        org.junit.Assert.assertEquals(202305, "2023-05".convertPatchLevel(false))
+        org.junit.Assert.assertEquals(20230501, "2023-05".convertPatchLevel(true))
+
+        org.junit.Assert.assertEquals(202305, "20230505".convertPatchLevel(false))
+        org.junit.Assert.assertEquals(20230505, "20230505".convertPatchLevel(true))
+
+        org.junit.Assert.assertEquals(202305, "2023-05-05".convertPatchLevel(false))
+        org.junit.Assert.assertEquals(20230505, "2023-05-05".convertPatchLevel(true))
+
+        org.junit.Assert.assertEquals(202305, "  2023-05-05  ".convertPatchLevel(false))
+        org.junit.Assert.assertEquals(20230505, "  2023-05-05  ".convertPatchLevel(true))
+    }
+
+    @Test
+    fun testConvertPatchLevel_invalidLengths() {
+        assertThrows(IllegalArgumentException::class.java) { "20230".convertPatchLevel(false) }
+        assertThrows(IllegalArgumentException::class.java) { "2023-0".convertPatchLevel(false) }
+        assertThrows(IllegalArgumentException::class.java) { "2023050".convertPatchLevel(false) }
+        assertThrows(IllegalArgumentException::class.java) { "202305050".convertPatchLevel(false) }
+        assertThrows(IllegalArgumentException::class.java) { "2023-05-050".convertPatchLevel(false) }
+    }
+
+    @Test
+    fun testConvertPatchLevel_invalidSeparators() {
+        assertThrows(IllegalArgumentException::class.java) { "20230-5".convertPatchLevel(false) }
+        assertThrows(IllegalArgumentException::class.java) { "20-2305".convertPatchLevel(false) }
+        assertThrows(IllegalArgumentException::class.java) { "2023--05".convertPatchLevel(false) }
+        assertThrows(IllegalArgumentException::class.java) { "2023-050-5".convertPatchLevel(false) }
+    }
+
+    @Test
+    fun testConvertPatchLevel_nonDigits() {
+        assertThrows(IllegalArgumentException::class.java) { "2023-AB".convertPatchLevel(false) }
+        assertThrows(IllegalArgumentException::class.java) { "2023-05-AB".convertPatchLevel(false) }
+        assertThrows(IllegalArgumentException::class.java) { "2023AB05".convertPatchLevel(false) }
+    }
+
+    @Test
+    fun testConvertPatchLevel_invalidDates() {
+        assertThrows(DateTimeException::class.java) { "2023-13".convertPatchLevel(false) } // Invalid month
+        assertThrows(DateTimeException::class.java) { "2023-00".convertPatchLevel(false) } // Invalid month
+        assertThrows(DateTimeException::class.java) { "2023-05-32".convertPatchLevel(false) } // Invalid day
+        assertThrows(DateTimeException::class.java) { "2023-02-29".convertPatchLevel(false) } // Invalid leap year
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap for the `String.convertPatchLevel` function in `Util.kt` has been addressed by adding a comprehensive suite of unit tests.

📊 **Coverage:** The new tests cover:
- Valid formats for 6, 7, 8, and 10 character inputs, including trailing/leading whitespace and variations of the `long` parameter.
- Edge cases for invalid lengths (too short, too long).
- Edge cases for invalid separators (dashes in incorrect positions).
- Error conditions for non-digit characters.
- Error conditions for invalid dates that would cause `DateTimeException` during parsing.

✨ **Result:** Increased test coverage and reliability for parsing Android security patch levels, ensuring the function throws appropriate exceptions when given malformed or logically invalid input.

---
*PR created automatically by Jules for task [15625581627882750895](https://jules.google.com/task/15625581627882750895) started by @tryigit*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for valid compact and hyphenated patch-level formats.
  - Added validation tests for invalid lengths, separators, non-numeric input, and calendar dates.
  - Included scenarios where day values are expanded automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->