### PR TITLE
🧪 [testing improvement] Add test for getPackageInfoCompat

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/Util.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Util.kt
@@ -235,7 +235,8 @@ fun IPackageManager.getPackageInfoCompat(
     name: String,
     flags: Long,
     userId: Int,
-) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+    sdkInt: Int = Build.VERSION.SDK_INT,
+) = if (sdkInt >= Build.VERSION_CODES.TIRAMISU) {
     getPackageInfo(name, flags, userId)
 } else {
     getPackageInfo(name, flags.toInt(), userId)

--- a/service/src/test/java/android/content/pm/IPackageManager.java
+++ b/service/src/test/java/android/content/pm/IPackageManager.java
@@ -3,6 +3,7 @@ public interface IPackageManager {
     public static abstract class Stub implements android.os.IBinder {
         public static IPackageManager asInterface(android.os.IBinder obj) { return null; }
     }
-    // Add methods used by Config if any, but currently getPackagesForUid is used by getPm() -> used by Config.
     String[] getPackagesForUid(int uid) throws android.os.RemoteException;
+    PackageInfo getPackageInfo(String packageName, long flags, int userId) throws android.os.RemoteException;
+    PackageInfo getPackageInfo(String packageName, int flags, int userId) throws android.os.RemoteException;
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/UtilTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/UtilTest.kt
@@ -7,8 +7,13 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
+import android.content.pm.IPackageManager
+import android.content.pm.PackageInfo
+import android.os.Build
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 
 @OptIn(ExperimentalStdlibApi::class)
 class UtilTest {
@@ -133,6 +138,36 @@ class UtilTest {
 
         assertTrue(bootKey.isUsableBootDigest())
         assertFalse(root.resolve("boot_key").readText().trim().all { it == '0' })
+    }
+
+    @Test
+    fun testGetPackageInfoCompat_TiramisuAndAbove() {
+        val pm = mock(IPackageManager::class.java)
+        val expectedInfo = PackageInfo()
+        val flags = 1234567890L
+        val userId = 0
+        val packageName = "com.test.app"
+
+        `when`(pm.getPackageInfo(packageName, flags, userId)).thenReturn(expectedInfo)
+
+        val result = pm.getPackageInfoCompat(packageName, flags, userId, Build.VERSION_CODES.TIRAMISU)
+
+        org.junit.Assert.assertEquals(expectedInfo, result)
+    }
+
+    @Test
+    fun testGetPackageInfoCompat_BelowTiramisu() {
+        val pm = mock(IPackageManager::class.java)
+        val expectedInfo = PackageInfo()
+        val flags = 12345L
+        val userId = 0
+        val packageName = "com.test.app"
+
+        `when`(pm.getPackageInfo(packageName, flags.toInt(), userId)).thenReturn(expectedInfo)
+
+        val result = pm.getPackageInfoCompat(packageName, flags, userId, Build.VERSION_CODES.S)
+
+        org.junit.Assert.assertEquals(expectedInfo, result)
     }
 
     @Test


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was testing the `getPackageInfoCompat` extension function, which was difficult because it relies on the static final field `Build.VERSION.SDK_INT` and a hidden API interface `IPackageManager`.
📊 **Coverage:** The tests now cover both execution branches: devices running Android Tiramisu (API 33) and above, and devices running older versions.
✨ **Result:** Test coverage for this utility function is significantly improved, ensuring future refactoring won't break backward compatibility.

---
*PR created automatically by Jules for task [10316616117682118915](https://jules.google.com/task/10316616117682118915) started by @tryigit*