### PR TITLE
🧹 Fix Deprecated NanoHTTPD API usage

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebUiBridge.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebUiBridge.kt
@@ -638,7 +638,6 @@ class WebUiBridge(
 
         override fun getCookies(): NanoHTTPD.CookieHandler? = null
 
-        @Deprecated("NanoHTTPD API")
         override fun getHeaders(): Map<String, String> = requestHeaders
 
         override fun getInputStream(): InputStream = ByteArrayInputStream(ByteArray(0))
@@ -650,7 +649,6 @@ class WebUiBridge(
 
         override fun getParameters(): Map<String, List<String>> = requestParameters
 
-        @Deprecated("NanoHTTPD API")
         override fun getQueryParameterString(): String = ""
 
         override fun getUri(): String = requestUri
@@ -659,10 +657,8 @@ class WebUiBridge(
             if (files != null && uploadField != null && uploadFile != null) files[uploadField] = uploadFile.absolutePath
         }
 
-        @Deprecated("NanoHTTPD API")
         override fun getRemoteIpAddress(): String = "native-webui"
 
-        @Deprecated("NanoHTTPD API")
         override fun getRemoteHostName(): String = "native-webui"
     }
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/MockIHTTPSession.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/MockIHTTPSession.kt
@@ -21,7 +21,6 @@ open class MockIHTTPSession(
 
     override fun getCookies(): CookieHandler? = null
 
-    @Deprecated("Deprecated by NanoHTTPD")
     override fun getHeaders(): Map<String, String> = headers
 
     override fun getInputStream(): InputStream? = inputStream
@@ -33,16 +32,13 @@ open class MockIHTTPSession(
 
     override fun getParameters(): Map<String, List<String>> = parameters
 
-    @Deprecated("Deprecated by NanoHTTPD")
     override fun getQueryParameterString(): String = queryParameterString
 
     override fun getUri(): String = uri
 
     override fun parseBody(files: MutableMap<String, String>?) {}
 
-    @Deprecated("Deprecated by NanoHTTPD")
     override fun getRemoteIpAddress(): String = remoteIpAddress
 
-    @Deprecated("Deprecated by NanoHTTPD")
     override fun getRemoteHostName(): String = remoteHostName
 }


### PR DESCRIPTION
🎯 **What:** Removed `@Deprecated("NanoHTTPD API")` and `@Deprecated("Deprecated by NanoHTTPD")` annotations from `WebUiBridge.kt` and `MockIHTTPSession.kt`. Kept the one on `getParms()` as it is genuinely deprecated.
💡 **Why:** The methods `getRemoteIpAddress()`, `getRemoteHostName()`, `getHeaders()`, etc. are not actually deprecated in the NanoHTTPD API `v2.3.1`. They are required methods for implementations of `IHTTPSession`. The false annotations created misleading warnings in the codebase.
✅ **Verification:** Verified against NanoHTTPD `2.3.1` sources. Compiled project, and ran all tests via `./gradlew :service:testDebugUnitTest :stub:testDebugUnitTest :encryptor-app:testDebugUnitTest`. All tests pass successfully.
✨ **Result:** A cleaner codebase with fewer false positive deprecation warnings, improving code health and maintainability without altering functionality.

---
*PR created automatically by Jules for task [11851537364058244491](https://jules.google.com/task/11851537364058244491) started by @tryigit*