### PR TITLE
🧹 [code health] Replace deprecated MockIHTTPSession getParms API

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -328,12 +328,11 @@ class WebServer(
         }
     }
 
-    @Suppress("DEPRECATION")
     private fun getParam(
         session: IHTTPSession,
         name: String,
     ): String? {
-        return session.parms[name]
+        return session.parameters[name]?.firstOrNull()
     }
 
     private fun isRateLimited(ip: String): Boolean {

--- a/service/src/test/java/cleveres/tricky/cleverestech/MockIHTTPSession.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/MockIHTTPSession.kt
@@ -9,7 +9,6 @@ open class MockIHTTPSession(
     private val uri: String = "/",
     private val method: Method = Method.GET,
     private val headers: Map<String, String> = mapOf("host" to "localhost"),
-    private val parms: Map<String, String> = emptyMap(),
     private val parameters: Map<String, List<String>> = emptyMap(),
     private val inputStream: InputStream? = null,
     private val queryParameterString: String = "",
@@ -29,7 +28,7 @@ open class MockIHTTPSession(
     override fun getMethod(): Method = method
 
     @Deprecated("Use getParameters")
-    override fun getParms(): Map<String, String> = parms
+    override fun getParms(): Map<String, String> = parameters.mapValues { it.value.first() }
 
     override fun getParameters(): Map<String, List<String>> = parameters
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerCsrfTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerCsrfTest.kt
@@ -20,8 +20,7 @@ class WebServerCsrfTest {
                 "origin" to origin,
                 "content-length" to "0",
             ),
-            parms = mapOf("token" to server.token),
-            parameters = mapOf("token" to listOf("testtoken"))
+            parameters = mapOf("token" to listOf(server.token))
         )
     }
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerSaveValidationTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerSaveValidationTest.kt
@@ -69,10 +69,10 @@ class WebServerSaveValidationTest {
             uri = "/api/save",
             method = NanoHTTPD.Method.POST,
             headers = mapOf("content-length" to "100", "host" to "localhost"),
-            parms = mapOf(
-                "token" to webServer.token,
-                "filename" to filename,
-                "content" to content,
+            parameters = mapOf(
+                "token" to listOf(webServer.token),
+                "filename" to listOf(filename),
+                "content" to listOf(content),
             )
         )
     }
@@ -250,7 +250,7 @@ class WebServerSaveValidationTest {
                 uri = "/api/reset_environment",
                 method = NanoHTTPD.Method.POST,
                 headers = mapOf("content-length" to "0", "host" to "localhost"),
-                parms = mapOf("token" to webServer.token),
+                parameters = mapOf("token" to listOf(webServer.token)),
             )
         )
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerStoredXssTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerStoredXssTest.kt
@@ -68,7 +68,7 @@ class WebServerStoredXssTest {
         val session = MockIHTTPSession(
             uri = "/api/app_config_structured",
             method = NanoHTTPD.Method.GET,
-            parms = mapOf("token" to webServer.token)
+            parameters = mapOf("token" to listOf(webServer.token))
         )
 
         val response = webServer.serve(session)

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerXssTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerXssTest.kt
@@ -68,7 +68,7 @@ class WebServerXssTest {
             uri = "/api/app_config_structured",
             method = NanoHTTPD.Method.POST,
             headers = mapOf("content-length" to jsonPayload.length.toString(), "host" to "localhost"),
-            parms = mapOf("token" to webServer.token, "data" to jsonPayload)
+            parameters = mapOf("token" to listOf(webServer.token), "data" to listOf(jsonPayload))
         )
 
         val response = webServer.serve(session)
@@ -94,7 +94,7 @@ class WebServerXssTest {
             uri = "/api/app_config_structured",
             method = NanoHTTPD.Method.POST,
             headers = mapOf("content-length" to jsonPayload.length.toString(), "host" to "localhost"),
-            parms = mapOf("token" to webServer.token, "data" to jsonPayload)
+            parameters = mapOf("token" to listOf(webServer.token), "data" to listOf(jsonPayload))
         )
 
         val response = webServer.serve(session)


### PR DESCRIPTION
Replaced usages of the deprecated `getParms` API in `MockIHTTPSession` and `WebServer` with the modern `getParameters` equivalent.

🎯 **What:**
- Removed `parms` constructor argument from `MockIHTTPSession` and replaced it with `parameters`.
- Updated `WebServer.getParam` to use `parameters`.
- Updated tests constructing `MockIHTTPSession` to pass `parameters` instead of `parms`.

💡 **Why:**
Using modern APIs reduces dependency on deprecated ones, reducing warnings and improving overall code health.

✅ **Verification:**
Ran `./gradlew :service:testDebugUnitTest :stub:testDebugUnitTest :encryptor-app:testDebugUnitTest`. All tests executed cleanly.

✨ **Result:**
The deprecated `getParms` property is no longer used, and tests/code are fully aligned with the `getParameters` replacement.

---
*PR created automatically by Jules for task [14117436884517379433](https://jules.google.com/task/14117436884517379433) started by @tryigit*