### PR TITLE
fix(service): normalize literal null autoIdentity to inherit in GET /api/app_config_structured

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/WebServer.kt
@@ -1847,7 +1847,8 @@ class WebServer(
                                         obj.put("template", tmpl)
                                         obj.put("keybox", kb)
                                         obj.put("privacy", parsedPrivacy.configValue)
-                                        obj.put("autoIdentity", autoIdentity)
+                                        val normalizedAutoIdentity = if (autoIdentity == "null") "inherit" else autoIdentity
+                                        obj.put("autoIdentity", normalizedAutoIdentity)
                                         array.put(obj)
                                     }
                                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * App configuration responses now consistently return `"inherit"` when automatic identity settings are configured as `"null"`.
  * Other automatic identity values remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->