### PR TITLE
🧹 Code Health: Fix deprecated MockIHTTPSession API

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/MockIHTTPSession.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/MockIHTTPSession.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
 package cleveres.tricky.cleverestech
 
 import fi.iki.elonen.NanoHTTPD
@@ -21,28 +22,23 @@ open class MockIHTTPSession(
 
     override fun getCookies(): CookieHandler? = null
 
-    @Deprecated("Deprecated by NanoHTTPD")
     override fun getHeaders(): Map<String, String> = headers
 
     override fun getInputStream(): InputStream? = inputStream
 
     override fun getMethod(): Method = method
 
-    @Deprecated("Use getParameters")
     override fun getParms(): Map<String, String> = parms
 
     override fun getParameters(): Map<String, List<String>> = parameters
 
-    @Deprecated("Deprecated by NanoHTTPD")
     override fun getQueryParameterString(): String = queryParameterString
 
     override fun getUri(): String = uri
 
     override fun parseBody(files: MutableMap<String, String>?) {}
 
-    @Deprecated("Deprecated by NanoHTTPD")
     override fun getRemoteIpAddress(): String = remoteIpAddress
 
-    @Deprecated("Deprecated by NanoHTTPD")
     override fun getRemoteHostName(): String = remoteHostName
 }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the usage of manual `@Deprecated` annotations on overridden methods in `MockIHTTPSession.kt`.

💡 **Why:** This improves maintainability by removing visual clutter and resolving compiler warnings cleanly with a file-level suppression.

✅ **Verification:** I ran the test suite using `./gradlew :service:testDebugUnitTest :stub:testDebugUnitTest :encryptor-app:testDebugUnitTest` and confirmed that the build was successful.

✨ **Result:** The code health issue is resolved and the codebase is cleaner.

---
*PR created automatically by Jules for task [656418918082220515](https://jules.google.com/task/656418918082220515) started by @tryigit*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified deprecation handling in the session implementation without changing its behavior or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->