### PR TITLE
🧹 Code Health: Clean up NanoHTTPD deprecation annotations in WebUiBridge

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebUiBridge.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebUiBridge.kt
@@ -625,7 +625,7 @@ class WebUiBridge(
         buffer[offset + 3] = value.toByte()
     }
 
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
     private class BridgeSession(
         private val requestMethod: NanoHTTPD.Method,
         private val requestUri: String,
@@ -638,19 +638,16 @@ class WebUiBridge(
 
         override fun getCookies(): NanoHTTPD.CookieHandler? = null
 
-        @Deprecated("NanoHTTPD API")
         override fun getHeaders(): Map<String, String> = requestHeaders
 
         override fun getInputStream(): InputStream = ByteArrayInputStream(ByteArray(0))
 
         override fun getMethod(): NanoHTTPD.Method = requestMethod
 
-        @Deprecated("NanoHTTPD API")
         override fun getParms(): Map<String, String> = requestParameters.mapValues { it.value.first() }
 
         override fun getParameters(): Map<String, List<String>> = requestParameters
 
-        @Deprecated("NanoHTTPD API")
         override fun getQueryParameterString(): String = ""
 
         override fun getUri(): String = requestUri
@@ -659,10 +656,8 @@ class WebUiBridge(
             if (files != null && uploadField != null && uploadFile != null) files[uploadField] = uploadFile.absolutePath
         }
 
-        @Deprecated("NanoHTTPD API")
         override fun getRemoteIpAddress(): String = "native-webui"
 
-        @Deprecated("NanoHTTPD API")
         override fun getRemoteHostName(): String = "native-webui"
     }
 


### PR DESCRIPTION
🎯 **What:** Removed redundant `@Deprecated` annotations from the `BridgeSession` overrides of `NanoHTTPD.IHTTPSession` and addressed the compiler warnings by suppressing `OVERRIDE_DEPRECATION` at the class level instead.

💡 **Why:** Adding custom `@Deprecated` annotations to methods just because they override a deprecated interface method clutters the code and adds unnecessary noise. Suppressing the override warning at the class level is the standard and cleaner way to handle unavoidable third-party library deprecations.

✅ **Verification:** Ran the full test suite (`./gradlew :service:testDebugUnitTest :stub:testDebugUnitTest :encryptor-app:testDebugUnitTest`) to ensure no regressions were introduced.

✨ **Result:** Improved code readability and maintainability without altering the functional behavior of the stubbed methods.

---
*PR created automatically by Jules for task [9866243909015573344](https://jules.google.com/task/9866243909015573344) started by @tryigit*