### PR TITLE
Preserve StrongBox attestation levels and harden restore transactions

### DIFF
--- a/rust/attestation-core/src/lib.rs
+++ b/rust/attestation-core/src/lib.rs
@@ -456,7 +456,7 @@ fn validate_security_level(encoded: &[u8]) -> Result<(), Error> {
     let level = parse_any(encoded)?;
     if level.tag() != Tag::Enumerated
         || level.value().len() != 1
-        || !matches!(level.value()[0], 0 | 1 | 2)
+        || !matches!(level.value()[0], 0..=2)
     {
         return Err(Error::InvalidStructure);
     }

--- a/rust/attestation-core/src/lib.rs
+++ b/rust/attestation-core/src/lib.rs
@@ -18,7 +18,6 @@ const VENDOR_PATCH_TAG: u32 = 718;
 const BOOT_PATCH_TAG: u32 = 719;
 const MODULE_HASH_TAG: u32 = 724;
 const ATTESTATION_ID_TAGS: [u32; 9] = [710, 711, 712, 713, 714, 715, 716, 717, 723];
-const ENUMERATED_TRUSTED_ENVIRONMENT: &[u8] = &[0x0a, 0x01, 0x01];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PatchDisposition {
@@ -150,7 +149,9 @@ pub fn rewrite_extension(request: &RewriteRequest<'_>) -> Result<RewriteResult, 
     }
 
     let attestation_version = decode_i32(&fields[0])?;
+    validate_security_level(&fields[1])?;
     let keymint_version = decode_i32(&fields[2])?;
+    validate_security_level(&fields[3])?;
     let supports_module_hash = attestation_version >= 400 && keymint_version >= 400;
 
     let list_six = parse_authorization_list(&fields[AUTHORIZATION_LIST_SOFTWARE_INDEX])?;
@@ -268,8 +269,6 @@ pub fn rewrite_extension(request: &RewriteRequest<'_>) -> Result<RewriteResult, 
     tee.sort_by_key(|field| field.tag);
     software.sort_by_key(|field| field.tag);
 
-    fields[1] = ENUMERATED_TRUSTED_ENVIRONMENT.to_vec();
-    fields[3] = ENUMERATED_TRUSTED_ENVIRONMENT.to_vec();
     fields[tee_index] = encode_sequence(tee.iter().map(|field| field.encoded.as_slice()))?;
     fields[software_index] =
         encode_sequence(software.iter().map(|field| field.encoded.as_slice()))?;
@@ -451,6 +450,17 @@ fn is_attestation_id_tag(tag: u32) -> bool {
 
 fn decode_i32(encoded: &[u8]) -> Result<i32, Error> {
     i32::from_der(encoded).map_err(|_| Error::InvalidStructure)
+}
+
+fn validate_security_level(encoded: &[u8]) -> Result<(), Error> {
+    let level = parse_any(encoded)?;
+    if level.tag() != Tag::Enumerated
+        || level.value().len() != 1
+        || !matches!(level.value()[0], 0 | 1 | 2)
+    {
+        return Err(Error::InvalidStructure);
+    }
+    Ok(())
 }
 
 fn decode_explicit_i32(encoded: &[u8]) -> Result<i32, Error> {
@@ -647,25 +657,18 @@ mod tests {
     }
 
     #[test]
-    fn rewrites_strongbox_security_levels_to_trusted_environment() {
+    fn preserves_strongbox_security_levels_during_rewrite() {
         let tee = auth_list([
             explicit_tag_raw(ROOT_OF_TRUST_TAG, &root_of_trust([7; 32], [8; 32])),
             explicit_integer_raw(VENDOR_PATCH_TAG, 20240101),
         ]);
         let software = auth_list([explicit_integer_raw(SYSTEM_PATCH_TAG, 202402)]);
+        let strongbox = Any::new(Tag::Enumerated, vec![2]).unwrap().to_der().unwrap();
         let extension = encode_sequence([
             300i32.to_der().unwrap().as_slice(),
-            Any::new(Tag::Enumerated, vec![2])
-                .unwrap()
-                .to_der()
-                .unwrap()
-                .as_slice(),
+            strongbox.as_slice(),
             300i32.to_der().unwrap().as_slice(),
-            Any::new(Tag::Enumerated, vec![2])
-                .unwrap()
-                .to_der()
-                .unwrap()
-                .as_slice(),
+            strongbox.as_slice(),
             Any::new(Tag::OctetString, Vec::<u8>::new())
                 .unwrap()
                 .to_der()
@@ -693,8 +696,48 @@ mod tests {
         let rewritten = rewrite_extension(&request).unwrap();
         let outer = parse_any(&rewritten.extension_der).unwrap();
         let fields = split_tlvs(outer.value(), MAX_KEY_DESCRIPTION_FIELDS).unwrap();
-        assert_eq!(fields[1], ENUMERATED_TRUSTED_ENVIRONMENT);
-        assert_eq!(fields[3], ENUMERATED_TRUSTED_ENVIRONMENT);
+        assert_eq!(fields[1], strongbox);
+        assert_eq!(fields[3], strongbox);
+    }
+
+    #[test]
+    fn rejects_unknown_attestation_security_level() {
+        let tee = auth_list([explicit_tag_raw(
+            ROOT_OF_TRUST_TAG,
+            &root_of_trust([7; 32], [8; 32]),
+        )]);
+        let software = auth_list([]);
+        let unknown = Any::new(Tag::Enumerated, vec![3]).unwrap().to_der().unwrap();
+        let trusted = Any::new(Tag::Enumerated, vec![1]).unwrap().to_der().unwrap();
+        let extension = encode_sequence([
+            300i32.to_der().unwrap().as_slice(),
+            unknown.as_slice(),
+            300i32.to_der().unwrap().as_slice(),
+            trusted.as_slice(),
+            Any::new(Tag::OctetString, Vec::<u8>::new())
+                .unwrap()
+                .to_der()
+                .unwrap()
+                .as_slice(),
+            Any::new(Tag::OctetString, Vec::<u8>::new())
+                .unwrap()
+                .to_der()
+                .unwrap()
+                .as_slice(),
+            software.as_slice(),
+            tee.as_slice(),
+        ])
+        .unwrap();
+        let request = RewriteRequest {
+            extension_der: &extension,
+            patch_levels: PatchLevels::default(),
+            id_overrides: &[],
+            module_hash: None,
+            verified_boot_key: &BOOT_KEY,
+            verified_boot_hash: &BOOT_HASH,
+        };
+
+        assert_eq!(rewrite_extension(&request), Err(Error::InvalidStructure));
     }
 
     #[test]

--- a/rust/attestation-core/src/lib.rs
+++ b/rust/attestation-core/src/lib.rs
@@ -663,7 +663,10 @@ mod tests {
             explicit_integer_raw(VENDOR_PATCH_TAG, 20240101),
         ]);
         let software = auth_list([explicit_integer_raw(SYSTEM_PATCH_TAG, 202402)]);
-        let strongbox = Any::new(Tag::Enumerated, vec![2]).unwrap().to_der().unwrap();
+        let strongbox = Any::new(Tag::Enumerated, vec![2])
+            .unwrap()
+            .to_der()
+            .unwrap();
         let extension = encode_sequence([
             300i32.to_der().unwrap().as_slice(),
             strongbox.as_slice(),
@@ -707,8 +710,14 @@ mod tests {
             &root_of_trust([7; 32], [8; 32]),
         )]);
         let software = auth_list([]);
-        let unknown = Any::new(Tag::Enumerated, vec![3]).unwrap().to_der().unwrap();
-        let trusted = Any::new(Tag::Enumerated, vec![1]).unwrap().to_der().unwrap();
+        let unknown = Any::new(Tag::Enumerated, vec![3])
+            .unwrap()
+            .to_der()
+            .unwrap();
+        let trusted = Any::new(Tag::Enumerated, vec![1])
+            .unwrap()
+            .to_der()
+            .unwrap();
         let extension = encode_sequence([
             300i32.to_der().unwrap().as_slice(),
             unknown.as_slice(),

--- a/rust/attestation-core/tests/security_level_detector.rs
+++ b/rust/attestation-core/tests/security_level_detector.rs
@@ -1,0 +1,133 @@
+// Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
+use cleverestricky_attestation_core::{rewrite_extension, PatchLevels, RewriteRequest};
+use der::asn1::{Any, AnyRef};
+use der::{Decode, Encode, Tag, TagNumber, Tagged};
+
+const ROOT_OF_TRUST_TAG: u32 = 704;
+const BOOT_KEY: [u8; 32] = [0x11; 32];
+const BOOT_HASH: [u8; 32] = [0x22; 32];
+const SOFTWARE: u8 = 0;
+const TRUSTED_ENVIRONMENT: u8 = 1;
+const STRONGBOX: u8 = 2;
+
+#[test]
+fn detector_observes_strongbox_after_rewrite() {
+    let original = key_description(STRONGBOX, STRONGBOX);
+    let rewritten = rewrite(&original);
+
+    assert_eq!(security_level(&rewritten, 1), STRONGBOX);
+    assert_eq!(security_level(&rewritten, 3), STRONGBOX);
+}
+
+#[test]
+fn detector_does_not_promote_tee_to_strongbox() {
+    let original = key_description(TRUSTED_ENVIRONMENT, TRUSTED_ENVIRONMENT);
+    let rewritten = rewrite(&original);
+
+    assert_eq!(security_level(&rewritten, 1), TRUSTED_ENVIRONMENT);
+    assert_eq!(security_level(&rewritten, 3), TRUSTED_ENVIRONMENT);
+}
+
+#[test]
+fn detector_preserves_software_security_level() {
+    let original = key_description(SOFTWARE, SOFTWARE);
+    let rewritten = rewrite(&original);
+
+    assert_eq!(security_level(&rewritten, 1), SOFTWARE);
+    assert_eq!(security_level(&rewritten, 3), SOFTWARE);
+}
+
+fn rewrite(extension: &[u8]) -> Vec<u8> {
+    rewrite_extension(&RewriteRequest {
+        extension_der: extension,
+        patch_levels: PatchLevels::default(),
+        id_overrides: &[],
+        module_hash: None,
+        verified_boot_key: &BOOT_KEY,
+        verified_boot_hash: &BOOT_HASH,
+    })
+    .expect("valid attestation rewrite")
+    .extension_der
+}
+
+fn key_description(attestation_level: u8, keymint_level: u8) -> Vec<u8> {
+    let software = sequence([]);
+    let tee = sequence([explicit_tag(
+        ROOT_OF_TRUST_TAG,
+        &root_of_trust([0x33; 32], [0x44; 32]),
+    )]);
+    sequence([
+        300i32.to_der().unwrap(),
+        enumerated(attestation_level),
+        300i32.to_der().unwrap(),
+        enumerated(keymint_level),
+        octets(&[]),
+        octets(&[]),
+        software,
+        tee,
+    ])
+}
+
+fn security_level(extension: &[u8], index: usize) -> u8 {
+    let outer = Any::from_der(extension).expect("KeyDescription DER");
+    let fields = split(outer.value()).expect("KeyDescription fields");
+    let level = Any::from_der(&fields[index]).expect("security level DER");
+    assert_eq!(level.tag(), Tag::Enumerated);
+    assert_eq!(level.value().len(), 1);
+    level.value()[0]
+}
+
+fn enumerated(value: u8) -> Vec<u8> {
+    Any::new(Tag::Enumerated, vec![value])
+        .unwrap()
+        .to_der()
+        .unwrap()
+}
+
+fn octets(value: &[u8]) -> Vec<u8> {
+    Any::new(Tag::OctetString, value.to_vec())
+        .unwrap()
+        .to_der()
+        .unwrap()
+}
+
+fn root_of_trust(key: [u8; 32], hash: [u8; 32]) -> Vec<u8> {
+    sequence([
+        octets(&key),
+        true.to_der().unwrap(),
+        enumerated(0),
+        octets(&hash),
+    ])
+}
+
+fn explicit_tag(tag: u32, inner: &[u8]) -> Vec<u8> {
+    Any::new(
+        Tag::ContextSpecific {
+            constructed: true,
+            number: TagNumber(tag),
+        },
+        inner.to_vec(),
+    )
+    .unwrap()
+    .to_der()
+    .unwrap()
+}
+
+fn sequence<const N: usize>(fields: [Vec<u8>; N]) -> Vec<u8> {
+    let mut value = Vec::new();
+    for field in fields {
+        value.extend_from_slice(&field);
+    }
+    Any::new(Tag::Sequence, value).unwrap().to_der().unwrap()
+}
+
+fn split(mut bytes: &[u8]) -> Result<Vec<Vec<u8>>, der::Error> {
+    let mut out = Vec::new();
+    while !bytes.is_empty() {
+        let (_, rest) = AnyRef::from_der_partial(bytes)?;
+        let used = bytes.len() - rest.len();
+        out.push(bytes[..used].to_vec());
+        bytes = rest;
+    }
+    Ok(out)
+}

--- a/rust/daemon/src/config_file_broker.rs
+++ b/rust/daemon/src/config_file_broker.rs
@@ -3,8 +3,11 @@
 mod pidfd_signal;
 
 use cleverestricky_service_core::secure_fs::TrustedDir;
+use std::collections::HashMap;
 use std::io::{self, Read};
 use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 pub const MAX_FILE_BYTES: usize = 20 * 1024 * 1024;
 pub const MAX_RELATIVE_PATH_BYTES: usize = 511;
@@ -26,9 +29,44 @@ const ACTION_TOUCH: u8 = 2;
 const ACTION_ROOT_VALIDATE: u8 = 3;
 const ACTION_STAGE_CREATE: u8 = 4;
 const ACTION_STAGE_APPEND: u8 = 5;
+const ACTION_RESTORE_BEGIN: u8 = 6;
+const ACTION_RESTORE_SNAPSHOT: u8 = 7;
+const ACTION_RESTORE_ROLLBACK: u8 = 8;
+const ACTION_RESTORE_COMMIT: u8 = 9;
+const ACTION_RESTORE_ABORT: u8 = 10;
+const ACTION_DELETE: u8 = 11;
+const ACTION_RESTORE_EXPORT: u8 = 12;
 const WRITE_COMMIT_MARKER: u8 = 0xa5;
 const FILE_MODE: u32 = 0o600;
 const DIRECTORY_MODE: u32 = 0o700;
+const RESTORE_TOKEN_BYTES: usize = 32;
+const MAX_RESTORE_SNAPSHOT_BYTES: usize = 32 * 1024 * 1024;
+const MAX_GLOBAL_RESTORE_SNAPSHOT_BYTES: usize = 64 * 1024 * 1024;
+const MAX_ACTIVE_RESTORE_TRANSACTIONS: usize = 4;
+const MAX_RESTORE_TARGETS: usize = 512;
+const RESTORE_TRANSACTION_TTL: Duration = Duration::from_secs(15 * 60);
+
+struct RestoreOriginal {
+    path: String,
+    bytes: Option<Vec<u8>>,
+}
+
+impl Drop for RestoreOriginal {
+    fn drop(&mut self) {
+        if let Some(bytes) = self.bytes.as_mut() {
+            bytes.fill(0);
+        }
+    }
+}
+
+struct RestoreTransaction {
+    max_snapshot_bytes: usize,
+    snapshot_bytes: usize,
+    originals: Vec<RestoreOriginal>,
+    touched: Instant,
+}
+
+static RESTORE_TRANSACTIONS: OnceLock<Mutex<HashMap<String, RestoreTransaction>>> = OnceLock::new();
 
 pub fn prepare_root() -> io::Result<TrustedDir> {
     if let Some(exit_code) = pidfd_signal::run_env_request_if_present() {
@@ -107,6 +145,13 @@ pub(crate) fn handle_stream_from<R: Read>(
             }
             ACTION_STAGE_CREATE => stage_create(root, path),
             ACTION_STAGE_APPEND => stage_append(root, path, reader, declared_body_len, scratch),
+            ACTION_RESTORE_BEGIN => restore_begin(root, path),
+            ACTION_RESTORE_SNAPSHOT => restore_snapshot(root, path),
+            ACTION_RESTORE_ROLLBACK => restore_rollback(root, path),
+            ACTION_RESTORE_COMMIT => restore_commit(path),
+            ACTION_RESTORE_ABORT => restore_abort(path),
+            ACTION_DELETE => delete_allowed(root, path),
+            ACTION_RESTORE_EXPORT => restore_export(root, path),
             _ => Err(invalid("unsupported config file action")),
         }
     })();
@@ -262,6 +307,273 @@ fn atomic_write_relative_from<R: Read>(
     }
 }
 
+enum RestoreTarget<'a> {
+    Root(&'a str),
+    Keybox(&'a str),
+}
+
+fn parse_restore_target(path: &str) -> io::Result<RestoreTarget<'_>> {
+    let mut components = path.split('/');
+    let first = components.next().unwrap_or_default();
+    let second = components.next();
+    if components.next().is_some() {
+        return Err(invalid("restore target path depth exceeds bound"));
+    }
+    match second {
+        None => {
+            validate_component(first)?;
+            Ok(RestoreTarget::Root(first))
+        }
+        Some(name) if first == KEYBOX_DIRECTORY => {
+            validate_component(name)?;
+            Ok(RestoreTarget::Keybox(name))
+        }
+        _ => Err(invalid("restore target is outside an allowed capability subtree")),
+    }
+}
+
+fn read_optional(dir: &TrustedDir, name: &str, max_bytes: usize) -> io::Result<Option<Vec<u8>>> {
+    match dir.read_bounded(name, max_bytes) {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn read_restore_target(root: &TrustedDir, path: &str, max_bytes: usize) -> io::Result<Option<Vec<u8>>> {
+    match parse_restore_target(path)? {
+        RestoreTarget::Root(name) => read_optional(root, name, max_bytes),
+        RestoreTarget::Keybox(name) => match root.open_child(KEYBOX_DIRECTORY) {
+            Ok(keyboxes) => read_optional(&keyboxes, name, max_bytes),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error),
+        },
+    }
+}
+
+fn restore_target(root: &TrustedDir, path: &str, bytes: Option<&[u8]>) -> io::Result<()> {
+    match (parse_restore_target(path)?, bytes) {
+        (RestoreTarget::Root(name), Some(bytes)) => root.atomic_write(name, bytes, FILE_MODE),
+        (RestoreTarget::Root(name), None) => root.unlink_file(name).and_then(|_| root.sync()),
+        (RestoreTarget::Keybox(name), Some(bytes)) => {
+            let keyboxes = root.mkdir_child(KEYBOX_DIRECTORY, DIRECTORY_MODE)?;
+            keyboxes.atomic_write(name, bytes, FILE_MODE)
+        }
+        (RestoreTarget::Keybox(name), None) => match root.open_child(KEYBOX_DIRECTORY) {
+            Ok(keyboxes) => keyboxes.unlink_file(name).and_then(|_| keyboxes.sync()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        },
+    }
+}
+
+fn delete_allowed(root: &TrustedDir, path: &str) -> io::Result<()> {
+    restore_target(root, path, None)
+}
+
+fn restore_transactions() -> &'static Mutex<HashMap<String, RestoreTransaction>> {
+    RESTORE_TRANSACTIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn parse_restore_token(value: &str) -> io::Result<&str> {
+    if value.len() != RESTORE_TOKEN_BYTES
+        || !value
+            .bytes()
+            .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
+    {
+        return Err(invalid("restore transaction token rejected"));
+    }
+    Ok(value)
+}
+
+fn parse_restore_pair(value: &str) -> io::Result<(&str, &str)> {
+    let (token, argument) = value
+        .split_once('\0')
+        .ok_or_else(|| invalid("restore transaction request is malformed"))?;
+    parse_restore_token(token)?;
+    if argument.is_empty() {
+        return Err(invalid("restore transaction argument is empty"));
+    }
+    Ok((token, argument))
+}
+
+fn encode_hex(value: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(value.len() * 2);
+    for byte in value {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+fn export_transaction_to_root(
+    root: &TrustedDir,
+    token: &str,
+    transaction: &RestoreTransaction,
+) -> io::Result<()> {
+    let mut created = Vec::new();
+    let mut manifest = String::new();
+    for (index, original) in transaction.originals.iter().enumerate() {
+        let encoded_path = encode_hex(original.path.as_bytes());
+        if let Some(bytes) = original.bytes.as_deref() {
+            let name = format!(".restore-recovery-{token}-{index:04}.bak");
+            if let Err(error) = root.atomic_write(&name, bytes, FILE_MODE) {
+                for created_name in &created {
+                    let _ = root.unlink_file(created_name);
+                }
+                return Err(error);
+            }
+            created.push(name);
+            manifest.push_str(&format!("{index:04}\tpresent\t{encoded_path}\n"));
+        } else {
+            manifest.push_str(&format!("{index:04}\tabsent\t{encoded_path}\n"));
+        }
+    }
+    let manifest_name = format!(".restore-recovery-{token}.manifest");
+    if let Err(error) = root.atomic_write(&manifest_name, manifest.as_bytes(), FILE_MODE) {
+        for created_name in &created {
+            let _ = root.unlink_file(created_name);
+        }
+        return Err(error);
+    }
+    root.sync()
+}
+
+fn prune_stale_restore_transactions(
+    root: &TrustedDir,
+    transactions: &mut HashMap<String, RestoreTransaction>,
+) {
+    let now = Instant::now();
+    let stale: Vec<String> = transactions
+        .iter()
+        .filter_map(|(token, transaction)| {
+            now.checked_duration_since(transaction.touched)
+                .filter(|age| *age >= RESTORE_TRANSACTION_TTL)
+                .map(|_| token.clone())
+        })
+        .collect();
+    for token in stale {
+        let exported = transactions
+            .get(&token)
+            .is_some_and(|transaction| export_transaction_to_root(root, &token, transaction).is_ok());
+        if exported {
+            transactions.remove(&token);
+        }
+    }
+}
+
+fn restore_begin(root: &TrustedDir, request: &str) -> io::Result<()> {
+    let (token, max_snapshot) = parse_restore_pair(request)?;
+    let max_snapshot_bytes = max_snapshot
+        .parse::<usize>()
+        .map_err(|_| invalid("restore snapshot limit rejected"))?;
+    if max_snapshot_bytes > MAX_RESTORE_SNAPSHOT_BYTES {
+        return Err(invalid("restore snapshot limit exceeds broker bound"));
+    }
+    let mut transactions = restore_transactions()
+        .lock()
+        .map_err(|_| io::Error::other("restore transaction state poisoned"))?;
+    prune_stale_restore_transactions(root, &mut transactions);
+    if transactions.contains_key(token) {
+        return Err(invalid("restore transaction token already active"));
+    }
+    if transactions.len() >= MAX_ACTIVE_RESTORE_TRANSACTIONS {
+        return Err(io::Error::other("restore transaction capacity exhausted"));
+    }
+    transactions.insert(
+        token.to_string(),
+        RestoreTransaction {
+            max_snapshot_bytes,
+            snapshot_bytes: 0,
+            originals: Vec::new(),
+            touched: Instant::now(),
+        },
+    );
+    Ok(())
+}
+
+fn restore_snapshot(root: &TrustedDir, request: &str) -> io::Result<()> {
+    let (token, path) = parse_restore_pair(request)?;
+    parse_restore_target(path)?;
+    let mut transactions = restore_transactions()
+        .lock()
+        .map_err(|_| io::Error::other("restore transaction state poisoned"))?;
+    prune_stale_restore_transactions(root, &mut transactions);
+    let global_used: usize = transactions.values().map(|transaction| transaction.snapshot_bytes).sum();
+    let transaction = transactions
+        .get_mut(token)
+        .ok_or_else(|| invalid("restore transaction is not active"))?;
+    if transaction.originals.len() >= MAX_RESTORE_TARGETS {
+        return Err(invalid("restore transaction target count exceeds bound"));
+    }
+    if transaction.originals.iter().any(|original| original.path == path) {
+        return Err(invalid("restore transaction target was already snapshotted"));
+    }
+    let own_remaining = transaction
+        .max_snapshot_bytes
+        .checked_sub(transaction.snapshot_bytes)
+        .ok_or_else(|| invalid("restore snapshot accounting underflow"))?;
+    let global_remaining = MAX_GLOBAL_RESTORE_SNAPSHOT_BYTES
+        .checked_sub(global_used)
+        .ok_or_else(|| invalid("global restore snapshot accounting overflow"))?;
+    let bytes = read_restore_target(root, path, own_remaining.min(global_remaining))?;
+    let added = bytes.as_ref().map_or(0, Vec::len);
+    transaction.snapshot_bytes = transaction
+        .snapshot_bytes
+        .checked_add(added)
+        .ok_or_else(|| invalid("restore snapshot accounting overflow"))?;
+    transaction.originals.push(RestoreOriginal {
+        path: path.to_string(),
+        bytes,
+    });
+    transaction.touched = Instant::now();
+    Ok(())
+}
+
+fn restore_rollback(root: &TrustedDir, token: &str) -> io::Result<()> {
+    parse_restore_token(token)?;
+    let mut transactions = restore_transactions()
+        .lock()
+        .map_err(|_| io::Error::other("restore transaction state poisoned"))?;
+    prune_stale_restore_transactions(root, &mut transactions);
+    let transaction = transactions
+        .get_mut(token)
+        .ok_or_else(|| invalid("restore transaction is not active"))?;
+    transaction.touched = Instant::now();
+    for original in transaction.originals.iter().rev() {
+        restore_target(root, &original.path, original.bytes.as_deref())?;
+    }
+    transactions.remove(token);
+    Ok(())
+}
+
+fn restore_commit(token: &str) -> io::Result<()> {
+    parse_restore_token(token)?;
+    let mut transactions = restore_transactions()
+        .lock()
+        .map_err(|_| io::Error::other("restore transaction state poisoned"))?;
+    transactions.remove(token);
+    Ok(())
+}
+
+fn restore_abort(token: &str) -> io::Result<()> {
+    restore_commit(token)
+}
+
+fn restore_export(root: &TrustedDir, token: &str) -> io::Result<()> {
+    parse_restore_token(token)?;
+    let mut transactions = restore_transactions()
+        .lock()
+        .map_err(|_| io::Error::other("restore transaction state poisoned"))?;
+    let transaction = transactions
+        .get(token)
+        .ok_or_else(|| invalid("restore transaction is not active"))?;
+    export_transaction_to_root(root, token, transaction)?;
+    transactions.remove(token);
+    Ok(())
+}
+
 fn validate_webui_download_name(value: &str) -> io::Result<()> {
     let id = value
         .strip_suffix(WEBUI_DOWNLOAD_SUFFIX)
@@ -352,6 +664,10 @@ mod tests {
             output.push(marker);
         }
         output
+    }
+
+    fn restore_pair(action: u8, token: &str, argument: &str) -> Vec<u8> {
+        request(action, &format!("{token}\0{argument}"), b"")
     }
 
     #[test]
@@ -578,6 +894,101 @@ mod tests {
         handle_from(&root, &request(ACTION_WRITE, "target.txt", b"inside")).unwrap();
         assert_eq!(fs::read(&outside).unwrap(), b"outside");
         assert_eq!(fs::read(test.path.join("target.txt")).unwrap(), b"inside");
+        let _ = fs::remove_file(outside);
+    }
+
+    #[test]
+    fn restore_transaction_rolls_back_existing_and_created_targets() {
+        let test = TestRoot::new();
+        let root = test.trusted();
+        fs::write(test.path.join("first.txt"), b"old-first").unwrap();
+        fs::create_dir(test.path.join(KEYBOX_DIRECTORY)).unwrap();
+        fs::write(test.path.join(KEYBOX_DIRECTORY).join("device.xml"), b"old-keybox").unwrap();
+        let token = "10000000000000000000000000000001";
+
+        handle_from(&root, &restore_pair(ACTION_RESTORE_BEGIN, token, "4096")).unwrap();
+        handle_from(&root, &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "first.txt")).unwrap();
+        handle_from(&root, &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "keyboxes/device.xml")).unwrap();
+        handle_from(&root, &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "created.txt")).unwrap();
+        fs::write(test.path.join("first.txt"), b"new-first").unwrap();
+        fs::write(test.path.join(KEYBOX_DIRECTORY).join("device.xml"), b"new-keybox").unwrap();
+        fs::write(test.path.join("created.txt"), b"created").unwrap();
+
+        handle_from(&root, &request(ACTION_RESTORE_ROLLBACK, token, b"")).unwrap();
+        assert_eq!(fs::read(test.path.join("first.txt")).unwrap(), b"old-first");
+        assert_eq!(
+            fs::read(test.path.join(KEYBOX_DIRECTORY).join("device.xml")).unwrap(),
+            b"old-keybox"
+        );
+        assert!(!test.path.join("created.txt").exists());
+    }
+
+    #[test]
+    fn restore_rollback_stays_bound_to_root_after_pathname_swap() {
+        let test = TestRoot::new();
+        fs::write(test.path.join("state.txt"), b"old").unwrap();
+        let root = test.trusted();
+        let token = "20000000000000000000000000000002";
+        handle_from(&root, &restore_pair(ACTION_RESTORE_BEGIN, token, "4096")).unwrap();
+        handle_from(&root, &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "state.txt")).unwrap();
+
+        let moved = test.path.with_extension("moved-root");
+        let outside = test.path.with_extension("outside-root");
+        fs::rename(&test.path, &moved).unwrap();
+        fs::create_dir(&outside).unwrap();
+        fs::write(outside.join("state.txt"), b"outside").unwrap();
+        symlink(&outside, &test.path).unwrap();
+        fs::write(moved.join("state.txt"), b"new").unwrap();
+
+        handle_from(&root, &request(ACTION_RESTORE_ROLLBACK, token, b"")).unwrap();
+        assert_eq!(fs::read(moved.join("state.txt")).unwrap(), b"old");
+        assert_eq!(fs::read(outside.join("state.txt")).unwrap(), b"outside");
+
+        let _ = fs::remove_file(&test.path);
+        let _ = fs::remove_dir_all(&outside);
+        let _ = fs::remove_dir_all(&moved);
+    }
+
+    #[test]
+    fn keybox_parent_symlink_swap_fails_closed_and_exports_recovery() {
+        let test = TestRoot::new();
+        let keyboxes = test.path.join(KEYBOX_DIRECTORY);
+        fs::create_dir(&keyboxes).unwrap();
+        fs::write(keyboxes.join("device.xml"), b"old").unwrap();
+        let root = test.trusted();
+        let token = "30000000000000000000000000000003";
+        handle_from(&root, &restore_pair(ACTION_RESTORE_BEGIN, token, "4096")).unwrap();
+        handle_from(&root, &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "keyboxes/device.xml")).unwrap();
+
+        let moved = test.path.join("moved-keyboxes");
+        let outside = test.path.join("outside-keyboxes");
+        fs::rename(&keyboxes, &moved).unwrap();
+        fs::create_dir(&outside).unwrap();
+        fs::write(outside.join("device.xml"), b"outside").unwrap();
+        symlink(&outside, &keyboxes).unwrap();
+
+        assert!(handle_from(&root, &request(ACTION_RESTORE_ROLLBACK, token, b"")).is_err());
+        assert_eq!(fs::read(outside.join("device.xml")).unwrap(), b"outside");
+        handle_from(&root, &request(ACTION_RESTORE_EXPORT, token, b"")).unwrap();
+        assert_eq!(
+            fs::read(test.path.join(format!(".restore-recovery-{token}-0000.bak"))).unwrap(),
+            b"old"
+        );
+        assert!(test.path.join(format!(".restore-recovery-{token}.manifest")).is_file());
+    }
+
+    #[test]
+    fn descriptor_relative_delete_never_follows_final_symlink() {
+        let test = TestRoot::new();
+        let outside = test.path.with_extension("delete-outside");
+        fs::write(&outside, b"outside").unwrap();
+        symlink(&outside, test.path.join("victim")) .unwrap();
+        let root = test.trusted();
+
+        handle_from(&root, &request(ACTION_DELETE, "victim", b"")).unwrap();
+        assert!(!test.path.join("victim").exists());
+        assert_eq!(fs::read(&outside).unwrap(), b"outside");
+        assert!(handle_from(&root, &request(ACTION_DELETE, "../outside", b"")).is_err());
         let _ = fs::remove_file(outside);
     }
 }

--- a/rust/daemon/src/config_file_broker.rs
+++ b/rust/daemon/src/config_file_broker.rs
@@ -460,12 +460,12 @@ fn prune_stale_restore_transactions(
         })
         .collect();
     for token in stale {
-        let exported = transactions.get(&token).is_some_and(|transaction| {
-            export_transaction_to_root(root, &token, transaction).is_ok()
-        });
-        if exported {
-            transactions.remove(&token);
+        if let Some(transaction) = transactions.get(&token) {
+            let _ = export_transaction_to_root(root, &token, transaction);
         }
+        // The TTL is a hard capacity bound. Best-effort recovery export must never let an expired
+        // transaction permanently consume one of the limited active slots.
+        transactions.remove(&token);
     }
 }
 
@@ -556,8 +556,21 @@ fn restore_rollback(root: &TrustedDir, token: &str) -> io::Result<()> {
         .get_mut(token)
         .ok_or_else(|| invalid("restore transaction is not active"))?;
     transaction.touched = Instant::now();
+    let mut first_error = None;
+    let mut failure_count = 0usize;
     for original in transaction.originals.iter().rev() {
-        restore_target(root, &original.path, original.bytes.as_deref())?;
+        if let Err(error) = restore_target(root, &original.path, original.bytes.as_deref()) {
+            failure_count += 1;
+            if first_error.is_none() {
+                first_error = Some(error);
+            }
+        }
+    }
+    if let Some(error) = first_error {
+        return Err(io::Error::new(
+            error.kind(),
+            format!("restore rollback failed for {failure_count} target(s): {error}"),
+        ));
     }
     transactions.remove(token);
     Ok(())
@@ -959,6 +972,41 @@ mod tests {
     }
 
     #[test]
+    fn restore_rollback_continues_after_an_independent_target_failure() {
+        let test = TestRoot::new();
+        fs::write(test.path.join("state.txt"), b"old-state").unwrap();
+        let keyboxes = test.path.join(KEYBOX_DIRECTORY);
+        fs::create_dir(&keyboxes).unwrap();
+        fs::write(keyboxes.join("device.xml"), b"old-keybox").unwrap();
+        let root = test.trusted();
+        let token = "15000000000000000000000000000005";
+        handle_from(&root, &restore_pair(ACTION_RESTORE_BEGIN, token, "4096")).unwrap();
+        handle_from(
+            &root,
+            &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "state.txt"),
+        )
+        .unwrap();
+        handle_from(
+            &root,
+            &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "keyboxes/device.xml"),
+        )
+        .unwrap();
+
+        fs::write(test.path.join("state.txt"), b"new-state").unwrap();
+        let moved = test.path.join("moved-keyboxes");
+        let outside = test.path.join("outside-keyboxes");
+        fs::rename(&keyboxes, &moved).unwrap();
+        fs::create_dir(&outside).unwrap();
+        fs::write(outside.join("device.xml"), b"outside").unwrap();
+        symlink(&outside, &keyboxes).unwrap();
+
+        assert!(handle_from(&root, &request(ACTION_RESTORE_ROLLBACK, token, b"")).is_err());
+        assert_eq!(fs::read(test.path.join("state.txt")).unwrap(), b"old-state");
+        assert_eq!(fs::read(outside.join("device.xml")).unwrap(), b"outside");
+        handle_from(&root, &request(ACTION_RESTORE_ABORT, token, b"")).unwrap();
+    }
+
+    #[test]
     fn restore_rollback_stays_bound_to_root_after_pathname_swap() {
         let test = TestRoot::new();
         fs::write(test.path.join("state.txt"), b"old").unwrap();
@@ -1025,6 +1073,36 @@ mod tests {
             .path
             .join(format!(".restore-recovery-{token}.manifest"))
             .is_file());
+    }
+
+    #[test]
+    fn stale_transaction_is_evicted_even_when_recovery_export_fails() {
+        let test = TestRoot::new();
+        let root = test.trusted();
+        let token = "40000000000000000000000000000004";
+        fs::create_dir(
+            test.path
+                .join(format!(".restore-recovery-{token}-0000.bak")),
+        )
+        .unwrap();
+        let mut transactions = HashMap::new();
+        transactions.insert(
+            token.to_string(),
+            RestoreTransaction {
+                max_snapshot_bytes: 4096,
+                snapshot_bytes: 3,
+                originals: vec![RestoreOriginal {
+                    path: "state.txt".to_string(),
+                    bytes: Some(b"old".to_vec()),
+                }],
+                touched: Instant::now()
+                    .checked_sub(RESTORE_TRANSACTION_TTL + Duration::from_secs(1))
+                    .unwrap(),
+            },
+        );
+
+        prune_stale_restore_transactions(&root, &mut transactions);
+        assert!(transactions.is_empty());
     }
 
     #[test]

--- a/rust/daemon/src/config_file_broker.rs
+++ b/rust/daemon/src/config_file_broker.rs
@@ -280,7 +280,9 @@ fn atomic_write_relative_from<R: Read>(
             .iter()
             .any(|original| original.path == path)
     }) {
-        return Err(invalid("active restore target requires a transaction-scoped write"));
+        return Err(invalid(
+            "active restore target requires a transaction-scoped write",
+        ));
     }
     atomic_write_target_from(root, path, reader, body_len, scratch)
 }
@@ -412,7 +414,9 @@ fn delete_allowed(root: &TrustedDir, path: &str) -> io::Result<()> {
             .iter()
             .any(|original| original.path == path)
     }) {
-        return Err(invalid("active restore target requires a transaction-scoped delete"));
+        return Err(invalid(
+            "active restore target requires a transaction-scoped delete",
+        ));
     }
     restore_target(root, path, None)
 }
