### PR TITLE
Fix KeyboxVerifier bug parsing large decimal serial numbers as hex literals

### DIFF
--- a/rust/crl-core/src/lib.rs
+++ b/rust/crl-core/src/lib.rs
@@ -266,7 +266,7 @@ fn normalize_entry(value: &str, output: &mut HashSet<Box<str>>) -> Result<(), Cr
     if PAD_LENGTHS.contains(&bytes.len()) && is_hex {
         insert_bounded(output, value.to_ascii_lowercase())?;
     }
-    if !added && is_hex {
+    if !is_decimal && !added && is_hex {
         if let Some(number) = BigInt::parse_bytes(bytes, 16) {
             insert_bounded(output, number.to_str_radix(16))?;
         }

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/ManagedCrlOracle.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/ManagedCrlOracle.kt
@@ -91,7 +91,7 @@ internal object ManagedCrlOracle {
         if (value.length in hashLengths && value.all(::isHexChar)) {
             output += value.lowercase()
         }
-        if (!added && value.all(::isHexChar)) {
+        if (!decimal && !added && value.all(::isHexChar)) {
             try {
                 output += BigInteger(value, 16).toString(16)
             } catch (_: Exception) {


### PR DESCRIPTION
Addresses an issue where a 25-digit decimal serial number is incorrectly parsed as a hex literal. It resolves this in both the Rust parser and the legacy Kotlin ManagedCrlOracle by adding a mutually exclusive check `!is_decimal` (`!decimal` in Kotlin) before falling back to hex literal parsing.

---
*PR created automatically by Jules for task [8565889828726965592](https://jules.google.com/task/8565889828726965592) started by @tryigit*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hexadecimal key normalization to prevent decimal-looking values from being interpreted as hexadecimal.
  * Avoided duplicate normalization paths for numeric inputs, ensuring consistent key handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->