### PR TITLE
fix: report truncated keybox broker IPC headers

### DIFF
--- a/rust/daemon/src/keybox_file_broker.rs
+++ b/rust/daemon/src/keybox_file_broker.rs
@@ -1,6 +1,8 @@
 // Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
 use cleverestricky_service_core::fd_transport::send_one_fd;
-use cleverestricky_service_core::ipc::{read_header_bounded, write_frame_bounded, FLAG_ERROR};
+use cleverestricky_service_core::ipc::{
+    read_header_bounded_or_eof, write_frame_bounded, FLAG_ERROR,
+};
 use cleverestricky_service_core::secure_fs::TrustedDir;
 use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom, Write};
@@ -36,12 +38,8 @@ struct FileFingerprint {
 pub fn serve(mut stream: UnixStream, root: &TrustedDir) -> io::Result<()> {
     let mut request = [0u8; MAX_REQUEST_BYTES];
     loop {
-        let header = match read_header_bounded(&mut stream, MAX_REQUEST_BYTES) {
-            Ok(header) => header,
-            Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => {
-                return Err(crate::service_guard::clean_exit_error())
-            }
-            Err(error) => return Err(error),
+        let Some(header) = read_header_bounded_or_eof(&mut stream, MAX_REQUEST_BYTES)? else {
+            return Err(crate::service_guard::clean_exit_error());
         };
         stream.read_exact(&mut request[..header.payload_len])?;
         if header.opcode != OP_KEYBOX_BROKER_OPEN || header.flags != 0 {
@@ -270,6 +268,7 @@ fn invalid(message: &'static str) -> io::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cleverestricky_service_core::ipc::PROTOCOL_MAGIC;
     use std::fs;
     use std::os::unix::fs::symlink;
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -456,5 +455,18 @@ mod tests {
         drop(client);
 
         assert!(crate::service_guard::run(|| serve(server, &root)).is_ok());
+    }
+
+    #[test]
+    fn partial_header_is_reported_as_broker_failure() {
+        let test = TestRoot::new();
+        let root = TrustedDir::open(&test.path).unwrap();
+        let (mut client, server) = UnixStream::pair().unwrap();
+        client.write_all(&PROTOCOL_MAGIC).unwrap();
+        drop(client);
+
+        let error = crate::service_guard::run(|| serve(server, &root))
+            .expect_err("truncated broker headers must reach the supervisor");
+        assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof);
     }
 }

--- a/rust/service-core/src/ipc.rs
+++ b/rust/service-core/src/ipc.rs
@@ -42,6 +42,14 @@ pub fn read_header<R: Read>(reader: &mut R) -> io::Result<FrameHeader> {
 
 /// Reads an IPC frame header with a custom maximum payload size.
 pub fn read_header_bounded<R: Read>(reader: &mut R, max_payload: usize) -> io::Result<FrameHeader> {
+    read_header_bounded_or_eof(reader, max_payload)?.ok_or_else(truncated_frame_error)
+}
+
+/// Reads a bounded IPC header, returning `None` only when EOF occurs before any header byte.
+pub fn read_header_bounded_or_eof<R: Read>(
+    reader: &mut R,
+    max_payload: usize,
+) -> io::Result<Option<FrameHeader>> {
     if max_payload > u32::MAX as usize {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -49,7 +57,9 @@ pub fn read_header_bounded<R: Read>(reader: &mut R, max_payload: usize) -> io::R
         ));
     }
     let mut header = [0u8; HEADER_BYTES];
-    read_exact_retry(reader, &mut header)?;
+    if !read_exact_retry_or_eof(reader, &mut header)? {
+        return Ok(None);
+    }
     if header[0..4] != PROTOCOL_MAGIC {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -79,11 +89,11 @@ pub fn read_header_bounded<R: Read>(reader: &mut R, max_payload: usize) -> io::R
             "IPC frame exceeds configured bound",
         ));
     }
-    Ok(FrameHeader {
+    Ok(Some(FrameHeader {
         opcode,
         flags,
         payload_len,
-    })
+    }))
 }
 
 /// Writes an IPC frame header with the default maximum payload size.
@@ -203,16 +213,26 @@ pub fn relay_exact_bounded<R: Read, W: Write>(
 }
 
 /// Reads exactly the required number of bytes, retrying on EINTR.
-fn read_exact_retry<R: Read>(reader: &mut R, mut output: &mut [u8]) -> io::Result<()> {
+fn read_exact_retry<R: Read>(reader: &mut R, output: &mut [u8]) -> io::Result<()> {
+    if read_exact_retry_or_eof(reader, output)? {
+        Ok(())
+    } else {
+        Err(truncated_frame_error())
+    }
+}
+
+/// Reads exactly the required bytes while preserving clean EOF before the first byte.
+fn read_exact_retry_or_eof<R: Read>(reader: &mut R, mut output: &mut [u8]) -> io::Result<bool> {
+    if output.is_empty() {
+        return Ok(true);
+    }
+    let mut read_any = false;
     while !output.is_empty() {
         match reader.read(output) {
-            Ok(0) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::UnexpectedEof,
-                    "truncated IPC frame",
-                ))
-            }
+            Ok(0) if !read_any => return Ok(false),
+            Ok(0) => return Err(truncated_frame_error()),
             Ok(read) => {
+                read_any = true;
                 let (_, rest) = output.split_at_mut(read);
                 output = rest;
             }
@@ -220,7 +240,11 @@ fn read_exact_retry<R: Read>(reader: &mut R, mut output: &mut [u8]) -> io::Resul
             Err(error) => return Err(error),
         }
     }
