### PR TITLE
🧪 [fix] Normalize zh-Hans locale variants to zh-CN

### DIFF
--- a/module/template/webroot/bridge.js
+++ b/module/template/webroot/bridge.js
@@ -143,6 +143,10 @@
 
     function normalizeLocale(value) {
         if (typeof value !== 'string' || !value) return null;
+        if (value.startsWith('zh-Hans-')) {
+            const mapped = 'zh-' + value.split('-')[2];
+            if (supportedLocales.has(mapped)) return mapped;
+        }
         if (supportedLocales.has(value)) return value;
         const base = value.split('-')[0];
         return supportedLocales.has(base) ? base : null;

--- a/module/template/webroot/ux.js
+++ b/module/template/webroot/ux.js
@@ -1493,6 +1493,10 @@
 
     function normalizeSupportedLocale(value) {
         if (typeof value !== 'string' || !value) return null;
+        if (value.startsWith('zh-Hans-')) {
+            const mapped = 'zh-' + value.split('-')[2];
+            if (SUPPORTED.some(([id]) => id === mapped)) return mapped;
+        }
         if (SUPPORTED.some(([id]) => id === value)) return value;
         const baseLang = value.split('-')[0];
         if (SUPPORTED.some(([id]) => id === baseLang)) return baseLang;
@@ -2409,6 +2413,10 @@
 
     function normalizeSupportedLocale(value) {
         if (typeof value !== 'string' || !value) return null;
+        if (value.startsWith('zh-Hans-')) {
+            const mapped = 'zh-' + value.split('-')[2];
+            if (SUPPORTED_LOCALES.has(mapped)) return mapped;
+        }
         if (SUPPORTED_LOCALES.has(value)) return value;
         const baseLang = value.split('-')[0];
         if (SUPPORTED_LOCALES.has(baseLang)) return baseLang;

--- a/module/webui-tests/localization.test.js
+++ b/module/webui-tests/localization.test.js
@@ -154,4 +154,13 @@ assert.strictEqual(loadI18n({ cachedSystemLocale: 'zh-CN', browserLocale: 'de-DE
 assert.strictEqual(loadI18n({ browserLocale: 'es-MX' }).i18n.locale, 'es');
 assert.strictEqual(loadI18n({ browserLocale: 'pt-BR' }).i18n.locale, 'en');
 
+assert.strictEqual(
+    loadI18n({ systemLocale: 'zh-Hans-CN', browserLocale: 'de-DE' }).i18n.locale,
+    'zh-CN'
+);
+assert.strictEqual(
+    loadI18n({ browserLocale: 'zh-Hans-CN' }).i18n.locale,
+    'zh-CN'
+);
+
 console.log('WebUI localization coverage tests passed');


### PR DESCRIPTION
🎯 **What**
Normalized `zh-Hans-*` locale variants to their corresponding `zh-*` catalogs across the WebUI components (ux.js, bridge.js, and ZIP-import resolver).

💡 **Why**
Resolves a regression where simplified Chinese locales from browsers and Android system settings (like `zh-Hans-CN`) were incorrectly falling back to the base `zh` catalog instead of properly resolving to `zh-CN`.

✅ **Verification**
- Added strict equivalence tests in `localization.test.js` validating that `zh-Hans-CN` inputs resolve to the `zh-CN` catalog structure properly.
- All localization tests passed via `node ./module/webui-tests/localization.test.js`.
- Passed full Android instrumentation tests and styling checks (`./gradlew test ktlintCheck`).

✨ **Result**
Chinese locales function properly matching standard regional fallback procedures while preserving previous general language fallbacks for unmatched variants.

---
*PR created automatically by Jules for task [17299946252766918236](https://jules.google.com/task/17299946252766918236) started by @tryigit*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Simplified Chinese locale recognition by mapping `zh-Hans-*` variants to the corresponding supported Chinese locale.
  * Ensured consistent locale handling for both system and browser language settings.

* **Tests**
  * Added coverage for `zh-Hans-CN` resolving correctly to `zh-CN`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->