@@ -1039,7 +1043,11 @@ mod tests {
         .is_err());
         assert!(handle_from(
             &root,
-            &request(ACTION_WRITE, &format!("{token}\0other.txt"), b"not-snapshotted"),
+            &request(
+                ACTION_WRITE,
+                &format!("{token}\0other.txt"),
+                b"not-snapshotted"
+            ),
         )
         .is_err());
         handle_from(

--- a/rust/daemon/src/config_file_broker.rs
+++ b/rust/daemon/src/config_file_broker.rs
@@ -6,7 +6,7 @@ use cleverestricky_service_core::secure_fs::TrustedDir;
 use std::collections::HashMap;
 use std::io::{self, Read};
 use std::path::Path;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 pub const MAX_FILE_BYTES: usize = 20 * 1024 * 1024;
@@ -60,7 +60,8 @@ impl Drop for RestoreOriginal {
 }
 
 struct RestoreTransaction {
-    keyboxes: Option<TrustedDir>,
+    keyboxes: Option<Arc<TrustedDir>>,
+    mutation_in_progress: bool,
     max_snapshot_bytes: usize,
     snapshot_bytes: usize,
     originals: Vec<RestoreOriginal>,
@@ -271,19 +272,21 @@ fn atomic_write_relative_from<R: Read>(
     if path.contains('\0') {
         return restore_write_from(root, path, reader, body_len, scratch);
     }
-    let mut transactions = restore_transactions()
-        .lock()
-        .map_err(|_| io::Error::other("restore transaction state poisoned"))?;
-    prune_stale_restore_transactions(root, &mut transactions);
-    if transactions.values().any(|transaction| {
-        transaction
-            .originals
-            .iter()
-            .any(|original| original.path == path)
-    }) {
-        return Err(invalid(
-            "active restore target requires a transaction-scoped write",
-        ));
+    {
+        let mut transactions = restore_transactions()
+            .lock()
+            .map_err(|_| io::Error::other("restore transaction state poisoned"))?;
+        prune_stale_restore_transactions(root, &mut transactions);
+        if transactions.values().any(|transaction| {
+            transaction
+                .originals
+                .iter()
+                .any(|original| original.path == path)
+        }) {
+            return Err(invalid(
+                "active restore target requires a transaction-scoped write",
+            ));
+        }
     }
     atomic_write_target_from(root, path, reader, body_len, scratch)
 }
@@ -428,7 +431,7 @@ fn restore_transaction_target(
 
 fn atomic_write_transaction_target_from<R: Read>(
     root: &TrustedDir,
-    transaction: &RestoreTransaction,
+    keyboxes: Option<&TrustedDir>,
     path: &str,
     reader: &mut R,
     body_len: usize,
@@ -448,7 +451,7 @@ fn atomic_write_transaction_target_from<R: Read>(
             root.atomic_write_from_confirmed(name, reader, body_len, FILE_MODE, scratch, confirm)
         }
         RestoreTarget::Keybox(name) => {
-            let keyboxes = transaction.keyboxes.as_ref().ok_or_else(|| {
+            let keyboxes = keyboxes.ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::NotFound,
                     "pinned keybox restore directory is unavailable",
@@ -516,6 +519,7 @@ fn transaction_for_snapshotted_target<'a>(
     let transaction = transactions
         .get_mut(token)
         .ok_or_else(|| invalid("restore transaction is not active"))?;
+    ensure_transaction_idle(transaction)?;
     if !transaction
         .originals
         .iter()
@@ -527,6 +531,58 @@ fn transaction_for_snapshotted_target<'a>(
     Ok(transaction)
 }
 
+fn begin_streaming_restore_mutation(
+    transactions: &mut HashMap<String, RestoreTransaction>,
+    token: &str,
+    path: &str,
+) -> io::Result<Option<Arc<TrustedDir>>> {
+    let target = parse_restore_target(path)?;
+    let transaction = transaction_for_snapshotted_target(transactions, token, path)?;
+    let keyboxes = match target {
+        RestoreTarget::Root(_) => None,
+        RestoreTarget::Keybox(_) => Some(
+            transaction
+                .keyboxes
+                .as_ref()
+                .cloned()
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "pinned keybox restore directory is unavailable",
+                    )
+                })?,
+        ),
+    };
+    transaction.mutation_in_progress = true;
+    Ok(keyboxes)
+}
+
+fn finish_streaming_restore_mutation(token: &str) -> io::Result<()> {
+    let mut transactions = restore_transactions()
+        .lock()
+        .map_err(|_| io::Error::other("restore transaction state poisoned"))?;
+    let transaction = transactions
+        .get_mut(token)
+        .ok_or_else(|| invalid("restore transaction is not active"))?;
+    if !transaction.mutation_in_progress {
+        return Err(io::Error::other("restore transaction mutation lease was not active"));
+    }
+    transaction.mutation_in_progress = false;
+    transaction.touched = Instant::now();
+    Ok(())
+}
+
+fn ensure_transaction_idle(transaction: &RestoreTransaction) -> io::Result<()> {
+    if transaction.mutation_in_progress {
+        Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            "restore transaction mutation is in progress",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
 fn restore_write_from<R: Read>(
     root: &TrustedDir,
     request: &str,
@@ -535,12 +591,34 @@ fn restore_write_from<R: Read>(
     scratch: &mut [u8],
 ) -> io::Result<()> {
     let (token, path) = parse_restore_pair(request)?;
-    let mut transactions = restore_transactions()
-        .lock()
-        .map_err(|_| io::Error::other("restore transaction state poisoned"))?;
-    prune_stale_restore_transactions(root, &mut transactions);
-    let transaction = transaction_for_snapshotted_target(&mut transactions, token, path)?;
-    atomic_write_transaction_target_from(root, transaction, path, reader, body_len, scratch)
+    let keyboxes = {
+        let mut transactions = restore_transactions()
+            .lock()
+            .map_err(|_| io::Error::other("restore transaction state poisoned"))?;
+        prune_stale_restore_transactions(root, &mut transactions);
+        begin_streaming_restore_mutation(&mut transactions, token, path)?
+    };
+
+    let write_result = atomic_write_transaction_target_from(
+        root,
+        keyboxes.as_deref(),
+        path,
+        reader,
+        body_len,
+        scratch,
+    );
+    let finish_result = finish_streaming_restore_mutation(token);
+    match (write_result, finish_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Err(error), Err(finish_error)) => Err(io::Error::new(
+            error.kind(),
+            format!(
+                "{error}; additionally failed to release restore mutation lease: {finish_error}"
+            ),
+        )),
+    }
 }
 
 fn restore_delete(root: &TrustedDir, request: &str) -> io::Result<()> {
@@ -604,6 +682,9 @@ fn prune_stale_restore_transactions(
     let stale: Vec<String> = transactions
         .iter()
         .filter_map(|(token, transaction)| {
+            if transaction.mutation_in_progress {
+                return None;
+            }
             now.checked_duration_since(transaction.touched)
                 .filter(|age| *age >= RESTORE_TRANSACTION_TTL)
                 .map(|_| token.clone())
@@ -638,7 +719,7 @@ fn restore_begin(root: &TrustedDir, request: &str) -> io::Result<()> {
         return Err(io::Error::other("restore transaction capacity exhausted"));
     }
     let keyboxes = match root.open_child(KEYBOX_DIRECTORY) {
-        Ok(keyboxes) => Some(keyboxes),
+        Ok(keyboxes) => Some(Arc::new(keyboxes)),
         Err(error) if error.kind() == io::ErrorKind::NotFound => None,
         Err(error) => return Err(error),
     };
@@ -646,6 +727,7 @@ fn restore_begin(root: &TrustedDir, request: &str) -> io::Result<()> {
         token.to_string(),
         RestoreTransaction {
             keyboxes,
+            mutation_in_progress: false,
             max_snapshot_bytes,
             snapshot_bytes: 0,
             originals: Vec::new(),
@@ -669,6 +751,7 @@ fn restore_snapshot(root: &TrustedDir, request: &str) -> io::Result<()> {
     let transaction = transactions
         .get_mut(token)
         .ok_or_else(|| invalid("restore transaction is not active"))?;
+    ensure_transaction_idle(transaction)?;
     if transaction.originals.len() >= MAX_RESTORE_TARGETS {
         return Err(invalid("restore transaction target count exceeds bound"));
     }
@@ -716,6 +799,7 @@ fn restore_rollback(root: &TrustedDir, token: &str) -> io::Result<()> {
     let transaction = transactions
         .get_mut(token)
         .ok_or_else(|| invalid("restore transaction is not active"))?;
+    ensure_transaction_idle(transaction)?;
     transaction.touched = Instant::now();
     let mut first_error = None;
     let mut failure_count = 0usize;
@@ -744,6 +828,9 @@ fn restore_commit(token: &str) -> io::Result<()> {
     let mut transactions = restore_transactions()
         .lock()
         .map_err(|_| io::Error::other("restore transaction state poisoned"))?;
+    if let Some(transaction) = transactions.get(token) {
+        ensure_transaction_idle(transaction)?;
+    }
     transactions.remove(token);
     Ok(())
 }
@@ -760,6 +847,7 @@ fn restore_export(root: &TrustedDir, token: &str) -> io::Result<()> {
     let transaction = transactions
         .get(token)
         .ok_or_else(|| invalid("restore transaction is not active"))?;
+    ensure_transaction_idle(transaction)?;
     export_transaction_to_root(root, token, transaction)?;
     transactions.remove(token);
     Ok(())
@@ -1144,6 +1232,68 @@ mod tests {
     }
 
     #[test]
+    fn streamed_restore_write_releases_registry_lock_and_blocks_commit() {
+        struct LockObservingReader {
+            inner: io::Cursor<Vec<u8>>,
+            token: &'static str,
+            observed: bool,
+        }
+
+        impl std::io::Read for LockObservingReader {
+            fn read(&mut self, output: &mut [u8]) -> io::Result<usize> {
+                if !self.observed {
+                    self.observed = true;
+                    assert!(restore_transactions().try_lock().is_ok());
+                    assert!(restore_commit(self.token).is_err());
+                    let transactions = restore_transactions().lock().unwrap();
+                    assert!(transactions
+                        .get(self.token)
+                        .expect("transaction must stay active")
+                        .mutation_in_progress);
+                }
+                std::io::Read::read(&mut self.inner, output)
+            }
+        }
+
+        let test = TestRoot::new();
+        let root = test.trusted();
+        fs::write(test.path.join("state.txt"), b"old").unwrap();
+        let token = "07000000000000000000000000000007";
+        handle_from(&root, &restore_pair(ACTION_RESTORE_BEGIN, token, "4096")).unwrap();
+        handle_from(
+            &root,
+            &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "state.txt"),
+        )
+        .unwrap();
+
+        let mut reader = LockObservingReader {
+            inner: io::Cursor::new(vec![b'n', b'e', b'w', WRITE_COMMIT_MARKER]),
+            token,
+            observed: false,
+        };
+        let mut scratch = [0u8; 8];
+        restore_write_from(
+            &root,
+            &format!("{token}\0state.txt"),
+            &mut reader,
+            3,
+            &mut scratch,
+        )
+        .unwrap();
+        assert!(reader.observed);
+        assert_eq!(fs::read(test.path.join("state.txt")).unwrap(), b"new");
+        {
+            let transactions = restore_transactions().lock().unwrap();
+            assert!(!transactions
+                .get(token)
+                .expect("transaction must stay active")
+                .mutation_in_progress);
+        }
+        handle_from(&root, &request(ACTION_RESTORE_ROLLBACK, token, b"")).unwrap();
+        assert_eq!(fs::read(test.path.join("state.txt")).unwrap(), b"old");
+    }
+
+    #[test]
     fn restore_transaction_rolls_back_existing_and_created_targets() {
         let test = TestRoot::new();
         let root = test.trusted();
@@ -1345,6 +1495,7 @@ mod tests {
             token.to_string(),
             RestoreTransaction {
                 keyboxes: None,
+                mutation_in_progress: false,
                 max_snapshot_bytes: 4096,
                 snapshot_bytes: 3,
                 originals: vec![RestoreOriginal {

--- a/rust/daemon/src/config_file_broker.rs
+++ b/rust/daemon/src/config_file_broker.rs
@@ -1241,7 +1241,26 @@ mod tests {
             fn read(&mut self, output: &mut [u8]) -> io::Result<usize> {
                 if !self.observed {
                     self.observed = true;
-                    assert!(restore_transactions().try_lock().is_ok());
+                    let deadline = Instant::now() + Duration::from_secs(2);
+                    loop {
+                        match restore_transactions().try_lock() {
+                            Ok(guard) => {
+                                drop(guard);
+                                break;
+                            }
+                            Err(std::sync::TryLockError::WouldBlock)
+                                if Instant::now() < deadline =>
+                            {
+                                std::thread::sleep(Duration::from_millis(1));
+                            }
+                            Err(std::sync::TryLockError::WouldBlock) => {
+                                panic!("restore registry lock remained held while streaming");
+                            }
+                            Err(std::sync::TryLockError::Poisoned(_)) => {
+                                panic!("restore registry lock is poisoned");
+                            }
+                        }
+                    }
                     assert!(restore_commit(self.token).is_err());
                     let transactions = restore_transactions().lock().unwrap();
                     assert!(

--- a/rust/daemon/src/config_file_broker.rs
+++ b/rust/daemon/src/config_file_broker.rs
@@ -454,9 +454,8 @@ fn atomic_write_transaction_target_from<R: Read>(
                     "pinned keybox restore directory is unavailable",
                 )
             })?;
-            keyboxes.atomic_write_from_confirmed(
-                name, reader, body_len, FILE_MODE, scratch, confirm,
-            )
+            keyboxes
+                .atomic_write_from_confirmed(name, reader, body_len, FILE_MODE, scratch, confirm)
         }
     }
 }
@@ -721,12 +720,9 @@ fn restore_rollback(root: &TrustedDir, token: &str) -> io::Result<()> {
     let mut first_error = None;
     let mut failure_count = 0usize;
     for original in transaction.originals.iter().rev() {
-        if let Err(error) = restore_transaction_target(
-            root,
-            transaction,
-            &original.path,
-            original.bytes.as_deref(),
-        ) {
+        if let Err(error) =
+            restore_transaction_target(root, transaction, &original.path, original.bytes.as_deref())
+        {
             failure_count += 1;
             if first_error.is_none() {
                 first_error = Some(error);
@@ -1321,11 +1317,17 @@ mod tests {
         )
         .unwrap();
         assert_eq!(fs::read(moved.join("device.xml")).unwrap(), b"new");
-        assert_eq!(fs::read(keyboxes.join("device.xml")).unwrap(), b"replacement");
+        assert_eq!(
+            fs::read(keyboxes.join("device.xml")).unwrap(),
+            b"replacement"
+        );
 
         handle_from(&root, &request(ACTION_RESTORE_ROLLBACK, token, b"")).unwrap();
         assert_eq!(fs::read(moved.join("device.xml")).unwrap(), b"old");
-        assert_eq!(fs::read(keyboxes.join("device.xml")).unwrap(), b"replacement");
+        assert_eq!(
+            fs::read(keyboxes.join("device.xml")).unwrap(),
+            b"replacement"
+        );
     }
 
     #[test]

--- a/rust/daemon/src/config_file_broker.rs
+++ b/rust/daemon/src/config_file_broker.rs
@@ -60,6 +60,7 @@ impl Drop for RestoreOriginal {
 }
 
 struct RestoreTransaction {
+    keyboxes: Option<TrustedDir>,
     max_snapshot_bytes: usize,
     snapshot_bytes: usize,
     originals: Vec<RestoreOriginal>,
@@ -369,17 +370,17 @@ fn read_optional(dir: &TrustedDir, name: &str, max_bytes: usize) -> io::Result<O
     }
 }
 
-fn read_restore_target(
+fn read_transaction_restore_target(
     root: &TrustedDir,
+    transaction: &RestoreTransaction,
     path: &str,
     max_bytes: usize,
 ) -> io::Result<Option<Vec<u8>>> {
     match parse_restore_target(path)? {
         RestoreTarget::Root(name) => read_optional(root, name, max_bytes),
-        RestoreTarget::Keybox(name) => match root.open_child(KEYBOX_DIRECTORY) {
-            Ok(keyboxes) => read_optional(&keyboxes, name, max_bytes),
-            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
-            Err(error) => Err(error),
+        RestoreTarget::Keybox(name) => match transaction.keyboxes.as_ref() {
+            Some(keyboxes) => read_optional(keyboxes, name, max_bytes),
+            None => Ok(None),
         },
     }
 }
@@ -397,6 +398,66 @@ fn restore_target(root: &TrustedDir, path: &str, bytes: Option<&[u8]>) -> io::Re
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
             Err(error) => Err(error),
         },
+    }
+}
+
+fn restore_transaction_target(
+    root: &TrustedDir,
+    transaction: &RestoreTransaction,
+    path: &str,
+    bytes: Option<&[u8]>,
+) -> io::Result<()> {
+    match (parse_restore_target(path)?, bytes) {
+        (RestoreTarget::Root(name), Some(bytes)) => root.atomic_write(name, bytes, FILE_MODE),
+        (RestoreTarget::Root(name), None) => root.unlink_file(name).and_then(|_| root.sync()),
+        (RestoreTarget::Keybox(name), Some(bytes)) => {
+            let keyboxes = transaction.keyboxes.as_ref().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "pinned keybox restore directory is unavailable",
+                )
+            })?;
+            keyboxes.atomic_write(name, bytes, FILE_MODE)
+        }
+        (RestoreTarget::Keybox(name), None) => match transaction.keyboxes.as_ref() {
+            Some(keyboxes) => keyboxes.unlink_file(name).and_then(|_| keyboxes.sync()),
+            None => Ok(()),
+        },
+    }
+}
+
+fn atomic_write_transaction_target_from<R: Read>(
+    root: &TrustedDir,
+    transaction: &RestoreTransaction,
+    path: &str,
+    reader: &mut R,
+    body_len: usize,
+    scratch: &mut [u8],
+) -> io::Result<()> {
+    let confirm = |source: &mut R| {
+        let mut marker = [0u8; 1];
+        source.read_exact(&mut marker)?;
+        if marker[0] != WRITE_COMMIT_MARKER {
+            return Err(invalid("config file commit marker rejected"));
+        }
+        Ok(())
+    };
+
+    match parse_restore_target(path)? {
+        RestoreTarget::Root(name) => {
+            root.atomic_write_from_confirmed(name, reader, body_len, FILE_MODE, scratch, confirm)
+        }
+        RestoreTarget::Keybox(name) => {
+            let keyboxes = transaction.keyboxes.as_ref().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "pinned keybox restore directory is unavailable",
+                )
+            })?;
+            keyboxes.atomic_write_from_confirmed(
+                name, reader, body_len, FILE_MODE, scratch, confirm,
+            )
+        }
     }
 }
 
@@ -479,8 +540,8 @@ fn restore_write_from<R: Read>(
         .lock()
         .map_err(|_| io::Error::other("restore transaction state poisoned"))?;
     prune_stale_restore_transactions(root, &mut transactions);
-    transaction_for_snapshotted_target(&mut transactions, token, path)?;
-    atomic_write_target_from(root, path, reader, body_len, scratch)
+    let transaction = transaction_for_snapshotted_target(&mut transactions, token, path)?;
+    atomic_write_transaction_target_from(root, transaction, path, reader, body_len, scratch)
 }
 
 fn restore_delete(root: &TrustedDir, request: &str) -> io::Result<()> {
@@ -489,8 +550,8 @@ fn restore_delete(root: &TrustedDir, request: &str) -> io::Result<()> {
         .lock()
         .map_err(|_| io::Error::other("restore transaction state poisoned"))?;
     prune_stale_restore_transactions(root, &mut transactions);
-    transaction_for_snapshotted_target(&mut transactions, token, path)?;
-    restore_target(root, path, None)
+    let transaction = transaction_for_snapshotted_target(&mut transactions, token, path)?;
+    restore_transaction_target(root, transaction, path, None)
 }
 
 fn encode_hex(value: &[u8]) -> String {
@@ -577,9 +638,15 @@ fn restore_begin(root: &TrustedDir, request: &str) -> io::Result<()> {
     if transactions.len() >= MAX_ACTIVE_RESTORE_TRANSACTIONS {
         return Err(io::Error::other("restore transaction capacity exhausted"));
     }
+    let keyboxes = match root.open_child(KEYBOX_DIRECTORY) {
+        Ok(keyboxes) => Some(keyboxes),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error),
+    };
     transactions.insert(
         token.to_string(),
         RestoreTransaction {
+            keyboxes,
             max_snapshot_bytes,
             snapshot_bytes: 0,
             originals: Vec::new(),
@@ -622,7 +689,12 @@ fn restore_snapshot(root: &TrustedDir, request: &str) -> io::Result<()> {
     let global_remaining = MAX_GLOBAL_RESTORE_SNAPSHOT_BYTES
         .checked_sub(global_used)
         .ok_or_else(|| invalid("global restore snapshot accounting overflow"))?;
-    let bytes = read_restore_target(root, path, own_remaining.min(global_remaining))?;
+    let bytes = read_transaction_restore_target(
+        root,
+        transaction,
+        path,
+        own_remaining.min(global_remaining),
+    )?;
     let added = bytes.as_ref().map_or(0, Vec::len);
     transaction.snapshot_bytes = transaction
         .snapshot_bytes
@@ -649,7 +721,12 @@ fn restore_rollback(root: &TrustedDir, token: &str) -> io::Result<()> {
     let mut first_error = None;
     let mut failure_count = 0usize;
     for original in transaction.originals.iter().rev() {
-        if let Err(error) = restore_target(root, &original.path, original.bytes.as_deref()) {
+        if let Err(error) = restore_transaction_target(
+            root,
+            transaction,
+            &original.path,
+            original.bytes.as_deref(),
+        ) {
             failure_count += 1;
             if first_error.is_none() {
                 first_error = Some(error);
@@ -1120,9 +1197,7 @@ mod tests {
     fn restore_rollback_continues_after_an_independent_target_failure() {
         let test = TestRoot::new();
         fs::write(test.path.join("state.txt"), b"old-state").unwrap();
-        let keyboxes = test.path.join(KEYBOX_DIRECTORY);
-        fs::create_dir(&keyboxes).unwrap();
-        fs::write(keyboxes.join("device.xml"), b"old-keybox").unwrap();
+        fs::write(test.path.join("blocked.txt"), b"old-blocked").unwrap();
         let root = test.trusted();
         let token = "15000000000000000000000000000005";
         handle_from(&root, &restore_pair(ACTION_RESTORE_BEGIN, token, "4096")).unwrap();
@@ -1133,21 +1208,17 @@ mod tests {
         .unwrap();
         handle_from(
             &root,
-            &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "keyboxes/device.xml"),
+            &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "blocked.txt"),
         )
         .unwrap();
 
         fs::write(test.path.join("state.txt"), b"new-state").unwrap();
-        let moved = test.path.join("moved-keyboxes");
-        let outside = test.path.join("outside-keyboxes");
-        fs::rename(&keyboxes, &moved).unwrap();
-        fs::create_dir(&outside).unwrap();
-        fs::write(outside.join("device.xml"), b"outside").unwrap();
-        symlink(&outside, &keyboxes).unwrap();
+        fs::remove_file(test.path.join("blocked.txt")).unwrap();
+        fs::create_dir(test.path.join("blocked.txt")).unwrap();
 
         assert!(handle_from(&root, &request(ACTION_RESTORE_ROLLBACK, token, b"")).is_err());
         assert_eq!(fs::read(test.path.join("state.txt")).unwrap(), b"old-state");
-        assert_eq!(fs::read(outside.join("device.xml")).unwrap(), b"outside");
+        assert!(test.path.join("blocked.txt").is_dir());
         handle_from(&root, &request(ACTION_RESTORE_ABORT, token, b"")).unwrap();
     }
 
@@ -1182,7 +1253,7 @@ mod tests {
     }
 
     #[test]
-    fn keybox_parent_symlink_swap_fails_closed_and_exports_recovery() {
+    fn keybox_parent_symlink_swap_stays_bound_to_pinned_directory() {
         let test = TestRoot::new();
         let keyboxes = test.path.join(KEYBOX_DIRECTORY);
         fs::create_dir(&keyboxes).unwrap();
@@ -1203,21 +1274,58 @@ mod tests {
         fs::write(outside.join("device.xml"), b"outside").unwrap();
         symlink(&outside, &keyboxes).unwrap();
 
-        assert!(handle_from(&root, &request(ACTION_RESTORE_ROLLBACK, token, b"")).is_err());
+        handle_from(
+            &root,
+            &request(
+                ACTION_WRITE,
+                &format!("{token}\0keyboxes/device.xml"),
+                b"new",
+            ),
+        )
+        .unwrap();
+        assert_eq!(fs::read(moved.join("device.xml")).unwrap(), b"new");
         assert_eq!(fs::read(outside.join("device.xml")).unwrap(), b"outside");
-        handle_from(&root, &request(ACTION_RESTORE_EXPORT, token, b"")).unwrap();
-        assert_eq!(
-            fs::read(
-                test.path
-                    .join(format!(".restore-recovery-{token}-0000.bak"))
-            )
-            .unwrap(),
-            b"old"
-        );
-        assert!(test
-            .path
-            .join(format!(".restore-recovery-{token}.manifest"))
-            .is_file());
+
+        handle_from(&root, &request(ACTION_RESTORE_ROLLBACK, token, b"")).unwrap();
+        assert_eq!(fs::read(moved.join("device.xml")).unwrap(), b"old");
+        assert_eq!(fs::read(outside.join("device.xml")).unwrap(), b"outside");
+    }
+
+    #[test]
+    fn keybox_parent_real_directory_swap_cannot_redirect_transaction() {
+        let test = TestRoot::new();
+        let keyboxes = test.path.join(KEYBOX_DIRECTORY);
+        fs::create_dir(&keyboxes).unwrap();
+        fs::write(keyboxes.join("device.xml"), b"old").unwrap();
+        let root = test.trusted();
+        let token = "35000000000000000000000000000005";
+        handle_from(&root, &restore_pair(ACTION_RESTORE_BEGIN, token, "4096")).unwrap();
+        handle_from(
+            &root,
+            &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "keyboxes/device.xml"),
+        )
+        .unwrap();
+
+        let moved = test.path.join("moved-keyboxes");
+        fs::rename(&keyboxes, &moved).unwrap();
+        fs::create_dir(&keyboxes).unwrap();
+        fs::write(keyboxes.join("device.xml"), b"replacement").unwrap();
+
+        handle_from(
+            &root,
+            &request(
+                ACTION_WRITE,
+                &format!("{token}\0keyboxes/device.xml"),
+                b"new",
+            ),
+        )
+        .unwrap();
+        assert_eq!(fs::read(moved.join("device.xml")).unwrap(), b"new");
+        assert_eq!(fs::read(keyboxes.join("device.xml")).unwrap(), b"replacement");
+
+        handle_from(&root, &request(ACTION_RESTORE_ROLLBACK, token, b"")).unwrap();
+        assert_eq!(fs::read(moved.join("device.xml")).unwrap(), b"old");
+        assert_eq!(fs::read(keyboxes.join("device.xml")).unwrap(), b"replacement");
     }
 
     #[test]
@@ -1234,6 +1342,7 @@ mod tests {
         transactions.insert(
             token.to_string(),
             RestoreTransaction {
+                keyboxes: None,
                 max_snapshot_bytes: 4096,
                 snapshot_bytes: 3,
                 originals: vec![RestoreOriginal {

--- a/rust/daemon/src/config_file_broker.rs
+++ b/rust/daemon/src/config_file_broker.rs
@@ -267,6 +267,31 @@ fn atomic_write_relative_from<R: Read>(
     body_len: usize,
     scratch: &mut [u8],
 ) -> io::Result<()> {
+    if path.contains('\0') {
+        return restore_write_from(root, path, reader, body_len, scratch);
+    }
+    let mut transactions = restore_transactions()
+        .lock()
+        .map_err(|_| io::Error::other("restore transaction state poisoned"))?;
+    prune_stale_restore_transactions(root, &mut transactions);
+    if transactions.values().any(|transaction| {
+        transaction
+            .originals
+            .iter()
+            .any(|original| original.path == path)
+    }) {
+        return Err(invalid("active restore target requires a transaction-scoped write"));
+    }
+    atomic_write_target_from(root, path, reader, body_len, scratch)
+}
+
+fn atomic_write_target_from<R: Read>(
+    root: &TrustedDir,
+    path: &str,
+    reader: &mut R,
+    body_len: usize,
+    scratch: &mut [u8],
+) -> io::Result<()> {
     let confirm = |source: &mut R| {
         let mut marker = [0u8; 1];
         source.read_exact(&mut marker)?;
@@ -374,6 +399,21 @@ fn restore_target(root: &TrustedDir, path: &str, bytes: Option<&[u8]>) -> io::Re
 }
 
 fn delete_allowed(root: &TrustedDir, path: &str) -> io::Result<()> {
+    if path.contains('\0') {
+        return restore_delete(root, path);
+    }
+    let mut transactions = restore_transactions()
+        .lock()
+        .map_err(|_| io::Error::other("restore transaction state poisoned"))?;
+    prune_stale_restore_transactions(root, &mut transactions);
+    if transactions.values().any(|transaction| {
+        transaction
+            .originals
+            .iter()
+            .any(|original| original.path == path)
+    }) {
+        return Err(invalid("active restore target requires a transaction-scoped delete"));
+    }
     restore_target(root, path, None)
 }
 
@@ -401,6 +441,52 @@ fn parse_restore_pair(value: &str) -> io::Result<(&str, &str)> {
         return Err(invalid("restore transaction argument is empty"));
     }
     Ok((token, argument))
+}
+
+fn transaction_for_snapshotted_target<'a>(
+    transactions: &'a mut HashMap<String, RestoreTransaction>,
+    token: &str,
+    path: &str,
+) -> io::Result<&'a mut RestoreTransaction> {
+    parse_restore_target(path)?;
+    let transaction = transactions
+        .get_mut(token)
+        .ok_or_else(|| invalid("restore transaction is not active"))?;
+    if !transaction
+        .originals
+        .iter()
+        .any(|original| original.path == path)
+    {
+        return Err(invalid("restore mutation target was not snapshotted"));
+    }
+    transaction.touched = Instant::now();
+    Ok(transaction)
+}
+
+fn restore_write_from<R: Read>(
+    root: &TrustedDir,
+    request: &str,
+    reader: &mut R,
+    body_len: usize,
+    scratch: &mut [u8],
+) -> io::Result<()> {
+    let (token, path) = parse_restore_pair(request)?;
+    let mut transactions = restore_transactions()
+        .lock()
+        .map_err(|_| io::Error::other("restore transaction state poisoned"))?;
+    prune_stale_restore_transactions(root, &mut transactions);
+    transaction_for_snapshotted_target(&mut transactions, token, path)?;
+    atomic_write_target_from(root, path, reader, body_len, scratch)
+}
+
+fn restore_delete(root: &TrustedDir, request: &str) -> io::Result<()> {
+    let (token, path) = parse_restore_pair(request)?;
+    let mut transactions = restore_transactions()
+        .lock()
+        .map_err(|_| io::Error::other("restore transaction state poisoned"))?;
+    prune_stale_restore_transactions(root, &mut transactions);
+    transaction_for_snapshotted_target(&mut transactions, token, path)?;
+    restore_target(root, path, None)
 }
 
 fn encode_hex(value: &[u8]) -> String {
@@ -923,6 +1009,57 @@ mod tests {
         assert_eq!(fs::read(&outside).unwrap(), b"outside");
         assert_eq!(fs::read(test.path.join("target.txt")).unwrap(), b"inside");
         let _ = fs::remove_file(outside);
+    }
+
+    #[test]
+    fn restore_transaction_mutations_require_matching_snapshot_token() {
+        let test = TestRoot::new();
+        let root = test.trusted();
+        fs::write(test.path.join("state.txt"), b"old").unwrap();
+        fs::write(test.path.join("other.txt"), b"other").unwrap();
+        let token = "05000000000000000000000000000005";
+        let wrong_token = "06000000000000000000000000000006";
+        handle_from(&root, &restore_pair(ACTION_RESTORE_BEGIN, token, "4096")).unwrap();
+        handle_from(
+            &root,
+            &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "state.txt"),
+        )
+        .unwrap();
+
+        assert!(handle_from(&root, &request(ACTION_WRITE, "state.txt", b"unscoped")).is_err());
+        assert_eq!(fs::read(test.path.join("state.txt")).unwrap(), b"old");
+        assert!(handle_from(
+            &root,
+            &request(
+                ACTION_WRITE,
+                &format!("{wrong_token}\0state.txt"),
+                b"wrong-token",
+            ),
+        )
+        .is_err());
+        assert!(handle_from(
+            &root,
+            &request(ACTION_WRITE, &format!("{token}\0other.txt"), b"not-snapshotted"),
+        )
+        .is_err());
+        handle_from(
+            &root,
+            &request(ACTION_WRITE, &format!("{token}\0state.txt"), b"new"),
+        )
+        .unwrap();
+        assert_eq!(fs::read(test.path.join("state.txt")).unwrap(), b"new");
+
+        assert!(handle_from(&root, &request(ACTION_DELETE, "state.txt", b"")).is_err());
+        handle_from(
+            &root,
+            &request(ACTION_DELETE, &format!("{token}\0state.txt"), b""),
+        )
+        .unwrap();
+        assert!(!test.path.join("state.txt").exists());
+
+        handle_from(&root, &request(ACTION_RESTORE_ROLLBACK, token, b"")).unwrap();
+        assert_eq!(fs::read(test.path.join("state.txt")).unwrap(), b"old");
+        assert_eq!(fs::read(test.path.join("other.txt")).unwrap(), b"other");
     }
 
     #[test]

--- a/rust/daemon/src/config_file_broker.rs
+++ b/rust/daemon/src/config_file_broker.rs
@@ -418,7 +418,7 @@ fn export_transaction_to_root(
     token: &str,
     transaction: &RestoreTransaction,
 ) -> io::Result<()> {
-    let mut created = Vec::new();
+    let mut created: Vec<String> = Vec::new();
     let mut manifest = String::new();
     for (index, original) in transaction.originals.iter().enumerate() {
         let encoded_path = encode_hex(original.path.as_bytes());

--- a/rust/daemon/src/config_file_broker.rs
+++ b/rust/daemon/src/config_file_broker.rs
@@ -540,18 +540,14 @@ fn begin_streaming_restore_mutation(
     let transaction = transaction_for_snapshotted_target(transactions, token, path)?;
     let keyboxes = match target {
         RestoreTarget::Root(_) => None,
-        RestoreTarget::Keybox(_) => Some(
-            transaction
-                .keyboxes
-                .as_ref()
-                .cloned()
-                .ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::NotFound,
-                        "pinned keybox restore directory is unavailable",
-                    )
-                })?,
-        ),
+        RestoreTarget::Keybox(_) => {
+            Some(transaction.keyboxes.as_ref().cloned().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "pinned keybox restore directory is unavailable",
+                )
+            })?)
+        }
     };
     transaction.mutation_in_progress = true;
     Ok(keyboxes)
@@ -565,7 +561,9 @@ fn finish_streaming_restore_mutation(token: &str) -> io::Result<()> {
         .get_mut(token)
         .ok_or_else(|| invalid("restore transaction is not active"))?;
     if !transaction.mutation_in_progress {
-        return Err(io::Error::other("restore transaction mutation lease was not active"));
+        return Err(io::Error::other(
+            "restore transaction mutation lease was not active",
+        ));
     }
     transaction.mutation_in_progress = false;
     transaction.touched = Instant::now();
@@ -1246,10 +1244,12 @@ mod tests {
                     assert!(restore_transactions().try_lock().is_ok());
                     assert!(restore_commit(self.token).is_err());
                     let transactions = restore_transactions().lock().unwrap();
-                    assert!(transactions
-                        .get(self.token)
-                        .expect("transaction must stay active")
-                        .mutation_in_progress);
+                    assert!(
+                        transactions
+                            .get(self.token)
+                            .expect("transaction must stay active")
+                            .mutation_in_progress
+                    );
                 }
                 std::io::Read::read(&mut self.inner, output)
             }
@@ -1284,10 +1284,12 @@ mod tests {
         assert_eq!(fs::read(test.path.join("state.txt")).unwrap(), b"new");
         {
             let transactions = restore_transactions().lock().unwrap();
-            assert!(!transactions
-                .get(token)
-                .expect("transaction must stay active")
-                .mutation_in_progress);
+            assert!(
+                !transactions
+                    .get(token)
+                    .expect("transaction must stay active")
+                    .mutation_in_progress
+            );
         }
         handle_from(&root, &request(ACTION_RESTORE_ROLLBACK, token, b"")).unwrap();
         assert_eq!(fs::read(test.path.join("state.txt")).unwrap(), b"old");

--- a/rust/daemon/src/config_file_broker.rs
+++ b/rust/daemon/src/config_file_broker.rs
@@ -328,7 +328,9 @@ fn parse_restore_target(path: &str) -> io::Result<RestoreTarget<'_>> {
             validate_component(name)?;
             Ok(RestoreTarget::Keybox(name))
         }
-        _ => Err(invalid("restore target is outside an allowed capability subtree")),
+        _ => Err(invalid(
+            "restore target is outside an allowed capability subtree",
+        )),
     }
 }
 
@@ -340,7 +342,11 @@ fn read_optional(dir: &TrustedDir, name: &str, max_bytes: usize) -> io::Result<O
     }
 }
 
-fn read_restore_target(root: &TrustedDir, path: &str, max_bytes: usize) -> io::Result<Option<Vec<u8>>> {
+fn read_restore_target(
+    root: &TrustedDir,
+    path: &str,
+    max_bytes: usize,
+) -> io::Result<Option<Vec<u8>>> {
     match parse_restore_target(path)? {
         RestoreTarget::Root(name) => read_optional(root, name, max_bytes),
         RestoreTarget::Keybox(name) => match root.open_child(KEYBOX_DIRECTORY) {
@@ -454,9 +460,9 @@ fn prune_stale_restore_transactions(
         })
         .collect();
     for token in stale {
-        let exported = transactions
-            .get(&token)
-            .is_some_and(|transaction| export_transaction_to_root(root, &token, transaction).is_ok());
+        let exported = transactions.get(&token).is_some_and(|transaction| {
+            export_transaction_to_root(root, &token, transaction).is_ok()
+        });
         if exported {
             transactions.remove(&token);
         }
@@ -500,15 +506,24 @@ fn restore_snapshot(root: &TrustedDir, request: &str) -> io::Result<()> {
         .lock()
         .map_err(|_| io::Error::other("restore transaction state poisoned"))?;
     prune_stale_restore_transactions(root, &mut transactions);
-    let global_used: usize = transactions.values().map(|transaction| transaction.snapshot_bytes).sum();
+    let global_used: usize = transactions
+        .values()
+        .map(|transaction| transaction.snapshot_bytes)
+        .sum();
     let transaction = transactions
         .get_mut(token)
         .ok_or_else(|| invalid("restore transaction is not active"))?;
     if transaction.originals.len() >= MAX_RESTORE_TARGETS {
         return Err(invalid("restore transaction target count exceeds bound"));
     }
-    if transaction.originals.iter().any(|original| original.path == path) {
-        return Err(invalid("restore transaction target was already snapshotted"));
+    if transaction
+        .originals
+        .iter()
+        .any(|original| original.path == path)
+    {
+        return Err(invalid(
+            "restore transaction target was already snapshotted",
+        ));
     }
     let own_remaining = transaction
         .max_snapshot_bytes
@@ -903,15 +918,35 @@ mod tests {
         let root = test.trusted();
         fs::write(test.path.join("first.txt"), b"old-first").unwrap();
         fs::create_dir(test.path.join(KEYBOX_DIRECTORY)).unwrap();
-        fs::write(test.path.join(KEYBOX_DIRECTORY).join("device.xml"), b"old-keybox").unwrap();
+        fs::write(
+            test.path.join(KEYBOX_DIRECTORY).join("device.xml"),
+            b"old-keybox",
+        )
+        .unwrap();
         let token = "10000000000000000000000000000001";
 
         handle_from(&root, &restore_pair(ACTION_RESTORE_BEGIN, token, "4096")).unwrap();
-        handle_from(&root, &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "first.txt")).unwrap();
-        handle_from(&root, &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "keyboxes/device.xml")).unwrap();
-        handle_from(&root, &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "created.txt")).unwrap();
+        handle_from(
+            &root,
+            &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "first.txt"),
+        )
+        .unwrap();
+        handle_from(
+            &root,
+            &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "keyboxes/device.xml"),
+        )
+        .unwrap();
+        handle_from(
+            &root,
+            &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "created.txt"),
+        )
+        .unwrap();
         fs::write(test.path.join("first.txt"), b"new-first").unwrap();
-        fs::write(test.path.join(KEYBOX_DIRECTORY).join("device.xml"), b"new-keybox").unwrap();
+        fs::write(
+            test.path.join(KEYBOX_DIRECTORY).join("device.xml"),
+            b"new-keybox",
+        )
+        .unwrap();
         fs::write(test.path.join("created.txt"), b"created").unwrap();
 
         handle_from(&root, &request(ACTION_RESTORE_ROLLBACK, token, b"")).unwrap();
@@ -930,7 +965,11 @@ mod tests {
         let root = test.trusted();
         let token = "20000000000000000000000000000002";
         handle_from(&root, &restore_pair(ACTION_RESTORE_BEGIN, token, "4096")).unwrap();
-        handle_from(&root, &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "state.txt")).unwrap();
+        handle_from(
+            &root,
+            &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "state.txt"),
+        )
+        .unwrap();
 
         let moved = test.path.with_extension("moved-root");
         let outside = test.path.with_extension("outside-root");
@@ -958,7 +997,11 @@ mod tests {
         let root = test.trusted();
         let token = "30000000000000000000000000000003";
         handle_from(&root, &restore_pair(ACTION_RESTORE_BEGIN, token, "4096")).unwrap();
-        handle_from(&root, &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "keyboxes/device.xml")).unwrap();
+        handle_from(
+            &root,
+            &restore_pair(ACTION_RESTORE_SNAPSHOT, token, "keyboxes/device.xml"),
+        )
+        .unwrap();
 
         let moved = test.path.join("moved-keyboxes");
         let outside = test.path.join("outside-keyboxes");
@@ -971,10 +1014,17 @@ mod tests {
         assert_eq!(fs::read(outside.join("device.xml")).unwrap(), b"outside");
         handle_from(&root, &request(ACTION_RESTORE_EXPORT, token, b"")).unwrap();
         assert_eq!(
-            fs::read(test.path.join(format!(".restore-recovery-{token}-0000.bak"))).unwrap(),
+            fs::read(
+                test.path
+                    .join(format!(".restore-recovery-{token}-0000.bak"))
+            )
+            .unwrap(),
             b"old"
         );
-        assert!(test.path.join(format!(".restore-recovery-{token}.manifest")).is_file());
+        assert!(test
+            .path
+            .join(format!(".restore-recovery-{token}.manifest"))
+            .is_file());
     }
 
     #[test]
@@ -982,7 +1032,7 @@ mod tests {
         let test = TestRoot::new();
         let outside = test.path.with_extension("delete-outside");
         fs::write(&outside, b"outside").unwrap();
-        symlink(&outside, test.path.join("victim")) .unwrap();
+        symlink(&outside, test.path.join("victim")).unwrap();
         let root = test.trusted();
 
         handle_from(&root, &request(ACTION_DELETE, "victim", b"")).unwrap();

--- a/service/src/main/java/cleveres/tricky/cleverestech/BackupTransaction.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/BackupTransaction.kt
@@ -1,15 +1,12 @@
 package cleveres.tricky.cleverestech
 
-import cleveres.tricky.cleverestech.util.SecureFile
+import cleveres.tricky.cleverestech.util.RestoreFiles
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
-import java.nio.channels.Channels
 import java.nio.file.Files
 import java.nio.file.LinkOption
-import java.nio.file.StandardCopyOption
-import java.nio.file.StandardOpenOption
 import java.util.UUID
 
 /** Shared bounded streaming used while creating backups. */
@@ -43,19 +40,13 @@ internal object BackupIo {
 }
 
 /**
- * Applies a validated restore set with rollback. All original files are snapshotted before
- * the first mutation, so a write/delete failure cannot leave a mixed configuration set.
+ * Applies a validated restore set with rollback. Original state is owned by a descriptor-bound
+ * backend before the first mutation so rollback cannot be redirected by ancestor path swaps.
  */
 internal object BackupRestoreTransaction {
     data class Mutation(
         val target: File,
         val replacement: ByteArray?,
-    )
-
-    private data class Original(
-        val target: File,
-        val existed: Boolean,
-        val backup: File?,
     )
 
     /** Preserves the original before-mutation callback API for existing callers. */
@@ -97,85 +88,35 @@ internal object BackupRestoreTransaction {
             if (normalized == rootPath || !normalized.startsWith(rootPath)) {
                 throw SecurityException("Restore transaction escaped configuration directory")
             }
-            var parent = normalized.parent
-            while (parent != null && parent != rootPath) {
-                if (Files.exists(parent, LinkOption.NOFOLLOW_LINKS) &&
-                    (Files.isSymbolicLink(parent) || !Files.isDirectory(parent, LinkOption.NOFOLLOW_LINKS))
-                ) {
-                    throw SecurityException("Restore transaction parent is unsafe")
-                }
-                parent = parent.parent
+            val relative = rootPath.relativize(normalized)
+            val allowed =
+                relative.nameCount == 1 ||
+                    (relative.nameCount == 2 && relative.getName(0).toString() == KEYBOX_DIRECTORY)
+            if (!allowed || relative.any { component -> !isSafeComponent(component.toString()) }) {
+                throw SecurityException("Restore target is outside an allowed capability subtree")
             }
-            if (parent != rootPath) throw SecurityException("Restore transaction escaped configuration directory")
             unique[normalized.toString()] = Mutation(normalized.toFile(), mutation.replacement)
         }
 
-        val transactionDir = File(rootPath.toFile(), ".restore-txn-${UUID.randomUUID()}")
-        SecureFile.mkdirs(transactionDir, 448)
-        val originals = ArrayList<Original>(unique.size)
-        var retainRecoveryArtifacts = false
+        val restoreFiles = RestoreFiles.current()
+        val token = UUID.randomUUID().toString().replace("-", "")
+        var transactionActive = false
+        var retainSecureRecoveryState = false
         try {
-            var snapshotBytes = 0L
-            unique.values.forEachIndexed { index, mutation ->
-                val path = mutation.target.toPath()
-                val existed = Files.exists(path, LinkOption.NOFOLLOW_LINKS)
-                if (existed && !Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
-                    throw SecurityException("Refusing non-regular restore transaction target")
+            restoreFiles.begin(configDir, token, maxSnapshotBytes)
+            transactionActive = true
+            try {
+                unique.values.forEach { mutation ->
+                    restoreFiles.snapshot(configDir, token, mutation.target)
                 }
-                val backup =
-                    if (existed) {
-                        val copy = File(transactionDir, index.toString().padStart(4, '0') + ".bak")
-                        try {
-                            val remaining = maxSnapshotBytes - snapshotBytes
-                            if (remaining < 0) throw IOException("Restore snapshot exceeds its size limit")
-                            val copied =
-                                Files.newByteChannel(path, StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS).use { channel ->
-                                    val initialSize = channel.size()
-                                    if (initialSize !in 0..remaining) {
-                                        throw IOException("Restore snapshot exceeds its size limit")
-                                    }
-                                    Files.newOutputStream(
-                                        copy.toPath(),
-                                        StandardOpenOption.CREATE_NEW,
-                                        StandardOpenOption.WRITE,
-                                    ).use { output ->
-                                        BackupIo.copyBounded(
-                                            Channels.newInputStream(channel),
-                                            output,
-                                            remaining,
-                                            remaining,
-                                        )
-                                    }.also { streamed ->
-                                        if (streamed != initialSize || channel.size() != initialSize) {
-                                            throw IOException("Restore transaction source changed while snapshotting")
-                                        }
-                                    }
-                                }
-                            if (!Files.isRegularFile(copy.toPath(), LinkOption.NOFOLLOW_LINKS) || copy.length() != copied) {
-                                throw IOException("Restore transaction snapshot is incomplete")
-                            }
-                            runCatching {
-                                Files.setPosixFilePermissions(
-                                    copy.toPath(),
-                                    Files.getPosixFilePermissions(path, LinkOption.NOFOLLOW_LINKS),
-                                )
-                            }
-                            runCatching {
-                                Files.setLastModifiedTime(
-                                    copy.toPath(),
-                                    Files.getLastModifiedTime(path, LinkOption.NOFOLLOW_LINKS),
-                                )
-                            }
-                            snapshotBytes += copied
-                        } catch (e: IOException) {
-                            runCatching { Files.deleteIfExists(copy.toPath()) }
-                            throw SecurityException("Refusing unsafe, unreadable, or oversized restore snapshot", e)
-                        }
-                        copy
-                    } else {
-                        null
-                    }
-                originals += Original(mutation.target, existed, backup)
+            } catch (snapshotFailure: Throwable) {
+                try {
+                    restoreFiles.abort(configDir, token)
+                    transactionActive = false
+                } catch (abortFailure: Throwable) {
+                    snapshotFailure.addSuppressed(abortFailure)
+                }
+                throw SecurityException("Refusing unsafe, unreadable, or oversized restore snapshot", snapshotFailure)
             }
 
             var afterMutationInvoked = false
@@ -184,88 +125,58 @@ internal object BackupRestoreTransaction {
                     beforeMutation?.invoke(index, mutation.target)
                     val replacement = mutation.replacement
                     if (replacement == null) {
-                        Files.deleteIfExists(mutation.target.toPath())
+                        restoreFiles.delete(configDir, token, mutation.target)
                     } else {
-                        mutation.target.parentFile?.let { parent ->
-                            if (parent.toPath() != rootPath && !Files.isDirectory(parent.toPath(), LinkOption.NOFOLLOW_LINKS)) {
-                                SecureFile.mkdirs(parent, 448)
-                            }
-                        }
-                        SecureFile.writeBytes(mutation.target, replacement)
+                        restoreFiles.replace(configDir, token, mutation.target, replacement)
                     }
                 }
                 if (afterMutation != null) {
                     afterMutationInvoked = true
                     afterMutation.invoke()
                 }
+                restoreFiles.commit(configDir, token)
+                transactionActive = false
             } catch (failure: Throwable) {
                 var rollbackFailure: Throwable? = null
-                originals.asReversed().forEach { original ->
+                try {
+                    restoreFiles.rollback(configDir, token)
+                    transactionActive = false
+                } catch (error: Throwable) {
+                    rollbackFailure = error
                     try {
-                        if (original.existed) {
-                            val backup = requireNotNull(original.backup)
-                            original.target.parentFile?.let { parent ->
-                                if (Files.isSymbolicLink(parent.toPath())) {
-                                    throw SecurityException("Restore rollback parent became a symbolic link")
-                                }
-                                if (!Files.isDirectory(parent.toPath(), LinkOption.NOFOLLOW_LINKS)) {
-                                    SecureFile.mkdirs(parent, 448)
-                                }
-                            }
-                            try {
-                                Files.move(
-                                    backup.toPath(),
-                                    original.target.toPath(),
-                                    StandardCopyOption.REPLACE_EXISTING,
-                                    StandardCopyOption.ATOMIC_MOVE,
-                                )
-                            } catch (_: java.nio.file.AtomicMoveNotSupportedException) {
-                                Files.move(
-                                    backup.toPath(),
-                                    original.target.toPath(),
-                                    StandardCopyOption.REPLACE_EXISTING,
-                                )
-                            }
-                        } else {
-                            Files.deleteIfExists(original.target.toPath())
-                        }
-                    } catch (error: Throwable) {
-                        if (original.existed && original.backup?.exists() == true) retainRecoveryArtifacts = true
-                        val existingFailure = rollbackFailure
-                        if (existingFailure == null) {
-                            rollbackFailure = error
-                        } else {
-                            existingFailure.addSuppressed(error)
-                        }
+                        val recoveryLocation = restoreFiles.exportRecovery(configDir, token)
+                        transactionActive = false
+                        failure.addSuppressed(
+                            IOException("Rollback recovery data retained at $recoveryLocation"),
+                        )
+                    } catch (exportFailure: Throwable) {
+                        error.addSuppressed(exportFailure)
+                        retainSecureRecoveryState = true
+                        failure.addSuppressed(
+                            IOException("Rollback recovery remains retained by the secure transaction backend"),
+                        )
                     }
                 }
-                if (afterMutationInvoked && onRollback != null) {
+
+                if (afterMutationInvoked && onRollback != null && rollbackFailure == null) {
                     try {
                         onRollback.invoke()
                     } catch (error: Throwable) {
-                        val existingFailure = rollbackFailure
-                        if (existingFailure == null) {
-                            rollbackFailure = error
-                        } else {
-                            existingFailure.addSuppressed(error)
-                        }
+                        rollbackFailure = error
                     }
-                }
-                if (retainRecoveryArtifacts) {
-                    failure.addSuppressed(
-                        IOException("Rollback recovery data retained in ${transactionDir.absolutePath}"),
-                    )
                 }
                 rollbackFailure?.let { failure.addSuppressed(it) }
                 throw failure
             }
         } finally {
-            if (!retainRecoveryArtifacts) {
-                originals.forEach { original ->
-                    runCatching { original.backup?.let { Files.deleteIfExists(it.toPath()) } }
-                }
-                runCatching { Files.deleteIfExists(transactionDir.toPath()) }
+            if (transactionActive && !retainSecureRecoveryState) {
+                runCatching { restoreFiles.abort(configDir, token) }
             }
         }
     }
+
+    private fun isSafeComponent(value: String): Boolean =
+        value.isNotEmpty() && value != "." && value != ".." && '/' !in value && '\u0000' !in value
+
+    private const val KEYBOX_DIRECTORY = "keyboxes"
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/BackupTransaction.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/BackupTransaction.kt
@@ -1,6 +1,7 @@
 package cleveres.tricky.cleverestech
 
 import cleveres.tricky.cleverestech.util.RestoreFiles
+import cleveres.tricky.cleverestech.util.SecureFile
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
@@ -98,6 +99,19 @@ internal object BackupRestoreTransaction {
             unique[normalized.toString()] = Mutation(normalized.toFile(), mutation.replacement)
         }
 
+        val needsKeyboxDirectory =
+            unique.values.any { mutation ->
+                if (mutation.replacement == null) return@any false
+                val relative = rootPath.relativize(mutation.target.toPath())
+                relative.nameCount == 2 && relative.getName(0).toString() == KEYBOX_DIRECTORY
+            }
+        if (needsKeyboxDirectory) {
+            // Creation happens before the transaction boundary. The backend then pins this exact
+            // directory handle before snapshotting, so later pathname replacement cannot redirect
+            // restore writes or rollback.
+            SecureFile.mkdirs(configDir.resolve(KEYBOX_DIRECTORY), DIRECTORY_MODE)
+        }
+
         val restoreFiles = RestoreFiles.current()
         val token = UUID.randomUUID().toString().replace("-", "")
         var transactionActive = false
@@ -179,4 +193,5 @@ internal object BackupRestoreTransaction {
         value.isNotEmpty() && value != "." && value != ".." && '/' !in value && '\u0000' !in value
 
     private const val KEYBOX_DIRECTORY = "keyboxes"
+    private const val DIRECTORY_MODE = 448
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/RestoreFileOperations.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/RestoreFileOperations.kt
@@ -5,6 +5,7 @@ import java.io.IOException
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
 import java.nio.file.DirectoryStream
+import java.nio.file.FileAlreadyExistsException
 import java.nio.file.FileSystems
 import java.nio.file.LinkOption
 import java.nio.file.NoSuchFileException
@@ -89,8 +90,23 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
         fun closeAndWipe() {
             originals.forEach { original -> original.bytes?.fill(0) }
             originals.clear()
-            keyboxes?.close()
-            root.close()
+            var closeFailure: Throwable? = null
+            try {
+                keyboxes?.close()
+            } catch (error: Throwable) {
+                closeFailure = error
+            }
+            try {
+                root.close()
+            } catch (error: Throwable) {
+                val first = closeFailure
+                if (first == null) {
+                    closeFailure = error
+                } else {
+                    first.addSuppressed(error)
+                }
+            }
+            closeFailure?.let { throw IOException("Could not close secure restore directory capabilities", it) }
         }
     }
 
@@ -120,6 +136,14 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
                 root.close()
                 throw error
             }
+        try {
+            verifyReplacementSemantics(root)
+            keyboxes?.let(::verifyReplacementSemantics)
+        } catch (error: Throwable) {
+            runCatching { keyboxes?.close() }
+            runCatching { root.close() }
+            throw error
+        }
         synchronized(lock) {
             if (transactions.containsKey(token)) {
                 keyboxes?.close()
@@ -405,6 +429,99 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
             created = false
         } finally {
             if (created) runCatching { parent.deleteFile(temporary) }
+        }
+    }
+
+    /**
+     * Verifies that this exact secure-directory provider replaces an existing regular target.
+     * SecureDirectoryStream.move has provider-specific replacement semantics and exposes no
+     * REPLACE_EXISTING option, so unsupported providers are rejected before any restore mutation.
+     */
+    private fun verifyReplacementSemantics(directory: SecureDirectoryStream<Path>) {
+        val source = FileSystems.getDefault().getPath(".restore-probe-${UUID.randomUUID()}.src")
+        val destination = FileSystems.getDefault().getPath(".restore-probe-${UUID.randomUUID()}.dst")
+        val sourceBytes = byteArrayOf(0x51, 0x52, 0x53)
+        val destinationBytes = byteArrayOf(0x21, 0x22)
+        try {
+            createProbeFile(directory, source, sourceBytes)
+            createProbeFile(directory, destination, destinationBytes)
+            try {
+                directory.move(source, directory, destination)
+            } catch (error: FileAlreadyExistsException) {
+                throw IOException(
+                    "Secure restore provider cannot replace an existing target through a pinned directory",
+                    error,
+                )
+            }
+            requireProbeSourceGone(directory, source)
+            verifyProbeContent(directory, destination, sourceBytes)
+        } finally {
+            sourceBytes.fill(0)
+            destinationBytes.fill(0)
+            runCatching { directory.deleteFile(source) }
+            runCatching { directory.deleteFile(destination) }
+        }
+    }
+
+    private fun createProbeFile(
+        directory: SecureDirectoryStream<Path>,
+        name: Path,
+        content: ByteArray,
+    ) {
+        val options =
+            setOf<OpenOption>(
+                StandardOpenOption.CREATE_NEW,
+                StandardOpenOption.WRITE,
+                LinkOption.NOFOLLOW_LINKS,
+            )
+        val attribute = PosixFilePermissions.asFileAttribute(PRIVATE_FILE_PERMISSIONS)
+        directory.newByteChannel(name, options, attribute).use { channel ->
+            val fileChannel = channel as? FileChannel
+                ?: throw IOException("Secure restore provider does not expose a durable file channel")
+            val buffer = ByteBuffer.wrap(content)
+            while (buffer.hasRemaining()) fileChannel.write(buffer)
+            fileChannel.force(true)
+        }
+    }
+
+    private fun requireProbeSourceGone(
+        directory: SecureDirectoryStream<Path>,
+        source: Path,
+    ) {
+        val options = setOf<OpenOption>(StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)
+        try {
+            directory.newByteChannel(source, options).use { }
+        } catch (_: NoSuchFileException) {
+            return
+        }
+        throw IOException("Secure restore provider did not move the replacement source")
+    }
+
+    private fun verifyProbeContent(
+        directory: SecureDirectoryStream<Path>,
+        destination: Path,
+        expected: ByteArray,
+    ) {
+        val options = setOf<OpenOption>(StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)
+        val actual = ByteArray(expected.size)
+        try {
+            directory.newByteChannel(destination, options).use { channel ->
+                val buffer = ByteBuffer.wrap(actual)
+                while (buffer.hasRemaining()) {
+                    val count = channel.read(buffer)
+                    if (count < 0) throw IOException("Secure restore replacement probe ended early")
+                    if (count == 0) continue
+                }
+                val trailing = ByteBuffer.allocate(1)
+                if (channel.read(trailing) > 0 || channel.size() != expected.size.toLong()) {
+                    throw IOException("Secure restore replacement probe produced an unexpected target size")
+                }
+            }
+            if (!actual.contentEquals(expected)) {
+                throw IOException("Secure restore provider did not replace the existing target")
+            }
+        } finally {
+            actual.fill(0)
         }
     }
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/RestoreFileOperations.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/RestoreFileOperations.kt
@@ -85,6 +85,7 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
         val maxSnapshotBytes: Long,
     ) {
         var snapshotBytes: Long = 0L
+        var keyboxesVerified: Boolean = false
         val originals = ArrayList<Original>()
 
         fun closeAndWipe() {
@@ -138,7 +139,6 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
             }
         try {
             verifyReplacementSemantics(root)
-            keyboxes?.let(::verifyReplacementSemantics)
         } catch (error: Throwable) {
             runCatching { keyboxes?.close() }
             runCatching { root.close() }
@@ -536,6 +536,10 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
             block(transaction.root, leaf)
         } else {
             val parent = transaction.keyboxes ?: throw NoSuchFileException(KEYBOX_DIRECTORY)
+            if (!transaction.keyboxesVerified) {
+                verifyReplacementSemantics(parent)
+                transaction.keyboxesVerified = true
+            }
             block(parent, leaf)
         }
     }

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/RestoreFileOperations.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/RestoreFileOperations.kt
@@ -244,7 +244,7 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
                         val name = ".restore-recovery-$token-${index.toString().padStart(4, '0')}.bak"
                         val path = FileSystems.getDefault().getPath(name)
                         atomicWrite(transaction.root, path, bytes)
-                        created += path
+                        created.add(path)
                         manifest.append(index.toString().padStart(4, '0'))
                             .append("\tpresent\t")
                             .append(encodedPath)

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/RestoreFileOperations.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/RestoreFileOperations.kt
@@ -1,0 +1,486 @@
+package cleveres.tricky.cleverestech.util
+
+import java.io.File
+import java.io.IOException
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.file.DirectoryStream
+import java.nio.file.FileSystems
+import java.nio.file.LinkOption
+import java.nio.file.NoSuchFileException
+import java.nio.file.OpenOption
+import java.nio.file.Path
+import java.nio.file.SecureDirectoryStream
+import java.nio.file.StandardOpenOption
+import java.nio.file.attribute.PosixFilePermissions
+import java.util.UUID
+
+/** Descriptor-bound filesystem operations used by backup restore transactions. */
+internal interface RestoreFileOperations {
+    fun begin(
+        configDir: File,
+        token: String,
+        maxSnapshotBytes: Long,
+    )
+
+    fun snapshot(
+        configDir: File,
+        token: String,
+        target: File,
+    )
+
+    fun replace(
+        configDir: File,
+        token: String,
+        target: File,
+        content: ByteArray,
+    )
+
+    fun delete(
+        configDir: File,
+        token: String,
+        target: File,
+    )
+
+    fun rollback(
+        configDir: File,
+        token: String,
+    )
+
+    fun commit(
+        configDir: File,
+        token: String,
+    )
+
+    fun abort(
+        configDir: File,
+        token: String,
+    )
+
+    fun exportRecovery(
+        configDir: File,
+        token: String,
+    ): String
+}
+
+/** Selects the privileged Android broker or a fail-closed descriptor-relative JVM backend. */
+internal object RestoreFiles {
+    private val jvmBackend: RestoreFileOperations = JvmSecureRestoreFileOperations()
+
+    fun current(): RestoreFileOperations =
+        (SecureFile.impl as? RestoreFileOperations) ?: jvmBackend
+}
+
+private class JvmSecureRestoreFileOperations : RestoreFileOperations {
+    private data class Original(
+        val relativePath: String,
+        val bytes: ByteArray?,
+    )
+
+    private class Transaction(
+        val rootPath: Path,
+        val root: SecureDirectoryStream<Path>,
+        val maxSnapshotBytes: Long,
+    ) {
+        var snapshotBytes: Long = 0L
+        val originals = ArrayList<Original>()
+
+        fun closeAndWipe() {
+            originals.forEach { original -> original.bytes?.fill(0) }
+            originals.clear()
+            root.close()
+        }
+    }
+
+    private val lock = Any()
+    private val transactions = HashMap<String, Transaction>()
+
+    override fun begin(
+        configDir: File,
+        token: String,
+        maxSnapshotBytes: Long,
+    ) {
+        validateToken(token)
+        require(maxSnapshotBytes in 0L..MAX_RESTORE_SNAPSHOT_BYTES) {
+            "Restore snapshot limit exceeds the secure backend bound"
+        }
+        val rootPath = normalizedRoot(configDir)
+        val root = openAbsoluteSecureDirectory(rootPath)
+        synchronized(lock) {
+            if (transactions.containsKey(token)) {
+                root.close()
+                throw IOException("Restore transaction token is already active")
+            }
+            if (transactions.size >= MAX_ACTIVE_RESTORE_TRANSACTIONS) {
+                root.close()
+                throw IOException("Restore transaction capacity exhausted")
+            }
+            transactions[token] = Transaction(rootPath, root, maxSnapshotBytes)
+        }
+    }
+
+    override fun snapshot(
+        configDir: File,
+        token: String,
+        target: File,
+    ) {
+        synchronized(lock) {
+            val transaction = requireTransaction(configDir, token)
+            val relative = relativeTarget(transaction.rootPath, target)
+            if (transaction.originals.any { it.relativePath == relative }) {
+                throw IOException("Restore target was already snapshotted")
+            }
+            if (transaction.originals.size >= MAX_RESTORE_TARGETS) {
+                throw IOException("Restore transaction target count exceeds bound")
+            }
+
+            val globalUsed = transactions.values.sumOf { it.snapshotBytes }
+            val ownRemaining = transaction.maxSnapshotBytes - transaction.snapshotBytes
+            val globalRemaining = MAX_GLOBAL_RESTORE_SNAPSHOT_BYTES - globalUsed
+            if (ownRemaining < 0L || globalRemaining < 0L) {
+                throw IOException("Restore snapshot accounting is inconsistent")
+            }
+            val bytes = readOptional(transaction.root, relative, minOf(ownRemaining, globalRemaining))
+            val added = bytes?.size?.toLong() ?: 0L
+            transaction.snapshotBytes = Math.addExact(transaction.snapshotBytes, added)
+            transaction.originals += Original(relative, bytes)
+        }
+    }
+
+    override fun replace(
+        configDir: File,
+        token: String,
+        target: File,
+        content: ByteArray,
+    ) {
+        synchronized(lock) {
+            val transaction = requireTransaction(configDir, token)
+            val relative = requireSnapshotted(transaction, target)
+            withParent(transaction.root, relative) { parent, leaf ->
+                atomicWrite(parent, leaf, content)
+            }
+        }
+    }
+
+    override fun delete(
+        configDir: File,
+        token: String,
+        target: File,
+    ) {
+        synchronized(lock) {
+            val transaction = requireTransaction(configDir, token)
+            val relative = requireSnapshotted(transaction, target)
+            try {
+                withParent(transaction.root, relative) { parent, leaf ->
+                    try {
+                        parent.deleteFile(leaf)
+                    } catch (_: NoSuchFileException) {
+                        // Already absent is the requested state.
+                    }
+                }
+            } catch (_: NoSuchFileException) {
+                // A missing approved parent also means the target is absent.
+            }
+        }
+    }
+
+    override fun rollback(
+        configDir: File,
+        token: String,
+    ) {
+        synchronized(lock) {
+            val transaction = requireTransaction(configDir, token)
+            var failure: Throwable? = null
+            transaction.originals.asReversed().forEach { original ->
+                try {
+                    restoreOriginal(transaction.root, original)
+                } catch (error: Throwable) {
+                    val first = failure
+                    if (first == null) {
+                        failure = error
+                    } else {
+                        first.addSuppressed(error)
+                    }
+                }
+            }
+            failure?.let { throw IOException("Secure restore rollback was incomplete", it) }
+            removeTransaction(token)
+        }
+    }
+
+    override fun commit(
+        configDir: File,
+        token: String,
+    ) {
+        synchronized(lock) {
+            requireTransaction(configDir, token)
+            removeTransaction(token)
+        }
+    }
+
+    override fun abort(
+        configDir: File,
+        token: String,
+    ) {
+        synchronized(lock) {
+            requireTransaction(configDir, token)
+            removeTransaction(token)
+        }
+    }
+
+    override fun exportRecovery(
+        configDir: File,
+        token: String,
+    ): String {
+        synchronized(lock) {
+            val transaction = requireTransaction(configDir, token)
+            val created = ArrayList<Path>()
+            val manifest = StringBuilder()
+            try {
+                transaction.originals.forEachIndexed { index, original ->
+                    val encodedPath = original.relativePath.toByteArray(Charsets.UTF_8).toHex()
+                    val bytes = original.bytes
+                    if (bytes != null) {
+                        val name = ".restore-recovery-$token-${index.toString().padStart(4, '0')}.bak"
+                        val path = FileSystems.getDefault().getPath(name)
+                        atomicWrite(transaction.root, path, bytes)
+                        created += path
+                        manifest.append(index.toString().padStart(4, '0'))
+                            .append("\tpresent\t")
+                            .append(encodedPath)
+                            .append('\n')
+                    } else {
+                        manifest.append(index.toString().padStart(4, '0'))
+                            .append("\tabsent\t")
+                            .append(encodedPath)
+                            .append('\n')
+                    }
+                }
+                val manifestName = ".restore-recovery-$token.manifest"
+                val manifestPath = FileSystems.getDefault().getPath(manifestName)
+                val manifestBytes = manifest.toString().toByteArray(Charsets.UTF_8)
+                try {
+                    atomicWrite(transaction.root, manifestPath, manifestBytes)
+                } finally {
+                    manifestBytes.fill(0)
+                }
+                removeTransaction(token)
+                return transaction.rootPath.resolve(manifestName).toString()
+            } catch (error: Throwable) {
+                created.forEach { path -> runCatching { transaction.root.deleteFile(path) } }
+                throw IOException("Could not export restore recovery data", error)
+            }
+        }
+    }
+
+    private fun requireTransaction(
+        configDir: File,
+        token: String,
+    ): Transaction {
+        validateToken(token)
+        val transaction = transactions[token] ?: throw IOException("Restore transaction is not active")
+        if (transaction.rootPath != normalizedRoot(configDir)) {
+            throw SecurityException("Restore transaction root changed")
+        }
+        return transaction
+    }
+
+    private fun removeTransaction(token: String) {
+        transactions.remove(token)?.closeAndWipe()
+    }
+
+    private fun requireSnapshotted(
+        transaction: Transaction,
+        target: File,
+    ): String {
+        val relative = relativeTarget(transaction.rootPath, target)
+        if (transaction.originals.none { it.relativePath == relative }) {
+            throw SecurityException("Restore mutation was not snapshotted")
+        }
+        return relative
+    }
+
+    private fun restoreOriginal(
+        root: SecureDirectoryStream<Path>,
+        original: Original,
+    ) {
+        val bytes = original.bytes
+        if (bytes == null) {
+            try {
+                withParent(root, original.relativePath) { parent, leaf ->
+                    try {
+                        parent.deleteFile(leaf)
+                    } catch (_: NoSuchFileException) {
+                        // The target was absent originally and remains absent.
+                    }
+                }
+            } catch (_: NoSuchFileException) {
+                // Missing approved parent is also equivalent to the original absent state.
+            }
+        } else {
+            withParent(root, original.relativePath) { parent, leaf ->
+                atomicWrite(parent, leaf, bytes)
+            }
+        }
+    }
+
+    private fun readOptional(
+        root: SecureDirectoryStream<Path>,
+        relative: String,
+        maxBytes: Long,
+    ): ByteArray? {
+        if (maxBytes < 0L) throw IOException("Restore snapshot exceeds its size limit")
+        return try {
+            withParent(root, relative) { parent, leaf ->
+                val options = setOf<OpenOption>(StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)
+                parent.newByteChannel(leaf, options).use { channel ->
+                    val size = channel.size()
+                    if (size < 0L || size > maxBytes || size > Int.MAX_VALUE.toLong()) {
+                        throw IOException("Restore snapshot exceeds its size limit")
+                    }
+                    val bytes = ByteArray(size.toInt())
+                    try {
+                        val buffer = ByteBuffer.wrap(bytes)
+                        while (buffer.hasRemaining()) {
+                            val count = channel.read(buffer)
+                            if (count < 0) throw IOException("Restore snapshot ended early")
+                            if (count == 0) continue
+                        }
+                        val trailing = ByteBuffer.allocate(1)
+                        if (channel.read(trailing) > 0 || channel.size() != size) {
+                            throw IOException("Restore source changed while snapshotting")
+                        }
+                        bytes
+                    } catch (error: Throwable) {
+                        bytes.fill(0)
+                        throw error
+                    }
+                }
+            }
+        } catch (_: NoSuchFileException) {
+            null
+        }
+    }
+
+    private fun atomicWrite(
+        parent: SecureDirectoryStream<Path>,
+        leaf: Path,
+        content: ByteArray,
+    ) {
+        val temporary = FileSystems.getDefault().getPath(".restore-${UUID.randomUUID()}.tmp")
+        val options =
+            setOf<OpenOption>(
+                StandardOpenOption.CREATE_NEW,
+                StandardOpenOption.WRITE,
+                LinkOption.NOFOLLOW_LINKS,
+            )
+        var created = false
+        try {
+            val attribute = PosixFilePermissions.asFileAttribute(PRIVATE_FILE_PERMISSIONS)
+            parent.newByteChannel(temporary, options, attribute).use { channel ->
+                created = true
+                val fileChannel = channel as? FileChannel
+                    ?: throw IOException("Secure restore provider does not expose a durable file channel")
+                val buffer = ByteBuffer.wrap(content)
+                while (buffer.hasRemaining()) fileChannel.write(buffer)
+                fileChannel.force(true)
+            }
+            parent.move(temporary, parent, leaf)
+            created = false
+        } finally {
+            if (created) runCatching { parent.deleteFile(temporary) }
+        }
+    }
+
+    private inline fun <T> withParent(
+        root: SecureDirectoryStream<Path>,
+        relative: String,
+        block: (SecureDirectoryStream<Path>, Path) -> T,
+    ): T {
+        val components = relative.split('/')
+        val leaf = FileSystems.getDefault().getPath(components.last())
+        return if (components.size == 1) {
+            block(root, leaf)
+        } else {
+            val parentName = FileSystems.getDefault().getPath(components.first())
+            root.newDirectoryStream(parentName, LinkOption.NOFOLLOW_LINKS).use { parent ->
+                block(parent, leaf)
+            }
+        }
+    }
+
+    private fun relativeTarget(
+        rootPath: Path,
+        target: File,
+    ): String {
+        val normalized = target.absoluteFile.toPath().normalize()
+        if (normalized == rootPath || !normalized.startsWith(rootPath)) {
+            throw SecurityException("Restore target escaped configuration directory")
+        }
+        val relative = rootPath.relativize(normalized)
+        val components = relative.map(Path::toString)
+        val allowed =
+            components.size == 1 ||
+                (components.size == 2 && components.first() == KEYBOX_DIRECTORY)
+        if (!allowed || components.any { !isSafeComponent(it) }) {
+            throw SecurityException("Restore target is outside an allowed capability subtree")
+        }
+        return components.joinToString("/")
+    }
+
+    private fun normalizedRoot(configDir: File): Path =
+        configDir.absoluteFile.toPath().normalize()
+
+    private fun openAbsoluteSecureDirectory(path: Path): SecureDirectoryStream<Path> {
+        val absolute = path.toAbsolutePath().normalize()
+        val filesystemRoot = absolute.root ?: throw IOException("Restore root has no filesystem root")
+        var current: DirectoryStream<Path> = java.nio.file.Files.newDirectoryStream(filesystemRoot)
+        var secure = current as? SecureDirectoryStream<Path>
+            ?: run {
+                current.close()
+                throw IOException("Filesystem provider does not support secure directory streams")
+            }
+        try {
+            for (component in filesystemRoot.relativize(absolute)) {
+                val next = secure.newDirectoryStream(component, LinkOption.NOFOLLOW_LINKS)
+                secure.close()
+                secure = next
+            }
+            return secure
+        } catch (error: Throwable) {
+            runCatching { secure.close() }
+            throw error
+        }
+    }
+
+    private fun validateToken(token: String) {
+        if (token.length != RESTORE_TOKEN_LENGTH || token.any { it !in '0'..'9' && it !in 'a'..'f' }) {
+            throw SecurityException("Invalid restore transaction token")
+        }
+    }
+
+    private fun isSafeComponent(value: String): Boolean =
+        value.isNotEmpty() && value != "." && value != ".." && '/' !in value && '\u0000' !in value
+
+    private fun ByteArray.toHex(): String {
+        val output = CharArray(size * 2)
+        val alphabet = "0123456789abcdef"
+        forEachIndexed { index, byte ->
+            val value = byte.toInt() and 0xff
+            output[index * 2] = alphabet[value ushr 4]
+            output[index * 2 + 1] = alphabet[value and 0x0f]
+        }
+        fill(0)
+        return output.concatToString()
+    }
+
+    private companion object {
+        const val KEYBOX_DIRECTORY = "keyboxes"
+        const val RESTORE_TOKEN_LENGTH = 32
+        const val MAX_RESTORE_SNAPSHOT_BYTES = 32L * 1024L * 1024L
+        const val MAX_GLOBAL_RESTORE_SNAPSHOT_BYTES = 64L * 1024L * 1024L
+        const val MAX_ACTIVE_RESTORE_TRANSACTIONS = 4
+        const val MAX_RESTORE_TARGETS = 512
+        val PRIVATE_FILE_PERMISSIONS = PosixFilePermissions.fromString("rw-------")
+    }
+}

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/RestoreFileOperations.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/RestoreFileOperations.kt
@@ -80,6 +80,7 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
     private class Transaction(
         val rootPath: Path,
         val root: SecureDirectoryStream<Path>,
+        val keyboxes: SecureDirectoryStream<Path>?,
         val maxSnapshotBytes: Long,
     ) {
         var snapshotBytes: Long = 0L
@@ -88,6 +89,7 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
         fun closeAndWipe() {
             originals.forEach { original -> original.bytes?.fill(0) }
             originals.clear()
+            keyboxes?.close()
             root.close()
         }
     }
@@ -106,16 +108,30 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
         }
         val rootPath = normalizedRoot(configDir)
         val root = openAbsoluteSecureDirectory(rootPath)
+        val keyboxes =
+            try {
+                root.newDirectoryStream(
+                    FileSystems.getDefault().getPath(KEYBOX_DIRECTORY),
+                    LinkOption.NOFOLLOW_LINKS,
+                )
+            } catch (_: NoSuchFileException) {
+                null
+            } catch (error: Throwable) {
+                root.close()
+                throw error
+            }
         synchronized(lock) {
             if (transactions.containsKey(token)) {
+                keyboxes?.close()
                 root.close()
                 throw IOException("Restore transaction token is already active")
             }
             if (transactions.size >= MAX_ACTIVE_RESTORE_TRANSACTIONS) {
+                keyboxes?.close()
                 root.close()
                 throw IOException("Restore transaction capacity exhausted")
             }
-            transactions[token] = Transaction(rootPath, root, maxSnapshotBytes)
+            transactions[token] = Transaction(rootPath, root, keyboxes, maxSnapshotBytes)
         }
     }
 
@@ -140,7 +156,7 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
             if (ownRemaining < 0L || globalRemaining < 0L) {
                 throw IOException("Restore snapshot accounting is inconsistent")
             }
-            val bytes = readOptional(transaction.root, relative, minOf(ownRemaining, globalRemaining))
+            val bytes = readOptional(transaction, relative, minOf(ownRemaining, globalRemaining))
             val added = bytes?.size?.toLong() ?: 0L
             transaction.snapshotBytes = Math.addExact(transaction.snapshotBytes, added)
             transaction.originals += Original(relative, bytes)
@@ -156,7 +172,7 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
         synchronized(lock) {
             val transaction = requireTransaction(configDir, token)
             val relative = requireSnapshotted(transaction, target)
-            withParent(transaction.root, relative) { parent, leaf ->
+            withParent(transaction, relative) { parent, leaf ->
                 atomicWrite(parent, leaf, content)
             }
         }
@@ -171,7 +187,7 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
             val transaction = requireTransaction(configDir, token)
             val relative = requireSnapshotted(transaction, target)
             try {
-                withParent(transaction.root, relative) { parent, leaf ->
+                withParent(transaction, relative) { parent, leaf ->
                     try {
                         parent.deleteFile(leaf)
                     } catch (_: NoSuchFileException) {
@@ -179,7 +195,7 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
                     }
                 }
             } catch (_: NoSuchFileException) {
-                // A missing approved parent also means the target is absent.
+                // A parent that was absent at begin also means the target is absent.
             }
         }
     }
@@ -193,7 +209,7 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
             var failure: Throwable? = null
             transaction.originals.asReversed().forEach { original ->
                 try {
-                    restoreOriginal(transaction.root, original)
+                    restoreOriginal(transaction, original)
                 } catch (error: Throwable) {
                     val first = failure
                     if (first == null) {
@@ -301,13 +317,13 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
     }
 
     private fun restoreOriginal(
-        root: SecureDirectoryStream<Path>,
+        transaction: Transaction,
         original: Original,
     ) {
         val bytes = original.bytes
         if (bytes == null) {
             try {
-                withParent(root, original.relativePath) { parent, leaf ->
+                withParent(transaction, original.relativePath) { parent, leaf ->
                     try {
                         parent.deleteFile(leaf)
                     } catch (_: NoSuchFileException) {
@@ -315,23 +331,23 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
                     }
                 }
             } catch (_: NoSuchFileException) {
-                // Missing approved parent is also equivalent to the original absent state.
+                // A parent absent at begin is equivalent to the original absent state.
             }
         } else {
-            withParent(root, original.relativePath) { parent, leaf ->
+            withParent(transaction, original.relativePath) { parent, leaf ->
                 atomicWrite(parent, leaf, bytes)
             }
         }
     }
 
     private fun readOptional(
-        root: SecureDirectoryStream<Path>,
+        transaction: Transaction,
         relative: String,
         maxBytes: Long,
     ): ByteArray? {
         if (maxBytes < 0L) throw IOException("Restore snapshot exceeds its size limit")
         return try {
-            withParent(root, relative) { parent, leaf ->
+            withParent(transaction, relative) { parent, leaf ->
                 val options = setOf<OpenOption>(StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)
                 parent.newByteChannel(leaf, options).use { channel ->
                     val size = channel.size()
@@ -393,19 +409,17 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
     }
 
     private inline fun <T> withParent(
-        root: SecureDirectoryStream<Path>,
+        transaction: Transaction,
         relative: String,
         block: (SecureDirectoryStream<Path>, Path) -> T,
     ): T {
         val components = relative.split('/')
         val leaf = FileSystems.getDefault().getPath(components.last())
         return if (components.size == 1) {
-            block(root, leaf)
+            block(transaction.root, leaf)
         } else {
-            val parentName = FileSystems.getDefault().getPath(components.first())
-            root.newDirectoryStream(parentName, LinkOption.NOFOLLOW_LINKS).use { parent ->
-                block(parent, leaf)
-            }
+            val parent = transaction.keyboxes ?: throw NoSuchFileException(KEYBOX_DIRECTORY)
+            block(parent, leaf)
         }
     }
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/RestoreFileOperations.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/RestoreFileOperations.kt
@@ -72,7 +72,9 @@ internal object RestoreFiles {
         (SecureFile.impl as? RestoreFileOperations) ?: jvmBackend
 }
 
-private class JvmSecureRestoreFileOperations : RestoreFileOperations {
+internal class JvmSecureRestoreFileOperations(
+    private val nowNanos: () -> Long = System::nanoTime,
+) : RestoreFileOperations {
     private data class Original(
         val relativePath: String,
         val bytes: ByteArray?,
@@ -83,6 +85,7 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
         val root: SecureDirectoryStream<Path>,
         val keyboxes: SecureDirectoryStream<Path>?,
         val maxSnapshotBytes: Long,
+        var touchedNanos: Long,
     ) {
         var snapshotBytes: Long = 0L
         var keyboxesVerified: Boolean = false
@@ -145,6 +148,7 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
             throw error
         }
         synchronized(lock) {
+            pruneExpiredTransactions()
             if (transactions.containsKey(token)) {
                 keyboxes?.close()
                 root.close()
@@ -155,7 +159,14 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
                 root.close()
                 throw IOException("Restore transaction capacity exhausted")
             }
-            transactions[token] = Transaction(rootPath, root, keyboxes, maxSnapshotBytes)
+            transactions[token] =
+                Transaction(
+                    rootPath = rootPath,
+                    root = root,
+                    keyboxes = keyboxes,
+                    maxSnapshotBytes = maxSnapshotBytes,
+                    touchedNanos = nowNanos(),
+                )
         }
     }
 
@@ -318,11 +329,29 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
         token: String,
     ): Transaction {
         validateToken(token)
+        pruneExpiredTransactions()
         val transaction = transactions[token] ?: throw IOException("Restore transaction is not active")
         if (transaction.rootPath != normalizedRoot(configDir)) {
             throw SecurityException("Restore transaction root changed")
         }
+        transaction.touchedNanos = nowNanos()
         return transaction
+    }
+
+    private fun pruneExpiredTransactions() {
+        val now = nowNanos()
+        val expired =
+            transactions.entries
+                .asSequence()
+                .filter { (_, transaction) ->
+                    now - transaction.touchedNanos >= RESTORE_TRANSACTION_TTL_NANOS
+                }
+                .map { it.key }
+                .toList()
+        expired.forEach { token ->
+            val transaction = transactions.remove(token) ?: return@forEach
+            runCatching { transaction.closeAndWipe() }
+        }
     }
 
     private fun removeTransaction(token: String) {
@@ -616,6 +645,7 @@ private class JvmSecureRestoreFileOperations : RestoreFileOperations {
         const val MAX_GLOBAL_RESTORE_SNAPSHOT_BYTES = 64L * 1024L * 1024L
         const val MAX_ACTIVE_RESTORE_TRANSACTIONS = 4
         const val MAX_RESTORE_TARGETS = 512
+        const val RESTORE_TRANSACTION_TTL_NANOS = 15L * 60L * 1_000_000_000L
         val PRIVATE_FILE_PERMISSIONS = PosixFilePermissions.fromString("rw-------")
     }
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/RustSecureFileOperations.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/RustSecureFileOperations.kt
@@ -114,7 +114,10 @@ internal class RustSecureFileOperations : SecureFileOperations, RestoreFileOpera
     ) {
         requireConfigRoot(configDir)
         validateRestoreToken(token)
-        restoreRelativePath(target)
+        val relative = restoreRelativePath(target)
+        if (relative.startsWith("$KEYBOX_DIRECTORY/")) {
+            transactControl(ACTION_MKDIR, KEYBOX_DIRECTORY.toByteArray(Charsets.UTF_8))
+        }
         writeBytes(target, content)
     }
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/RustSecureFileOperations.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/RustSecureFileOperations.kt
@@ -116,9 +116,6 @@ internal class RustSecureFileOperations : SecureFileOperations, RestoreFileOpera
         validateRestoreToken(token)
         require(content.size <= MAX_FILE_BYTES) { "File exceeds the Rust broker size limit" }
         val relative = restoreRelativePath(target)
-        if (relative.startsWith("$KEYBOX_DIRECTORY/")) {
-            transactControl(ACTION_MKDIR, KEYBOX_DIRECTORY.toByteArray(Charsets.UTF_8))
-        }
         ByteArrayInputStream(content).use { input ->
             transactAtomicWrite(restorePair(token, relative), input, content.size)
         }

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/RustSecureFileOperations.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/RustSecureFileOperations.kt
@@ -30,7 +30,7 @@ internal class RustSecureFileOperations : SecureFileOperations, RestoreFileOpera
     ) {
         require(content.size <= MAX_FILE_BYTES) { "File exceeds the Rust broker size limit" }
         ByteArrayInputStream(content).use { input ->
-            transactAtomicWrite(file, input, content.size)
+            transactAtomicWrite(relativePath(file), input, content.size)
         }
     }
 
@@ -54,7 +54,7 @@ internal class RustSecureFileOperations : SecureFileOperations, RestoreFileOpera
         // known (for example the fixed-size privacy seed). Keep that path atomic through the
         // descriptor-relative broker. WebUI download staging above is the maximum-bound stream
         // where the final length is intentionally unknown in advance.
-        transactAtomicWrite(file, inputStream, limit.toInt())
+        transactAtomicWrite(relative, inputStream, limit.toInt())
     }
 
     override fun mkdirs(
@@ -114,11 +114,14 @@ internal class RustSecureFileOperations : SecureFileOperations, RestoreFileOpera
     ) {
         requireConfigRoot(configDir)
         validateRestoreToken(token)
+        require(content.size <= MAX_FILE_BYTES) { "File exceeds the Rust broker size limit" }
         val relative = restoreRelativePath(target)
         if (relative.startsWith("$KEYBOX_DIRECTORY/")) {
             transactControl(ACTION_MKDIR, KEYBOX_DIRECTORY.toByteArray(Charsets.UTF_8))
         }
-        writeBytes(target, content)
+        ByteArrayInputStream(content).use { input ->
+            transactAtomicWrite(restorePair(token, relative), input, content.size)
+        }
     }
 
     override fun delete(
@@ -128,7 +131,10 @@ internal class RustSecureFileOperations : SecureFileOperations, RestoreFileOpera
     ) {
         requireConfigRoot(configDir)
         validateRestoreToken(token)
-        transactControl(ACTION_DELETE, restoreRelativePath(target).toByteArray(Charsets.UTF_8))
+        transactControl(
+            ACTION_DELETE,
+            restorePairBytes(token, restoreRelativePath(target)),
+        )
     }
 
     override fun rollback(
@@ -189,11 +195,11 @@ internal class RustSecureFileOperations : SecureFileOperations, RestoreFileOpera
     }
 
     private fun transactAtomicWrite(
-        file: File,
+        relativePath: String,
         input: InputStream,
         declaredBodyLength: Int,
     ) {
-        val pathBytes = relativePath(file).toByteArray(Charsets.UTF_8)
+        val pathBytes = relativePath.toByteArray(Charsets.UTF_8)
         val scratch = ByteArray(STREAM_BUFFER_BYTES)
         try {
             require(pathBytes.size <= MAX_RELATIVE_PATH_BYTES)
@@ -339,16 +345,21 @@ internal class RustSecureFileOperations : SecureFileOperations, RestoreFileOpera
         }
     }
 
-    private fun restorePairBytes(
+    private fun restorePair(
         token: String,
         argument: String,
-    ): ByteArray {
+    ): String {
         validateRestoreToken(token)
         if (argument.isEmpty() || '\u0000' in argument) {
             throw SecurityException("Invalid restore transaction argument")
         }
-        return "$token\u0000$argument".toByteArray(Charsets.UTF_8)
+        return "$token\u0000$argument"
     }
+
+    private fun restorePairBytes(
+        token: String,
+        argument: String,
+    ): ByteArray = restorePair(token, argument).toByteArray(Charsets.UTF_8)
 
     private fun validateRestoreToken(token: String) {
         if (token.length != RESTORE_TOKEN_LENGTH || token.any { it !in '0'..'9' && it !in 'a'..'f' }) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/util/RustSecureFileOperations.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/util/RustSecureFileOperations.kt
@@ -11,7 +11,7 @@ import java.io.InputStream
 import java.io.OutputStream
 
 /** Thin Android adapter for descriptor-relative mutations owned by the privileged Rust daemon. */
-internal class RustSecureFileOperations : SecureFileOperations {
+internal class RustSecureFileOperations : SecureFileOperations, RestoreFileOperations {
     override fun writeText(
         file: File,
         content: String,
@@ -75,6 +75,90 @@ internal class RustSecureFileOperations : SecureFileOperations {
     ) {
         require(mode == FILE_MODE) { "Rust broker only accepts private config files" }
         transactControl(ACTION_TOUCH, relativePathBytes(file))
+    }
+
+    override fun begin(
+        configDir: File,
+        token: String,
+        maxSnapshotBytes: Long,
+    ) {
+        requireConfigRoot(configDir)
+        validateRestoreToken(token)
+        require(maxSnapshotBytes in 0L..MAX_RESTORE_SNAPSHOT_BYTES) {
+            "Restore snapshot limit exceeds the Rust broker bound"
+        }
+        transactControl(
+            ACTION_RESTORE_BEGIN,
+            restorePairBytes(token, maxSnapshotBytes.toString()),
+        )
+    }
+
+    override fun snapshot(
+        configDir: File,
+        token: String,
+        target: File,
+    ) {
+        requireConfigRoot(configDir)
+        validateRestoreToken(token)
+        transactControl(
+            ACTION_RESTORE_SNAPSHOT,
+            restorePairBytes(token, restoreRelativePath(target)),
+        )
+    }
+
+    override fun replace(
+        configDir: File,
+        token: String,
+        target: File,
+        content: ByteArray,
+    ) {
+        requireConfigRoot(configDir)
+        validateRestoreToken(token)
+        restoreRelativePath(target)
+        writeBytes(target, content)
+    }
+
+    override fun delete(
+        configDir: File,
+        token: String,
+        target: File,
+    ) {
+        requireConfigRoot(configDir)
+        validateRestoreToken(token)
+        transactControl(ACTION_DELETE, restoreRelativePath(target).toByteArray(Charsets.UTF_8))
+    }
+
+    override fun rollback(
+        configDir: File,
+        token: String,
+    ) {
+        requireConfigRoot(configDir)
+        transactRestoreToken(ACTION_RESTORE_ROLLBACK, token)
+    }
+
+    override fun commit(
+        configDir: File,
+        token: String,
+    ) {
+        requireConfigRoot(configDir)
+        transactRestoreToken(ACTION_RESTORE_COMMIT, token)
+    }
+
+    override fun abort(
+        configDir: File,
+        token: String,
+    ) {
+        requireConfigRoot(configDir)
+        transactRestoreToken(ACTION_RESTORE_ABORT, token)
+    }
+
+    override fun exportRecovery(
+        configDir: File,
+        token: String,
+    ): String {
+        requireConfigRoot(configDir)
+        transactRestoreToken(ACTION_RESTORE_EXPORT, token)
+        return File(configDir, ".restore-recovery-$token.manifest").absolutePath
     }
 
     private fun awaitAdapterRegistration() {
@@ -167,6 +251,14 @@ internal class RustSecureFileOperations : SecureFileOperations {
         }
     }
 
+    private fun transactRestoreToken(
+        action: Int,
+        token: String,
+    ) {
+        validateRestoreToken(token)
+        transactControl(action, token.toByteArray(Charsets.UTF_8))
+    }
+
     private fun transactControl(
         action: Int,
         pathBytes: ByteArray,
@@ -238,7 +330,39 @@ internal class RustSecureFileOperations : SecureFileOperations {
         socket.setSoTimeout(IO_TIMEOUT_MS)
     }
 
+    private fun requireConfigRoot(configDir: File) {
+        if (configDir.absoluteFile.toPath().normalize().toString() != CONFIG_ROOT) {
+            throw SecurityException("Restore root does not match the Rust config capability")
+        }
+    }
+
+    private fun restorePairBytes(
+        token: String,
+        argument: String,
+    ): ByteArray {
+        validateRestoreToken(token)
+        if (argument.isEmpty() || '\u0000' in argument) {
+            throw SecurityException("Invalid restore transaction argument")
+        }
+        return "$token\u0000$argument".toByteArray(Charsets.UTF_8)
+    }
+
+    private fun validateRestoreToken(token: String) {
+        if (token.length != RESTORE_TOKEN_LENGTH || token.any { it !in '0'..'9' && it !in 'a'..'f' }) {
+            throw SecurityException("Invalid restore transaction token")
+        }
+    }
+
     private fun relativePathBytes(file: File): ByteArray = relativePath(file).toByteArray(Charsets.UTF_8)
+
+    private fun restoreRelativePath(file: File): String {
+        val relative = relativePath(file)
+        val components = relative.split('/')
+        if (components.size != 1 && !(components.size == 2 && components[0] == KEYBOX_DIRECTORY)) {
+            throw IOException("Restore target is outside an allowed capability subtree")
+        }
+        return relative
+    }
 
     private fun relativePath(file: File): String {
         val absolute = file.absolutePath
@@ -388,6 +512,13 @@ internal class RustSecureFileOperations : SecureFileOperations {
         const val ACTION_ROOT_VALIDATE = 3
         const val ACTION_STAGE_CREATE = 4
         const val ACTION_STAGE_APPEND = 5
+        const val ACTION_RESTORE_BEGIN = 6
+        const val ACTION_RESTORE_SNAPSHOT = 7
+        const val ACTION_RESTORE_ROLLBACK = 8
+        const val ACTION_RESTORE_COMMIT = 9
+        const val ACTION_RESTORE_ABORT = 10
+        const val ACTION_DELETE = 11
+        const val ACTION_RESTORE_EXPORT = 12
         const val WRITE_COMMIT_MARKER = 0xa5
         const val HEADER_BYTES = 16
         const val REQUEST_PREFIX_BYTES = 7
@@ -395,6 +526,8 @@ internal class RustSecureFileOperations : SecureFileOperations {
         const val FILE_MODE = 384
         const val DIRECTORY_MODE = 448
         const val MAX_FILE_BYTES = 20 * 1024 * 1024
+        const val MAX_RESTORE_SNAPSHOT_BYTES = 32L * 1024L * 1024L
+        const val RESTORE_TOKEN_LENGTH = 32
         const val MAX_RELATIVE_PATH_BYTES = 511
         const val MAX_COMPONENT_BYTES = 255
         const val MAX_REQUEST_BYTES = REQUEST_PREFIX_BYTES + MAX_RELATIVE_PATH_BYTES + MAX_FILE_BYTES + WRITE_COMMIT_BYTES

--- a/service/src/test/java/cleveres/tricky/cleverestech/DeepBugSweepRegressionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/DeepBugSweepRegressionTest.kt
@@ -69,9 +69,48 @@ class DeepBugSweepRegressionTest {
             assertEquals("old-first", first.readText())
             assertEquals("old-second", second.readText())
             assertFalse(created.exists())
-            assertFalse(root.listFiles().orEmpty().any { it.name.startsWith(".restore-txn-") })
+            assertFalse(root.listFiles().orEmpty().any { it.name.startsWith(".restore-recovery-") })
         } finally {
             root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `restore rollback remains bound to original root after pathname swap`() {
+        val rootPath = Files.createTempDirectory("cleveres-restore-root-swap")
+        val root = rootPath.toFile()
+        val moved = rootPath.resolveSibling("${root.fileName}-moved")
+        val outside = rootPath.resolveSibling("${root.fileName}-outside")
+        try {
+            root.resolve("state.txt").writeText("old-state")
+
+            assertThrows(IOException::class.java) {
+                BackupRestoreTransaction.apply(
+                    root,
+                    listOf(
+                        BackupRestoreTransaction.Mutation(
+                            root.resolve("state.txt"),
+                            "new-state".toByteArray(),
+                        ),
+                    ),
+                    maxSnapshotBytes = 4_096,
+                    afterMutation = {
+                        Files.move(rootPath, moved)
+                        Files.createDirectory(outside)
+                        Files.writeString(outside.resolve("state.txt"), "outside")
+                        Files.createSymbolicLink(rootPath, outside)
+                        throw IOException("injected runtime failure after root swap")
+                    },
+                    onRollback = null,
+                )
+            }
+
+            assertEquals("old-state", Files.readString(moved.resolve("state.txt")))
+            assertEquals("outside", Files.readString(outside.resolve("state.txt")))
+        } finally {
+            Files.deleteIfExists(rootPath)
+            outside.toFile().deleteRecursively()
+            moved.toFile().deleteRecursively()
         }
     }
 
@@ -284,7 +323,7 @@ class DeepBugSweepRegressionTest {
             assertEquals("new-first", first.readText())
             assertFalse(second.exists())
             assertEquals("new-created", created.readText())
-            assertFalse(root.listFiles().orEmpty().any { it.name.startsWith(".restore-txn-") })
+            assertFalse(root.listFiles().orEmpty().any { it.name.startsWith(".restore-recovery-") })
         } finally {
             root.deleteRecursively()
         }
@@ -310,14 +349,14 @@ class DeepBugSweepRegressionTest {
 
             assertEquals(4_097L, oversized.length())
             assertEquals("old", untouched.readText())
-            assertFalse(root.listFiles().orEmpty().any { it.name.startsWith(".restore-txn-") })
+            assertFalse(root.listFiles().orEmpty().any { it.name.startsWith(".restore-recovery-") })
         } finally {
             root.deleteRecursively()
         }
     }
 
     @Test
-    fun `restore retains the original snapshot when disk rollback cannot complete`() {
+    fun `restore exports original snapshot when rollback cannot complete`() {
         val root = Files.createTempDirectory("cleveres-restore-recovery-retention").toFile()
         try {
             val directory = root.resolve("keyboxes").apply { mkdirs() }
@@ -339,8 +378,10 @@ class DeepBugSweepRegressionTest {
                     )
                 }
 
-            val recoveryDirectory = root.listFiles().orEmpty().single { it.name.startsWith(".restore-txn-") }
-            val recovery = recoveryDirectory.listFiles().orEmpty().single { it.extension == "bak" }
+            val recovery = root.listFiles().orEmpty().single { it.name.endsWith(".bak") }
+            val manifest = root.listFiles().orEmpty().single { it.name.endsWith(".manifest") }
+            assertTrue(recovery.name.startsWith(".restore-recovery-"))
+            assertTrue(manifest.name.startsWith(".restore-recovery-"))
             assertEquals("original", recovery.readText())
             assertTrue(failure.suppressed.any { it.message?.contains("recovery data retained") == true })
         } finally {

--- a/service/src/test/java/cleveres/tricky/cleverestech/DeepBugSweepRegressionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/DeepBugSweepRegressionTest.kt
@@ -79,8 +79,8 @@ class DeepBugSweepRegressionTest {
     fun `restore rollback remains bound to original root after pathname swap`() {
         val rootPath = Files.createTempDirectory("cleveres-restore-root-swap")
         val root = rootPath.toFile()
-        val moved = rootPath.resolveSibling("${root.fileName}-moved")
-        val outside = rootPath.resolveSibling("${root.fileName}-outside")
+        val moved = rootPath.resolveSibling("${root.name}-moved")
+        val outside = rootPath.resolveSibling("${root.name}-outside")
         try {
             root.resolve("state.txt").writeText("old-state")
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/WebServerZipBombTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/WebServerZipBombTest.kt
@@ -1,5 +1,6 @@
 package cleveres.tricky.cleverestech
 
+import cleveres.tricky.cleverestech.util.RestoreFileOperations
 import cleveres.tricky.cleverestech.util.SecureFile
 import cleveres.tricky.cleverestech.util.SecureFileOperations
 import org.junit.After
@@ -30,7 +31,7 @@ class WebServerZipBombTest {
         configDir = tempFolder.newFolder("config")
         originalImpl = SecureFile.impl
         SecureFile.impl =
-            object : SecureFileOperations {
+            object : SecureFileOperations, RestoreFileOperations {
                 override fun writeText(
                     file: File,
                     content: String,
@@ -52,6 +53,53 @@ class WebServerZipBombTest {
                     file: File,
                     mode: Int,
                 ) = Unit
+
+                override fun begin(
+                    configDir: File,
+                    token: String,
+                    maxSnapshotBytes: Long,
+                ) = Unit
+
+                override fun snapshot(
+                    configDir: File,
+                    token: String,
+                    target: File,
+                ) = Unit
+
+                override fun replace(
+                    configDir: File,
+                    token: String,
+                    target: File,
+                    content: ByteArray,
+                ) {
+                    writeBytesCalled = true
+                }
+
+                override fun delete(
+                    configDir: File,
+                    token: String,
+                    target: File,
+                ) = Unit
+
+                override fun rollback(
+                    configDir: File,
+                    token: String,
+                ) = Unit
+
+                override fun commit(
+                    configDir: File,
+                    token: String,
+                ) = Unit
+
+                override fun abort(
+                    configDir: File,
+                    token: String,
+                ) = Unit
+
+                override fun exportRecovery(
+                    configDir: File,
+                    token: String,
+                ): String = configDir.resolve("recovery").absolutePath
             }
     }
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/util/JvmRestoreTransactionExpiryTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/util/JvmRestoreTransactionExpiryTest.kt
@@ -1,0 +1,40 @@
+package cleveres.tricky.cleverestech.util
+
+import org.junit.Assert.assertThrows
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.IOException
+
+class JvmRestoreTransactionExpiryTest {
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun expiredTransactionsCannotPermanentlyExhaustRestoreCapacity() {
+        var nowNanos = 0L
+        val backend = JvmSecureRestoreFileOperations { nowNanos }
+        val configDir = tempFolder.newFolder("config")
+        val activeTokens =
+            (1..4).map { value ->
+                value.toString(16).padStart(32, '0')
+            }
+
+        activeTokens.forEach { token ->
+            backend.begin(configDir, token, 0L)
+        }
+
+        val replacementToken = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+        assertThrows(IOException::class.java) {
+            backend.begin(configDir, replacementToken, 0L)
+        }
+
+        nowNanos = 16L * 60L * 1_000_000_000L
+        backend.begin(configDir, replacementToken, 0L)
+
+        assertThrows(IOException::class.java) {
+            backend.abort(configDir, activeTokens.first())
+        }
+        backend.abort(configDir, replacementToken)
+    }
+}


### PR DESCRIPTION
## Root cause

`rust/attestation-core::rewrite_extension` parsed the genuine Android key attestation extension and then unconditionally replaced both `attestationSecurityLevel` and `keyMintSecurityLevel` with `TrustedEnvironment` (TEE). That downgraded a genuinely StrongBox-generated key to TEE in the reconstructed leaf certificate, matching the reported detector failure: StrongBox feature and key generation succeed, but the returned attestation chain exposes security level TEE.

## Attestation fix

- preserve the genuine DER-encoded security levels from the original hardware attestation instead of normalizing them to TEE
- validate those fields fail-closed against Android's defined SecurityLevel values (`Software=0`, `TrustedEnvironment=1`, `StrongBox=2`)
- do **not** promote TEE keys to StrongBox and do not fabricate hardware capability

This keeps the existing certificate-rewrite architecture intact: the genuine leaf remains the source of hardware-backed attestation metadata while the existing configured patch/id/root-of-trust rewrite continues unchanged.

## Restore hardening follow-up

Review of the surrounding backup/restore path exposed independent rollback and availability hazards, so this branch also hardens restore transactions end-to-end:

- move restore snapshot/mutation/rollback behind descriptor-bound filesystem capabilities
- carry transaction tokens through privileged Rust write/delete operations and require prior snapshots
- pin restore roots and keybox capabilities against path-swap races
- release the global restore registry lock before streamed request-body I/O while preventing commit/rollback during an in-flight mutation
- bound transaction counts, snapshot bytes, targets, stale retention, and JVM fallback retention
- export recovery artifacts after rollback failure and fail closed when secure replacement semantics are unsupported
- keep root-only restores independent of keybox replacement probing

## Regression / detector coverage

- StrongBox survives attestation rewrite byte-for-byte
- TEE and Software are preserved and never promoted
- unknown security-level enums are rejected
- wrong-token, unsnapshotted-target, and unscoped restore mutations are rejected
- streamed writes do not monopolize the restore registry and cannot be committed mid-stream
- rollback continues across failures and recovery export paths remain bounded
- root/keybox path swaps, secure replacement semantics, transaction expiry, and JVM capacity reclamation have deterministic regressions

## External contract checked

Android's current attestation `KeyDescription` defines `attestationSecurityLevel` and `keyMintSecurityLevel` as `SecurityLevel ::= Software (0), TrustedEnvironment (1), StrongBox (2)`. Android also defines `FEATURE_STRONGBOX_KEYSTORE` as Keystore backed by a dedicated secure processor. The security-level fields therefore must reflect the genuine key-generation path rather than be rewritten by presentation logic.

## Security boundary

This change cannot create StrongBox on hardware that did not produce it. A genuine TEE attestation remains TEE. It only stops CleveresTricky from destroying a genuine StrongBox signal already present in the source certificate.

Restore mutations are likewise fail-closed: they are limited to approved capability subtrees, require bounded snapshots and active transaction tokens, and do not fall back to pathname-based rollback when a secure capability operation fails.

## Verification

Exact head `72059eb25df16eff3b60b275d996a91768e1f9c7` passed Build, Security Regression, Native Hardening, CodeQL, Rust Lockfile Check, Rust Fuzz Smoke, and CodeRabbit. All inline review threads are resolved.