-    Ok(())
+    Ok(true)
+}
+
+fn truncated_frame_error() -> io::Error {
+    io::Error::new(io::ErrorKind::UnexpectedEof, "truncated IPC frame")
 }
 
 /// Writes all bytes from input, retrying on EINTR.
@@ -317,6 +341,22 @@ mod tests {
         let mut scratch = [0u8; 8];
         assert_eq!(
             read_frame_into(&mut reader, &mut scratch)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::UnexpectedEof
+        );
+    }
+
+    #[test]
+    fn optional_header_distinguishes_clean_eof_from_truncation() {
+        let mut empty = Cursor::new(Vec::<u8>::new());
+        assert!(read_header_bounded_or_eof(&mut empty, MAX_FRAME_BYTES)
+            .unwrap()
+            .is_none());
+
+        let mut partial = Cursor::new(PROTOCOL_MAGIC.to_vec());
+        assert_eq!(
+            read_header_bounded_or_eof(&mut partial, MAX_FRAME_BYTES)
                 .unwrap_err()
                 .kind(),
             io::ErrorKind::UnexpectedEof


### PR DESCRIPTION
## Summary

- distinguish a clean EOF before any IPC header byte from a truncated header
- propagate partial keybox-broker headers as `UnexpectedEof` so the supervisor observes the broker failure
- preserve clean completion when the backend closes the broker socket without a pending frame
- add service-core and broker-level regression coverage for both cases

## Root cause

`read_exact_retry` returned `UnexpectedEof` for both an empty peer shutdown and a header truncated after one or more bytes. The keybox broker treated every `UnexpectedEof` from header parsing as an expected shutdown, so `service_guard` converted the failure to success and `spawn_keybox_broker` did not notify the backend supervisor.

## Validation

- reproduced the transport sequence with a Unix socket pair: 4 header bytes are read, followed by zero-byte EOF
- `git diff --check origin/master...origin/fix/keybox-broker-truncated-ipc`
- confirmed the remote branch tree matches the locally reviewed tree (`40928769da30f8c08552bd069b35d6da02d0b66a`)

The local environment does not include `cargo`, `rustc`, or `rustfmt`, so the repository's Rust fmt/clippy/workspace test commands could not be run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of closed IPC connections so clean peer shutdowns complete without unnecessary errors.
  - Truncated or incomplete message headers are now correctly reported as unexpected end-of-file errors.
  - Added coverage to verify consistent error handling for partial messages and clean connection closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->