### PR TITLE
🧪 [testing improvement] Add test coverage for getTransactCode error handling

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/UtilTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/UtilTest.kt
@@ -159,4 +159,54 @@ class UtilTest {
             org.junit.Assert.assertEquals("Length mismatch for: $sample", expected, actual)
         }
     }
+
+    @Test
+    fun testGetTransactCode_successField() {
+        val code = getTransactCode(DummyStub::class.java, "testMethod")
+        org.junit.Assert.assertEquals(42, code)
+    }
+
+    @Test
+    fun testGetTransactCode_fallbackMethod() {
+        val code = getTransactCode(DummyStub::class.java, "fallbackMethod")
+        org.junit.Assert.assertEquals(43, code)
+    }
+
+    @Test
+    fun testGetTransactCode_errorHandling() {
+        val code = getTransactCode(ErrorStub::class.java, "someMethod")
+        org.junit.Assert.assertEquals(-1, code)
+    }
+
+    @Test
+    fun testGetTransactCode_notFound() {
+        val code = getTransactCode(FailedStub::class.java, "someMethod")
+        org.junit.Assert.assertEquals(-1, code)
+    }
+
+    class DummyStub {
+        companion object {
+            @JvmField
+            val TRANSACTION_testMethod = 42
+
+            @JvmStatic
+            fun getDefaultTransactionName(transactionCode: Int): String? {
+                return when (transactionCode) {
+                    43 -> "fallbackMethod"
+                    else -> null
+                }
+            }
+        }
+    }
+
+    class ErrorStub {
+        companion object {
+            @JvmStatic
+            fun getDefaultTransactionName(transactionCode: Int): String? {
+                throw RuntimeException("Intentional crash")
+            }
+        }
+    }
+
+    class FailedStub
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `getTransactCode` function uses reflection to get transaction codes, with a fallback method and error handling if reflection fails. Previously, the error handling and fallback logic was not adequately tested.

📊 **Coverage:** What scenarios are now tested
- Success: Field `TRANSACTION_testMethod` exists and is read.
- Fallback Method: Field is missing, but `getDefaultTransactionName` method exists and returns the correct transaction name.
- Error Handling: Fallback method throws an exception, returning `-1`.
- Not Found: Neither the field nor the fallback method exist, returning `-1`.

✨ **Result:** The improvement in test coverage
The `getTransactCode` function is now fully covered, ensuring that its reflection error handling and fallback behavior works correctly. We avoided complex mocking by using static inner stub classes to naturally trigger `NoSuchFieldException` and test the catch block.

---
*PR created automatically by Jules for task [16343386177168739332](https://jules.google.com/task/16343386177168739332) started by @tryigit*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for transaction code lookup, including direct field retrieval and fallback method lookup.
  - Added tests for error handling and cases where transaction metadata is unavailable.
  - Introduced test stubs representing successful, failing, and missing lookup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->