### PR TITLE
🧹 Fix deprecated NanoHTTPD API usage (getParms)

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -328,12 +328,11 @@ class WebServer(
         }
     }
 
-    @Suppress("DEPRECATION")
     private fun getParam(
         session: IHTTPSession,
         name: String,
     ): String? {
-        return session.parms[name]
+        return session.parameters[name]?.firstOrNull()
     }
 
     private fun isRateLimited(ip: String): Boolean {

--- a/service/src/main/java/cleveres/tricky/cleverestech/WebUiBridge.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebUiBridge.kt
@@ -638,19 +638,19 @@ class WebUiBridge(
 
         override fun getCookies(): NanoHTTPD.CookieHandler? = null
 
-        @Deprecated("NanoHTTPD API")
+        @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
         override fun getHeaders(): Map<String, String> = requestHeaders
 
         override fun getInputStream(): InputStream = ByteArrayInputStream(ByteArray(0))
 
         override fun getMethod(): NanoHTTPD.Method = requestMethod
 
-        @Deprecated("NanoHTTPD API")
+        @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
         override fun getParms(): Map<String, String> = requestParameters.mapValues { it.value.first() }
 
         override fun getParameters(): Map<String, List<String>> = requestParameters
 
-        @Deprecated("NanoHTTPD API")
+        @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
         override fun getQueryParameterString(): String = ""
 
         override fun getUri(): String = requestUri
@@ -659,10 +659,10 @@ class WebUiBridge(
             if (files != null && uploadField != null && uploadFile != null) files[uploadField] = uploadFile.absolutePath
         }
 
-        @Deprecated("NanoHTTPD API")
+        @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
         override fun getRemoteIpAddress(): String = "native-webui"
 
-        @Deprecated("NanoHTTPD API")
+        @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
         override fun getRemoteHostName(): String = "native-webui"
     }
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/MockIHTTPSession.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/MockIHTTPSession.kt
@@ -21,28 +21,28 @@ open class MockIHTTPSession(
 
     override fun getCookies(): CookieHandler? = null
 
-    @Deprecated("Deprecated by NanoHTTPD")
+    @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
     override fun getHeaders(): Map<String, String> = headers
 
     override fun getInputStream(): InputStream? = inputStream
 
     override fun getMethod(): Method = method
 
-    @Deprecated("Use getParameters")
+    @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
     override fun getParms(): Map<String, String> = parms
 
-    override fun getParameters(): Map<String, List<String>> = parameters
+    override fun getParameters(): Map<String, List<String>> = if (parameters.isEmpty() && parms.isNotEmpty()) parms.mapValues { listOf(it.value) } else parameters
 
-    @Deprecated("Deprecated by NanoHTTPD")
+    @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
     override fun getQueryParameterString(): String = queryParameterString
 
     override fun getUri(): String = uri
 
     override fun parseBody(files: MutableMap<String, String>?) {}
 
-    @Deprecated("Deprecated by NanoHTTPD")
+    @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
     override fun getRemoteIpAddress(): String = remoteIpAddress
 
-    @Deprecated("Deprecated by NanoHTTPD")
+    @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
     override fun getRemoteHostName(): String = remoteHostName
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerCsrfTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerCsrfTest.kt
@@ -21,7 +21,7 @@ class WebServerCsrfTest {
                 "content-length" to "0",
             ),
             parms = mapOf("token" to server.token),
-            parameters = mapOf("token" to listOf("testtoken"))
+            parameters = mapOf("token" to listOf(server.token))
         )
     }
 


### PR DESCRIPTION
🎯 **What:** Resolved the deprecated NanoHTTPD API usage by migrating from `getParms()` to `getParameters()`.
💡 **Why:** `getParms()` is deprecated in NanoHTTPD and `getParameters()` is the direct replacement. This improves code health and maintainability by moving away from deprecated APIs.
✅ **Verification:** Ran the full test suite (`./gradlew :service:testDebugUnitTest :stub:testDebugUnitTest :encryptor-app:testDebugUnitTest`) and confirmed that all tests, including validation and CSRF tests, continue to pass successfully. Handled backward compatibility in `MockIHTTPSession` so tests don't break.
✨ **Result:** Improved code health by eliminating a deprecated API warning and adhering to the recommended NanoHTTPD usage patterns.

---
*PR created automatically by Jules for task [9362684505703783887](https://jules.google.com/task/9362684505703783887) started by @tryigit*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of request parameters to ensure submitted values are read reliably.
  - Updated security-token validation coverage to use the active token, improving test accuracy and helping prevent false results.
- **Maintenance**
  - Updated compatibility handling for the underlying web server interface, preserving existing behavior while improving support for current APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->