### PR TITLE
Preserve StrongBox attestation provenance without cross-signing

### DIFF
--- a/rust/backend/src/certificate_wire.rs
+++ b/rust/backend/src/certificate_wire.rs
@@ -7,7 +7,7 @@ use cleverestricky_certificate_core::{
 };
 use zeroize::Zeroize;
 
-const INSPECT_WIRE_VERSION: u8 = 1;
+const INSPECT_WIRE_VERSION: u8 = 2;
 const REWRITE_WIRE_VERSION: u8 = 2;
 const SIGNING_EC_P256_SHA256: u8 = 1;
 const SIGNING_RSA_PKCS1_SHA256: u8 = 2;
@@ -19,7 +19,7 @@ const REWRITE_FIXED_BYTES: usize = 1 + 1 + 3 * 5 + 1 + 2 + 4 + KEY_ID_BYTES + 2 
 const MAX_ID_WIRE_BYTES: usize = MAX_ID_OVERRIDES * (2 + 2 + MAX_ATTESTATION_ID_BYTES);
 
 pub const MAX_INSPECT_REQUEST_BYTES: usize = MAX_CERTIFICATE_DER_BYTES;
-pub const INSPECT_RESPONSE_BYTES: usize = 1 + 1 + 2 + 3 * 5 + 2 * 32;
+pub const INSPECT_RESPONSE_BYTES: usize = 1 + 1 + 2 + 3 * 5 + 2 * 32 + 2;
 pub const MAX_REWRITE_REQUEST_BYTES: usize =
     REWRITE_FIXED_BYTES + MAX_ID_WIRE_BYTES + MAX_MODULE_HASH_BYTES + MAX_CERTIFICATE_DER_BYTES;
 pub const MAX_REWRITE_RESPONSE_BYTES: usize = MAX_CERTIFICATE_DER_BYTES;
@@ -47,6 +47,8 @@ pub fn inspect_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'static str>
         encode_optional_i32(&mut output, inspection.captured_patch_levels.boot);
         output.extend_from_slice(&inspection.original_boot_key.unwrap_or([0; 32]));
         output.extend_from_slice(&inspection.original_boot_hash.unwrap_or([0; 32]));
+        output.push(inspection.attestation_security_level.wire_value());
+        output.push(inspection.keymint_security_level.wire_value());
         debug_assert_eq!(output.len(), INSPECT_RESPONSE_BYTES);
         Ok(output)
     })();

--- a/rust/backend/src/certificate_wire.rs
+++ b/rust/backend/src/certificate_wire.rs
@@ -2,8 +2,8 @@
 use crate::keybox_wire::key_store::{self, KeyId, KEY_ID_BYTES};
 use cleverestricky_certificate_core::{
     inspect_certificate, rewrite_certificate_prepared, AttestationIdOverride, PatchComponent,
-    PatchLevels, PreparedCertificateRewriteRequest, SigningAlgorithm, MAX_ATTESTATION_ID_BYTES,
-    MAX_CERTIFICATE_DER_BYTES, MAX_MODULE_HASH_BYTES,
+    PatchLevels, PreparedCertificateRewriteRequest, SecurityLevel, SigningAlgorithm,
+    MAX_ATTESTATION_ID_BYTES, MAX_CERTIFICATE_DER_BYTES, MAX_MODULE_HASH_BYTES,
 };
 use zeroize::Zeroize;
 
@@ -62,6 +62,19 @@ pub fn rewrite_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'static str>
             return Err("certificate rewrite request rejected");
         }
         let parsed = parse_rewrite_request(&request)?;
