### PR TITLE
🧪 Add tests for getBootHashFromProp

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/UtilTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/UtilTest.kt
@@ -87,7 +87,6 @@ class UtilTest {
 
     @Test
     fun testGetBootHashFromProp_missing() {
-        setProp("ro.boot.vbmeta.digest", "")
         assertNull(getBootHashFromProp())
     }
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/UtilTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/UtilTest.kt
@@ -79,13 +79,28 @@ class UtilTest {
     }
 
     @Test
-    fun testGetBootHashFromProp_rejectsZeroSentinel() {
-        setProp("ro.boot.vbmeta.digest", "0".repeat(64))
-        assertNull(getBootHashFromProp())
-
+    fun testGetBootHashFromProp_primary() {
         val expected = ByteArray(32) { 0xCD.toByte() }
         setProp("ro.boot.vbmeta.digest", expected.toHexString())
         assertArrayEquals(expected, getBootHashFromProp())
+    }
+
+    @Test
+    fun testGetBootHashFromProp_missing() {
+        setProp("ro.boot.vbmeta.digest", "")
+        assertNull(getBootHashFromProp())
+    }
+
+    @Test
+    fun testGetBootHashFromProp_invalidLength() {
+        setProp("ro.boot.vbmeta.digest", "1234567890")
+        assertNull(getBootHashFromProp())
+    }
+
+    @Test
+    fun testGetBootHashFromProp_rejectsZeroSentinel() {
+        setProp("ro.boot.vbmeta.digest", "0".repeat(64))
+        assertNull(getBootHashFromProp())
     }
 
     @Test


### PR DESCRIPTION
🎯 **What:** Added tests for `getBootHashFromProp` to improve testing gap.
📊 **Coverage:** Covered missing case, primary happy case, invalid length case, and zero sentinel case in isolation.
✨ **Result:** Better test coverage matching tests for `getBootKeyFromProp`.

---
*PR created automatically by Jules for task [16291351056140762287](https://jules.google.com/task/16291351056140762287) started by @tryigit*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded validation coverage for boot hash properties.
  - Added checks for missing values and invalid-length values.
  - Separated primary-value verification from zero-sentinel rejection testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->