### PR TITLE
🧪 test: add test for getBootKeyFromProp

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/UtilTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/UtilTest.kt
@@ -98,6 +98,15 @@ class UtilTest {
     }
 
     @Test
+    fun testGetBootKeyFromProp_fetchesExpectedProperty() {
+        val expected = ByteArray(32) { 0x11.toByte() }
+        setProp("ro.boot.vbmeta.public_key_digest", "11".repeat(32))
+
+        val result = getBootKeyFromProp()
+        assertArrayEquals(expected, result)
+    }
+
+    @Test
     fun testGetBootKeyFromProp_invalidLength() {
         setProp("ro.boot.vbmeta.public_key_digest", "1234567890")
         setProp("ro.boot.verifiedbootkey", "abcdef")


### PR DESCRIPTION
🎯 **What:** Added a unit test for `getBootKeyFromProp`.
📊 **Coverage:** Tests the happy path where a valid hex digest string is parsed back into the expected byte array successfully when fetching the primary property.
✨ **Result:** Improved test coverage for `getBootKeyFromProp` and validated property-fetching behavior.

---
*PR created automatically by Jules for task [12618643865458725669](https://jules.google.com/task/12618643865458725669) started by @tryigit*