+
+        // Defense in depth: do not trust the managed caller to classify provenance correctly.
+        // The production replacement keybox format proves key ownership/signature validity but not
+        // a hardware TEE-vs-StrongBox origin. Reinspect the genuine source and reject every source
+        // that is not unambiguously TEE/TEE before an opaque replacement issuer can sign it.
+        let provenance = inspect_certificate(parsed.genuine_leaf_der)
+            .map_err(|_| "certificate rewrite provenance rejected")?;
+        if provenance.attestation_security_level != SecurityLevel::TrustedEnvironment
+            || provenance.keymint_security_level != SecurityLevel::TrustedEnvironment
+        {
+            return Err("certificate rewrite provenance is not TEE compatible");
+        }
+
         key_store::with_prepared_key(&parsed.key_id, |stored_algorithm, prepared_issuer| {
             if stored_algorithm != parsed.signing_algorithm
                 || prepared_issuer.algorithm() != stored_algorithm

--- a/rust/certificate-core/src/entry.rs
+++ b/rust/certificate-core/src/entry.rs
@@ -10,4 +10,4 @@ pub use cleverestricky_attestation_core::{
     MAX_MODULE_HASH_BYTES,
 };
 pub use core::*;
-pub use inspection::{inspect_certificate, CertificateInspection};
+pub use inspection::{inspect_certificate, CertificateInspection, SecurityLevel};

--- a/rust/certificate-core/src/inspection.rs
+++ b/rust/certificate-core/src/inspection.rs
@@ -12,6 +12,21 @@ const ID_TAGS: [u32; 9] = [710, 711, 712, 713, 714, 715, 716, 717, 723];
 const MAX_FIELDS: usize = 16;
 const MAX_TAGS: usize = 256;
 
+/// Canonical Android KeyMint security levels carried by KeyDescription.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum SecurityLevel {
+    Software = 0,
+    TrustedEnvironment = 1,
+    StrongBox = 2,
+}
+
+impl SecurityLevel {
+    pub const fn wire_value(self) -> u8 {
+        self as u8
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CertificateInspection {
     pub captured_patch_levels: CapturedPatchLevels,
@@ -19,6 +34,8 @@ pub struct CertificateInspection {
     pub supports_module_hash: bool,
     pub original_boot_key: Option<[u8; 32]>,
     pub original_boot_hash: Option<[u8; 32]>,
+    pub attestation_security_level: SecurityLevel,
+    pub keymint_security_level: SecurityLevel,
 }
 
 pub fn inspect_certificate(leaf_der: &[u8]) -> Result<CertificateInspection, Error> {
@@ -53,8 +70,10 @@ pub fn inspect_certificate(leaf_der: &[u8]) -> Result<CertificateInspection, Err
     }
     let attestation_version = <i32 as attestation_der::Decode>::from_der(&fields[0])
         .map_err(|_| Error::AttestationRewrite)?;
+    let attestation_security_level = decode_security_level(&fields[1])?;
     let keymint_version = <i32 as attestation_der::Decode>::from_der(&fields[2])
         .map_err(|_| Error::AttestationRewrite)?;
+    let keymint_security_level = decode_security_level(&fields[3])?;
     let list_six = tagged_fields(&fields[SOFTWARE_INDEX])?;
     let list_seven = tagged_fields(&fields[TEE_INDEX])?;
     let six_has_root = list_six.iter().any(|field| field.0 == ROOT_OF_TRUST_TAG);
@@ -85,7 +104,22 @@ pub fn inspect_certificate(leaf_der: &[u8]) -> Result<CertificateInspection, Err
         supports_module_hash: attestation_version >= 400 && keymint_version >= 400,
         original_boot_key,
         original_boot_hash,
+        attestation_security_level,
+        keymint_security_level,
     })
+}
+
+fn decode_security_level(encoded: &[u8]) -> Result<SecurityLevel, Error> {
+    let level = AnyRef::from_der(encoded).map_err(|_| Error::AttestationRewrite)?;
+    if level.tag() != Tag::Enumerated || level.value().len() != 1 {
+        return Err(Error::AttestationRewrite);
+    }
+    match level.value()[0] {
+        0 => Ok(SecurityLevel::Software),
+        1 => Ok(SecurityLevel::TrustedEnvironment),
+        2 => Ok(SecurityLevel::StrongBox),
+        _ => Err(Error::AttestationRewrite),
+    }
 }
 
 fn tagged_fields(encoded: &[u8]) -> Result<Vec<(u32, Vec<u8>)>, Error> {

--- a/rust/certificate-core/src/inspection.rs
+++ b/rust/certificate-core/src/inspection.rs
@@ -28,6 +28,12 @@ impl SecurityLevel {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct SecurityLevels {
+    pub attestation: SecurityLevel,
+    pub keymint: SecurityLevel,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CertificateInspection {
     pub captured_patch_levels: CapturedPatchLevels,
     pub present_id_mask: u16,
@@ -70,10 +76,9 @@ pub fn inspect_certificate(leaf_der: &[u8]) -> Result<CertificateInspection, Err
     }
     let attestation_version = <i32 as attestation_der::Decode>::from_der(&fields[0])
         .map_err(|_| Error::AttestationRewrite)?;
-    let attestation_security_level = decode_security_level(&fields[1])?;
+    let security_levels = security_levels_from_fields(&fields)?;
     let keymint_version = <i32 as attestation_der::Decode>::from_der(&fields[2])
         .map_err(|_| Error::AttestationRewrite)?;
-    let keymint_security_level = decode_security_level(&fields[3])?;
     let list_six = tagged_fields(&fields[SOFTWARE_INDEX])?;
     let list_seven = tagged_fields(&fields[TEE_INDEX])?;
     let six_has_root = list_six.iter().any(|field| field.0 == ROOT_OF_TRUST_TAG);
@@ -104,8 +109,27 @@ pub fn inspect_certificate(leaf_der: &[u8]) -> Result<CertificateInspection, Err
         supports_module_hash: attestation_version >= 400 && keymint_version >= 400,
         original_boot_key,
         original_boot_hash,
-        attestation_security_level,
-        keymint_security_level,
+        attestation_security_level: security_levels.attestation,
+        keymint_security_level: security_levels.keymint,
+    })
+}
+
+pub(crate) fn inspect_security_levels(extension_der: &[u8]) -> Result<SecurityLevels, Error> {
+    let outer = AnyRef::from_der(extension_der).map_err(|_| Error::AttestationRewrite)?;
+    if outer.tag() != Tag::Sequence {
+        return Err(Error::AttestationRewrite);
+    }
+    let fields = split(outer.value(), MAX_FIELDS)?;
+    if fields.len() <= TEE_INDEX {
+        return Err(Error::AttestationRewrite);
+    }
+    security_levels_from_fields(&fields)
+}
+
+fn security_levels_from_fields(fields: &[Vec<u8>]) -> Result<SecurityLevels, Error> {
+    Ok(SecurityLevels {
+        attestation: decode_security_level(&fields[1])?,
+        keymint: decode_security_level(&fields[3])?,
     })
 }
 

--- a/rust/certificate-core/src/inspection.rs
+++ b/rust/certificate-core/src/inspection.rs
@@ -28,9 +28,9 @@ impl SecurityLevel {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct SecurityLevels {
-    pub attestation: SecurityLevel,
-    pub keymint: SecurityLevel,
+struct SecurityLevels {
+    attestation: SecurityLevel,
+    keymint: SecurityLevel,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -112,18 +112,6 @@ pub fn inspect_certificate(leaf_der: &[u8]) -> Result<CertificateInspection, Err
         attestation_security_level: security_levels.attestation,
         keymint_security_level: security_levels.keymint,
     })
-}
-
-pub(crate) fn inspect_security_levels(extension_der: &[u8]) -> Result<SecurityLevels, Error> {
-    let outer = AnyRef::from_der(extension_der).map_err(|_| Error::AttestationRewrite)?;
-    if outer.tag() != Tag::Sequence {
-        return Err(Error::AttestationRewrite);
-    }
-    let fields = split(outer.value(), MAX_FIELDS)?;
-    if fields.len() <= TEE_INDEX {
-        return Err(Error::AttestationRewrite);
-    }
-    security_levels_from_fields(&fields)
 }
 
 fn security_levels_from_fields(fields: &[Vec<u8>]) -> Result<SecurityLevels, Error> {

--- a/rust/certificate-core/tests/inspection.rs
+++ b/rust/certificate-core/tests/inspection.rs
@@ -1,6 +1,6 @@
 // Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
 use cleverestricky_attestation_core::CapturedPatchLevels;
-use cleverestricky_certificate_core::{inspect_certificate, Error};
+use cleverestricky_certificate_core::{inspect_certificate, Error, SecurityLevel};
 
 mod fixture {
     include!("rewrite.rs");
@@ -50,6 +50,14 @@ fn inspection_returns_only_policy_inputs_needed_by_android_adapter() {
     assert!(inspected.supports_module_hash);
     assert_eq!(inspected.original_boot_key, Some([0x21; 32]));
     assert_eq!(inspected.original_boot_hash, Some([0x31; 32]));
+    assert_eq!(
+        inspected.attestation_security_level,
+        SecurityLevel::TrustedEnvironment
+    );
+    assert_eq!(
+        inspected.keymint_security_level,
+        SecurityLevel::TrustedEnvironment
+    );
 }
 
 #[test]

--- a/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
@@ -11,6 +11,9 @@ object CertificateBackend {
     const val PATCH_KEEP = 0
     const val PATCH_OMIT = 1
     const val PATCH_REPLACE = 2
+    const val SECURITY_LEVEL_SOFTWARE = 0
+    const val SECURITY_LEVEL_TEE = 1
+    const val SECURITY_LEVEL_STRONGBOX = 2
 
     data class Inspection(
         val systemPatch: Int?,
@@ -20,6 +23,8 @@ object CertificateBackend {
         val supportsModuleHash: Boolean,
         val originalBootKey: ByteArray?,
         val originalBootHash: ByteArray?,
+        val attestationSecurityLevel: Int,
+        val keymintSecurityLevel: Int,
     ) {
         fun wipe() {
             originalBootKey?.fill(0)
@@ -188,6 +193,8 @@ object CertificateBackend {
             val bootPatch = readOptionalI32(response, 14)
             val key = decodeOptionalDigest(response, 19, flags and FLAG_BOOT_KEY_PRESENT != 0)
             val hash = decodeOptionalDigest(response, 51, flags and FLAG_BOOT_HASH_PRESENT != 0)
+            val attestationSecurityLevel = decodeSecurityLevel(response[83])
+            val keymintSecurityLevel = decodeSecurityLevel(response[84])
             return Inspection(
                 systemPatch,
                 vendorPatch,
@@ -196,10 +203,20 @@ object CertificateBackend {
                 flags and FLAG_MODULE_HASH_SUPPORTED != 0,
                 key,
                 hash,
+                attestationSecurityLevel,
+                keymintSecurityLevel,
             )
         } finally {
             response.fill(0)
         }
+    }
+
+    private fun decodeSecurityLevel(encoded: Byte): Int {
+        val level = encoded.toInt() and 0xff
+        if (level !in SECURITY_LEVEL_SOFTWARE..SECURITY_LEVEL_STRONGBOX) {
+            throw RustBackendUnavailableException(IOException("Invalid certificate security level"))
+        }
+        return level
     }
 
     private fun readOptionalI32(
@@ -308,9 +325,9 @@ object CertificateBackend {
 
     private const val OP_CERTIFICATE_INSPECT = 25
     private const val OP_CERTIFICATE_REWRITE = 26
-    private const val INSPECT_WIRE_VERSION = 1
+    private const val INSPECT_WIRE_VERSION = 2
     private const val REWRITE_WIRE_VERSION = 2
-    private const val INSPECT_RESPONSE_BYTES = 83
+    private const val INSPECT_RESPONSE_BYTES = 85
     private const val FLAG_MODULE_HASH_SUPPORTED = 1
     private const val FLAG_BOOT_KEY_PRESENT = 1 shl 1
     private const val FLAG_BOOT_HASH_PRESENT = 1 shl 2

--- a/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
@@ -103,27 +103,6 @@ object CertificateBackend {
             return null
         }
 
-        // The currently supported replacement keybox format proves key ownership and chain
-        // signatures, but it carries no trustworthy TEE-vs-StrongBox provenance. Cross-signing a
-        // StrongBox (or mixed-level) genuine leaf with that issuer would preserve the DER enum while
-        // lying about the signer graph. Only the legacy TEE/TEE case is therefore eligible for
-        // replacement. StrongBox, Software, mixed and malformed inputs preserve their genuine chain.
-        val sourceInspection =
-            try {
-                inspect(genuineLeafDer)
-            } catch (_: RustBackendUnavailableException) {
-                null
-            } ?: return null
-        try {
-            if (sourceInspection.attestationSecurityLevel != SECURITY_LEVEL_TEE ||
-                sourceInspection.keymintSecurityLevel != SECURITY_LEVEL_TEE
-            ) {
-                return null
-            }
-        } finally {
-            sourceInspection.wipe()
-        }
-
         val orderedIds = idOverrides.entries.sortedBy { it.key }
         var idWireBytes = 0
         for ((tag, value) in orderedIds) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
@@ -103,6 +103,27 @@ object CertificateBackend {
             return null
         }
 
+        // The currently supported replacement keybox format proves key ownership and chain
+        // signatures, but it carries no trustworthy TEE-vs-StrongBox provenance. Cross-signing a
+        // StrongBox (or mixed-level) genuine leaf with that issuer would preserve the DER enum while
+        // lying about the signer graph. Only the legacy TEE/TEE case is therefore eligible for
+        // replacement. StrongBox, Software, mixed and malformed inputs preserve their genuine chain.
+        val sourceInspection =
+            try {
+                inspect(genuineLeafDer)
+            } catch (_: RustBackendUnavailableException) {
+                null
+            } ?: return null
+        try {
+            if (sourceInspection.attestationSecurityLevel != SECURITY_LEVEL_TEE ||
+                sourceInspection.keymintSecurityLevel != SECURITY_LEVEL_TEE
+            ) {
+                return null
+            }
+        } finally {
+            sourceInspection.wipe()
+        }
+
         val orderedIds = idOverrides.entries.sortedBy { it.key }
         var idWireBytes = 0
         for ((tag, value) in orderedIds) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
@@ -174,6 +174,8 @@ object CertificateBackend {
     }
 
     internal fun decodeInspection(response: ByteArray): Inspection {
+        var key: ByteArray? = null
+        var hash: ByteArray? = null
         try {
             if (response.size != INSPECT_RESPONSE_BYTES ||
                 (response[0].toInt() and 0xff) != INSPECT_WIRE_VERSION
@@ -191,10 +193,12 @@ object CertificateBackend {
             val systemPatch = readOptionalI32(response, 4)
             val vendorPatch = readOptionalI32(response, 9)
             val bootPatch = readOptionalI32(response, 14)
-            val key = decodeOptionalDigest(response, 19, flags and FLAG_BOOT_KEY_PRESENT != 0)
-            val hash = decodeOptionalDigest(response, 51, flags and FLAG_BOOT_HASH_PRESENT != 0)
+            // Validate cheap scalar provenance before copying either boot digest out of the
+            // transport buffer. Any later decode failure wipes whichever digest was already made.
             val attestationSecurityLevel = decodeSecurityLevel(response[83])
             val keymintSecurityLevel = decodeSecurityLevel(response[84])
+            key = decodeOptionalDigest(response, 19, flags and FLAG_BOOT_KEY_PRESENT != 0)
+            hash = decodeOptionalDigest(response, 51, flags and FLAG_BOOT_HASH_PRESENT != 0)
             return Inspection(
                 systemPatch,
                 vendorPatch,
@@ -206,6 +210,10 @@ object CertificateBackend {
                 attestationSecurityLevel,
                 keymintSecurityLevel,
             )
+        } catch (error: Throwable) {
+            key?.fill(0)
+            hash?.fill(0)
+            throw error
         } finally {
             response.fill(0)
         }

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -19,9 +19,6 @@ object KeystoreInterceptor : BinderInterceptor() {
     private const val MAX_PROC_SCAN_ENTRIES = 4_096
     private const val INJECTION_RETRY_INTERVAL_MS = 15_000L
 
-    private val getSecurityLevelTransaction =
-        getTransactCode(IKeystoreService.Stub::class.java, "getSecurityLevel") // 1
-
     private val getKeyEntryTransaction =
         getTransactCode(IKeystoreService.Stub::class.java, "getKeyEntry") // 2
 
@@ -48,9 +45,6 @@ object KeystoreInterceptor : BinderInterceptor() {
         data: Parcel,
     ): Result {
         if (target != keystore || !CertHack.canHack()) return Skip
-        if (code == getSecurityLevelTransaction) {
-            return if (Config.needHack(callingUid) && teeTarget != null) Continue else Skip
-        }
         if (code == getKeyEntryTransaction) {
             val targeted = Config.needHack(callingUid)
             val mayReadGrantedChain =
@@ -76,24 +70,6 @@ object KeystoreInterceptor : BinderInterceptor() {
             resultCode != 0 ||
             !CertHack.canHack()
         ) {
-            return Skip
-        }
-
-        if (code == getSecurityLevelTransaction) {
-            if (!Config.needHack(callingUid)) return Skip
-            val currentTeeTarget = teeTarget ?: return Skip
-            try {
-                reply.readException()
-                val returned = reply.readStrongBinder()
-                if (returned != null && strongBoxTarget != null && returned == strongBoxTarget) {
-                    val p = Parcel.obtain()
-                    p.writeNoException()
-                    p.writeStrongBinder(currentTeeTarget)
-                    return OverrideReply(0, p)
-                }
-            } catch (_: Throwable) {
-                return Skip
-            }
             return Skip
         }
 
@@ -276,12 +252,12 @@ object KeystoreInterceptor : BinderInterceptor() {
 
     fun refreshKernelIdentity(): Boolean {
         val pid = findKeystore2Pid() ?: return false
-        
+
         val needsActivation = synchronized(this) {
             injected && injectedPid == pid
         }
         if (!needsActivation) return true
-        
+
         return runNativeActivation(pid, "resume")
     }
 
@@ -297,7 +273,7 @@ object KeystoreInterceptor : BinderInterceptor() {
                 return false
             }
         val bd = getBinderControlEndpoint(b)
-        
+
         binderBackdoor = bd
         if (bd == null) {
             val pid = findKeystore2Pid()
@@ -306,7 +282,7 @@ object KeystoreInterceptor : BinderInterceptor() {
                 triedCount.incrementAndGet()
                 return false
             }
-            
+
             val now = SystemClock.elapsedRealtime()
             val symbol = synchronized(this) {
                 if (lastInjectionAttemptMs != 0L && now - lastInjectionAttemptMs < INJECTION_RETRY_INTERVAL_MS) {
@@ -315,13 +291,13 @@ object KeystoreInterceptor : BinderInterceptor() {
                 lastInjectionAttemptMs = now
                 if (injected && injectedPid == pid) "resume" else "entry"
             }
-            
+
             Logger.i("trying to activate the keystore Binder hook ...")
             if (!runNativeActivation(pid, symbol)) {
                 triedCount.incrementAndGet()
                 return false
             }
-            
+
             Logger.i("keystore Binder hook activated successfully")
             synchronized(this) {
                 injected = true
@@ -330,7 +306,7 @@ object KeystoreInterceptor : BinderInterceptor() {
             triedCount.incrementAndGet()
             return false
         }
-        
+
         val ks = IKeystoreService.Stub.asInterface(b)
         val tee =
             try {
@@ -344,16 +320,20 @@ object KeystoreInterceptor : BinderInterceptor() {
             } catch (e: Exception) {
                 null
             }
-        val interceptedCodes =
-            validTransactCodes(getSecurityLevelTransaction, getKeyEntryTransaction)
-            
+
+        // Keep the service-level Binder transparent for getSecurityLevel. Returning a TEE binder
+        // for a genuine StrongBox request destroys hardware provenance before generateKey even runs.
+        // TEE and StrongBox child binders are intercepted independently below, so the root service
+        // only needs getKeyEntry for cached certificate-chain handling.
+        val interceptedCodes = validTransactCodes(getKeyEntryTransaction)
+
         val registeredHook = registerBinderInterceptor(bd, b, this, interceptedCodes)
         if (!registeredHook) {
             Logger.e("Failed to register the Keystore Binder interceptor")
             parkBinderHook(bd)
             return false
         }
-        
+
         synchronized(this) {
             keystore = b
             binderBackdoor = bd
@@ -411,19 +391,19 @@ object KeystoreInterceptor : BinderInterceptor() {
         } catch (error: android.os.RemoteException) {
             Logger.w("Keystore exited before its interceptor lifecycle could be monitored")
         }
-        
+
         synchronized(this) {
             if (linkSuccess) {
                 deathRecipientLinked = true
             }
         }
-        
+
         val linked = synchronized(this) { deathRecipientLinked }
         if (!linked) {
             stopKeystoreInterceptor()
             return false
         }
-        
+
         synchronized(this) {
             registered = true
         }
@@ -440,11 +420,11 @@ object KeystoreInterceptor : BinderInterceptor() {
             targetAlive = ::keystore.isInitialized && keystore.isBinderAlive
             control = binderBackdoor
         }
-        
+
         if (control == null && targetAlive) {
             control = getBinderControlEndpoint(keystore)
         }
-        
+
         var stopped = control?.let(::clearAndParkBinderHook) == true
         if (!stopped && control != null) {
             strongBoxInterceptor?.let { interceptor ->
@@ -462,7 +442,7 @@ object KeystoreInterceptor : BinderInterceptor() {
             }
             stopped = parkBinderHook(control)
         }
-        
+
         val shouldUnlink = synchronized(this) {
             val hasKnownRegistration =
                 registered || keystoreRegistered || teeInterceptor != null || strongBoxInterceptor != null

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -25,9 +25,7 @@ object KeystoreInterceptor : BinderInterceptor() {
     private lateinit var keystore: IBinder
 
     private var teeInterceptor: SecurityLevelInterceptor? = null
-    private var strongBoxInterceptor: SecurityLevelInterceptor? = null
     private var teeTarget: IBinder? = null
-    private var strongBoxTarget: IBinder? = null
     private var binderBackdoor: IBinder? = null
 
     @Volatile private var keystoreRegistered = false
@@ -298,7 +296,7 @@ object KeystoreInterceptor : BinderInterceptor() {
                 return false
             }
 
-            Logger.i("keystore Binder hook activated successfully")
+            Logger.i("Keystore Binder hook activated successfully")
             synchronized(this) {
                 injected = true
                 injectedPid = pid
@@ -314,17 +312,11 @@ object KeystoreInterceptor : BinderInterceptor() {
             } catch (e: Exception) {
                 null
             }
-        val strongBox =
-            try {
-                ks.getSecurityLevel(SecurityLevel.STRONGBOX)
-            } catch (e: Exception) {
-                null
-            }
 
-        // Keep the service-level Binder transparent for getSecurityLevel. Returning a TEE binder
-        // for a genuine StrongBox request destroys hardware provenance before generateKey even runs.
-        // TEE and StrongBox child binders are intercepted independently below, so the root service
-        // only needs getKeyEntry for cached certificate-chain handling.
+        // Keep the service-level Binder transparent for getSecurityLevel. StrongBox is neither
+        // acquired nor registered with our child interceptor, so StrongBox binder identity and
+        // generateKey replies stay entirely inside the platform. The root service only needs
+        // getKeyEntry for cached TEE replacement-chain handling and provenance-safe passthrough.
         val interceptedCodes = validTransactCodes(getKeyEntryTransaction)
 
         val registeredHook = registerBinderInterceptor(bd, b, this, interceptedCodes)
@@ -361,27 +353,6 @@ object KeystoreInterceptor : BinderInterceptor() {
             Logger.i("TEE SecurityLevel interceptor registered")
         } else {
             Logger.i("TEE SecurityLevel is unavailable")
-        }
-        if (strongBox != null) {
-            val interceptor = SecurityLevelInterceptor(allowGenericReplacement = false)
-            if (!registerBinderInterceptor(
-                    bd,
-                    strongBox.asBinder(),
-                    interceptor,
-                    SecurityLevelInterceptor.INTERCEPTED_CODES,
-                )
-            ) {
-                Logger.e("Failed to register the StrongBox SecurityLevel interceptor")
-                stopKeystoreInterceptor()
-                return false
-            }
-            synchronized(this) {
-                strongBoxInterceptor = interceptor
-                strongBoxTarget = strongBox.asBinder()
-            }
-            Logger.i("StrongBox SecurityLevel interceptor registered")
-        } else {
-            Logger.i("StrongBox SecurityLevel is unavailable")
         }
 
         var linkSuccess = false
@@ -427,11 +398,6 @@ object KeystoreInterceptor : BinderInterceptor() {
 
         var stopped = control?.let(::clearAndParkBinderHook) == true
         if (!stopped && control != null) {
-            strongBoxInterceptor?.let { interceptor ->
-                strongBoxTarget?.let { target ->
-                    unregisterBinderInterceptor(control, target, interceptor)
-                }
-            }
             teeInterceptor?.let { interceptor ->
                 teeTarget?.let { target ->
                     unregisterBinderInterceptor(control, target, interceptor)
@@ -444,8 +410,7 @@ object KeystoreInterceptor : BinderInterceptor() {
         }
 
         val shouldUnlink = synchronized(this) {
-            val hasKnownRegistration =
-                registered || keystoreRegistered || teeInterceptor != null || strongBoxInterceptor != null
+            val hasKnownRegistration = registered || keystoreRegistered || teeInterceptor != null
             if (!targetAlive || (!hasKnownRegistration && control == null)) stopped = true
             if (!stopped) {
                 binderBackdoor = control
@@ -465,8 +430,6 @@ object KeystoreInterceptor : BinderInterceptor() {
 
         synchronized(this) {
             deathRecipientLinked = false
-            strongBoxInterceptor = null
-            strongBoxTarget = null
             teeInterceptor = null
             teeTarget = null
             keystoreRegistered = false
@@ -490,8 +453,6 @@ object KeystoreInterceptor : BinderInterceptor() {
         binderBackdoor = null
         teeInterceptor = null
         teeTarget = null
-        strongBoxInterceptor = null
-        strongBoxTarget = null
         Config.signalRuntimeController()
     }
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -363,7 +363,7 @@ object KeystoreInterceptor : BinderInterceptor() {
             Logger.i("TEE SecurityLevel is unavailable")
         }
         if (strongBox != null) {
-            val interceptor = SecurityLevelInterceptor()
+            val interceptor = SecurityLevelInterceptor(allowGenericReplacement = false)
             if (!registerBinderInterceptor(
                     bd,
                     strongBox.asBinder(),

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -81,10 +81,21 @@ object KeystoreInterceptor : BinderInterceptor() {
         val p = Parcel.obtain()
         try {
             val response = reply.readTypedObject(KeyEntryResponse.CREATOR)
-            if (response == null || response.metadata == null) {
+            val metadata = response?.metadata
+            if (metadata == null) {
                 p.recycle()
                 return Skip
             }
+
+            // getKeyEntry exposes the platform-owned security level directly in KeyMetadata.
+            // Generic replacement is a TEE-only policy, so reject StrongBox/software metadata
+            // before cache hashing, X.509 parsing or Rust IPC. This keeps StrongBox reads fully
+            // platform-owned and removes even the first-read provenance-classification overhead.
+            if (metadata.keySecurityLevel != SecurityLevel.TRUSTED_ENVIRONMENT) {
+                p.recycle()
+                return Skip
+            }
+
             val targeted = Config.needHack(callingUid)
             val mayReadGrantedChain = callingUid >= FIRST_APPLICATION_UID
 
@@ -96,7 +107,7 @@ object KeystoreInterceptor : BinderInterceptor() {
             // getEncoded(), issuer parsing and every Rust backend operation on the measured path.
             if (
                 (targeted || mayReadGrantedChain) &&
-                CertHack.applyCachedCertificateChain(response.metadata)
+                CertHack.applyCachedCertificateChain(metadata)
             ) {
                 p.writeNoException()
                 p.writeTypedObject(response, 0)

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -10,20 +10,18 @@ import cleveres.tricky.cleverestech.keystore.Utils
 import java.security.cert.Certificate
 
 /**
- * Rewrites only the certificate chain returned by a successful, genuine
+ * Rewrites only the certificate chain returned by a successful, genuine TEE
  * KeyMint key generation. The private key and every later cryptographic
  * operation remain owned by the platform security level.
  *
- * Generic keybox replacement is enabled only for the TEE child binder. The StrongBox child binder
- * is registered with [allowGenericReplacement] disabled so its generateKey reply remains completely
- * platform-owned even if a malformed/vendor certificate were to report an unexpected security level.
- * Targeted TEE generateKey and getKeyEntry calls deliberately use the same certificate-compatibility
- * path. No synthetic timing delay is added here; certificate caching in CertHack handles repeated
- * reads without parking Keystore threads.
+ * This interceptor is registered only on the TEE child binder. StrongBox is
+ * deliberately left completely unhooked so its binder identity, generateKey
+ * reply and genuine hardware certificate chain remain platform-owned. Targeted
+ * TEE generateKey and getKeyEntry calls use the same certificate-compatibility
+ * path. No synthetic timing delay is added here; certificate caching in
+ * CertHack handles repeated reads without parking Keystore threads.
  */
-class SecurityLevelInterceptor(
-    private val allowGenericReplacement: Boolean = true,
-) : BinderInterceptor() {
+class SecurityLevelInterceptor : BinderInterceptor() {
     companion object {
         private val generateKeyTransaction =
             getTransactCode(IKeystoreSecurityLevel.Stub::class.java, "generateKey")
@@ -40,7 +38,6 @@ class SecurityLevelInterceptor(
         data: Parcel,
     ): Result {
         return if (
-            allowGenericReplacement &&
             code == generateKeyTransaction &&
             CertHack.canHack() &&
             Config.needHack(callingUid)

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -14,13 +14,16 @@ import java.security.cert.Certificate
  * KeyMint key generation. The private key and every later cryptographic
  * operation remain owned by the platform security level.
  *
- * Targeted generateKey and getKeyEntry calls deliberately use the same
- * certificate-compatibility path. The retired RKP passthrough switch must not
- * split those two paths, otherwise the same alias can expose two different
- * attestation leaves. No synthetic timing delay is added here; certificate
- * caching in CertHack handles repeated reads without parking Keystore threads.
+ * Generic keybox replacement is enabled only for the TEE child binder. The StrongBox child binder
+ * is registered with [allowGenericReplacement] disabled so its generateKey reply remains completely
+ * platform-owned even if a malformed/vendor certificate were to report an unexpected security level.
+ * Targeted TEE generateKey and getKeyEntry calls deliberately use the same certificate-compatibility
+ * path. No synthetic timing delay is added here; certificate caching in CertHack handles repeated
+ * reads without parking Keystore threads.
  */
-class SecurityLevelInterceptor : BinderInterceptor() {
+class SecurityLevelInterceptor(
+    private val allowGenericReplacement: Boolean = true,
+) : BinderInterceptor() {
     companion object {
         private val generateKeyTransaction =
             getTransactCode(IKeystoreSecurityLevel.Stub::class.java, "generateKey")
@@ -37,6 +40,7 @@ class SecurityLevelInterceptor : BinderInterceptor() {
         data: Parcel,
     ): Result {
         return if (
+            allowGenericReplacement &&
             code == generateKeyTransaction &&
             CertHack.canHack() &&
             Config.needHack(callingUid)
@@ -90,7 +94,7 @@ class SecurityLevelInterceptor : BinderInterceptor() {
                 return Skip
             }
 
-            // A successful attestation rewrite discards Android's genuine issuer chain and
+            // A successful TEE attestation rewrite discards Android's genuine issuer chain and
             // replaces it with the selected keybox chain. Parsing every genuine issuer first
             // therefore adds work only to attested generateKey calls. Keep the hot path leaf-only
             // until CertHack confirms that a replacement can actually be produced.

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -77,13 +77,14 @@ public final class CertHack {
 
     /**
      * One immutable cache value serves both compatibility APIs and the latency-sensitive raw
-     * KeyMetadata readback path. Certificate bytes are public data. Keeping their already-encoded
-     * form avoids reparsing the genuine chain and re-encoding the replacement on every getKeyEntry.
+     * KeyMetadata readback path. Replacement entries retain public encoded certificate bytes.
+     * Passthrough entries are marker-only and deliberately retain no certificate or chain arrays.
      */
     private static final class CachedCertificateChain {
         final Certificate[] certificates;
         final byte[] leafEncoded;
         final byte[] issuerChainEncoded;
+        final boolean passthrough;
 
         CachedCertificateChain(
                 Certificate[] certificates,
@@ -93,13 +94,26 @@ public final class CertHack {
             this.certificates = certificates.clone();
             this.leafEncoded = Objects.requireNonNull(leafEncoded, "leafEncoded");
             this.issuerChainEncoded = Objects.requireNonNull(issuerChainEncoded, "issuerChainEncoded");
+            this.passthrough = false;
+        }
+
+        private CachedCertificateChain() {
+            this.certificates = null;
+            this.leafEncoded = null;
+            this.issuerChainEncoded = null;
+            this.passthrough = true;
+        }
+
+        static CachedCertificateChain passthrough() {
+            return new CachedCertificateChain();
         }
 
         Certificate[] certificateCopy() {
-            return certificates.clone();
+            return passthrough ? null : certificates.clone();
         }
 
         void applyTo(KeyMetadata metadata) {
+            if (passthrough) return;
             // Parcel.writeTypedObject copies these byte arrays synchronously. The transient
             // KeyMetadata object never owns or mutates the cache storage after the reply is built.
             metadata.certificate = leafEncoded;
@@ -318,11 +332,9 @@ public final class CertHack {
     }
 
     /**
-     * Applies an already-produced attestation replacement directly to the raw KeyMetadata bytes.
-     * Duck Detector's side-channel probe repeatedly measures service.getKeyEntry for the same two
-     * keys, so the attested key should hit this path after generateKey populated the cache. A hit
-     * performs only one bounded DER hash/equality lookup and the later Parcel serialization: no
-     * CertificateFactory, no issuer-chain parsing, no getEncoded(), and no Rust IPC.
+     * Applies a cached replacement or passthrough decision directly to raw KeyMetadata bytes.
+     * A passthrough hit is intentionally a no-op and still returns true, allowing repeated
+     * getKeyEntry calls to avoid X.509 parsing and Rust IPC while preserving the genuine reply.
      */
     public static boolean applyCachedCertificateChain(KeyMetadata metadata) {
         if (metadata == null || metadata.certificate == null ||
@@ -346,7 +358,9 @@ public final class CertHack {
             byte[] leafEncoded = caList[0].getEncoded();
             if (leafEncoded.length == 0 || leafEncoded.length > MAX_LEAF_CERTIFICATE_BYTES) return null;
             CachedCertificateChain cached = state.certificateCache.get(new CacheKey(leafEncoded));
-            return cached == null ? null : cached.certificateCopy();
+            if (cached == null) return null;
+            Certificate[] replacement = cached.certificateCopy();
+            return replacement == null ? caList : replacement;
         } catch (Throwable error) {
             Logger.e("Could not resolve a cached attestation chain", error);
             return null;
@@ -378,49 +392,51 @@ public final class CertHack {
             Object cacheEpoch;
             synchronized (cache) {
                 CachedCertificateChain cached = cache.get(cacheKey);
-                if (cached != null) return cached.certificateCopy();
+                if (cached != null) {
+                    Certificate[] replacement = cached.certificateCopy();
+                    return replacement == null ? caList : replacement;
+                }
                 cacheEpoch = currentState.certificateCacheEpoch;
             }
 
-            // Preserve 2.5.8's ordering: look for a completed replacement first, then classify an
-            // uncached leaf locally. This keeps repeated attested getKeyEntry off the X.509/OID
-            // classifier while guaranteeing a non-attested cache miss never enters the Rust
-            // certificate backend.
+            // Preserve the local non-attested fast path. Only genuine Android attestation leaves
+            // cross the Rust certificate-inspection boundary.
             if (!Utils.hasAndroidAttestationExtension(caList[0])) return caList;
 
-            // In 2.6.0 every fresh attested key paid one backend round trip just to inspect fields
-            // that are irrelevant when security-patch rewriting is disabled. Keep DER parsing and
-            // signing in the hardened Rust backend, but do not ask it to inspect a leaf unless
-            // policy or verified-boot fallback actually needs data from that leaf.
+            // Security provenance is mandatory before choosing any replacement issuer. This is one
+            // bounded inspection for a fresh attested leaf. The existing 64-entry LRU stores both
+            // rewrite results and marker-only passthrough decisions, so repeated StrongBox reads do
+            // not create recurring IPC, parsing, allocations, timers or background work.
+            inspection = CertificateBackend.inspect(leafEncoded);
+            if (inspection == null) return caList;
+            if (inspection.getAttestationSecurityLevel() != CertificateBackend.SECURITY_LEVEL_TEE ||
+                    inspection.getKeymintSecurityLevel() != CertificateBackend.SECURITY_LEVEL_TEE) {
+                synchronized (cache) {
+                    if (state == currentState && currentState.certificateCacheEpoch == cacheEpoch) {
+                        cache.putIfAbsent(cacheKey, CachedCertificateChain.passthrough());
+                    }
+                }
+                return caList;
+            }
+
             boolean needsCapturedPatchLevels = PolicyState.INSTANCE.isFeatureEnabled(
                     PolicyState.Feature.SECURITY_PATCH, uid);
             byte[] verifiedBootKey = usableBootDigest(UtilKt.getBootKey());
             byte[] verifiedBootHash = usableBootDigest(UtilKt.getBootHash());
-            boolean needsInspection = needsCapturedPatchLevels
-                    || verifiedBootKey == null
-                    || verifiedBootHash == null;
-
-            Config.AttestationPatchLevels patchLevels;
-            if (needsInspection) {
-                inspection = CertificateBackend.inspect(leafEncoded);
-                if (inspection == null) return caList;
-                patchLevels = needsCapturedPatchLevels
-                        ? PolicyState.INSTANCE.resolveAttestationPatchLevels(
-                                uid,
-                                inspection.getSystemPatch(),
-                                inspection.getVendorPatch(),
-                                inspection.getBootPatch())
-                        : keepPatchLevels();
-                if (verifiedBootKey == null) {
-                    verifiedBootKey = firstUsableBootDigest(
-                            null, inspection.getOriginalBootKey(), UtilKt.getPersistentBootKey());
-                }
-                if (verifiedBootHash == null) {
-                    verifiedBootHash = firstUsableBootDigest(
-                            null, inspection.getOriginalBootHash(), UtilKt.getPersistentBootHash());
-                }
-            } else {
-                patchLevels = keepPatchLevels();
+            Config.AttestationPatchLevels patchLevels = needsCapturedPatchLevels
+                    ? PolicyState.INSTANCE.resolveAttestationPatchLevels(
+                            uid,
+                            inspection.getSystemPatch(),
+                            inspection.getVendorPatch(),
+                            inspection.getBootPatch())
+                    : keepPatchLevels();
+            if (verifiedBootKey == null) {
+                verifiedBootKey = firstUsableBootDigest(
+                        null, inspection.getOriginalBootKey(), UtilKt.getPersistentBootKey());
+            }
+            if (verifiedBootHash == null) {
+                verifiedBootHash = firstUsableBootDigest(
+                        null, inspection.getOriginalBootHash(), UtilKt.getPersistentBootHash());
             }
 
             String preferredSignerAlgorithm = KeyProperties.KEY_ALGORITHM_EC;
@@ -445,10 +461,8 @@ public final class CertHack {
                 return caList;
             }
 
-            Map<Integer, byte[]> idOverrides = inspection == null
-                    ? configuredIdOverrides(uid)
-                    : presentIdOverrides(uid, inspection.getPresentIdMask());
-            byte[] moduleHash = inspection == null || inspection.getSupportsModuleHash()
+            Map<Integer, byte[]> idOverrides = presentIdOverrides(uid, inspection.getPresentIdMask());
+            byte[] moduleHash = inspection.getSupportsModuleHash()
                     ? Config.INSTANCE.getModuleHash()
                     : null;
             keyId = keybox.keyPair.getPrivate().getEncoded();
@@ -479,7 +493,10 @@ public final class CertHack {
                     return result;
                 }
                 CachedCertificateChain raced = cache.get(cacheKey);
-                if (raced != null) return raced.certificateCopy();
+                if (raced != null) {
+                    Certificate[] replacement = raced.certificateCopy();
+                    return replacement == null ? caList : replacement;
+                }
                 cache.put(cacheKey, completed);
             }
             return result;

--- a/service/src/test/java/cleveres/tricky/cleverestech/CertificateBackendProvenanceTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/CertificateBackendProvenanceTest.kt
@@ -1,0 +1,125 @@
+package cleveres.tricky.cleverestech
+
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+class CertificateBackendProvenanceTest {
+    private val rewriteCalls = AtomicInteger(0)
+
+    @Before
+    fun setUp() {
+        CertificateBackend.resetForTesting()
+        rewriteCalls.set(0)
+        CertificateBackend.rewriteOverride = {
+            rewriteCalls.incrementAndGet()
+            byteArrayOf(0x30, 0x00)
+        }
+    }
+
+    @After
+    fun tearDown() {
+        CertificateBackend.resetForTesting()
+    }
+
+    @Test
+    fun `TEE source remains eligible for bounded replacement signing`() {
+        CertificateBackend.inspectionOverride = {
+            inspection(
+                CertificateBackend.SECURITY_LEVEL_TEE,
+                CertificateBackend.SECURITY_LEVEL_TEE,
+            )
+        }
+
+        val rewritten = rewrite()
+
+        assertArrayEquals(byteArrayOf(0x30, 0x00), rewritten)
+        assertEquals(1, rewriteCalls.get())
+    }
+
+    @Test
+    fun `StrongBox source preserves genuine chain instead of cross signing`() {
+        CertificateBackend.inspectionOverride = {
+            inspection(
+                CertificateBackend.SECURITY_LEVEL_STRONGBOX,
+                CertificateBackend.SECURITY_LEVEL_STRONGBOX,
+            )
+        }
+
+        assertNull(rewrite())
+        assertEquals(0, rewriteCalls.get())
+    }
+
+    @Test
+    fun `mixed attestation and KeyMint levels fail closed`() {
+        val combinations =
+            listOf(
+                CertificateBackend.SECURITY_LEVEL_TEE to CertificateBackend.SECURITY_LEVEL_STRONGBOX,
+                CertificateBackend.SECURITY_LEVEL_STRONGBOX to CertificateBackend.SECURITY_LEVEL_TEE,
+                CertificateBackend.SECURITY_LEVEL_SOFTWARE to CertificateBackend.SECURITY_LEVEL_TEE,
+            )
+        for ((attestation, keymint) in combinations) {
+            CertificateBackend.inspectionOverride = { inspection(attestation, keymint) }
+            assertNull(rewrite())
+        }
+        assertEquals(0, rewriteCalls.get())
+    }
+
+    @Test
+    fun `provenance inspection boot digests are wiped after decision`() {
+        val key = ByteArray(32) { 0x41 }
+        val hash = ByteArray(32) { 0x42 }
+        CertificateBackend.inspectionOverride = {
+            inspection(
+                CertificateBackend.SECURITY_LEVEL_STRONGBOX,
+                CertificateBackend.SECURITY_LEVEL_STRONGBOX,
+                key,
+                hash,
+            )
+        }
+
+        assertNull(rewrite())
+        assertTrue(key.all { it == 0.toByte() })
+        assertTrue(hash.all { it == 0.toByte() })
+    }
+
+    private fun inspection(
+        attestationLevel: Int,
+        keymintLevel: Int,
+        bootKey: ByteArray? = null,
+        bootHash: ByteArray? = null,
+    ) =
+        CertificateBackend.Inspection(
+            systemPatch = null,
+            vendorPatch = null,
+            bootPatch = null,
+            presentIdMask = 0,
+            supportsModuleHash = false,
+            originalBootKey = bootKey,
+            originalBootHash = bootHash,
+            attestationSecurityLevel = attestationLevel,
+            keymintSecurityLevel = keymintLevel,
+        )
+
+    private fun rewrite(): ByteArray? =
+        CertificateBackend.rewrite(
+            genuineLeafDer = byteArrayOf(0x30, 0x00),
+            keyId = ByteArray(16) { 0x11 },
+            signingAlgorithm = CertificateBackend.SIGNING_EC_P256_SHA256,
+            systemDisposition = CertificateBackend.PATCH_KEEP,
+            systemValue = 0,
+            vendorDisposition = CertificateBackend.PATCH_KEEP,
+            vendorValue = 0,
+            bootDisposition = CertificateBackend.PATCH_KEEP,
+            bootValue = 0,
+            idOverrides = emptyMap(),
+            moduleHash = null,
+            verifiedBootKey = ByteArray(32) { 0x21 },
+            verifiedBootHash = ByteArray(32) { 0x31 },
+        )
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/CertificateBackendProvenanceTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/CertificateBackendProvenanceTest.kt
@@ -33,6 +33,28 @@ class CertificateBackendProvenanceTest {
     }
 
     @Test
+    fun `Rust rewrite boundary independently rejects non TEE provenance before issuer access`() {
+        val source =
+            File(
+                locateRoot(),
+                "rust/backend/src/certificate_wire.rs",
+            ).readText()
+        val rewrite = source.indexOf("pub fn rewrite_and_encode")
+        val provenance = source.indexOf("inspect_certificate(parsed.genuine_leaf_der)", rewrite)
+        val attestationGate =
+            source.indexOf("provenance.attestation_security_level != SecurityLevel::TrustedEnvironment", provenance)
+        val keymintGate =
+            source.indexOf("provenance.keymint_security_level != SecurityLevel::TrustedEnvironment", attestationGate)
+        val issuerAccess = source.indexOf("key_store::with_prepared_key", keymintGate)
+
+        assertTrue(rewrite >= 0)
+        assertTrue(provenance > rewrite)
+        assertTrue(attestationGate > provenance)
+        assertTrue(keymintGate > attestationGate)
+        assertTrue(issuerAccess > keymintGate)
+    }
+
+    @Test
     fun `passthrough cache is marker only and adds no background execution`() {
         val source =
             File(
@@ -50,7 +72,7 @@ class CertificateBackendProvenanceTest {
     }
 
     @Test
-    fun `certificate backend rewrite does not repeat provenance inspection`() {
+    fun `certificate backend rewrite does not repeat managed provenance inspection`() {
         val source =
             File(
                 locateRoot(),

--- a/service/src/test/java/cleveres/tricky/cleverestech/CertificateBackendProvenanceTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/CertificateBackendProvenanceTest.kt
@@ -1,125 +1,74 @@
 package cleveres.tricky.cleverestech
 
-import org.junit.After
-import org.junit.Assert.assertArrayEquals
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Test
-import java.util.concurrent.atomic.AtomicInteger
+import java.io.File
 
 class CertificateBackendProvenanceTest {
-    private val rewriteCalls = AtomicInteger(0)
+    @Test
+    fun `StrongBox provenance is classified before issuer selection and cached as passthrough`() {
+        val source =
+            File(
+                locateRoot(),
+                "service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java",
+            ).readText()
+        val method = source.indexOf("public static Certificate[] hackCertificateChain")
+        val inspect = source.indexOf("inspection = CertificateBackend.inspect(leafEncoded)", method)
+        val attestationGate =
+            source.indexOf("inspection.getAttestationSecurityLevel() != CertificateBackend.SECURITY_LEVEL_TEE", inspect)
+        val keymintGate =
+            source.indexOf("inspection.getKeymintSecurityLevel() != CertificateBackend.SECURITY_LEVEL_TEE", attestationGate)
+        val passthrough = source.indexOf("CachedCertificateChain.passthrough()", keymintGate)
+        val issuerSelection = source.indexOf("selectKeyboxPool(", passthrough)
+        val rewrite = source.indexOf("CertificateBackend.rewrite(", issuerSelection)
 
-    @Before
-    fun setUp() {
-        CertificateBackend.resetForTesting()
-        rewriteCalls.set(0)
-        CertificateBackend.rewriteOverride = {
-            rewriteCalls.incrementAndGet()
-            byteArrayOf(0x30, 0x00)
-        }
-    }
-
-    @After
-    fun tearDown() {
-        CertificateBackend.resetForTesting()
+        assertTrue(method >= 0)
+        assertTrue(inspect > method)
+        assertTrue(attestationGate > inspect)
+        assertTrue(keymintGate > attestationGate)
+        assertTrue(passthrough > keymintGate)
+        assertTrue(issuerSelection > passthrough)
+        assertTrue(rewrite > issuerSelection)
     }
 
     @Test
-    fun `TEE source remains eligible for bounded replacement signing`() {
-        CertificateBackend.inspectionOverride = {
-            inspection(
-                CertificateBackend.SECURITY_LEVEL_TEE,
-                CertificateBackend.SECURITY_LEVEL_TEE,
-            )
-        }
+    fun `passthrough cache is marker only and adds no background execution`() {
+        val source =
+            File(
+                locateRoot(),
+                "service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java",
+            ).readText()
 
-        val rewritten = rewrite()
-
-        assertArrayEquals(byteArrayOf(0x30, 0x00), rewritten)
-        assertEquals(1, rewriteCalls.get())
+        assertTrue(source.contains("this.certificates = null"))
+        assertTrue(source.contains("if (passthrough) return;"))
+        assertTrue(source.contains("size() > MAX_CERTIFICATE_CACHE_ENTRIES"))
+        assertFalse(source.contains("ScheduledExecutor"))
+        assertFalse(source.contains("Timer("))
+        assertFalse(source.contains("Thread.sleep"))
+        assertFalse(source.contains("while (true)"))
     }
 
     @Test
-    fun `StrongBox source preserves genuine chain instead of cross signing`() {
-        CertificateBackend.inspectionOverride = {
-            inspection(
-                CertificateBackend.SECURITY_LEVEL_STRONGBOX,
-                CertificateBackend.SECURITY_LEVEL_STRONGBOX,
-            )
-        }
+    fun `certificate backend rewrite does not repeat provenance inspection`() {
+        val source =
+            File(
+                locateRoot(),
+                "service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt",
+            ).readText()
+        val rewrite = source.indexOf("fun rewrite(")
+        val decode = source.indexOf("internal fun decodeInspection", rewrite)
+        val body = source.substring(rewrite, decode)
 
-        assertNull(rewrite())
-        assertEquals(0, rewriteCalls.get())
+        assertFalse(body.contains("inspect(genuineLeafDer)"))
     }
 
-    @Test
-    fun `mixed attestation and KeyMint levels fail closed`() {
-        val combinations =
-            listOf(
-                CertificateBackend.SECURITY_LEVEL_TEE to CertificateBackend.SECURITY_LEVEL_STRONGBOX,
-                CertificateBackend.SECURITY_LEVEL_STRONGBOX to CertificateBackend.SECURITY_LEVEL_TEE,
-                CertificateBackend.SECURITY_LEVEL_SOFTWARE to CertificateBackend.SECURITY_LEVEL_TEE,
-            )
-        for ((attestation, keymint) in combinations) {
-            CertificateBackend.inspectionOverride = { inspection(attestation, keymint) }
-            assertNull(rewrite())
+    private fun locateRoot(): File {
+        var current = File(requireNotNull(System.getProperty("user.dir"))).canonicalFile
+        repeat(6) {
+            if (File(current, "service").isDirectory && File(current, "rust").isDirectory) return current
+            current = current.parentFile ?: return@repeat
         }
-        assertEquals(0, rewriteCalls.get())
+        error("Repository root not found")
     }
-
-    @Test
-    fun `provenance inspection boot digests are wiped after decision`() {
-        val key = ByteArray(32) { 0x41 }
-        val hash = ByteArray(32) { 0x42 }
-        CertificateBackend.inspectionOverride = {
-            inspection(
-                CertificateBackend.SECURITY_LEVEL_STRONGBOX,
-                CertificateBackend.SECURITY_LEVEL_STRONGBOX,
-                key,
-                hash,
-            )
-        }
-
-        assertNull(rewrite())
-        assertTrue(key.all { it == 0.toByte() })
-        assertTrue(hash.all { it == 0.toByte() })
-    }
-
-    private fun inspection(
-        attestationLevel: Int,
-        keymintLevel: Int,
-        bootKey: ByteArray? = null,
-        bootHash: ByteArray? = null,
-    ) =
-        CertificateBackend.Inspection(
-            systemPatch = null,
-            vendorPatch = null,
-            bootPatch = null,
-            presentIdMask = 0,
-            supportsModuleHash = false,
-            originalBootKey = bootKey,
-            originalBootHash = bootHash,
-            attestationSecurityLevel = attestationLevel,
-            keymintSecurityLevel = keymintLevel,
-        )
-
-    private fun rewrite(): ByteArray? =
-        CertificateBackend.rewrite(
-            genuineLeafDer = byteArrayOf(0x30, 0x00),
-            keyId = ByteArray(16) { 0x11 },
-            signingAlgorithm = CertificateBackend.SIGNING_EC_P256_SHA256,
-            systemDisposition = CertificateBackend.PATCH_KEEP,
-            systemValue = 0,
-            vendorDisposition = CertificateBackend.PATCH_KEEP,
-            vendorValue = 0,
-            bootDisposition = CertificateBackend.PATCH_KEEP,
-            bootValue = 0,
-            idOverrides = emptyMap(),
-            moduleHash = null,
-            verifiedBootKey = ByteArray(32) { 0x21 },
-            verifiedBootHash = ByteArray(32) { 0x31 },
-        )
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/CertificateBackendWireTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/CertificateBackendWireTest.kt
@@ -1,6 +1,5 @@
 package cleveres.tricky.cleverestech
 
-
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -12,8 +11,8 @@ import org.junit.Test
 class CertificateBackendWireTest {
     @Test
     fun `inspection response decodes strict fields and wipes transport bytes`() {
-        val response = ByteArray(83)
-        response[0] = 1
+        val response = ByteArray(85)
+        response[0] = 2
         response[1] = 0x07
         writeU16(response, 2, (1 shl 0) or (1 shl 4) or (1 shl 8))
         writeOptionalI32(response, 4, 20260105)
@@ -23,6 +22,8 @@ class CertificateBackendWireTest {
             response[19 + index] = (index + 1).toByte()
             response[51 + index] = (0x40 + index).toByte()
         }
+        response[83] = CertificateBackend.SECURITY_LEVEL_STRONGBOX.toByte()
+        response[84] = CertificateBackend.SECURITY_LEVEL_STRONGBOX.toByte()
 
         val inspection = CertificateBackend.decodeInspection(response)
 
@@ -31,6 +32,8 @@ class CertificateBackendWireTest {
         assertEquals(20260205, inspection.bootPatch)
         assertEquals((1 shl 0) or (1 shl 4) or (1 shl 8), inspection.presentIdMask)
         assertTrue(inspection.supportsModuleHash)
+        assertEquals(CertificateBackend.SECURITY_LEVEL_STRONGBOX, inspection.attestationSecurityLevel)
+        assertEquals(CertificateBackend.SECURITY_LEVEL_STRONGBOX, inspection.keymintSecurityLevel)
         assertArrayEquals(ByteArray(32) { (it + 1).toByte() }, inspection.originalBootKey)
         assertArrayEquals(ByteArray(32) { (0x40 + it).toByte() }, inspection.originalBootHash)
         assertTrue(response.all { it == 0.toByte() })
@@ -41,33 +44,46 @@ class CertificateBackendWireTest {
     }
 
     @Test
-    fun `reserved flags and noncanonical absent fields fail closed`() {
-        val reserved = ByteArray(83)
-        reserved[0] = 1
+    fun `reserved flags noncanonical fields and unknown levels fail closed`() {
+        val reserved = canonicalResponse()
         reserved[1] = 0x08
         assertThrows(RustBackendUnavailableException::class.java) {
             CertificateBackend.decodeInspection(reserved)
         }
         assertTrue(reserved.all { it == 0.toByte() })
 
-        val noncanonical = ByteArray(83)
-        noncanonical[0] = 1
+        val noncanonical = canonicalResponse()
         writeI32(noncanonical, 5, 1)
         assertThrows(RustBackendUnavailableException::class.java) {
             CertificateBackend.decodeInspection(noncanonical)
         }
         assertTrue(noncanonical.all { it == 0.toByte() })
+
+        val unknownLevel = canonicalResponse()
+        unknownLevel[83] = 3
+        assertThrows(RustBackendUnavailableException::class.java) {
+            CertificateBackend.decodeInspection(unknownLevel)
+        }
+        assertTrue(unknownLevel.all { it == 0.toByte() })
     }
 
     @Test
     fun `absent boot digests remain absent`() {
-        val response = ByteArray(83)
-        response[0] = 1
+        val response = canonicalResponse()
         val inspection = CertificateBackend.decodeInspection(response)
         assertFalse(inspection.supportsModuleHash)
         assertNull(inspection.originalBootKey)
         assertNull(inspection.originalBootHash)
+        assertEquals(CertificateBackend.SECURITY_LEVEL_TEE, inspection.attestationSecurityLevel)
+        assertEquals(CertificateBackend.SECURITY_LEVEL_TEE, inspection.keymintSecurityLevel)
     }
+
+    private fun canonicalResponse(): ByteArray =
+        ByteArray(85).also {
+            it[0] = 2
+            it[83] = CertificateBackend.SECURITY_LEVEL_TEE.toByte()
+            it[84] = CertificateBackend.SECURITY_LEVEL_TEE.toByte()
+        }
 
     private fun writeOptionalI32(
         bytes: ByteArray,

--- a/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
@@ -40,7 +40,7 @@ class GenerateKeyTimingFastPathTest {
     }
 
     @Test
-    fun `fresh attested generateKey performs exactly one provenance inspection before issuer selection`() {
+    fun `fresh attested generateKey performs exactly one dual provenance inspection before issuer selection`() {
         val root = locateRoot()
         val source =
             File(
@@ -54,17 +54,20 @@ class GenerateKeyTimingFastPathTest {
             source.indexOf("inspection = CertificateBackend.inspect(leafEncoded)", localExtensionGuard)
         val nextBackendInspect =
             source.indexOf("inspection = CertificateBackend.inspect(leafEncoded)", backendInspect + 1)
-        val provenanceGate =
+        val attestationGate =
             source.indexOf("inspection.getAttestationSecurityLevel()", backendInspect)
-        val issuerSelection = source.indexOf("selectKeyboxPool(", provenanceGate)
+        val keymintGate =
+            source.indexOf("inspection.getKeymintSecurityLevel()", attestationGate)
+        val issuerSelection = source.indexOf("selectKeyboxPool(", keymintGate)
         val backendRewrite = source.indexOf("byte[] rewrittenDer = CertificateBackend.rewrite", issuerSelection)
 
         assertTrue(method >= 0)
         assertTrue(localExtensionGuard > method)
         assertTrue(backendInspect > localExtensionGuard)
         assertTrue(nextBackendInspect < 0)
-        assertTrue(provenanceGate > backendInspect)
-        assertTrue(issuerSelection > provenanceGate)
+        assertTrue(attestationGate > backendInspect)
+        assertTrue(keymintGate > attestationGate)
+        assertTrue(issuerSelection > keymintGate)
         assertTrue(backendRewrite > issuerSelection)
     }
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
@@ -69,7 +69,7 @@ class GenerateKeyTimingFastPathTest {
     }
 
     @Test
-    fun `measured getKeyEntry serves encoded cache before X509 chain parsing`() {
+    fun `measured getKeyEntry serves encoded TEE cache before X509 chain parsing`() {
         val root = locateRoot()
         val source =
             File(
@@ -78,14 +78,22 @@ class GenerateKeyTimingFastPathTest {
             ).readText()
         val postTransact = source.indexOf("override fun onPostTransact")
         val responseRead = source.indexOf("val response = reply.readTypedObject", postTransact)
+        val metadataRead = source.indexOf("val metadata = response?.metadata", responseRead)
+        val levelGate =
+            source.indexOf(
+                "metadata.keySecurityLevel != SecurityLevel.TRUSTED_ENVIRONMENT",
+                metadataRead,
+            )
         val encodedCache =
-            source.indexOf("CertHack.applyCachedCertificateChain(response.metadata)", responseRead)
+            source.indexOf("CertHack.applyCachedCertificateChain(metadata)", levelGate)
         val chainRead =
             source.indexOf("val originalChain = Utils.getCertificateChain(response)", encodedCache)
 
         assertTrue(postTransact >= 0)
         assertTrue(responseRead > postTransact)
-        assertTrue(encodedCache > responseRead)
+        assertTrue(metadataRead > responseRead)
+        assertTrue(levelGate > metadataRead)
+        assertTrue(encodedCache > levelGate)
         assertTrue(chainRead > encodedCache)
     }
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
@@ -40,32 +40,32 @@ class GenerateKeyTimingFastPathTest {
     }
 
     @Test
-    fun `default attested generateKey does not require a Rust inspection round trip`() {
+    fun `fresh attested generateKey performs exactly one provenance inspection before issuer selection`() {
         val root = locateRoot()
         val source =
             File(
                 root,
                 "service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java",
             ).readText()
-        val featureGate =
-            source.indexOf("PolicyState.Feature.SECURITY_PATCH, uid")
-        val inspectionDecision =
-            source.indexOf("boolean needsInspection = needsCapturedPatchLevels", featureGate)
-        val conditionalInspection =
-            source.indexOf("if (needsInspection)", inspectionDecision)
+        val method = source.indexOf("public static Certificate[] hackCertificateChain")
+        val localExtensionGuard =
+            source.indexOf("!Utils.hasAndroidAttestationExtension(caList[0])", method)
         val backendInspect =
-            source.indexOf("inspection = CertificateBackend.inspect(leafEncoded)", conditionalInspection)
-        val configuredIds =
-            source.indexOf("? configuredIdOverrides(uid)", backendInspect)
-        val backendRewrite =
-            source.indexOf("byte[] rewrittenDer = CertificateBackend.rewrite", configuredIds)
+            source.indexOf("inspection = CertificateBackend.inspect(leafEncoded)", localExtensionGuard)
+        val nextBackendInspect =
+            source.indexOf("inspection = CertificateBackend.inspect(leafEncoded)", backendInspect + 1)
+        val provenanceGate =
+            source.indexOf("inspection.getAttestationSecurityLevel()", backendInspect)
+        val issuerSelection = source.indexOf("selectKeyboxPool(", provenanceGate)
+        val backendRewrite = source.indexOf("byte[] rewrittenDer = CertificateBackend.rewrite", issuerSelection)
 
-        assertTrue(featureGate >= 0)
-        assertTrue(inspectionDecision > featureGate)
-        assertTrue(conditionalInspection > inspectionDecision)
-        assertTrue(backendInspect > conditionalInspection)
-        assertTrue(configuredIds > backendInspect)
-        assertTrue(backendRewrite > configuredIds)
+        assertTrue(method >= 0)
+        assertTrue(localExtensionGuard > method)
+        assertTrue(backendInspect > localExtensionGuard)
+        assertTrue(nextBackendInspect < 0)
+        assertTrue(provenanceGate > backendInspect)
+        assertTrue(issuerSelection > provenanceGate)
+        assertTrue(backendRewrite > issuerSelection)
     }
 
     @Test
@@ -131,7 +131,7 @@ class GenerateKeyTimingFastPathTest {
         assertTrue(cacheLookup > method)
         assertTrue(localExtensionGuard > cacheLookup)
         assertTrue(backendInspect > localExtensionGuard)
-        assertTrue(backendRewrite > localExtensionGuard)
+        assertTrue(backendRewrite > backendInspect)
     }
 
     @Test

--- a/service/src/test/java/cleveres/tricky/cleverestech/KeystoreStrongBoxRedirectionTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/KeystoreStrongBoxRedirectionTest.kt
@@ -1,15 +1,15 @@
 package cleveres.tricky.cleverestech
 
 import android.system.keystore2.IKeystoreService
+import java.io.File
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import java.io.File
 
 class KeystoreStrongBoxRedirectionTest {
-
     @Before
     fun setUp() {
         Config.reset()
@@ -21,13 +21,13 @@ class KeystoreStrongBoxRedirectionTest {
     }
 
     @Test
-    fun `keystore interceptor declares getSecurityLevel and getKeyEntry codes`() {
+    fun `root keystore leaves getSecurityLevel transparent and intercepts only getKeyEntry`() {
         val source = sourceFile("KeystoreInterceptor.kt").readText()
 
-        assertTrue(source.contains("getSecurityLevelTransaction"))
+        assertFalse(source.contains("getSecurityLevelTransaction"))
         assertTrue(source.contains("getKeyEntryTransaction"))
-        assertTrue(source.contains("validTransactCodes"))
-        assertTrue(source.contains("getSecurityLevelTransaction, getKeyEntryTransaction"))
+        assertTrue(source.contains("validTransactCodes(getKeyEntryTransaction)"))
+        assertFalse(source.contains("SecurityLevel.STRONGBOX"))
     }
 
     @Test

--- a/service/src/test/java/cleveres/tricky/cleverestech/ManagedCertificateBackendOracle.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ManagedCertificateBackendOracle.kt
@@ -43,6 +43,8 @@ object ManagedCertificateBackendOracle {
             val sequence = ASN1Sequence.getInstance(extension.extnValue.octets)
             val fields = sequence.toArray()
             require(fields.size > 7)
+            val attestationSecurityLevel = decodeSecurityLevel(fields[1])
+            val keymintSecurityLevel = decodeSecurityLevel(fields[3])
             val listSix = ASN1Sequence.getInstance(fields[6])
             val listSeven = ASN1Sequence.getInstance(fields[7])
             val sixSummary = summarize(listSix)
@@ -69,6 +71,8 @@ object ManagedCertificateBackendOracle {
                         ASN1Integer.getInstance(fields[2]).value.intValueExact() >= 400,
                 originalBootKey = root?.let { usableDigest(it.getObjectAt(0)) },
                 originalBootHash = root?.let { usableDigest(it.getObjectAt(3)) },
+                attestationSecurityLevel = attestationSecurityLevel,
+                keymintSecurityLevel = keymintSecurityLevel,
             )
         }.getOrNull()
 
@@ -81,6 +85,8 @@ object ManagedCertificateBackendOracle {
             val sequence = ASN1Sequence.getInstance(extension.extnValue.octets)
             val fields = sequence.toArray()
             require(fields.size > 7)
+            require(decodeSecurityLevel(fields[1]) == CertificateBackend.SECURITY_LEVEL_TEE)
+            require(decodeSecurityLevel(fields[3]) == CertificateBackend.SECURITY_LEVEL_TEE)
             val listSix = ASN1Sequence.getInstance(fields[6])
             val listSeven = ASN1Sequence.getInstance(fields[7])
             val sixSummary = summarize(listSix)
@@ -205,6 +211,12 @@ object ManagedCertificateBackendOracle {
             val signer = JcaContentSignerBuilder(signatureAlgorithm).build(keyMaterial.privateKey)
             builder.build(signer).encoded
         }.getOrNull()
+
+    private fun decodeSecurityLevel(field: ASN1Encodable): Int {
+        val value = ASN1Enumerated.getInstance(field).value.intValueExact()
+        require(value in CertificateBackend.SECURITY_LEVEL_SOFTWARE..CertificateBackend.SECURITY_LEVEL_STRONGBOX)
+        return value
+    }
 
     private fun shouldRemovePatch(
         tag: Int,

--- a/service/src/test/java/cleveres/tricky/cleverestech/StrongBoxBinderRoutingTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/StrongBoxBinderRoutingTest.kt
@@ -31,6 +31,27 @@ class StrongBoxBinderRoutingTest {
     }
 
     @Test
+    fun `non TEE getKeyEntry exits before cache hashing or certificate parsing`() {
+        val source = source("KeystoreInterceptor.kt")
+        val metadataRead = source.indexOf("val metadata = response?.metadata")
+        val levelGate =
+            source.indexOf(
+                "metadata.keySecurityLevel != SecurityLevel.TRUSTED_ENVIRONMENT",
+                metadataRead,
+            )
+        val cacheLookup = source.indexOf("CertHack.applyCachedCertificateChain(metadata)", levelGate)
+        val chainRead = source.indexOf("val originalChain = Utils.getCertificateChain(response)", cacheLookup)
+        val gateBody = source.substring(levelGate, cacheLookup)
+
+        assertTrue(metadataRead >= 0)
+        assertTrue(levelGate > metadataRead)
+        assertTrue(cacheLookup > levelGate)
+        assertTrue(chainRead > cacheLookup)
+        assertTrue(gateBody.contains("p.recycle()"))
+        assertTrue(gateBody.contains("return Skip"))
+    }
+
+    @Test
     fun `security level interceptor is used only for TEE generateKey`() {
         val keystore = source("KeystoreInterceptor.kt")
         val interceptor = source("SecurityLevelInterceptor.kt")

--- a/service/src/test/java/cleveres/tricky/cleverestech/StrongBoxBinderRoutingTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/StrongBoxBinderRoutingTest.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 class StrongBoxBinderRoutingTest {
     @Test
     fun `root keystore interceptor never remaps StrongBox to TEE`() {
-        val source = keystoreInterceptorSource()
+        val source = source("KeystoreInterceptor.kt")
 
         assertFalse(source.contains("getSecurityLevelTransaction"))
         assertFalse(source.contains("returned == strongBoxTarget"))
@@ -17,23 +17,45 @@ class StrongBoxBinderRoutingTest {
     }
 
     @Test
-    fun `real StrongBox child binder remains independently intercepted`() {
-        val source = keystoreInterceptorSource()
+    fun `real StrongBox child binder is registered with generic replacement disabled`() {
+        val source = source("KeystoreInterceptor.kt")
         val strongBoxLookup = source.indexOf("ks.getSecurityLevel(SecurityLevel.STRONGBOX)")
+        val transparentInterceptor =
+            source.indexOf(
+                "SecurityLevelInterceptor(allowGenericReplacement = false)",
+                strongBoxLookup,
+            )
         val strongBoxRegistration =
-            source.indexOf("strongBox.asBinder(),", strongBoxLookup)
+            source.indexOf("strongBox.asBinder(),", transparentInterceptor)
         val strongBoxTargetCapture =
             source.indexOf("strongBoxTarget = strongBox.asBinder()", strongBoxRegistration)
 
         assertTrue(strongBoxLookup >= 0)
-        assertTrue(strongBoxRegistration > strongBoxLookup)
+        assertTrue(transparentInterceptor > strongBoxLookup)
+        assertTrue(strongBoxRegistration > transparentInterceptor)
         assertTrue(strongBoxTargetCapture > strongBoxRegistration)
     }
 
-    private fun keystoreInterceptorSource(): String =
+    @Test
+    fun `security level interceptor gates generateKey before policy and backend work`() {
+        val source = source("SecurityLevelInterceptor.kt")
+        val preTransact = source.indexOf("override fun onPreTransact")
+        val replacementGate = source.indexOf("allowGenericReplacement &&", preTransact)
+        val generateKeyGate = source.indexOf("code == generateKeyTransaction", replacementGate)
+        val backendGate = source.indexOf("CertHack.canHack()", generateKeyGate)
+        val policyGate = source.indexOf("Config.needHack(callingUid)", backendGate)
+
+        assertTrue(preTransact >= 0)
+        assertTrue(replacementGate > preTransact)
+        assertTrue(generateKeyGate > replacementGate)
+        assertTrue(backendGate > generateKeyGate)
+        assertTrue(policyGate > backendGate)
+    }
+
+    private fun source(name: String): String =
         File(
             locateRoot(),
-            "service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt",
+            "service/src/main/java/cleveres/tricky/cleverestech/$name",
         ).readText()
 
     private fun locateRoot(): File {

--- a/service/src/test/java/cleveres/tricky/cleverestech/StrongBoxBinderRoutingTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/StrongBoxBinderRoutingTest.kt
@@ -1,0 +1,47 @@
+package cleveres.tricky.cleverestech
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StrongBoxBinderRoutingTest {
+    @Test
+    fun `root keystore interceptor never remaps StrongBox to TEE`() {
+        val source = keystoreInterceptorSource()
+
+        assertFalse(source.contains("getSecurityLevelTransaction"))
+        assertFalse(source.contains("returned == strongBoxTarget"))
+        assertFalse(source.contains("writeStrongBinder(currentTeeTarget)"))
+        assertTrue(source.contains("validTransactCodes(getKeyEntryTransaction)"))
+    }
+
+    @Test
+    fun `real StrongBox child binder remains independently intercepted`() {
+        val source = keystoreInterceptorSource()
+        val strongBoxLookup = source.indexOf("ks.getSecurityLevel(SecurityLevel.STRONGBOX)")
+        val strongBoxRegistration =
+            source.indexOf("strongBox.asBinder(),", strongBoxLookup)
+        val strongBoxTargetCapture =
+            source.indexOf("strongBoxTarget = strongBox.asBinder()", strongBoxRegistration)
+
+        assertTrue(strongBoxLookup >= 0)
+        assertTrue(strongBoxRegistration > strongBoxLookup)
+        assertTrue(strongBoxTargetCapture > strongBoxRegistration)
+    }
+
+    private fun keystoreInterceptorSource(): String =
+        File(
+            locateRoot(),
+            "service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt",
+        ).readText()
+
+    private fun locateRoot(): File {
+        var current = File(requireNotNull(System.getProperty("user.dir"))).canonicalFile
+        repeat(6) {
+            if (File(current, "service").isDirectory && File(current, "rust").isDirectory) return current
+            current = current.parentFile ?: return@repeat
+        }
+        error("Repository root not found")
+    }
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/StrongBoxBinderRoutingTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/StrongBoxBinderRoutingTest.kt
@@ -17,39 +17,34 @@ class StrongBoxBinderRoutingTest {
     }
 
     @Test
-    fun `real StrongBox child binder is registered with generic replacement disabled`() {
+    fun `StrongBox child binder remains completely unhooked`() {
         val source = source("KeystoreInterceptor.kt")
-        val strongBoxLookup = source.indexOf("ks.getSecurityLevel(SecurityLevel.STRONGBOX)")
-        val transparentInterceptor =
-            source.indexOf(
-                "SecurityLevelInterceptor(allowGenericReplacement = false)",
-                strongBoxLookup,
-            )
-        val strongBoxRegistration =
-            source.indexOf("strongBox.asBinder(),", transparentInterceptor)
-        val strongBoxTargetCapture =
-            source.indexOf("strongBoxTarget = strongBox.asBinder()", strongBoxRegistration)
+        val teeLookup = source.indexOf("ks.getSecurityLevel(SecurityLevel.TRUSTED_ENVIRONMENT)")
+        val teeRegistration = source.indexOf("tee.asBinder(),", teeLookup)
 
-        assertTrue(strongBoxLookup >= 0)
-        assertTrue(transparentInterceptor > strongBoxLookup)
-        assertTrue(strongBoxRegistration > transparentInterceptor)
-        assertTrue(strongBoxTargetCapture > strongBoxRegistration)
+        assertTrue(teeLookup >= 0)
+        assertTrue(teeRegistration > teeLookup)
+        assertFalse(source.contains("SecurityLevel.STRONGBOX"))
+        assertFalse(source.contains("strongBox.asBinder()"))
+        assertFalse(source.contains("strongBoxInterceptor"))
+        assertFalse(source.contains("strongBoxTarget"))
     }
 
     @Test
-    fun `security level interceptor gates generateKey before policy and backend work`() {
-        val source = source("SecurityLevelInterceptor.kt")
-        val preTransact = source.indexOf("override fun onPreTransact")
-        val replacementGate = source.indexOf("allowGenericReplacement &&", preTransact)
-        val generateKeyGate = source.indexOf("code == generateKeyTransaction", replacementGate)
-        val backendGate = source.indexOf("CertHack.canHack()", generateKeyGate)
-        val policyGate = source.indexOf("Config.needHack(callingUid)", backendGate)
+    fun `security level interceptor is used only for TEE generateKey`() {
+        val keystore = source("KeystoreInterceptor.kt")
+        val interceptor = source("SecurityLevelInterceptor.kt")
+        val teeLookup = keystore.indexOf("ks.getSecurityLevel(SecurityLevel.TRUSTED_ENVIRONMENT)")
+        val interceptorCreation = keystore.indexOf("SecurityLevelInterceptor()", teeLookup)
+        val generateKeyGate = interceptor.indexOf("code == generateKeyTransaction")
+        val backendGate = interceptor.indexOf("CertHack.canHack()", generateKeyGate)
+        val policyGate = interceptor.indexOf("Config.needHack(callingUid)", backendGate)
 
-        assertTrue(preTransact >= 0)
-        assertTrue(replacementGate > preTransact)
-        assertTrue(generateKeyGate > replacementGate)
+        assertTrue(interceptorCreation > teeLookup)
+        assertTrue(generateKeyGate >= 0)
         assertTrue(backendGate > generateKeyGate)
         assertTrue(policyGate > backendGate)
+        assertFalse(interceptor.contains("allowGenericReplacement"))
     }
 
     private fun source(name: String): String =


### PR DESCRIPTION
## Problem

#1194 stopped the DER rewrite from flattening Android SecurityLevel values, but two separate provenance breaks remained:

1. The root Keystore interceptor could replace a returned **StrongBox** `IKeystoreSecurityLevel` binder with the **TEE** binder before `generateKey` ran.
2. The replacement-certificate path could re-sign a genuine non-TEE/StrongBox attestation leaf with a generic EC/RSA keybox issuer chain whose hardware provenance was not proven compatible.

Either path can produce the failure class seen by StrongBox/attestation detectors: StrongBox requested, but TEE-level material or an incompatible AttestKey graph is observed.

## Root fix

The current implementation removes both provenance breaks instead of trying to synthesize a StrongBox-looking chain:

- The root `IKeystoreService` hook no longer intercepts `getSecurityLevel`; it only intercepts `getKeyEntry` for TEE certificate compatibility/readback.
- The module no longer acquires or registers a child interceptor on the StrongBox binder. StrongBox binder identity, `generateKey` traffic and the genuine StrongBox certificate chain therefore stay platform-owned.
- Only the genuine TEE child binder receives `SecurityLevelInterceptor`.
- `getKeyEntry` checks the platform `KeyMetadata.keySecurityLevel` immediately after decoding metadata. Anything other than `TRUSTED_ENVIRONMENT` exits unchanged **before** certificate-cache hashing, X.509 parsing or Rust certificate IPC. This keeps StrongBox/software reads off the replacement path even on a first uncached read.
- Rust parses both Android `attestationSecurityLevel` and `keyMintSecurityLevel` from the genuine KeyDescription and accepts only canonical Software=0, TEE=1, StrongBox=2 encodings. Unknown/malformed values fail closed.
- Certificate inspection wire v2 carries both levels to the JVM; the JVM validates them before copying boot-digest material.
- Generic keybox replacement is eligible only when the genuine source is unambiguously **TEE/TEE**. StrongBox, Software and mixed TEE↔StrongBox sources preserve the genuine chain.
- The Rust rewrite boundary independently reinspects the genuine leaf and rejects non-TEE provenance before an opaque replacement issuer can be used.
- The host-JVM managed certificate oracle now mirrors the same security-level parsing and TEE-only rewrite rule, preventing tests from silently exercising a weaker policy than production.

## CPU / RAM policy

This change adds no watcher, timer, polling loop, coroutine, thread or recurring task.

- StrongBox `generateKey` is not intercepted at all.
- StrongBox/software `getKeyEntry` exits on the scalar platform security-level field before certificate-cache hashing, X.509 parsing or Rust IPC.
- Non-attested TEE leaves still exit locally before certificate-backend IPC.
- A fresh attested TEE cache miss performs one managed provenance inspection; the Rust rewrite boundary performs a second bounded provenance check only immediately before an actual replacement signature.
- Marker-only passthrough remains a defense-in-depth cache result for anomalous non-TEE provenance that reaches `CertHack`; it retains no replacement certificate/chain arrays and the cache remains bounded to 64 entries.
- Existing raw `KeyMetadata` cache handling remains the repeat-read fast path for eligible TEE replacements. No unbounded queue or collection was introduced.

## Secret / failure handling

- Rust certificate request buffers are zeroized after processing.
- JVM inspection transport buffers are wiped after decode.
- If inspection decoding fails after a boot digest was copied, the partial digest is wiped before the exception propagates.
- Opaque key identifiers continue to be wiped after use.
- Malformed, unknown, mixed or non-TEE provenance never falls back to generic cross-signing.
- Unknown/noncanonical platform `keySecurityLevel` values fail closed by taking the unchanged passthrough path.

## Regression coverage

- Wire v2 TEE/StrongBox decode and invalid-level rejection.
- Rust inspection reports fixture TEE/TEE provenance.
- Managed provenance classification occurs before issuer selection.
- Rust independently enforces TEE/TEE before `with_prepared_key` issuer access.
- Managed host-test oracle parses both security levels and refuses non-TEE rewrites.
- Root Keystore interception must not include `getSecurityLevel`.
- StrongBox binder acquisition/registration symbols are forbidden; only TEE child interception is allowed.
- Non-TEE `getKeyEntry` must exit before cache hashing, certificate parsing and certificate-backend work.
- Passthrough cache remains marker-only, bounded and free of background execution constructs.
- Fresh attested TEE `generateKey` performs exactly one managed provenance inspection; cached reads keep the raw-byte fast path.

## Current head

`d00fd9430539ee400372d4b008c285ac29ccdccb`

Full exact-head CI and CodeRabbit review are required before this PR is considered merge-ready. PR remains open and unmerged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security and Compatibility**
  * Certificate inspection now reports attestation and KeyMint security levels.
  * Certificates with unsupported, malformed, or non-TEE security metadata are rejected during rewriting.
  * Inspection responses use an updated protocol format with stronger validation.

* **Certificate Handling**
  * Fresh attested certificates are inspected before issuer selection and rewriting.
  * Valid cached passthrough certificates can be reused without repeated processing.
  * TEE certificate compatibility handling is more consistent across key generation and retrieval.

* **Behavior Changes**
  * StrongBox certificate operations are no longer intercepted; interception is limited to TEE-backed operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->