### PR TITLE
fix(keystore): restore unified attestation rewrite and eliminate RootOfTrust divergence

### DIFF
--- a/rust/attestation-core/tests/boot_digest.rs
+++ b/rust/attestation-core/tests/boot_digest.rs
@@ -1,7 +1,7 @@
 // Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
 use cleverestricky_attestation_core::{rewrite_extension, PatchLevels, RewriteRequest};
 use der::asn1::Any;
-use der::{Encode, Tag};
+use der::{Decode, Encode, Tag, Tagged};
 
 #[test]
 fn rejects_zero_verified_boot_material() {
@@ -23,6 +23,79 @@ fn rejects_zero_verified_boot_material() {
             "zero verified boot material must fail closed",
         );
     }
+}
+
+const ROOT_OF_TRUST_TAG: u32 = 704;
+
+#[test]
+fn rewrites_unlocked_root_of_trust_to_locked_and_verified_state() {
+    let raw_key = [0x33u8; 32];
+    let raw_hash = [0x44u8; 32];
+    let expected_boot_key = [0x11u8; 32];
+    let expected_boot_hash = [0x22u8; 32];
+
+    // Genuine hardware RootOfTrust: deviceLocked = false (unlocked), verifiedBootState = 2 (Unverified)
+    let unlocked_root = sequence([
+        Any::new(Tag::OctetString, raw_key.to_vec())
+            .unwrap()
+            .to_der()
+            .unwrap(),
+        false.to_der().unwrap(),
+        Any::new(Tag::Enumerated, vec![2])
+            .unwrap()
+            .to_der()
+            .unwrap(),
+        Any::new(Tag::OctetString, raw_hash.to_vec())
+            .unwrap()
+            .to_der()
+            .unwrap(),
+    ]);
+    let tee = sequence([explicit_tag(ROOT_OF_TRUST_TAG, &unlocked_root)]);
+    let software = sequence([]);
+    let extension = sequence([
+        400i32.to_der().unwrap(),
+        Any::new(Tag::Enumerated, vec![1])
+            .unwrap()
+            .to_der()
+            .unwrap(),
+        400i32.to_der().unwrap(),
+        Any::new(Tag::Enumerated, vec![1])
+            .unwrap()
+            .to_der()
+            .unwrap(),
+        Any::new(Tag::OctetString, Vec::<u8>::new())
+            .unwrap()
+            .to_der()
+            .unwrap(),
+        Any::new(Tag::OctetString, Vec::<u8>::new())
+            .unwrap()
+            .to_der()
+            .unwrap(),
+        software,
+        tee,
+    ]);
+
+    let result = rewrite_extension(&RewriteRequest {
+        extension_der: &extension,
+        patch_levels: PatchLevels::default(),
+        id_overrides: &[],
+        module_hash: None,
+        verified_boot_key: &expected_boot_key,
+        verified_boot_hash: &expected_boot_hash,
+    })
+    .expect("rewrite_extension must succeed");
+
+    let (key, locked, state, hash) = extract_root_of_trust(&result.extension_der);
+    assert!(locked, "deviceLocked must be forced to true (locked)");
+    assert_eq!(state, 0, "verifiedBootState must be forced to 0 (Verified)");
+    assert_eq!(
+        key, expected_boot_key,
+        "verifiedBootKey must match spoofed key"
+    );
+    assert_eq!(
+        hash, expected_boot_hash,
+        "verifiedBootHash must match ro.boot.vbmeta.digest"
+    );
 }
 
 fn key_description() -> Vec<u8> {
@@ -56,4 +129,56 @@ fn sequence<const N: usize>(fields: [Vec<u8>; N]) -> Vec<u8> {
         value.extend_from_slice(&field);
     }
     Any::new(Tag::Sequence, value).unwrap().to_der().unwrap()
+}
+
+fn explicit_tag(tag: u32, inner: &[u8]) -> Vec<u8> {
+    Any::new(
+        Tag::ContextSpecific {
+            constructed: true,
+            number: der::TagNumber(tag),
+        },
+        inner.to_vec(),
+    )
+    .unwrap()
+    .to_der()
+    .unwrap()
+}
+
+fn split(mut bytes: &[u8]) -> Result<Vec<Vec<u8>>, der::Error> {
+    let mut out = Vec::new();
+    while !bytes.is_empty() {
+        let (_, rest) = der::asn1::AnyRef::from_der_partial(bytes)?;
+        let used = bytes.len() - rest.len();
+        out.push(bytes[..used].to_vec());
+        bytes = rest;
+    }
+    Ok(out)
+}
+
+fn extract_root_of_trust(extension_der: &[u8]) -> ([u8; 32], bool, u8, [u8; 32]) {
+    use der::Decode;
+    let outer = Any::from_der(extension_der).expect("KeyDescription DER");
+    let fields = split(outer.value()).expect("KeyDescription fields");
+    let tee = split(Any::from_der(&fields[7]).expect("tee DER").value()).expect("tee fields");
+    for field in tee {
+        let tagged = Any::from_der(&field).expect("tagged field");
+        if tagged.tag()
+            == (Tag::ContextSpecific {
+                constructed: true,
+                number: der::TagNumber(ROOT_OF_TRUST_TAG),
+            })
+        {
+            let root_seq = Any::from_der(tagged.value()).expect("root seq");
+            let root_fields = split(root_seq.value()).expect("root fields");
+            let key_any = Any::from_der(&root_fields[0]).expect("key");
+            let key: [u8; 32] = key_any.value().try_into().expect("32 byte key");
+            let locked = root_fields[1] == true.to_der().unwrap();
+            let state_any = Any::from_der(&root_fields[2]).expect("state");
+            let state = state_any.value()[0];
+            let hash_any = Any::from_der(&root_fields[3]).expect("hash");
+            let hash: [u8; 32] = hash_any.value().try_into().expect("32 byte hash");
+            return (key, locked, state, hash);
+        }
+    }
+    panic!("ROOT_OF_TRUST_TAG not found");
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -32,15 +32,12 @@ class SecurityLevelInterceptor : BinderInterceptor() {
         callingPid: Int,
         data: Parcel,
     ): Result {
-        if (code == generateKeyTransaction) {
-            // Caller-selected AttestKeys (!usesDefaultAttestationKey) must execute natively on hardware KeyMint.
-            if (!Utils.usesDefaultAttestationKey(data)) {
-                return Continue
-            }
-
-            if (CertHack.canHack() && Config.needHack(callingUid)) {
-                return Continue
-            }
+        if (
+            code == generateKeyTransaction &&
+            CertHack.canHack() &&
+            Config.needHack(callingUid)
+        ) {
+            return Continue
         }
 
         return Skip
@@ -64,13 +61,6 @@ class SecurityLevelInterceptor : BinderInterceptor() {
             reply == null ||
             resultCode != 0
         ) {
-            return Skip
-        }
-
-        // Caller-selected AttestKeys (!usesDefaultAttestationKey) must never be rewritten with a
-        // generic keybox chain. Preserving the genuine hardware-signed child certificate preserves
-        // its cryptographic parent-child relationship untouched.
-        if (!Utils.usesDefaultAttestationKey(data)) {
             return Skip
         }
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -32,15 +32,15 @@ class SecurityLevelInterceptor : BinderInterceptor() {
         callingPid: Int,
         data: Parcel,
     ): Result {
-        if (
-            code == generateKeyTransaction &&
-            CertHack.canHack() &&
-            Config.needHack(callingUid)
-        ) {
-            // Both default attestation and caller-selected AttestKey continue to hardware.
-            // Hardware executes the key generation natively without custom exception replies
-            // or parcel byte mutation.
-            return Continue
+        if (code == generateKeyTransaction) {
+            // Caller-selected AttestKeys (!usesDefaultAttestationKey) must execute natively on hardware KeyMint.
+            if (!Utils.usesDefaultAttestationKey(data)) {
+                return Continue
+            }
+
+            if (CertHack.canHack() && Config.needHack(callingUid)) {
+                return Continue
+            }
         }
 
         return Skip

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationInterceptorContractTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationInterceptorContractTest.java
@@ -71,8 +71,8 @@ public class AttestationInterceptorContractTest {
             assertSame(BinderInterceptor.Skip.INSTANCE, postResult);
             childCert.verify(parent.getPublic());
 
-            backend.verify(CertHack::canHack);
-            backend.verifyNoMoreInteractions();
+            backend.verify(() -> CertHack.hackCertificateChain(any(), anyInt(), anyBoolean()), never());
+            backend.verifyNoInteractions();
         } finally {
             globalModeField.set(Config.INSTANCE, prevGlobalMode);
         }
@@ -103,11 +103,25 @@ public class AttestationInterceptorContractTest {
                         target, code, 0, 10_001, 42, explicitRequest);
                 assertSame(BinderInterceptor.Continue.INSTANCE, explicitResult);
 
-                backend.verify(CertHack::canHack, org.mockito.Mockito.times(2));
+                backend.verify(CertHack::canHack, org.mockito.Mockito.times(1));
                 backend.verify(() -> CertHack.hackCertificateChain(any(), anyInt(), anyBoolean()), never());
             }
         } finally {
             globalModeField.set(Config.INSTANCE, prevGlobalMode);
+        }
+    }
+
+    @Test
+    public void callerSelectedAttestKeyContinuesEvenWhenCertHackCannotHack() throws Exception {
+        Binder target = new Binder();
+        int code = field(SecurityLevelInterceptor.class, "generateKeyTransaction").getInt(null);
+        Parcel explicitRequest = AttestationRequestContractTest.request(true);
+        try (MockedStatic<CertHack> backend = mockStatic(CertHack.class)) {
+            backend.when(CertHack::canHack).thenReturn(false);
+            BinderInterceptor.Result result = new SecurityLevelInterceptor().onPreTransact(
+                    target, code, 0, 10_001, 42, explicitRequest);
+            assertSame(BinderInterceptor.Continue.INSTANCE, result);
+            backend.verify(CertHack::canHack, never());
         }
     }
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationInterceptorContractTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationInterceptorContractTest.java
@@ -47,81 +47,60 @@ import static org.mockito.Mockito.when;
 
 public class AttestationInterceptorContractTest {
     @Test
-    public void callerSelectedAttestKeyContinuesPreTransactAndSkipsPostTransact() throws Exception {
+    public void attestedKeyGenerationUniformlyRewritesAcrossDefaultAndCustomAttestKey() throws Exception {
         Binder target = new Binder();
         int code = field(SecurityLevelInterceptor.class, "generateKeyTransaction").getInt(null);
-        Parcel request = AttestationRequestContractTest.request(true);
         Field globalModeField = field(Config.class, "isGlobalMode");
         boolean prevGlobalMode = (boolean) globalModeField.get(Config.INSTANCE);
         globalModeField.set(Config.INSTANCE, true);
         Config.INSTANCE.setPackagesForTesting(10_001, new String[] {"com.test.app"});
         try (MockedStatic<CertHack> backend = mockStatic(CertHack.class)) {
             backend.when(CertHack::canHack).thenReturn(true);
-            BinderInterceptor.Result result = new SecurityLevelInterceptor().onPreTransact(
-                    target, code, 0, 10_001, 42, request);
-            assertSame(BinderInterceptor.Continue.INSTANCE, result);
+            backend.when(() -> CertHack.applyCachedCertificateChain(any())).thenReturn(false);
 
-            // In onPostTransact, explicit AttestKey requests return Skip, preserving genuine hardware child cert
             KeyPair parent = keyPair("EC");
             KeyPair childKey = keyPair("EC");
             X509Certificate childCert = certificate(childKey, parent, "child", "parent");
             KeyMetadata metadata = metadata(childCert, childCert.getEncoded());
-            Parcel reply = generatedReply(metadata);
+            X509Certificate replacementCert = certificate(childKey, parent, "replacement", "parent");
+            Certificate[] rewrittenChain = new Certificate[] {replacementCert};
+            backend.when(() -> CertHack.hackCertificateChain(any(), anyInt(), anyBoolean()))
+                    .thenReturn(rewrittenChain);
+
+            // Test both default RKP request (false) and custom AttestKey request (true)
+            for (boolean explicitAttestKey : new boolean[] {false, true}) {
+                Parcel request = AttestationRequestContractTest.request(explicitAttestKey);
+                BinderInterceptor.Result preResult = new SecurityLevelInterceptor().onPreTransact(
+                        target, code, 0, 10_001, 42, request);
+                assertSame(BinderInterceptor.Continue.INSTANCE, preResult);
+
+                Parcel reply = generatedReply(metadata);
+                BinderInterceptor.Result postResult = generate(request, reply);
+                assertTrue("Attested key (explicitAttestKey=" + explicitAttestKey + ") must receive OverrideReply",
+                        postResult instanceof BinderInterceptor.OverrideReply);
+            }
+
+            backend.verify(CertHack::canHack, org.mockito.Mockito.times(2));
+            backend.verify(() -> CertHack.hackCertificateChain(any(), anyInt(), anyBoolean()),
+                    org.mockito.Mockito.times(2));
+        } finally {
+            globalModeField.set(Config.INSTANCE, prevGlobalMode);
+        }
+    }
+
+    @Test
+    public void nonAttestedKeysBypassCertHackRewrite() throws Exception {
+        KeyPair c = keyPair("EC");
+        X509Certificate ordinary = certificate(c, c, "ordinary", "ordinary", false);
+        KeyMetadata metadata = metadata(ordinary, new byte[0]);
+        Parcel request = AttestationRequestContractTest.request(false);
+        Parcel reply = generatedReply(metadata);
+
+        try (MockedStatic<CertHack> backend = mockStatic(CertHack.class)) {
+            backend.when(CertHack::canHack).thenReturn(true);
             BinderInterceptor.Result postResult = generate(request, reply);
             assertSame(BinderInterceptor.Skip.INSTANCE, postResult);
-            childCert.verify(parent.getPublic());
-
             backend.verify(() -> CertHack.hackCertificateChain(any(), anyInt(), anyBoolean()), never());
-            backend.verifyNoInteractions();
-        } finally {
-            globalModeField.set(Config.INSTANCE, prevGlobalMode);
-        }
-        verify(request, org.mockito.Mockito.atLeastOnce()).setDataPosition(28);
-    }
-
-    @Test
-    public void generateKeyPermitsExplicitAttestKeyNativelyAndContinuesDefault() throws Exception {
-        Binder target = new Binder();
-        Field globalModeField = field(Config.class, "isGlobalMode");
-        boolean prevGlobalMode = (boolean) globalModeField.get(Config.INSTANCE);
-        globalModeField.set(Config.INSTANCE, true);
-        Config.INSTANCE.setPackagesForTesting(10_001, new String[] {"com.test.app"});
-        try {
-            int code = field(SecurityLevelInterceptor.class, "generateKeyTransaction").getInt(null);
-            try (MockedStatic<CertHack> backend = mockStatic(CertHack.class)) {
-                backend.when(CertHack::canHack).thenReturn(true);
-
-                // Default request returns Continue natively
-                Parcel defaultRequest = AttestationRequestContractTest.request(false);
-                BinderInterceptor.Result defaultResult = new SecurityLevelInterceptor().onPreTransact(
-                        target, code, 0, 10_001, 42, defaultRequest);
-                assertSame(BinderInterceptor.Continue.INSTANCE, defaultResult);
-
-                // Explicit attest key requests also return Continue natively to let hardware execute
-                Parcel explicitRequest = AttestationRequestContractTest.request(true);
-                BinderInterceptor.Result explicitResult = new SecurityLevelInterceptor().onPreTransact(
-                        target, code, 0, 10_001, 42, explicitRequest);
-                assertSame(BinderInterceptor.Continue.INSTANCE, explicitResult);
-
-                backend.verify(CertHack::canHack, org.mockito.Mockito.times(1));
-                backend.verify(() -> CertHack.hackCertificateChain(any(), anyInt(), anyBoolean()), never());
-            }
-        } finally {
-            globalModeField.set(Config.INSTANCE, prevGlobalMode);
-        }
-    }
-
-    @Test
-    public void callerSelectedAttestKeyContinuesEvenWhenCertHackCannotHack() throws Exception {
-        Binder target = new Binder();
-        int code = field(SecurityLevelInterceptor.class, "generateKeyTransaction").getInt(null);
-        Parcel explicitRequest = AttestationRequestContractTest.request(true);
-        try (MockedStatic<CertHack> backend = mockStatic(CertHack.class)) {
-            backend.when(CertHack::canHack).thenReturn(false);
-            BinderInterceptor.Result result = new SecurityLevelInterceptor().onPreTransact(
-                    target, code, 0, 10_001, 42, explicitRequest);
-            assertSame(BinderInterceptor.Continue.INSTANCE, result);
-            backend.verify(CertHack::canHack, never());
         }
     }
 
@@ -219,13 +198,14 @@ public class AttestationInterceptorContractTest {
                         assertSame(BinderInterceptor.Skip.INSTANCE,
                                 generate(AttestationRequestContractTest.request(false), generatedReply(metadata)));
                     } else {
-                        // Caller-selected AttestKey children continue in pre-transact and skip in post-transact
+                        // Attested keys (including custom AttestKey children) uniformly rewrite in post-transact
                         int code = field(SecurityLevelInterceptor.class, "generateKeyTransaction").getInt(null);
                         BinderInterceptor.Result preResult = new SecurityLevelInterceptor().onPreTransact(
                                 target, code, 0, 10_001, 42, AttestationRequestContractTest.request(true));
                         assertSame(BinderInterceptor.Continue.INSTANCE, preResult);
-                        assertSame(BinderInterceptor.Skip.INSTANCE,
-                                generate(AttestationRequestContractTest.request(true), generatedReply(metadata)));
+                        assertTrue(
+                                generate(AttestationRequestContractTest.request(true), generatedReply(metadata))
+                                        instanceof BinderInterceptor.OverrideReply);
                     }
 
                     for (int read = 0; read < 320; read++) {


### PR DESCRIPTION
## Summary of Changes

This PR restores unified attestation certificate rewriting across all key generation requests (both default attestation and caller-selected AttestKey paths), eliminating RootOfTrust divergence across key generation paths while maintaining strict RootOfTrust spoofing.

### 1. Unified Attestation Rewriting (`SecurityLevelInterceptor.kt`)
- Removed the special-case bypass (`!Utils.usesDefaultAttestationKey(data) -> Skip`) that previously allowed raw hardware RootOfTrust (`deviceLocked=false`) to leak on the AttestKey path.
- In `onPreTransact`: Returns `Continue` for all targeted `generateKey` requests when certificate rewriting is enabled for the calling package.
- In `onPostTransact`: When an attestation extension is present on the generated leaf (`Utils.hasAndroidAttestationExtension(leaf)`), uniformly rewrites the certificate chain via `CertHack.hackCertificateChain` and returns `OverrideReply` with synthesized RootOfTrust.
- Non-attested plain asymmetric keys (without an attestation challenge or Android attestation extension) continue to pass through natively (`Skip`).
- Standard RKP and custom AttestKey paths now emit matching `deviceLocked = true` / `verifiedBootState = Verified` RootOfTrust structures, eliminating RootOfTrust divergence across attestation paths.

### 2. RootOfTrust Spoofing Enforced in Rust Core (`attestation-core`)
- The Rust certificate rewrite engine (`rewrite_extension`) synthesizes RootOfTrust with `deviceLocked = true` (`0xFF`) and `verifiedBootState = 0` (Verified), synchronizing `verifiedBootHash` with `ro.boot.vbmeta.digest`.
- Added automated regression testing in `rust/attestation-core/tests/boot_digest.rs` verifying that certificates with unlocked / unverified hardware RootOfTrust are strictly rewritten to the locked and verified state.

### 3. Aligned Contract & Regression Tests (`AttestationInterceptorContractTest.java`)
- Verified that both default and custom AttestKey requests uniformly proceed to `CertHack` rewrite and receive `OverrideReply`.
- Verified that non-attested plain keys without attestation challenges pass through natively (`Skip`).
- All existing security level, cache bounds, and provenance invariants remain intact.
