### PR TITLE
🧹 Fix incorrect NanoHTTPD API deprecation handling

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebUiBridge.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebUiBridge.kt
@@ -638,19 +638,17 @@ class WebUiBridge(
 
         override fun getCookies(): NanoHTTPD.CookieHandler? = null
 
-        @Deprecated("NanoHTTPD API")
         override fun getHeaders(): Map<String, String> = requestHeaders
 
         override fun getInputStream(): InputStream = ByteArrayInputStream(ByteArray(0))
 
         override fun getMethod(): NanoHTTPD.Method = requestMethod
 
-        @Deprecated("NanoHTTPD API")
+        @Suppress("OVERRIDE_DEPRECATION")
         override fun getParms(): Map<String, String> = requestParameters.mapValues { it.value.first() }
 
         override fun getParameters(): Map<String, List<String>> = requestParameters
 
-        @Deprecated("NanoHTTPD API")
         override fun getQueryParameterString(): String = ""
 
         override fun getUri(): String = requestUri
@@ -659,10 +657,8 @@ class WebUiBridge(
             if (files != null && uploadField != null && uploadFile != null) files[uploadField] = uploadFile.absolutePath
         }
 
-        @Deprecated("NanoHTTPD API")
         override fun getRemoteIpAddress(): String = "native-webui"
 
-        @Deprecated("NanoHTTPD API")
         override fun getRemoteHostName(): String = "native-webui"
     }
 


### PR DESCRIPTION
🎯 **What:** Removed incorrect `@Deprecated("NanoHTTPD API")` annotations from non-deprecated `NanoHTTPD.IHTTPSession` methods in `WebUiBridge.kt` and properly handled the genuinely deprecated `getParms()` method using `@Suppress("OVERRIDE_DEPRECATION")`.
💡 **Why:** Using `@Deprecated` to signal an external library's deprecation is incorrect and incorrectly deprecates the local overridden method. Furthermore, applying it to non-deprecated methods creates confusing technical debt. Using `@Suppress` is the idiomatic way to handle overriding a mandatory but deprecated Java interface method.
✅ **Verification:** Verified compilation using `./gradlew :service:compileDebugKotlin` which passed without `-Werror` warnings, and ensured the full unit test suite passed without regression.
✨ **Result:** Improved code maintainability by clearing confusing and incorrect metadata while cleanly handling necessary deprecation suppressions.

---
*PR created automatically by Jules for task [17212305465056448741](https://jules.google.com/task/17212305465056448741) started by @tryigit*