### PR TITLE
🧪 Add test edge cases for utf8ByteLength

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/UtilTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/UtilTest.kt
@@ -152,6 +152,12 @@ class UtilTest {
                 "A".repeat(1000),
                 "Ç".repeat(1000),
                 "中".repeat(1000),
+                "\u0000",
+                "\u007F",
+                "\u0080",
+                "\u07FF",
+                "\u0800",
+                "\uFFFF",
             )
         for (sample in samples) {
             val expected = sample.toByteArray(Charsets.UTF_8).size


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of boundary cases for 1-byte, 2-byte, and 3-byte UTF-8 sequences when calculating the UTF-8 string byte length.
📊 **Coverage:** Evaluates correct lengths for `\u0000`, `\u007F`, `\u0080`, `\u07FF`, `\u0800`, and `\uFFFF`.
✨ **Result:** Better confidence and coverage for the utf8ByteLength algorithm.

---
*PR created automatically by Jules for task [14800273773898793833](https://jules.google.com/task/14800273773898793833) started by @tryigit*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded UTF-8 byte-length test coverage for key encoding boundaries, including control characters and maximum BMP characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->