### PR TITLE
perf(keystore): eliminate dynamic ASN.1 reconstruction and defer leaf certificate parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ node_modules/
 keys/
 *.key
 
+.kotlin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,16 @@
 ## V2.7.4
 
 - **Key Attestation & Security:**
+  - Unified attestation certificate rewriting: eliminated RootOfTrust divergence across default and custom AttestKey key generation requests while strictly synthesizing verified boot state (`deviceLocked = true`, `verifiedBootState = Verified`, matching `vbmeta.digest`).
   - Preserved caller-selected AttestKey certificate chains natively without breaking parent-child cryptographic signatures.
   - Seamless StrongBox support: automatically utilizes genuine StrongBox keyboxes when available and routes standard TEE keys cleanly without duplicate errors or app crashes.
+  - Hardened module integrity protection: transitioned integrity verification to startup-only quarantine, preventing accidental module self-deletion during concurrent write churn.
   - Optimized O(1) keybox classification: precomputed security level mapping ensures instant key selection without runtime overhead.
 - **WebUI & User Experience:**
-  - Added clear, mobile-friendly **StrongBox** and **TEE** badges next to keyboxes in the Keybox Hub, making it easy to identify keybox capabilities at a glance.
-  - Localized remote server status messages for all supported interface languages.
+  - Added clear, mobile-friendly **StrongBox**, **TEE**, and **RKP** badges next to keyboxes in the Keybox Hub, making it easy to identify keybox capabilities at a glance.
 - **Module Installation & Compatibility:**
   - Automatically detects and removes conflicting or outdated third-party attestation modules during installation to prevent conflicts and ensure a clean setup.
-- **Performance & Reliability:**
-  - Faster keystore response times with zero delay when applications check certificates.
-  - Consistent readback cache synchronization between key generation and entry queries.
-  - Eliminated key generation timing side-channels by deferring X.509 leaf certificate parsing on the reply path.
+- **Performance & Latency:**
+  - Eliminated key generation timing side-channels by deferring X.509 leaf parsing via lazy wrappers and streaming reply parcel serialization in-place without intermediary allocations.
+  - Streamlined high-frequency Binder transaction reply paths: purged logging, reflection, and redundant memory copies from latency-critical key generation routines.
+  - Faster keystore response times with pre-encoded issuer chain caching and consistent readback cache synchronization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Module Installation & Compatibility:**
   - Automatically detects and removes conflicting or outdated third-party attestation modules during installation to prevent conflicts and ensure a clean setup.
 - **Performance & Latency:**
-  - Eliminated key generation timing side-channels by deferring X.509 leaf parsing via lazy wrappers and streaming reply parcel serialization in-place without intermediary allocations.
+  - Eliminated key generation timing side-channels by deferring X.509 leaf parsing via lazy wrappers, bypassing dynamic ASN.1 re-serialization with zero-copy TLV slicing, and streaming reply parcel serialization in-place without intermediary allocations.
+  - Pre-computed constant DER byte templates for RootOfTrust structures in the native attestation engine, reducing post-processing latency to negligible sub-microsecond levels.
   - Streamlined high-frequency Binder transaction reply paths: purged logging, reflection, and redundant memory copies from latency-critical key generation routines.
   - Faster keystore response times with pre-encoded issuer chain caching and consistent readback cache synchronization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
 - **Performance & Reliability:**
   - Faster keystore response times with zero delay when applications check certificates.
   - Consistent readback cache synchronization between key generation and entry queries.
+  - Eliminated key generation timing side-channels by deferring X.509 leaf certificate parsing on the reply path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,16 @@
 ## V2.7.4
 
 - **Key Attestation & Security:**
-  - Unified attestation certificate rewriting: eliminated RootOfTrust divergence across default and custom AttestKey key generation requests while strictly synthesizing verified boot state (`deviceLocked = true`, `verifiedBootState = Verified`, matching `vbmeta.digest`).
-  - Preserved caller-selected AttestKey certificate chains natively without breaking parent-child cryptographic signatures.
+  - Unified attestation certificate rewriting: eliminated RootOfTrust divergence across default and custom AttestKey requests, ensuring consistent device and bootloader state spoofing.
+  - Preserved caller-selected AttestKey certificate chains natively without breaking certificate signatures.
   - Seamless StrongBox support: automatically utilizes genuine StrongBox keyboxes when available and routes standard TEE keys cleanly without duplicate errors or app crashes.
-  - Hardened module integrity protection: transitioned integrity verification to startup-only quarantine, preventing accidental module self-deletion during concurrent write churn.
-  - Optimized O(1) keybox classification: precomputed security level mapping ensures instant key selection without runtime overhead.
+  - Hardened module integrity protection: prevents accidental module self-deletion during high filesystem churn.
+  - Instant keybox selection: optimized security level detection for faster key creation.
 - **WebUI & User Experience:**
   - Added clear, mobile-friendly **StrongBox**, **TEE**, and **RKP** badges next to keyboxes in the Keybox Hub, making it easy to identify keybox capabilities at a glance.
 - **Module Installation & Compatibility:**
   - Automatically detects and removes conflicting or outdated third-party attestation modules during installation to prevent conflicts and ensure a clean setup.
 - **Performance & Latency:**
-  - Significantly reduced key generation timing-side-channel exposure by deferring X.509 leaf parsing via lazy wrappers, bypassing dynamic ASN.1 re-serialization with zero-copy TLV slicing, and streaming reply parcel serialization in-place without intermediary allocations.
-  - Pre-computed constant DER byte templates for RootOfTrust structures in the native attestation engine, reducing post-processing latency to negligible sub-microsecond levels.
-  - Streamlined high-frequency Binder transaction reply paths: purged logging, reflection, and redundant memory copies from latency-critical key generation routines.
-  - Faster keystore response times with pre-encoded issuer chain caching and consistent readback cache synchronization.
+  - Significantly reduced key generation latency and timing-side-channel exposure during attestation checks.
+  - Streamlined keystore background transactions by eliminating unnecessary memory allocations and logging overhead.
+  - Faster keystore response times with pre-cached certificate chains and synchronized readback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - **Module Installation & Compatibility:**
   - Automatically detects and removes conflicting or outdated third-party attestation modules during installation to prevent conflicts and ensure a clean setup.
 - **Performance & Latency:**
-  - Eliminated key generation timing side-channels by deferring X.509 leaf parsing via lazy wrappers, bypassing dynamic ASN.1 re-serialization with zero-copy TLV slicing, and streaming reply parcel serialization in-place without intermediary allocations.
+  - Significantly reduced key generation timing-side-channel exposure by deferring X.509 leaf parsing via lazy wrappers, bypassing dynamic ASN.1 re-serialization with zero-copy TLV slicing, and streaming reply parcel serialization in-place without intermediary allocations.
   - Pre-computed constant DER byte templates for RootOfTrust structures in the native attestation engine, reducing post-processing latency to negligible sub-microsecond levels.
   - Streamlined high-frequency Binder transaction reply paths: purged logging, reflection, and redundant memory copies from latency-critical key generation routines.
   - Faster keystore response times with pre-encoded issuer chain caching and consistent readback cache synchronization.

--- a/rust/attestation-core/src/lib.rs
+++ b/rust/attestation-core/src/lib.rs
@@ -594,7 +594,7 @@ fn encode_sequence<'a>(parts: impl IntoIterator<Item = &'a [u8]>) -> Result<Vec<
         }
     }
 
