### PR TITLE
test(keystore): strengthen assertions for zero-copy LazyX509Certificate construction

### DIFF
--- a/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/GenerateKeyTimingFastPathTest.kt
@@ -217,7 +217,7 @@ class GenerateKeyTimingFastPathTest {
             ).readText()
         val method = source.indexOf("public static Certificate[] hackCertificateChain")
         val backendRewrite = source.indexOf("byte[] rewrittenDer = CertificateBackend.rewrite", method)
-        val lazyLeaf = source.indexOf("Certificate rewrittenLeaf = new LazyX509Certificate(rewrittenDer", backendRewrite)
+        val lazyLeaf = source.indexOf("Certificate rewrittenLeaf = new LazyX509Certificate(rewrittenDer, false)", backendRewrite)
         val eagerFactory = source.indexOf("CERTIFICATE_FACTORY.get().generateCertificate", backendRewrite)
 
         assertTrue(backendRewrite > method)

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/LazyX509CertificateTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/LazyX509CertificateTest.java
@@ -129,6 +129,10 @@ public class LazyX509CertificateTest {
         LazyX509Certificate lazy = new LazyX509Certificate(buffer, false);
         assertArrayEquals(buffer, lazy.getEncoded());
         assertFalse(lazy.isDelegateInstantiatedForTesting());
+
+        buffer[4] = 0x02;
+        assertEquals("Mutating underlying buffer must reflect in getEncoded() to prove zero-copy array sharing",
+                0x02, lazy.getEncoded()[4]);
     }
 
     @Test


### PR DESCRIPTION
## Summary
Follow-up to PR #1201 addressing CodeRabbit review feedback in https://github.com/tryigit/CleveresTricky/pull/1201#discussion_r3950250344:

- In \LazyX509CertificateTest.java\: mutate the underlying buffer after constructing \LazyX509Certificate(buffer, false)\ and assert that \lazy.getEncoded()\ reflects the mutation, strictly proving zero-copy array sharing rather than defensive cloning.
- In \GenerateKeyTimingFastPathTest.kt\: require the complete \
ew LazyX509Certificate(rewrittenDer, false)\ constructor call in the architectural guard test to prevent accidental regressions back to defensive cloning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated timing-side-channel coverage for explicit certificate construction behavior.
  - Expanded certificate tests to verify that encoded data reflects changes to the original backing array.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->