-    let mut encoded = Vec::with_capacity(total_len + 4);
+    let mut encoded = Vec::with_capacity(total_len + 5);
     encoded.push(0x30);
     if total_len < 128 {
         encoded.push(total_len as u8);
@@ -604,6 +604,11 @@ fn encode_sequence<'a>(parts: impl IntoIterator<Item = &'a [u8]>) -> Result<Vec<
     } else if total_len <= 0xffff {
         encoded.push(0x82);
         encoded.push((total_len >> 8) as u8);
+        encoded.push((total_len & 0xff) as u8);
+    } else if total_len <= MAX_ATTESTATION_EXTENSION_BYTES {
+        encoded.push(0x83);
+        encoded.push((total_len >> 16) as u8);
+        encoded.push(((total_len >> 8) & 0xff) as u8);
         encoded.push((total_len & 0xff) as u8);
     } else {
         return Err(Error::Bounds);

--- a/rust/attestation-core/src/lib.rs
+++ b/rust/attestation-core/src/lib.rs
@@ -1190,4 +1190,46 @@ mod tests {
     fn assert_sorted(fields: &[TaggedTlv]) {
         assert!(fields.windows(2).all(|pair| pair[0].tag <= pair[1].tag));
     }
+
+    #[test]
+    fn encode_sequence_length_boundaries() {
+        let zero = encode_sequence([]).unwrap();
+        assert_eq!(zero, &[0x30, 0x00]);
+
+        let payload_127 = vec![0xaa; 127];
+        let enc_127 = encode_sequence([payload_127.as_slice()]).unwrap();
+        assert_eq!(&enc_127[..2], &[0x30, 0x7f]);
+        assert_eq!(&enc_127[2..], payload_127.as_slice());
+
+        let payload_128 = vec![0xbb; 128];
+        let enc_128 = encode_sequence([payload_128.as_slice()]).unwrap();
+        assert_eq!(&enc_128[..3], &[0x30, 0x81, 0x80]);
+        assert_eq!(&enc_128[3..], payload_128.as_slice());
+
+        let payload_255 = vec![0xcc; 255];
+        let enc_255 = encode_sequence([payload_255.as_slice()]).unwrap();
+        assert_eq!(&enc_255[..3], &[0x30, 0x81, 0xff]);
+        assert_eq!(&enc_255[3..], payload_255.as_slice());
+
+        let payload_256 = vec![0xdd; 256];
+        let enc_256 = encode_sequence([payload_256.as_slice()]).unwrap();
+        assert_eq!(&enc_256[..4], &[0x30, 0x82, 0x01, 0x00]);
+        assert_eq!(&enc_256[4..], payload_256.as_slice());
+
+        let payload_65535 = vec![0xee; 65535];
+        let enc_65535 = encode_sequence([payload_65535.as_slice()]).unwrap();
+        assert_eq!(&enc_65535[..4], &[0x30, 0x82, 0xff, 0xff]);
+        assert_eq!(&enc_65535[4..], payload_65535.as_slice());
+
+        let payload_max = vec![0x11; MAX_ATTESTATION_EXTENSION_BYTES];
+        let enc_max = encode_sequence([payload_max.as_slice()]).unwrap();
+        assert_eq!(&enc_max[..5], &[0x30, 0x83, 0x01, 0x00, 0x00]);
+        assert_eq!(&enc_max[5..], payload_max.as_slice());
+
+        let payload_over = vec![0x22; MAX_ATTESTATION_EXTENSION_BYTES + 1];
+        assert_eq!(
+            encode_sequence([payload_over.as_slice()]),
+            Err(Error::Bounds)
+        );
+    }
 }

--- a/rust/attestation-core/src/lib.rs
+++ b/rust/attestation-core/src/lib.rs
@@ -131,10 +131,10 @@ struct AuthorizationSummary {
     boot_patch: Option<i32>,
 }
 
-#[derive(Debug)]
-struct TaggedTlv {
+#[derive(Clone, Debug)]
+struct TaggedTlv<'a> {
     tag: u32,
-    encoded: Vec<u8>,
+    encoded: std::borrow::Cow<'a, [u8]>,
 }
 
 pub fn rewrite_extension(request: &RewriteRequest<'_>) -> Result<RewriteResult, Error> {
@@ -143,15 +143,15 @@ pub fn rewrite_extension(request: &RewriteRequest<'_>) -> Result<RewriteResult, 
     if outer.tag() != Tag::Sequence {
         return Err(Error::InvalidStructure);
     }
-    let mut fields = split_tlvs(outer.value(), MAX_KEY_DESCRIPTION_FIELDS)?;
-    if fields.len() <= AUTHORIZATION_LIST_TEE_INDEX {
+    let raw_fields = split_tlvs(outer.value(), MAX_KEY_DESCRIPTION_FIELDS)?;
+    if raw_fields.len() <= AUTHORIZATION_LIST_TEE_INDEX {
         return Err(Error::InvalidStructure);
     }
 
-    let attestation_version = decode_i32(&fields[0])?;
-    let attestation_level = decode_security_level(&fields[1])?;
-    let keymint_version = decode_i32(&fields[2])?;
-    let keymint_level = decode_security_level(&fields[3])?;
+    let attestation_version = decode_i32(raw_fields[0])?;
+    let attestation_level = decode_security_level(raw_fields[1])?;
+    let keymint_version = decode_i32(raw_fields[2])?;
+    let keymint_level = decode_security_level(raw_fields[3])?;
     let supports_module_hash = attestation_version >= 400 && keymint_version >= 400;
 
     let valid_hardware = matches!((attestation_level, keymint_level), (1, 1) | (2, 2) | (1, 2));
@@ -159,8 +159,8 @@ pub fn rewrite_extension(request: &RewriteRequest<'_>) -> Result<RewriteResult, 
         return Err(Error::InvalidStructure);
     }
 
-    let list_six = parse_authorization_list(&fields[AUTHORIZATION_LIST_SOFTWARE_INDEX])?;
-    let list_seven = parse_authorization_list(&fields[AUTHORIZATION_LIST_TEE_INDEX])?;
+    let list_six = parse_authorization_list(raw_fields[AUTHORIZATION_LIST_SOFTWARE_INDEX])?;
+    let list_seven = parse_authorization_list(raw_fields[AUTHORIZATION_LIST_TEE_INDEX])?;
     let summary_six = summarize_authorization_list(&list_six)?;
     let summary_seven = summarize_authorization_list(&list_seven)?;
 
@@ -195,7 +195,7 @@ pub fn rewrite_extension(request: &RewriteRequest<'_>) -> Result<RewriteResult, 
 
     let mut tee = Vec::with_capacity(tee_original.len().saturating_add(8));
     let mut software = Vec::with_capacity(software_original.len().saturating_add(4));
-    let mut original_module_hash: Option<TaggedTlv> = None;
+    let mut original_module_hash: Option<TaggedTlv<'_>> = None;
     let mut pending_ids = Vec::new();
 
     let mut sorted_overrides = request.id_overrides.to_vec();
@@ -216,7 +216,10 @@ pub fn rewrite_extension(request: &RewriteRequest<'_>) -> Result<RewriteResult, 
             if let Ok(index) = sorted_overrides.binary_search_by_key(&field.tag, |o| o.tag) {
                 pending_ids.push(TaggedTlv {
                     tag: field.tag,
-                    encoded: explicit_octet_string(field.tag, sorted_overrides[index].value)?,
+                    encoded: std::borrow::Cow::Owned(explicit_octet_string(
+                        field.tag,
+                        sorted_overrides[index].value,
+                    )?),
                 });
                 continue;
             }
@@ -267,7 +270,10 @@ pub fn rewrite_extension(request: &RewriteRequest<'_>) -> Result<RewriteResult, 
         if let Some(module_hash) = request.module_hash {
             software.push(TaggedTlv {
                 tag: MODULE_HASH_TAG,
-                encoded: explicit_octet_string(MODULE_HASH_TAG, module_hash)?,
+                encoded: std::borrow::Cow::Owned(explicit_octet_string(
+                    MODULE_HASH_TAG,
+                    module_hash,
+                )?),
             });
         } else if let Some(original) = original_module_hash {
             software.push(original);
@@ -276,15 +282,25 @@ pub fn rewrite_extension(request: &RewriteRequest<'_>) -> Result<RewriteResult, 
 
     tee.push(TaggedTlv {
         tag: ROOT_OF_TRUST_TAG,
-        encoded: explicit_root_of_trust(request.verified_boot_key, request.verified_boot_hash)?,
+        encoded: std::borrow::Cow::Owned(explicit_root_of_trust(
+            request.verified_boot_key,
+            request.verified_boot_hash,
+        )?),
     });
     tee.sort_by_key(|field| field.tag);
     software.sort_by_key(|field| field.tag);
 
-    fields[tee_index] = encode_sequence(tee.iter().map(|field| field.encoded.as_slice()))?;
-    fields[software_index] =
-        encode_sequence(software.iter().map(|field| field.encoded.as_slice()))?;
-    let extension_der = encode_sequence(fields.iter().map(Vec::as_slice))?;
+    let mut fields: Vec<std::borrow::Cow<'_, [u8]>> = raw_fields
+        .into_iter()
+        .map(std::borrow::Cow::Borrowed)
+        .collect();
+    fields[tee_index] = std::borrow::Cow::Owned(encode_sequence(
+        tee.iter().map(|field| field.encoded.as_ref()),
+    )?);
+    fields[software_index] = std::borrow::Cow::Owned(encode_sequence(
+        software.iter().map(|field| field.encoded.as_ref()),
+    )?);
+    let extension_der = encode_sequence(fields.iter().map(|f| f.as_ref()))?;
     if extension_der.len() > MAX_ATTESTATION_EXTENSION_BYTES {
         return Err(Error::Bounds);
     }
@@ -307,8 +323,8 @@ pub fn inspect_captured_patch_levels(extension_der: &[u8]) -> Result<CapturedPat
     if fields.len() <= AUTHORIZATION_LIST_TEE_INDEX {
         return Err(Error::InvalidStructure);
     }
-    let list_six = parse_authorization_list(&fields[AUTHORIZATION_LIST_SOFTWARE_INDEX])?;
-    let list_seven = parse_authorization_list(&fields[AUTHORIZATION_LIST_TEE_INDEX])?;
+    let list_six = parse_authorization_list(fields[AUTHORIZATION_LIST_SOFTWARE_INDEX])?;
+    let list_seven = parse_authorization_list(fields[AUTHORIZATION_LIST_TEE_INDEX])?;
     let summary_six = summarize_authorization_list(&list_six)?;
     let summary_seven = summarize_authorization_list(&list_seven)?;
     if summary_six.has_root_of_trust == summary_seven.has_root_of_trust {
@@ -365,7 +381,7 @@ fn validate_request(request: &RewriteRequest<'_>) -> Result<(), Error> {
     Ok(())
 }
 
-fn parse_authorization_list(encoded: &[u8]) -> Result<Vec<TaggedTlv>, Error> {
+fn parse_authorization_list<'a>(encoded: &'a [u8]) -> Result<Vec<TaggedTlv<'a>>, Error> {
     let sequence = parse_any(encoded)?;
     if sequence.tag() != Tag::Sequence {
         return Err(Error::InvalidStructure);
@@ -373,8 +389,8 @@ fn parse_authorization_list(encoded: &[u8]) -> Result<Vec<TaggedTlv>, Error> {
     let fields = split_tlvs(sequence.value(), MAX_AUTHORIZATION_TAGS)?;
     fields
         .into_iter()
-        .map(|encoded| {
-            let any = parse_any(&encoded)?;
+        .map(|slice| {
+            let any = parse_any(slice)?;
             let tag = match any.tag() {
                 Tag::ContextSpecific {
                     constructed: true,
@@ -382,12 +398,15 @@ fn parse_authorization_list(encoded: &[u8]) -> Result<Vec<TaggedTlv>, Error> {
                 } => number.value(),
                 _ => return Err(Error::InvalidStructure),
             };
-            Ok(TaggedTlv { tag, encoded })
+            Ok(TaggedTlv {
+                tag,
+                encoded: std::borrow::Cow::Borrowed(slice),
+            })
         })
         .collect()
 }
 
-fn summarize_authorization_list(fields: &[TaggedTlv]) -> Result<AuthorizationSummary, Error> {
+fn summarize_authorization_list(fields: &[TaggedTlv<'_>]) -> Result<AuthorizationSummary, Error> {
     let mut summary = AuthorizationSummary::default();
     for field in fields {
         match field.tag {
@@ -441,9 +460,9 @@ fn should_remove_patch(tag: u32, levels: PatchLevels) -> bool {
     }
 }
 
-fn add_patch_tag(
-    tee: &mut Vec<TaggedTlv>,
-    software: &mut Vec<TaggedTlv>,
+fn add_patch_tag<'a>(
+    tee: &mut Vec<TaggedTlv<'a>>,
+    software: &mut Vec<TaggedTlv<'a>>,
     tag: u32,
     component: PatchComponent,
     was_tee: bool,
@@ -456,11 +475,14 @@ fn add_patch_tag(
     if was_tee || !was_software {
         tee.push(TaggedTlv {
             tag,
-            encoded: encoded.clone(),
+            encoded: std::borrow::Cow::Owned(encoded.clone()),
         });
     }
     if was_software {
-        software.push(TaggedTlv { tag, encoded });
+        software.push(TaggedTlv {
+            tag,
+            encoded: std::borrow::Cow::Owned(encoded),
+        });
     }
     Ok(())
 }
@@ -517,19 +539,19 @@ fn validate_root_of_trust(encoded: &[u8]) -> Result<(), Error> {
     if fields.len() != 4 {
         return Err(Error::InvalidStructure);
     }
-    let key = parse_any(&fields[0])?;
+    let key = parse_any(fields[0])?;
     if key.tag() != Tag::OctetString {
         return Err(Error::InvalidStructure);
     }
-    bool::from_der(&fields[1]).map_err(|_| Error::InvalidStructure)?;
-    let state = parse_any(&fields[2])?;
+    bool::from_der(fields[1]).map_err(|_| Error::InvalidStructure)?;
+    let state = parse_any(fields[2])?;
     if state.tag() != Tag::Enumerated
         || state.value().len() != 1
         || !matches!(state.value()[0], 0..=3)
     {
         return Err(Error::InvalidStructure);
     }
-    let hash = parse_any(&fields[3])?;
+    let hash = parse_any(fields[3])?;
     if hash.tag() != Tag::OctetString {
         return Err(Error::InvalidStructure);
     }
@@ -537,26 +559,16 @@ fn validate_root_of_trust(encoded: &[u8]) -> Result<(), Error> {
 }
 
 fn explicit_root_of_trust(boot_key: &[u8; 32], boot_hash: &[u8; 32]) -> Result<Vec<u8>, Error> {
-    let key = Any::new(Tag::OctetString, boot_key.to_vec())
-        .map_err(|_| Error::Bounds)?
-        .to_der()
-        .map_err(|_| Error::Der)?;
-    let verified = true.to_der().map_err(|_| Error::Der)?;
-    let state = Any::new(Tag::Enumerated, vec![0])
-        .map_err(|_| Error::Der)?
-        .to_der()
-        .map_err(|_| Error::Der)?;
-    let hash = Any::new(Tag::OctetString, boot_hash.to_vec())
-        .map_err(|_| Error::Bounds)?
-        .to_der()
-        .map_err(|_| Error::Der)?;
-    let sequence = encode_sequence([
-        key.as_slice(),
-        verified.as_slice(),
-        state.as_slice(),
-        hash.as_slice(),
-    ])?;
-    explicit_tag(ROOT_OF_TRUST_TAG, &sequence)
+    let mut root = vec![0u8; 80];
+    root[0..4].copy_from_slice(&[0xbf, 0x85, 0x40, 0x4c]);
+    root[4..6].copy_from_slice(&[0x30, 0x4a]);
+    root[6..8].copy_from_slice(&[0x04, 0x20]);
+    root[8..40].copy_from_slice(boot_key);
+    root[40..43].copy_from_slice(&[0x01, 0x01, 0xff]);
+    root[43..46].copy_from_slice(&[0x0a, 0x01, 0x00]);
+    root[46..48].copy_from_slice(&[0x04, 0x20]);
+    root[48..80].copy_from_slice(boot_hash);
+    Ok(root)
 }
 
 fn explicit_tag(tag: u32, inner_der: &[u8]) -> Result<Vec<u8>, Error> {
@@ -573,25 +585,40 @@ fn explicit_tag(tag: u32, inner_der: &[u8]) -> Result<Vec<u8>, Error> {
 }
 
 fn encode_sequence<'a>(parts: impl IntoIterator<Item = &'a [u8]>) -> Result<Vec<u8>, Error> {
-    let mut value = Vec::new();
-    for part in parts {
-        let new_len = value.len().checked_add(part.len()).ok_or(Error::Bounds)?;
-        if new_len > MAX_ATTESTATION_EXTENSION_BYTES {
+    let mut total_len = 0usize;
+    let parts_vec: Vec<&'a [u8]> = parts.into_iter().collect();
+    for part in &parts_vec {
+        total_len = total_len.checked_add(part.len()).ok_or(Error::Bounds)?;
+        if total_len > MAX_ATTESTATION_EXTENSION_BYTES {
             return Err(Error::Bounds);
         }
-        value.extend_from_slice(part);
     }
-    Any::new(Tag::Sequence, value)
-        .map_err(|_| Error::Bounds)?
-        .to_der()
-        .map_err(|_| Error::Der)
+
+    let mut encoded = Vec::with_capacity(total_len + 4);
+    encoded.push(0x30);
+    if total_len < 128 {
+        encoded.push(total_len as u8);
+    } else if total_len <= 0xff {
+        encoded.push(0x81);
+        encoded.push(total_len as u8);
+    } else if total_len <= 0xffff {
+        encoded.push(0x82);
+        encoded.push((total_len >> 8) as u8);
+        encoded.push((total_len & 0xff) as u8);
+    } else {
+        return Err(Error::Bounds);
+    }
+    for part in parts_vec {
+        encoded.extend_from_slice(part);
+    }
+    Ok(encoded)
 }
 
 fn parse_any(encoded: &[u8]) -> Result<AnyRef<'_>, Error> {
     AnyRef::from_der(encoded).map_err(|_| Error::Der)
 }
 
-fn split_tlvs(mut encoded: &[u8], max_items: usize) -> Result<Vec<Vec<u8>>, Error> {
+fn split_tlvs(mut encoded: &[u8], max_items: usize) -> Result<Vec<&[u8]>, Error> {
     let mut output = Vec::new();
     while !encoded.is_empty() {
         if output.len() >= max_items {
@@ -602,7 +629,7 @@ fn split_tlvs(mut encoded: &[u8], max_items: usize) -> Result<Vec<Vec<u8>>, Erro
         if consumed == 0 {
             return Err(Error::Der);
         }
-        output.push(encoded[..consumed].to_vec());
+        output.push(&encoded[..consumed]);
         encoded = rest;
     }
     Ok(output)
@@ -750,8 +777,8 @@ mod tests {
         let rewritten = rewrite_extension(&request).unwrap();
         let outer = parse_any(&rewritten.extension_der).unwrap();
         let fields = split_tlvs(outer.value(), MAX_KEY_DESCRIPTION_FIELDS).unwrap();
-        assert_eq!(fields[1], strongbox);
-        assert_eq!(fields[3], strongbox);
+        assert_eq!(fields[1], strongbox.as_slice());
+        assert_eq!(fields[3], strongbox.as_slice());
     }
 
     #[test]
@@ -1099,11 +1126,11 @@ mod tests {
         .unwrap()
     }
 
-    fn authorization_lists(extension: &[u8]) -> (Vec<TaggedTlv>, Vec<TaggedTlv>) {
+    fn authorization_lists(extension: &[u8]) -> (Vec<TaggedTlv<'_>>, Vec<TaggedTlv<'_>>) {
         let outer = parse_any(extension).unwrap();
         let fields = split_tlvs(outer.value(), MAX_KEY_DESCRIPTION_FIELDS).unwrap();
-        let six = parse_authorization_list(&fields[6]).unwrap();
-        let seven = parse_authorization_list(&fields[7]).unwrap();
+        let six = parse_authorization_list(fields[6]).unwrap();
+        let seven = parse_authorization_list(fields[7]).unwrap();
         let six_summary = summarize_authorization_list(&six).unwrap();
         let seven_summary = summarize_authorization_list(&seven).unwrap();
         if six_summary.has_root_of_trust && !seven_summary.has_root_of_trust {
@@ -1113,14 +1140,14 @@ mod tests {
         }
     }
 
-    fn decode_tagged_i32(fields: &[TaggedTlv], tag: u32) -> Option<i32> {
+    fn decode_tagged_i32(fields: &[TaggedTlv<'_>], tag: u32) -> Option<i32> {
         fields
             .iter()
             .find(|field| field.tag == tag)
             .map(|field| decode_explicit_i32(&field.encoded).unwrap())
     }
 
-    fn decode_tagged_octets(fields: &[TaggedTlv], tag: u32) -> Option<Vec<u8>> {
+    fn decode_tagged_octets(fields: &[TaggedTlv<'_>], tag: u32) -> Option<Vec<u8>> {
         fields.iter().find(|field| field.tag == tag).map(|field| {
             let outer = parse_any(&field.encoded).unwrap();
             let inner = parse_any(outer.value()).unwrap();
@@ -1129,7 +1156,7 @@ mod tests {
         })
     }
 
-    fn root_of_trust_fields(tee: &[TaggedTlv]) -> (Vec<u8>, bool, u8, Vec<u8>) {
+    fn root_of_trust_fields(tee: &[TaggedTlv<'_>]) -> (Vec<u8>, bool, u8, Vec<u8>) {
         let root = tee
             .iter()
             .find(|field| field.tag == ROOT_OF_TRUST_TAG)
@@ -1139,13 +1166,13 @@ mod tests {
         assert_eq!(sequence.tag(), Tag::Sequence);
         let fields = split_tlvs(sequence.value(), 4).unwrap();
         assert_eq!(fields.len(), 4);
-        let key = parse_any(&fields[0]).unwrap();
+        let key = parse_any(fields[0]).unwrap();
         assert_eq!(key.tag(), Tag::OctetString);
-        let locked = bool::from_der(&fields[1]).unwrap();
-        let state = parse_any(&fields[2]).unwrap();
+        let locked = bool::from_der(fields[1]).unwrap();
+        let state = parse_any(fields[2]).unwrap();
         assert_eq!(state.tag(), Tag::Enumerated);
         assert_eq!(state.value().len(), 1);
-        let hash = parse_any(&fields[3]).unwrap();
+        let hash = parse_any(fields[3]).unwrap();
         assert_eq!(hash.tag(), Tag::OctetString);
         (
             key.value().to_vec(),

--- a/rust/certificate-core/src/inspection.rs
+++ b/rust/certificate-core/src/inspection.rs
@@ -76,13 +76,13 @@ pub fn inspect_certificate(leaf_der: &[u8]) -> Result<CertificateInspection, Err
     if fields.len() <= TEE_INDEX {
         return Err(Error::AttestationRewrite);
     }
-    let attestation_version = <i32 as attestation_der::Decode>::from_der(&fields[0])
+    let attestation_version = <i32 as attestation_der::Decode>::from_der(fields[0])
         .map_err(|_| Error::AttestationRewrite)?;
     let security_levels = security_levels_from_fields(&fields)?;
-    let keymint_version = <i32 as attestation_der::Decode>::from_der(&fields[2])
+    let keymint_version = <i32 as attestation_der::Decode>::from_der(fields[2])
         .map_err(|_| Error::AttestationRewrite)?;
-    let list_six = tagged_fields(&fields[SOFTWARE_INDEX])?;
-    let list_seven = tagged_fields(&fields[TEE_INDEX])?;
+    let list_six = tagged_fields(fields[SOFTWARE_INDEX])?;
+    let list_seven = tagged_fields(fields[TEE_INDEX])?;
     let six_root_count = list_six
         .iter()
         .filter(|field| field.0 == ROOT_OF_TRUST_TAG)
@@ -123,10 +123,10 @@ pub fn inspect_certificate(leaf_der: &[u8]) -> Result<CertificateInspection, Err
     })
 }
 
-fn security_levels_from_fields(fields: &[Vec<u8>]) -> Result<SecurityLevels, Error> {
+fn security_levels_from_fields(fields: &[&[u8]]) -> Result<SecurityLevels, Error> {
     Ok(SecurityLevels {
-        attestation: decode_security_level(&fields[1])?,
-        keymint: decode_security_level(&fields[3])?,
+        attestation: decode_security_level(fields[1])?,
+        keymint: decode_security_level(fields[3])?,
     })
 }
 
@@ -143,15 +143,15 @@ fn decode_security_level(encoded: &[u8]) -> Result<SecurityLevel, Error> {
     }
 }
 
-fn tagged_fields(encoded: &[u8]) -> Result<Vec<(u32, Vec<u8>)>, Error> {
+fn tagged_fields(encoded: &[u8]) -> Result<Vec<(u32, &[u8])>, Error> {
     let sequence = AnyRef::from_der(encoded).map_err(|_| Error::AttestationRewrite)?;
     if sequence.tag() != Tag::Sequence {
         return Err(Error::AttestationRewrite);
     }
     split(sequence.value(), MAX_TAGS)?
         .into_iter()
-        .map(|encoded| {
-            let any = AnyRef::from_der(&encoded).map_err(|_| Error::AttestationRewrite)?;
+        .map(|slice| {
+            let any = AnyRef::from_der(slice).map_err(|_| Error::AttestationRewrite)?;
             let tag = match any.tag() {
                 Tag::ContextSpecific {
                     constructed: true,
@@ -159,7 +159,7 @@ fn tagged_fields(encoded: &[u8]) -> Result<Vec<(u32, Vec<u8>)>, Error> {
                 } => number.value(),
                 _ => return Err(Error::AttestationRewrite),
             };
-            Ok((tag, encoded))
+            Ok((tag, slice))
         })
         .collect()
 }
@@ -174,24 +174,24 @@ fn parse_root_of_trust(encoded: &[u8]) -> Result<BootDigests, Error> {
     if fields.len() != 4 {
         return Err(Error::AttestationRewrite);
     }
-    let key_ref = AnyRef::from_der(&fields[0]).map_err(|_| Error::AttestationRewrite)?;
+    let key_ref = AnyRef::from_der(fields[0]).map_err(|_| Error::AttestationRewrite)?;
     if key_ref.tag() != Tag::OctetString {
         return Err(Error::AttestationRewrite);
     }
-    <bool as AttestationDecode>::from_der(&fields[1]).map_err(|_| Error::AttestationRewrite)?;
-    let state_ref = AnyRef::from_der(&fields[2]).map_err(|_| Error::AttestationRewrite)?;
+    <bool as AttestationDecode>::from_der(fields[1]).map_err(|_| Error::AttestationRewrite)?;
+    let state_ref = AnyRef::from_der(fields[2]).map_err(|_| Error::AttestationRewrite)?;
     if state_ref.tag() != Tag::Enumerated
         || state_ref.value().len() != 1
         || !matches!(state_ref.value()[0], 0..=3)
     {
         return Err(Error::AttestationRewrite);
     }
-    let hash_ref = AnyRef::from_der(&fields[3]).map_err(|_| Error::AttestationRewrite)?;
+    let hash_ref = AnyRef::from_der(fields[3]).map_err(|_| Error::AttestationRewrite)?;
     if hash_ref.tag() != Tag::OctetString {
         return Err(Error::AttestationRewrite);
     }
-    let key = decode_digest(&fields[0]);
-    let hash = decode_digest(&fields[3]);
+    let key = decode_digest(fields[0]);
+    let hash = decode_digest(fields[3]);
     Ok((key, hash))
 }
 
@@ -204,7 +204,7 @@ fn decode_digest(encoded: &[u8]) -> Option<[u8; 32]> {
     (!digest.iter().all(|byte| *byte == 0)).then_some(digest)
 }
 
-fn split(mut encoded: &[u8], max_items: usize) -> Result<Vec<Vec<u8>>, Error> {
+fn split(mut encoded: &[u8], max_items: usize) -> Result<Vec<&[u8]>, Error> {
     let mut output = Vec::new();
     while !encoded.is_empty() {
         if output.len() >= max_items {
@@ -218,7 +218,7 @@ fn split(mut encoded: &[u8], max_items: usize) -> Result<Vec<Vec<u8>>, Error> {
         if consumed == 0 {
             return Err(Error::AttestationRewrite);
         }
-        output.push(encoded[..consumed].to_vec());
+        output.push(&encoded[..consumed]);
         encoded = rest;
     }
     Ok(output)

--- a/rust/certificate-core/src/lib.rs
+++ b/rust/certificate-core/src/lib.rs
@@ -437,3 +437,83 @@ fn encode_signed_certificate(
         .map_err(|_| Error::Encoding)?;
     encode_sequence(&[tbs_der, algorithm_der, &signature])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_sequence_and_explicit_length_boundaries() {
+        let zero = encode_sequence(&[]).unwrap();
+        assert_eq!(zero, &[0x30, 0x00]);
+
+        let payload_127 = vec![0x11; 127];
+        let seq_127 = encode_sequence(&[&payload_127]).unwrap();
+        assert_eq!(&seq_127[..2], &[0x30, 0x7f]);
+        assert_eq!(&seq_127[2..], payload_127.as_slice());
+
+        let payload_128 = vec![0x22; 128];
+        let seq_128 = encode_sequence(&[&payload_128]).unwrap();
+        assert_eq!(&seq_128[..3], &[0x30, 0x81, 0x80]);
+        assert_eq!(&seq_128[3..], payload_128.as_slice());
+
+        let payload_255 = vec![0x33; 255];
+        let seq_255 = encode_sequence(&[&payload_255]).unwrap();
+        assert_eq!(&seq_255[..3], &[0x30, 0x81, 0xff]);
+        assert_eq!(&seq_255[3..], payload_255.as_slice());
+
+        let payload_256 = vec![0x44; 256];
+        let seq_256 = encode_sequence(&[&payload_256]).unwrap();
+        assert_eq!(&seq_256[..4], &[0x30, 0x82, 0x01, 0x00]);
+        assert_eq!(&seq_256[4..], payload_256.as_slice());
+
+        let payload_65535 = vec![0x55; 65535];
+        let seq_65535 = encode_sequence(&[&payload_65535]).unwrap();
+        assert_eq!(&seq_65535[..4], &[0x30, 0x82, 0xff, 0xff]);
+        assert_eq!(&seq_65535[4..], payload_65535.as_slice());
+
+        let payload_65536 = vec![0x66; 65536];
+        let seq_65536 = encode_sequence(&[&payload_65536]).unwrap();
+        assert_eq!(&seq_65536[..5], &[0x30, 0x83, 0x01, 0x00, 0x00]);
+        assert_eq!(&seq_65536[5..], payload_65536.as_slice());
+
+        let payload_max = vec![0x77; MAX_CERTIFICATE_DER_BYTES];
+        let seq_max = encode_sequence(&[&payload_max]).unwrap();
+        assert_eq!(&seq_max[..5], &[0x30, 0x83, 0x04, 0x00, 0x00]);
+        assert_eq!(&seq_max[5..], payload_max.as_slice());
+
+        let payload_over = vec![0x88; MAX_CERTIFICATE_DER_BYTES + 1];
+        assert_eq!(encode_sequence(&[&payload_over]), Err(Error::Bounds));
+
+        // Test encode_explicit (tag < 31)
+        let exp_0 = encode_explicit(3, &[]).unwrap();
+        assert_eq!(exp_0, &[0xa3, 0x00]);
+
+        let exp_127 = encode_explicit(3, &payload_127).unwrap();
+        assert_eq!(&exp_127[..2], &[0xa3, 0x7f]);
+        assert_eq!(&exp_127[2..], payload_127.as_slice());
+
+        let exp_128 = encode_explicit(3, &payload_128).unwrap();
+        assert_eq!(&exp_128[..3], &[0xa3, 0x81, 0x80]);
+        assert_eq!(&exp_128[3..], payload_128.as_slice());
+
+        let exp_256 = encode_explicit(3, &payload_256).unwrap();
+        assert_eq!(&exp_256[..4], &[0xa3, 0x82, 0x01, 0x00]);
+        assert_eq!(&exp_256[4..], payload_256.as_slice());
+
+        let exp_65536 = encode_explicit(3, &payload_65536).unwrap();
+        assert_eq!(&exp_65536[..5], &[0xa3, 0x83, 0x01, 0x00, 0x00]);
+        assert_eq!(&exp_65536[5..], payload_65536.as_slice());
+
+        let exp_max = encode_explicit(3, &payload_max).unwrap();
+        assert_eq!(&exp_max[..5], &[0xa3, 0x83, 0x04, 0x00, 0x00]);
+        assert_eq!(&exp_max[5..], payload_max.as_slice());
+
+        assert_eq!(encode_explicit(3, &payload_over), Err(Error::Bounds));
+
+        // Test encode_explicit (tag >= 31, uses Any::new)
+        let exp_high = encode_explicit(31, &[0x01, 0x02]).unwrap();
+        assert_eq!(&exp_high[..3], &[0xbf, 0x1f, 0x02]);
+        assert_eq!(&exp_high[3..], &[0x01, 0x02]);
+    }
+}

--- a/rust/certificate-core/src/lib.rs
+++ b/rust/certificate-core/src/lib.rs
@@ -299,6 +299,8 @@ fn signature_algorithm_der(algorithm: SigningAlgorithm) -> &'static [u8] {
     }
 }
 
+const VERSION_V3_DER: &[u8] = &[0xa0, 0x03, 0x02, 0x01, 0x02];
+
 fn rebuild_tbs_certificate(
     leaf: &Certificate,
     issuer_name_der: &[u8],
@@ -310,7 +312,6 @@ fn rebuild_tbs_certificate(
     // Match the managed X509v3CertificateBuilder oracle: rebuild from genuine serial, validity,
     // subject, SPKI and extensions; issuer comes from the selected keybox. The managed builder did
     // not preserve issuer/subject unique IDs, so they are intentionally omitted here as well.
-    let version = encode_explicit(0, &2i32.to_der().map_err(|_| Error::Encoding)?)?;
     let serial = leaf_tbs
         .serial_number()
         .to_der()
@@ -325,7 +326,7 @@ fn rebuild_tbs_certificate(
     let extensions = encode_explicit(3, &extensions)?;
 
     encode_sequence(&[
-        &version,
+        VERSION_V3_DER,
         &serial,
         algorithm_der,
         issuer_name_der,
@@ -337,45 +338,82 @@ fn rebuild_tbs_certificate(
 }
 
 fn encode_extensions(extensions: &Extensions) -> Result<Vec<u8>, Error> {
-    let mut encoded = Vec::new();
+    let mut total_len = 0usize;
+    let mut encoded_fields = Vec::with_capacity(extensions.len());
     for extension in extensions {
         let field = extension.to_der().map_err(|_| Error::Encoding)?;
-        encoded
-            .try_reserve(field.len())
-            .map_err(|_| Error::Encoding)?;
-        encoded.extend_from_slice(&field);
+        total_len = total_len.checked_add(field.len()).ok_or(Error::Encoding)?;
+        encoded_fields.push(field);
     }
-    Any::new(Tag::Sequence, encoded)
-        .map_err(|_| Error::Encoding)?
-        .to_der()
-        .map_err(|_| Error::Encoding)
+    if total_len > MAX_CERTIFICATE_DER_BYTES {
+        return Err(Error::Bounds);
+    }
+    let refs: Vec<&[u8]> = encoded_fields.iter().map(Vec::as_slice).collect();
+    encode_sequence(&refs)
 }
 
 fn encode_explicit(tag: u32, inner: &[u8]) -> Result<Vec<u8>, Error> {
-    Any::new(
-        Tag::ContextSpecific {
-            constructed: true,
-            number: TagNumber(tag),
-        },
-        inner.to_vec(),
-    )
-    .map_err(|_| Error::Encoding)?
-    .to_der()
-    .map_err(|_| Error::Encoding)
+    let total_len = inner.len();
+    if total_len > MAX_CERTIFICATE_DER_BYTES {
+        return Err(Error::Bounds);
+    }
+    let mut encoded = Vec::with_capacity(total_len + 6);
+    if tag < 31 {
+        encoded.push(0x80 | 0x20 | (tag as u8));
+    } else {
+        return Any::new(
+            Tag::ContextSpecific {
+                constructed: true,
+                number: TagNumber(tag),
+            },
+            inner.to_vec(),
+        )
+        .map_err(|_| Error::Encoding)?
+        .to_der()
+        .map_err(|_| Error::Encoding);
+    }
+    if total_len < 128 {
+        encoded.push(total_len as u8);
+    } else if total_len <= 0xff {
+        encoded.push(0x81);
+        encoded.push(total_len as u8);
+    } else if total_len <= 0xffff {
+        encoded.push(0x82);
+        encoded.push((total_len >> 8) as u8);
+        encoded.push((total_len & 0xff) as u8);
+    } else {
+        return Err(Error::Encoding);
+    }
+    encoded.extend_from_slice(inner);
+    Ok(encoded)
 }
 
 fn encode_sequence(fields: &[&[u8]]) -> Result<Vec<u8>, Error> {
-    let mut encoded = Vec::new();
+    let mut total_len = 0usize;
     for field in fields {
-        encoded
-            .try_reserve(field.len())
-            .map_err(|_| Error::Encoding)?;
+        total_len = total_len.checked_add(field.len()).ok_or(Error::Encoding)?;
+    }
+    if total_len > MAX_CERTIFICATE_DER_BYTES {
+        return Err(Error::Bounds);
+    }
+    let mut encoded = Vec::with_capacity(total_len + 4);
+    encoded.push(0x30);
+    if total_len < 128 {
+        encoded.push(total_len as u8);
+    } else if total_len <= 0xff {
+        encoded.push(0x81);
+        encoded.push(total_len as u8);
+    } else if total_len <= 0xffff {
+        encoded.push(0x82);
+        encoded.push((total_len >> 8) as u8);
+        encoded.push((total_len & 0xff) as u8);
+    } else {
+        return Err(Error::Encoding);
+    }
+    for field in fields {
         encoded.extend_from_slice(field);
     }
-    Any::new(Tag::Sequence, encoded)
-        .map_err(|_| Error::Encoding)?
-        .to_der()
-        .map_err(|_| Error::Encoding)
+    Ok(encoded)
 }
 
 fn encode_signed_certificate(

--- a/rust/certificate-core/src/lib.rs
+++ b/rust/certificate-core/src/lib.rs
@@ -381,6 +381,11 @@ fn encode_explicit(tag: u32, inner: &[u8]) -> Result<Vec<u8>, Error> {
         encoded.push(0x82);
         encoded.push((total_len >> 8) as u8);
         encoded.push((total_len & 0xff) as u8);
+    } else if total_len <= MAX_CERTIFICATE_DER_BYTES {
+        encoded.push(0x83);
+        encoded.push((total_len >> 16) as u8);
+        encoded.push(((total_len >> 8) & 0xff) as u8);
+        encoded.push((total_len & 0xff) as u8);
     } else {
         return Err(Error::Encoding);
     }
@@ -396,7 +401,7 @@ fn encode_sequence(fields: &[&[u8]]) -> Result<Vec<u8>, Error> {
     if total_len > MAX_CERTIFICATE_DER_BYTES {
         return Err(Error::Bounds);
     }
-    let mut encoded = Vec::with_capacity(total_len + 4);
+    let mut encoded = Vec::with_capacity(total_len + 5);
     encoded.push(0x30);
     if total_len < 128 {
         encoded.push(total_len as u8);
@@ -406,6 +411,11 @@ fn encode_sequence(fields: &[&[u8]]) -> Result<Vec<u8>, Error> {
     } else if total_len <= 0xffff {
         encoded.push(0x82);
         encoded.push((total_len >> 8) as u8);
+        encoded.push((total_len & 0xff) as u8);
+    } else if total_len <= MAX_CERTIFICATE_DER_BYTES {
+        encoded.push(0x83);
+        encoded.push((total_len >> 16) as u8);
+        encoded.push(((total_len >> 8) & 0xff) as u8);
         encoded.push((total_len & 0xff) as u8);
     } else {
         return Err(Error::Encoding);

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -67,9 +67,7 @@ class SecurityLevelInterceptor : BinderInterceptor() {
         return try {
             reply.readException()
             val metadata = reply.readTypedObject(KeyMetadata.CREATOR) ?: return Skip
-            val isFullChain = Utils.isCertificateChainRewriteCandidate(metadata)
-            val isLeafOnly = Utils.hasRewritableLeafCertificate(metadata)
-            if (!isFullChain && !isLeafOnly) {
+            if (!Utils.isCertificateChainRewriteCandidate(metadata) && !Utils.hasRewritableLeafCertificate(metadata)) {
                 return Skip
             }
 
@@ -102,19 +100,12 @@ class SecurityLevelInterceptor : BinderInterceptor() {
             if (!CertHack.applyCachedCertificateChain(metadata)) {
                 Utils.putCertificateChain(metadata, rewritten)
             }
-            val replacement = Parcel.obtain()
-            try {
-                replacement.writeNoException()
-                replacement.writeTypedObject(metadata, 0)
-                OverrideReply(0, replacement)
-            } catch (t: Throwable) {
-                replacement.recycle()
-                throw t
-            }
-        } catch (error: Throwable) {
-            if (error.javaClass.simpleName != "ServiceSpecificException") {
-                Logger.e("Could not rewrite a generated attestation chain: ${error.javaClass.simpleName}")
-            }
+            reply.setDataSize(0)
+            reply.setDataPosition(0)
+            reply.writeNoException()
+            reply.writeTypedObject(metadata, 0)
+            OverrideReply(0, reply)
+        } catch (_: Throwable) {
             Skip
         }
     }

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -122,7 +122,7 @@ public final class CertHack {
                 byte[] issuerChainEncoded,
                 boolean leafOnlySafe
         ) {
-            this.certificates = certificates;
+            this.certificates = certificates.clone();
             this.leafEncoded = Objects.requireNonNull(leafEncoded, "leafEncoded");
             this.issuerChainEncoded = Objects.requireNonNull(issuerChainEncoded, "issuerChainEncoded");
             this.passthrough = false;

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -957,7 +957,7 @@ public final class CertHack {
             if (rewrittenDer == null || rewrittenDer.length == 0 || rewrittenDer.length > MAX_LEAF_CERTIFICATE_BYTES) {
                 return caList;
             }
-            Certificate rewrittenLeaf = new LazyX509Certificate(rewrittenDer);
+            Certificate rewrittenLeaf = new LazyX509Certificate(rewrittenDer, false);
             Certificate[] result = new Certificate[prepared.issuerChain.length + 1];
             result[0] = rewrittenLeaf;
             System.arraycopy(prepared.issuerChain, 0, result, 1, prepared.issuerChain.length);

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -964,8 +964,7 @@ public final class CertHack {
                 }
                 return caList;
             }
-            Certificate rewrittenLeaf = CERTIFICATE_FACTORY.get().generateCertificate(
-                    new ByteArrayInputStream(rewrittenDer));
+            Certificate rewrittenLeaf = new LazyX509Certificate(rewrittenDer);
             Certificate[] result = new Certificate[prepared.issuerChain.length + 1];
             result[0] = rewrittenLeaf;
             System.arraycopy(prepared.issuerChain, 0, result, 1, prepared.issuerChain.length);

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -122,7 +122,7 @@ public final class CertHack {
                 byte[] issuerChainEncoded,
                 boolean leafOnlySafe
         ) {
-            this.certificates = certificates.clone();
+            this.certificates = certificates;
             this.leafEncoded = Objects.requireNonNull(leafEncoded, "leafEncoded");
             this.issuerChainEncoded = Objects.requireNonNull(issuerChainEncoded, "issuerChainEncoded");
             this.passthrough = false;
@@ -793,7 +793,6 @@ public final class CertHack {
             Certificate[] replacement = cached.certificateCopy();
             return replacement == null ? caList : replacement;
         } catch (Throwable error) {
-            Logger.e("Could not resolve a cached attestation chain", error);
             return null;
         }
     }
@@ -820,7 +819,6 @@ public final class CertHack {
             State currentState = state;
             byte[] leafEncoded = caList[0].getEncoded();
             if (leafEncoded.length == 0 || leafEncoded.length > MAX_LEAF_CERTIFICATE_BYTES) {
-                Logger.e("Attestation leaf certificate has an invalid size");
                 return caList;
             }
             CacheKey cacheKey = new CacheKey(leafEncoded);
@@ -925,7 +923,6 @@ public final class CertHack {
                 }
             }
             if (list.isEmpty()) {
-                Logger.w("No compatible keybox is available for security level (isStrongbox=" + isStrongbox + ")");
                 return caList;
             }
 
@@ -936,7 +933,6 @@ public final class CertHack {
             if (signingAlgorithm == 0) return caList;
 
             if (verifiedBootKey == null || verifiedBootHash == null) {
-                Logger.e("Verified boot key/hash is unavailable; preserving the original certificate chain");
                 return caList;
             }
 
@@ -959,9 +955,6 @@ public final class CertHack {
                     verifiedBootKey,
                     verifiedBootHash);
             if (rewrittenDer == null || rewrittenDer.length == 0 || rewrittenDer.length > MAX_LEAF_CERTIFICATE_BYTES) {
-                if (rewrittenDer != null && rewrittenDer.length > MAX_LEAF_CERTIFICATE_BYTES) {
-                    Logger.e("Rewritten certificate exceeds maximum leaf size: " + rewrittenDer.length);
-                }
                 return caList;
             }
             Certificate rewrittenLeaf = new LazyX509Certificate(rewrittenDer);
@@ -983,7 +976,6 @@ public final class CertHack {
             }
             return result;
         } catch (Throwable t) {
-            Logger.e("Exception in hackCertificateChain", t);
             return caList;
         } finally {
             if (keyId != null) Arrays.fill(keyId, (byte) 0);
@@ -1000,6 +992,7 @@ public final class CertHack {
 
 
     private static Map<Integer, byte[]> presentIdOverrides(int uid, int mask) {
+        if (mask == 0) return Collections.emptyMap();
         Map<Integer, byte[]> overrides = new HashMap<>();
         for (int index = 0; index < ATTESTATION_ID_TAGS.length; index++) {
             if ((mask & (1 << index)) == 0) continue;

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/LazyX509Certificate.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/LazyX509Certificate.java
@@ -36,7 +36,7 @@ import javax.security.auth.x500.X500Principal;
  * path incurs an unnecessary ~15-25 microsecond parsing overhead, which exposes a measurable
  * timing side-channel distinguishing attested from non-attested key generation.
  */
-final class LazyX509Certificate extends X509Certificate {
+public final class LazyX509Certificate extends X509Certificate {
     private static final long serialVersionUID = 1L;
 
     private static final ThreadLocal<CertificateFactory> FACTORY =
@@ -48,14 +48,37 @@ final class LazyX509Certificate extends X509Certificate {
                 }
             });
 
+    private static final byte[] ANDROID_ATTESTATION_OID_DER = new byte[] {
+            0x06, 0x0a, 0x2b, 0x06, 0x01, 0x04, 0x01, (byte) 0xd6, 0x79, 0x02, 0x01, 0x11
+    };
+
     private final byte[] der;
     private volatile X509Certificate delegate;
 
-    LazyX509Certificate(byte[] der) {
+    public LazyX509Certificate(byte[] der) {
         this.der = Objects.requireNonNull(der, "der").clone();
     }
 
-    boolean isDelegateInstantiatedForTesting() {
+    boolean hasAttestationExtension() {
+        return indexOfSubarray(der, ANDROID_ATTESTATION_OID_DER) >= 0;
+    }
+
+    private static int indexOfSubarray(byte[] array, byte[] target) {
+        if (target.length == 0 || array.length < target.length) return -1;
+        int max = array.length - target.length;
+        outer:
+        for (int i = 0; i <= max; i++) {
+            for (int j = 0; j < target.length; j++) {
+                if (array[i + j] != target[j]) {
+                    continue outer;
+                }
+            }
+            return i;
+        }
+        return -1;
+    }
+
+    public boolean isDelegateInstantiatedForTesting() {
         return delegate != null;
     }
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/LazyX509Certificate.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/LazyX509Certificate.java
@@ -56,7 +56,12 @@ public final class LazyX509Certificate extends X509Certificate {
     private volatile X509Certificate delegate;
 
     public LazyX509Certificate(byte[] der) {
-        this.der = Objects.requireNonNull(der, "der").clone();
+        this(der, true);
+    }
+
+    LazyX509Certificate(byte[] der, boolean copy) {
+        Objects.requireNonNull(der, "der");
+        this.der = copy ? der.clone() : der;
     }
 
     boolean hasAttestationExtension() {
@@ -379,8 +384,12 @@ public final class LazyX509Certificate extends X509Certificate {
         if (other instanceof LazyX509Certificate lazy) {
             return Arrays.equals(this.der, lazy.der);
         }
-        if (other instanceof Certificate) {
-            return delegate().equals(other);
+        if (other instanceof Certificate cert) {
+            try {
+                return Arrays.equals(this.der, cert.getEncoded());
+            } catch (CertificateEncodingException ignored) {
+                return false;
+            }
         }
         return false;
     }

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/LazyX509Certificate.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/LazyX509Certificate.java
@@ -60,22 +60,127 @@ public final class LazyX509Certificate extends X509Certificate {
     }
 
     boolean hasAttestationExtension() {
-        return indexOfSubarray(der, ANDROID_ATTESTATION_OID_DER) >= 0;
-    }
+        try {
+            DerReader certReader = new DerReader(der, 0, der.length);
+            DerReader certSeq = certReader.readConstructed(0x30); // Certificate SEQUENCE
+            if (certSeq == null) return false;
 
-    private static int indexOfSubarray(byte[] array, byte[] target) {
-        if (target.length == 0 || array.length < target.length) return -1;
-        int max = array.length - target.length;
-        outer:
-        for (int i = 0; i <= max; i++) {
-            for (int j = 0; j < target.length; j++) {
-                if (array[i + j] != target[j]) {
-                    continue outer;
+            DerReader tbsSeq = certSeq.readConstructed(0x30); // TBSCertificate SEQUENCE
+            if (tbsSeq == null) return false;
+
+            // 1. version [0] EXPLICIT
+            if (tbsSeq.peekTag() == 0xa0) {
+                if (!tbsSeq.skipTlv()) return false;
+            }
+            // 2. serialNumber (0x02 INTEGER)
+            if (tbsSeq.peekTag() != 0x02 || !tbsSeq.skipTlv()) return false;
+            // 3. signature (0x30 SEQUENCE)
+            if (tbsSeq.peekTag() != 0x30 || !tbsSeq.skipTlv()) return false;
+            // 4. issuer (0x30 SEQUENCE)
+            if (tbsSeq.peekTag() != 0x30 || !tbsSeq.skipTlv()) return false;
+            // 5. validity (0x30 SEQUENCE)
+            if (tbsSeq.peekTag() != 0x30 || !tbsSeq.skipTlv()) return false;
+            // 6. subject (0x30 SEQUENCE)
+            if (tbsSeq.peekTag() != 0x30 || !tbsSeq.skipTlv()) return false;
+            // 7. subjectPublicKeyInfo (0x30 SEQUENCE)
+            if (tbsSeq.peekTag() != 0x30 || !tbsSeq.skipTlv()) return false;
+
+            // Optional issuerUniqueID [1]
+            if (tbsSeq.peekTag() == 0x81 || tbsSeq.peekTag() == 0xa1) {
+                if (!tbsSeq.skipTlv()) return false;
+            }
+            // Optional subjectUniqueID [2]
+            if (tbsSeq.peekTag() == 0x82 || tbsSeq.peekTag() == 0xa2) {
+                if (!tbsSeq.skipTlv()) return false;
+            }
+
+            // 8. extensions [3] EXPLICIT (tag 0xa3)
+            if (tbsSeq.peekTag() != 0xa3) return false;
+            DerReader extContainer = tbsSeq.readConstructed(0xa3);
+            if (extContainer == null) return false;
+
+            DerReader extsSeq = extContainer.readConstructed(0x30); // Extensions SEQUENCE
+            if (extsSeq == null) return false;
+
+            while (extsSeq.hasNext()) {
+                DerReader extSeq = extsSeq.readConstructed(0x30); // Extension SEQUENCE
+                if (extSeq == null) return false;
+
+                // First item in Extension SEQUENCE is extnID (OBJECT IDENTIFIER 0x06)
+                if (extSeq.peekTag() == 0x06 && extSeq.matchesNextBytes(ANDROID_ATTESTATION_OID_DER)) {
+                    return true;
                 }
             }
-            return i;
+            return false;
+        } catch (Throwable ignored) {
+            return false;
         }
-        return -1;
+    }
+
+    private static final class DerReader {
+        private final byte[] data;
+        private int pos;
+        private final int limit;
+
+        DerReader(byte[] data, int offset, int length) {
+            this.data = data;
+            this.pos = offset;
+            this.limit = offset + length;
+        }
+
+        boolean hasNext() {
+            return pos < limit;
+        }
+
+        int peekTag() {
+            if (pos >= limit) return -1;
+            return data[pos] & 0xff;
+        }
+
+        DerReader readConstructed(int expectedTag) {
+            if (pos >= limit) return null;
+            int tag = data[pos++] & 0xff;
+            if (tag != expectedTag) return null;
+            int len = readLength();
+            if (len < 0 || pos + len > limit) return null;
+            int start = pos;
+            pos += len;
+            return new DerReader(data, start, len);
+        }
+
+        boolean skipTlv() {
+            if (pos >= limit) return false;
+            pos++;
+            int len = readLength();
+            if (len < 0 || pos + len > limit) return false;
+            pos += len;
+            return true;
+        }
+
+        private int readLength() {
+            if (pos >= limit) return -1;
+            int b = data[pos++] & 0xff;
+            if ((b & 0x80) == 0) {
+                return b;
+            }
+            int numBytes = b & 0x7f;
+            if (numBytes == 0 || numBytes > 4 || pos + numBytes > limit) {
+                return -1;
+            }
+            int len = 0;
+            for (int i = 0; i < numBytes; i++) {
+                len = (len << 8) | (data[pos++] & 0xff);
+            }
+            return len;
+        }
+
+        boolean matchesNextBytes(byte[] target) {
+            if (limit - pos < target.length) return false;
+            for (int i = 0; i < target.length; i++) {
+                if (data[pos + i] != target[i]) return false;
+            }
+            return true;
+        }
     }
 
     public boolean isDelegateInstantiatedForTesting() {

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/LazyX509Certificate.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/LazyX509Certificate.java
@@ -1,0 +1,264 @@
+package cleveres.tricky.cleverestech.keystore;
+
+import java.io.ByteArrayInputStream;
+import java.math.BigInteger;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Principal;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.SignatureException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateExpiredException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.CertificateNotYetValidException;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import javax.security.auth.x500.X500Principal;
+
+/**
+ * An X509Certificate wrapper around pre-encoded DER bytes that defers instantiation
+ * of the heavyweight platform X.509 certificate object until one of its parsed accessor
+ * methods is actually invoked.
+ *
+ * On the latency-critical generateKey reply path, SecurityLevelInterceptor directly applies
+ * pre-encoded replacement bytes to KeyMetadata without ever inspecting the individual fields
+ * of the rewritten leaf. Eagerly invoking CertificateFactory.generateCertificate on that
+ * path incurs an unnecessary ~15-25 microsecond parsing overhead, which exposes a measurable
+ * timing side-channel distinguishing attested from non-attested key generation.
+ */
+final class LazyX509Certificate extends X509Certificate {
+    private static final long serialVersionUID = 1L;
+
+    private static final ThreadLocal<CertificateFactory> FACTORY =
+            ThreadLocal.withInitial(() -> {
+                try {
+                    return CertificateFactory.getInstance("X.509");
+                } catch (CertificateException error) {
+                    throw new IllegalStateException("X.509 certificate factory is unavailable", error);
+                }
+            });
+
+    private final byte[] der;
+    private volatile X509Certificate delegate;
+
+    LazyX509Certificate(byte[] der) {
+        this.der = Objects.requireNonNull(der, "der").clone();
+    }
+
+    boolean isDelegateInstantiatedForTesting() {
+        return delegate != null;
+    }
+
+    private X509Certificate delegate() {
+        X509Certificate d = delegate;
+        if (d == null) {
+            synchronized (this) {
+                d = delegate;
+                if (d == null) {
+                    try {
+                        CertificateFactory factory = FACTORY.get();
+                        d = (X509Certificate) factory.generateCertificate(new ByteArrayInputStream(der));
+                        delegate = d;
+                    } catch (CertificateException error) {
+                        throw new IllegalStateException("Failed to parse X.509 certificate", error);
+                    }
+                }
+            }
+        }
+        return d;
+    }
+
+    @Override
+    public byte[] getEncoded() {
+        return der.clone();
+    }
+
+    @Override
+    public void verify(PublicKey key)
+            throws CertificateException, NoSuchAlgorithmException, InvalidKeyException,
+            NoSuchProviderException, SignatureException {
+        delegate().verify(key);
+    }
+
+    @Override
+    public void verify(PublicKey key, String sigProvider)
+            throws CertificateException, NoSuchAlgorithmException, InvalidKeyException,
+            NoSuchProviderException, SignatureException {
+        delegate().verify(key, sigProvider);
+    }
+
+    @Override
+    public void verify(PublicKey key, Provider sigProvider)
+            throws CertificateException, NoSuchAlgorithmException, InvalidKeyException,
+            SignatureException {
+        delegate().verify(key, sigProvider);
+    }
+
+    @Override
+    public String toString() {
+        return delegate().toString();
+    }
+
+    @Override
+    public PublicKey getPublicKey() {
+        return delegate().getPublicKey();
+    }
+
+    @Override
+    public boolean hasUnsupportedCriticalExtension() {
+        return delegate().hasUnsupportedCriticalExtension();
+    }
+
+    @Override
+    public Set<String> getCriticalExtensionOIDs() {
+        return delegate().getCriticalExtensionOIDs();
+    }
+
+    @Override
+    public Set<String> getNonCriticalExtensionOIDs() {
+        return delegate().getNonCriticalExtensionOIDs();
+    }
+
+    @Override
+    public byte[] getExtensionValue(String oid) {
+        return delegate().getExtensionValue(oid);
+    }
+
+    @Override
+    public void checkValidity() throws CertificateExpiredException, CertificateNotYetValidException {
+        delegate().checkValidity();
+    }
+
+    @Override
+    public void checkValidity(Date date)
+            throws CertificateExpiredException, CertificateNotYetValidException {
+        delegate().checkValidity(date);
+    }
+
+    @Override
+    public int getVersion() {
+        return delegate().getVersion();
+    }
+
+    @Override
+    public BigInteger getSerialNumber() {
+        return delegate().getSerialNumber();
+    }
+
+    @Override
+    public Principal getIssuerDN() {
+        return delegate().getIssuerDN();
+    }
+
+    @Override
+    public X500Principal getIssuerX500Principal() {
+        return delegate().getIssuerX500Principal();
+    }
+
+    @Override
+    public Principal getSubjectDN() {
+        return delegate().getSubjectDN();
+    }
+
+    @Override
+    public X500Principal getSubjectX500Principal() {
+        return delegate().getSubjectX500Principal();
+    }
+
+    @Override
+    public Date getNotBefore() {
+        return delegate().getNotBefore();
+    }
+
+    @Override
+    public Date getNotAfter() {
+        return delegate().getNotAfter();
+    }
+
+    @Override
+    public byte[] getTBSCertificate() throws CertificateEncodingException {
+        return delegate().getTBSCertificate();
+    }
+
+    @Override
+    public byte[] getSignature() {
+        return delegate().getSignature();
+    }
+
+    @Override
+    public String getSigAlgName() {
+        return delegate().getSigAlgName();
+    }
+
+    @Override
+    public String getSigAlgOID() {
+        return delegate().getSigAlgOID();
+    }
+
+    @Override
+    public byte[] getSigAlgParams() {
+        return delegate().getSigAlgParams();
+    }
+
+    @Override
+    public boolean[] getIssuerUniqueID() {
+        return delegate().getIssuerUniqueID();
+    }
+
+    @Override
+    public boolean[] getSubjectUniqueID() {
+        return delegate().getSubjectUniqueID();
+    }
+
+    @Override
+    public boolean[] getKeyUsage() {
+        return delegate().getKeyUsage();
+    }
+
+    @Override
+    public List<String> getExtendedKeyUsage() throws CertificateParsingException {
+        return delegate().getExtendedKeyUsage();
+    }
+
+    @Override
+    public int getBasicConstraints() {
+        return delegate().getBasicConstraints();
+    }
+
+    @Override
+    public Collection<List<?>> getSubjectAlternativeNames() throws CertificateParsingException {
+        return delegate().getSubjectAlternativeNames();
+    }
+
+    @Override
+    public Collection<List<?>> getIssuerAlternativeNames() throws CertificateParsingException {
+        return delegate().getIssuerAlternativeNames();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other instanceof LazyX509Certificate lazy) {
+            return Arrays.equals(this.der, lazy.der);
+        }
+        if (other instanceof Certificate) {
+            return delegate().equals(other);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(der);
+    }
+}

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
@@ -147,6 +147,9 @@ public final class Utils {
      * the fixed extension OID is bounded and avoids any backend IPC for that common negative case.
      */
     public static boolean hasAndroidAttestationExtension(Certificate certificate) {
+        if (certificate instanceof LazyX509Certificate lazy) {
+            return lazy.hasAttestationExtension();
+        }
         if (!(certificate instanceof X509Certificate x509Certificate)) return false;
         try {
             return x509Certificate.getExtensionValue(ANDROID_ATTESTATION_EXTENSION_OID) != null;
@@ -187,7 +190,11 @@ public final class Utils {
      * is unnecessary work on the latency-sensitive generateKey reply path.
      */
     public static X509Certificate getLeafCertificate(KeyMetadata metadata) {
-        return metadata == null ? null : toCertificate(metadata.certificate);
+        if (metadata == null || metadata.certificate == null || metadata.certificate.length == 0 ||
+                metadata.certificate.length > MAX_CERTIFICATE_BYTES) {
+            return null;
+        }
+        return new LazyX509Certificate(metadata.certificate);
     }
 
     public static Certificate[] getCertificateChain(KeyEntryResponse response) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
@@ -133,7 +133,6 @@ public final class Utils {
             return (X509Certificate) factory.generateCertificate(
                     new ByteArrayInputStream(encoded));
         } catch (CertificateException | ClassCastException error) {
-            Log.w(TAG, "Could not parse an X.509 certificate");
             return null;
         }
     }
@@ -152,7 +151,6 @@ public final class Utils {
         try {
             return x509Certificate.getExtensionValue(ANDROID_ATTESTATION_EXTENSION_OID) != null;
         } catch (RuntimeException error) {
-            Log.w(TAG, "Could not inspect Android attestation extension");
             return false;
         }
     }
@@ -179,7 +177,6 @@ public final class Utils {
             }
             return certificates;
         } catch (CertificateException error) {
-            Log.w(TAG, "Could not parse an X.509 certificate chain");
             return List.of();
         }
     }

--- a/service/src/test/java/android/os/Parcel.java
+++ b/service/src/test/java/android/os/Parcel.java
@@ -65,6 +65,7 @@ public class Parcel {
     public byte[] createByteArray() { return new byte[0]; }
     public void readByteArray(byte[] val) {}
     public void setDataPosition(int pos) {}
+    public void setDataSize(int size) {}
     public int dataPosition() { return 0; }
     public int dataAvail() { return queue.isEmpty() ? lastDeclaredSize : Integer.MAX_VALUE; }
     public void appendFrom(Parcel parcel, int offset, int length) {}

--- a/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
@@ -217,7 +217,7 @@ class GenerateKeyTimingFastPathTest {
             ).readText()
         val method = source.indexOf("public static Certificate[] hackCertificateChain")
         val backendRewrite = source.indexOf("byte[] rewrittenDer = CertificateBackend.rewrite", method)
-        val lazyLeaf = source.indexOf("Certificate rewrittenLeaf = new LazyX509Certificate(rewrittenDer)", backendRewrite)
+        val lazyLeaf = source.indexOf("Certificate rewrittenLeaf = new LazyX509Certificate(rewrittenDer", backendRewrite)
         val eagerFactory = source.indexOf("CERTIFICATE_FACTORY.get().generateCertificate", backendRewrite)
 
         assertTrue(backendRewrite > method)

--- a/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
@@ -225,6 +225,52 @@ class GenerateKeyTimingFastPathTest {
         assertTrue("Eager CertificateFactory call must not exist on the rewrite completion path", eagerFactory < 0)
     }
 
+    @Test
+    fun `generateKey reply stream reuses existing reply parcel in place without Parcel obtain allocation`() {
+        val root = locateRoot()
+        val source =
+            File(
+                root,
+                "service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt",
+            ).readText()
+        val postTransact = source.indexOf("override fun onPostTransact")
+        val inPlaceReset = source.indexOf("reply.setDataSize(0)", postTransact)
+        val inPlacePosition = source.indexOf("reply.setDataPosition(0)", postTransact)
+        val inPlaceNoException = source.indexOf("reply.writeNoException()", postTransact)
+        val inPlaceTypedObject = source.indexOf("reply.writeTypedObject(metadata, 0)", postTransact)
+        val inPlaceReply = source.indexOf("OverrideReply(0, reply)", postTransact)
+        val parcelObtain = source.indexOf("Parcel.obtain()", postTransact)
+
+        assertTrue(postTransact >= 0)
+        assertTrue(inPlaceReset > postTransact)
+        assertTrue(inPlacePosition > inPlaceReset)
+        assertTrue(inPlaceNoException > inPlacePosition)
+        assertTrue(inPlaceTypedObject > inPlaceNoException)
+        assertTrue(inPlaceReply > inPlaceTypedObject)
+        assertTrue("Hot path onPostTransact must not allocate new Parcel instances via Parcel.obtain()", parcelObtain < 0)
+    }
+
+    @Test
+    fun `hot path interceptor and CertHack completion path contain zero Logger calls`() {
+        val root = locateRoot()
+        val interceptorSource =
+            File(
+                root,
+                "service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt",
+            ).readText()
+        assertFalse("SecurityLevelInterceptor must contain zero Logger calls", interceptorSource.contains("Logger."))
+
+        val certHackSource =
+            File(
+                root,
+                "service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java",
+            ).readText()
+        val method = certHackSource.indexOf("public static Certificate[] hackCertificateChain")
+        val methodEnd = certHackSource.indexOf("private static Config.AttestationPatchLevels keepPatchLevels", method)
+        val hackMethodBody = certHackSource.substring(method, methodEnd)
+        assertFalse("CertHack.hackCertificateChain must contain zero Logger calls", hackMethodBody.contains("Logger."))
+    }
+
     private fun locateRoot(): File {
         var current = File(requireNotNull(System.getProperty("user.dir"))).canonicalFile
         repeat(6) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
@@ -271,6 +271,21 @@ class GenerateKeyTimingFastPathTest {
         assertFalse("CertHack.hackCertificateChain must contain zero Logger calls", hackMethodBody.contains("Logger."))
     }
 
+    @Test
+    fun `getLeafCertificate returns LazyX509Certificate and attestation check never instantiates delegate`() {
+        val metadata = android.system.keystore2.KeyMetadata()
+        metadata.certificate = ByteArray(64) { 0x30.toByte() }
+        val leaf = Utils.getLeafCertificate(metadata)
+
+        assertTrue(leaf is cleveres.tricky.cleverestech.keystore.LazyX509Certificate)
+        val lazyLeaf = leaf as cleveres.tricky.cleverestech.keystore.LazyX509Certificate
+        assertFalse(lazyLeaf.isDelegateInstantiatedForTesting)
+
+        val hasAttestation = Utils.hasAndroidAttestationExtension(leaf)
+        assertFalse(hasAttestation)
+        assertFalse("Lazy leaf delegate must not be instantiated during attestation extension check", lazyLeaf.isDelegateInstantiatedForTesting)
+    }
+
     private fun locateRoot(): File {
         var current = File(requireNotNull(System.getProperty("user.dir"))).canonicalFile
         repeat(6) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
@@ -207,6 +207,24 @@ class GenerateKeyTimingFastPathTest {
         assertTrue(fallbackEncode > applyCache)
     }
 
+    @Test
+    fun `hackCertificateChain defers X509 parsing of rewritten leaf to avoid generateKey timing side channel`() {
+        val root = locateRoot()
+        val source =
+            File(
+                root,
+                "service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java",
+            ).readText()
+        val method = source.indexOf("public static Certificate[] hackCertificateChain")
+        val backendRewrite = source.indexOf("byte[] rewrittenDer = CertificateBackend.rewrite", method)
+        val lazyLeaf = source.indexOf("Certificate rewrittenLeaf = new LazyX509Certificate(rewrittenDer)", backendRewrite)
+        val eagerFactory = source.indexOf("CERTIFICATE_FACTORY.get().generateCertificate", backendRewrite)
+
+        assertTrue(backendRewrite > method)
+        assertTrue(lazyLeaf > backendRewrite)
+        assertTrue("Eager CertificateFactory call must not exist on the rewrite completion path", eagerFactory < 0)
+    }
+
     private fun locateRoot(): File {
         var current = File(requireNotNull(System.getProperty("user.dir"))).canonicalFile
         repeat(6) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/LazyX509CertificateTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/LazyX509CertificateTest.java
@@ -16,10 +16,13 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
 import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.NoSuchProviderException;
 import java.security.Security;
+import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Date;
 import java.util.concurrent.CountDownLatch;
@@ -100,7 +103,32 @@ public class LazyX509CertificateTest {
                 lazy1.isDelegateInstantiatedForTesting());
         assertFalse(lazy2.isDelegateInstantiatedForTesting());
 
-        assertTrue("Lazy cert must equal genuine cert with same DER", lazy1.equals(original));
+        LazyX509Certificate lazyNoDelegate = new LazyX509Certificate(encoded);
+        assertTrue("Lazy cert must equal genuine cert with same DER", lazyNoDelegate.equals(original));
+        assertFalse("Equality check against genuine cert must not instantiate delegate",
+                lazyNoDelegate.isDelegateInstantiatedForTesting());
+        assertTrue("Genuine cert must equal lazy cert with same DER", original.equals(lazyNoDelegate));
+        assertFalse("Equality check from genuine cert must not instantiate delegate",
+                lazyNoDelegate.isDelegateInstantiatedForTesting());
+        assertEquals("Hash codes must match between lazy and genuine cert", original.hashCode(), lazyNoDelegate.hashCode());
+        assertFalse("HashCode check must not instantiate delegate",
+                lazyNoDelegate.isDelegateInstantiatedForTesting());
+
+        try {
+            CertificateFactory sunFactory = CertificateFactory.getInstance("X.509", "SUN");
+            X509Certificate sunCert = (X509Certificate) sunFactory.generateCertificate(new ByteArrayInputStream(encoded));
+            assertEquals("Standard platform cert hash must match lazy cert hash", sunCert.hashCode(), lazyNoDelegate.hashCode());
+        } catch (NoSuchProviderException ignored) {
+            // SUN provider not on Android, only on JVM
+        }
+    }
+
+    @Test
+    public void zeroCopyConstructorSharesArrayWithoutCloning() {
+        byte[] buffer = new byte[] { 0x30, 0x03, 0x02, 0x01, 0x01 };
+        LazyX509Certificate lazy = new LazyX509Certificate(buffer, false);
+        assertArrayEquals(buffer, lazy.getEncoded());
+        assertFalse(lazy.isDelegateInstantiatedForTesting());
     }
 
     @Test

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/LazyX509CertificateTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/LazyX509CertificateTest.java
@@ -138,4 +138,62 @@ public class LazyX509CertificateTest {
             executor.shutdownNow();
         }
     }
+
+    private static X509Certificate generateCertWithExtension(
+            org.bouncycastle.asn1.ASN1ObjectIdentifier oid,
+            byte[] value
+    ) throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", "BC");
+        kpg.initialize(256);
+        KeyPair kp = kpg.generateKeyPair();
+        X500Name name = new X500Name("CN=Test Subject, O=CleveresTricky, C=US");
+        BigInteger serial = BigInteger.valueOf(123456789L);
+        Date notBefore = new Date(System.currentTimeMillis() - 10_000);
+        Date notAfter = new Date(System.currentTimeMillis() + 100_000);
+        X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+                name, serial, notBefore, notAfter, name, kp.getPublic());
+        if (oid != null && value != null) {
+            builder.addExtension(oid, false, new org.bouncycastle.asn1.DEROctetString(value));
+        }
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withECDSA").build(kp.getPrivate());
+        return new JcaX509CertificateConverter().getCertificate(builder.build(signer));
+    }
+
+    @Test
+    public void hasAttestationExtensionDetectsAndroidAttestationOid() throws Exception {
+        org.bouncycastle.asn1.ASN1ObjectIdentifier attestationOid =
+                new org.bouncycastle.asn1.ASN1ObjectIdentifier("1.3.6.1.4.1.11129.2.1.17");
+        X509Certificate cert = generateCertWithExtension(attestationOid, new byte[] { 0x30, 0x00 });
+        LazyX509Certificate lazy = new LazyX509Certificate(cert.getEncoded());
+
+        assertTrue(lazy.hasAttestationExtension());
+        assertFalse("Delegate must not be instantiated during attestation extension check",
+                lazy.isDelegateInstantiatedForTesting());
+    }
+
+    @Test
+    public void hasAttestationExtensionRejectsOidInUnrelatedExtensionValue() throws Exception {
+        byte[] rawAttestationOidBytes = new byte[] {
+                0x06, 0x0a, 0x2b, 0x06, 0x01, 0x04, 0x01, (byte) 0xd6, 0x79, 0x02, 0x01, 0x11
+        };
+        org.bouncycastle.asn1.ASN1ObjectIdentifier unrelatedOid =
+                new org.bouncycastle.asn1.ASN1ObjectIdentifier("1.2.3.4.5");
+        X509Certificate cert = generateCertWithExtension(unrelatedOid, rawAttestationOidBytes);
+        LazyX509Certificate lazy = new LazyX509Certificate(cert.getEncoded());
+
+        assertFalse("Oid bytes embedded inside an unrelated extension value must not trigger attestation detection",
+                lazy.hasAttestationExtension());
+        assertFalse("Delegate must not be instantiated during attestation extension check",
+                lazy.isDelegateInstantiatedForTesting());
+    }
+
+    @Test
+    public void hasAttestationExtensionReturnsFalseWhenNoExtensionsPresent() throws Exception {
+        X509Certificate cert = generateTestCert();
+        LazyX509Certificate lazy = new LazyX509Certificate(cert.getEncoded());
+
+        assertFalse(lazy.hasAttestationExtension());
+        assertFalse("Delegate must not be instantiated during attestation extension check",
+                lazy.isDelegateInstantiatedForTesting());
+    }
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/LazyX509CertificateTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/LazyX509CertificateTest.java
@@ -130,9 +130,12 @@ public class LazyX509CertificateTest {
             });
         }
 
-        assertTrue("All threads should complete within timeout",
-                latch.await(5, TimeUnit.SECONDS));
-        assertFalse("No concurrent access error should occur", errorOccurred.get());
-        executor.shutdown();
+        try {
+            assertTrue("All threads should complete within timeout",
+                    latch.await(5, TimeUnit.SECONDS));
+            assertFalse("No concurrent access error should occur", errorOccurred.get());
+        } finally {
+            executor.shutdownNow();
+        }
     }
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/LazyX509CertificateTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/LazyX509CertificateTest.java
@@ -1,0 +1,138 @@
+package cleveres.tricky.cleverestech.keystore;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class LazyX509CertificateTest {
+
+    @BeforeClass
+    public static void setUp() {
+        if (Security.getProvider("BC") == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    private static X509Certificate generateTestCert() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", "BC");
+        kpg.initialize(256);
+        KeyPair kp = kpg.generateKeyPair();
+        X500Name name = new X500Name("CN=Test Subject, O=CleveresTricky, C=US");
+        BigInteger serial = BigInteger.valueOf(123456789L);
+        Date notBefore = new Date(System.currentTimeMillis() - 10_000);
+        Date notAfter = new Date(System.currentTimeMillis() + 100_000);
+        X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+                name, serial, notBefore, notAfter, name, kp.getPublic());
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withECDSA").build(kp.getPrivate());
+        return new JcaX509CertificateConverter().getCertificate(builder.build(signer));
+    }
+
+    @Test
+    public void getEncodedDoesNotInstantiateDelegate() throws Exception {
+        X509Certificate original = generateTestCert();
+        byte[] encoded = original.getEncoded();
+
+        LazyX509Certificate lazy = new LazyX509Certificate(encoded);
+        assertFalse("Delegate must not be instantiated on construction",
+                lazy.isDelegateInstantiatedForTesting());
+
+        byte[] lazyEncoded = lazy.getEncoded();
+        assertFalse("getEncoded must NOT trigger delegate instantiation",
+                lazy.isDelegateInstantiatedForTesting());
+        assertArrayEquals("Encoded bytes must match original exactly", encoded, lazyEncoded);
+    }
+
+    @Test
+    public void fieldAccessInstantiatesDelegateAndMatchesOriginal() throws Exception {
+        X509Certificate original = generateTestCert();
+        byte[] encoded = original.getEncoded();
+
+        LazyX509Certificate lazy = new LazyX509Certificate(encoded);
+        assertFalse(lazy.isDelegateInstantiatedForTesting());
+
+        assertEquals(original.getSubjectDN().getName(), lazy.getSubjectDN().getName());
+        assertTrue("Delegate must be instantiated after field access",
+                lazy.isDelegateInstantiatedForTesting());
+
+        assertEquals(original.getIssuerDN().getName(), lazy.getIssuerDN().getName());
+        assertEquals(original.getSerialNumber(), lazy.getSerialNumber());
+        assertEquals(original.getPublicKey(), lazy.getPublicKey());
+        assertEquals(original.getSigAlgName(), lazy.getSigAlgName());
+        assertNotNull(lazy.getSignature());
+        lazy.checkValidity();
+    }
+
+    @Test
+    public void equalityAndHashCodeMatch() throws Exception {
+        X509Certificate original = generateTestCert();
+        byte[] encoded = original.getEncoded();
+
+        LazyX509Certificate lazy1 = new LazyX509Certificate(encoded);
+        LazyX509Certificate lazy2 = new LazyX509Certificate(encoded);
+
+        assertEquals("Two LazyX509Certificates with same DER must be equal", lazy1, lazy2);
+        assertEquals("Hash codes must match for same DER", lazy1.hashCode(), lazy2.hashCode());
+        assertFalse("Equality check between lazy certs must not instantiate delegate",
+                lazy1.isDelegateInstantiatedForTesting());
+        assertFalse(lazy2.isDelegateInstantiatedForTesting());
+
+        assertTrue("Lazy cert must equal genuine cert with same DER", lazy1.equals(original));
+    }
+
+    @Test
+    public void concurrentAccessIsThreadSafe() throws Exception {
+        X509Certificate original = generateTestCert();
+        byte[] encoded = original.getEncoded();
+        LazyX509Certificate lazy = new LazyX509Certificate(encoded);
+
+        int threads = 8;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        CountDownLatch latch = new CountDownLatch(threads);
+        AtomicBoolean errorOccurred = new AtomicBoolean(false);
+
+        for (int i = 0; i < threads; i++) {
+            executor.submit(() -> {
+                try {
+                    for (int j = 0; j < 50; j++) {
+                        assertNotNull(lazy.getSubjectDN());
+                        assertEquals(original.getSerialNumber(), lazy.getSerialNumber());
+                        assertNotNull(lazy.getEncoded());
+                    }
+                } catch (Throwable t) {
+                    errorOccurred.set(true);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        assertTrue("All threads should complete within timeout",
+                latch.await(5, TimeUnit.SECONDS));
+        assertFalse("No concurrent access error should occur", errorOccurred.get());
+        executor.shutdown();
+    }
+}


### PR DESCRIPTION
## Summary of Changes

This PR decisively closes key generation timing side-channels by optimizing execution latency across both the Android managed layer and the native Rust attestation core on the `generateKey` reply path.

### 1. Observable Failure & Root Cause
- During key generation benchmarks, attested key generation exhibited a measurable latency delta compared to non-attested key generation, elevating the attested-to-non-attested latency ratio close to or above the 1.10x threshold.
- Analysis of the post-transaction path identified four distinct overhead sources:
  1. Eager parsing of rewritten and genuine leaf certificates via `CertificateFactory.generateCertificate(ByteArrayInputStream)` in `Utils.getLeafCertificate()` and `CertHack.hackCertificateChain()`, consuming ~15-25 µs.
  2. Redundant `Parcel.obtain()` allocations and Parcel object recycling on every key generation reply.
  3. `Logger` formatting and string concatenation in Binder interceptor hot paths.
  4. Dynamic ASN.1 tree parsing, per-tag vector allocations, and dynamic sequence encoding in `cleverestricky-attestation-core` and `cleverestricky-certificate-core`.

### 2. Architectural Solution
1. **Deferred X.509 Leaf Parsing & Raw DER OID Fast-Path (`LazyX509Certificate.java` & `Utils.java`):**
   - Created `LazyX509Certificate` wrapping pre-encoded DER byte arrays, deferring `CertificateFactory` delegate instantiation until parsed fields are explicitly accessed.
   - Added `hasAttestationExtension()` method performing fast raw DER scanning for the Android Key Attestation OID (`1.3.6.1.4.1.11129.2.1.17`), allowing `Utils.hasAndroidAttestationExtension()` to check leaf certificates without instantiating the delegate.
   - Updated `Utils.getLeafCertificate(KeyMetadata)` to return `LazyX509Certificate` directly instead of eagerly parsing.

2. **Zero-Allocation Reply Parcel Handling (`SecurityLevelInterceptor.kt`):**
   - Reused the existing `reply` parcel directly in-place (`reply.setDataSize(0); reply.setDataPosition(0); reply.writeNoException(); reply.writeTypedObject(metadata, 0); OverrideReply(0, reply)`), eliminating new `Parcel.obtain()` allocations.

3. **Hot-Path Logging & Reflection Purge (`SecurityLevelInterceptor.kt` & `CertHack.java`):**
   - Stripped all `Logger.*` calls, debug string formatting, and reflection lookups from `generateKey` interceptor transactions.

4. **Zero-Copy ASN.1 Reconstruction in Native Rust Core (`cleverestricky-attestation-core` & `cleverestricky-certificate-core`):**
   - Converted ASN.1 authorization tags to borrowed `Cow<'a, [u8]>` slices (`split_tlvs(mut encoded: &[u8]) -> Result<Vec<&[u8]>, Error>`), eliminating intermediate heap vector allocations for unmodified tags.
   - Implemented pre-computed 80-byte DER template for `explicit_root_of_trust`, avoiding dynamic ASN.1 builder allocations.
   - Used static Version 3 DER sequence constants and pre-sized single-pass `encode_sequence` and `encode_explicit` encoders.

### 3. Verification & Regression Coverage
- **Unit & Property Tests:**
  - Added unit tests in `LazyX509CertificateTest.java` verifying deferred instantiation, equality, and thread safety.
  - Added regression test in `GenerateKeyTimingFastPathTest.kt` asserting that `Utils.getLeafCertificate()` returns `LazyX509Certificate` and attestation checks never instantiate the delegate.
  - Rust test suite passed across all crates (`cargo test -p cleverestricky-attestation-core -p cleverestricky-certificate-core`).
  - Native clippy and formatting passed (`cargo fmt --check`, `cargo clippy -- -D warnings`).
- **Managed Preflight Checks:**
  - `ktlintCheck`: Passed.
  - `:service:lintDebug :stub:lintDebug :encryptor-app:lintDebug`: Passed.
  - Keystore unit test suite (`cleveres.tricky.cleverestech.keystore.*` and `GenerateKeyTimingFastPathTest`): Passed.
- Updated `CHANGELOG.md` under Performance & Latency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Improved certificate metadata handling while preserving validation and attestation behavior.
  - Added safer handling for cached certificate chains and malformed certificate data.

- **Performance**
  - Reduced memory allocation and transaction overhead during certificate processing and key generation.
  - Improved efficiency when handling certificate chains and attestation data.

- **Documentation**
  - Updated the V2.7.4 changelog with clearer attestation, integrity, key-selection, and performance descriptions.

- **Tests**
  - Expanded coverage for deferred parsing, certificate compatibility, concurrency, and optimized key-generation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->