### PR TITLE
fix: align WebUI policy limits with backend

### DIFF
--- a/module/template/webroot/policy.js
+++ b/module/template/webroot/policy.js
@@ -141,7 +141,7 @@ function normalizeProfile(profile) {
     }
   });
   const applications = Array.isArray(source.applications)
-    ? [...new Set(source.applications.map(value => String(value).trim()).filter(value => value && value.length <= MAX_PROFILE_VALUE_LENGTH))].slice(0, MAX_PROFILE_APPLICATIONS)
+    ? [...new Set(source.applications.map(value => String(value).trim()).filter(value => value && value.length <= MAX_PROFILE_VALUE_LENGTH))]
     : [];
   const template = typeof source.template === 'string' && source.template.length <= MAX_PROFILE_VALUE_LENGTH ? source.template : null;
   const keybox = typeof source.keybox === 'string' && source.keybox.length <= MAX_PROFILE_VALUE_LENGTH ? source.keybox : null;
@@ -191,21 +191,21 @@ function validatePolicyLimits(source) {
 }
 
 function stateForSave(source) {
-  validatePolicyLimits(source);
-  const normalizedPatch = normalizeSecurityPatch(source.securityPatch);
-  return {
+  const normalized = {
     version: Number(source.version) || 2,
     features: normalizePolicyFeatures(source.features),
-    securityPatch: normalizedPatch,
+    securityPatch: normalizeSecurityPatch(source.securityPatch),
     profiles: Array.isArray(source.profiles) ? source.profiles.map(normalizeProfile) : [],
     activeProfile: typeof source.activeProfile === 'string' ? source.activeProfile.slice(0, MAX_PROFILE_VALUE_LENGTH) : null
   };
+  validatePolicyLimits(normalized);
+  return normalized;
 }
 
 function normalizePolicyState(value) {
   const source = value && typeof value === 'object' && !Array.isArray(value) ? safeClone(value) : {};
   source.features = normalizePolicyFeatures(source.features);
-  source.profiles = Array.isArray(source.profiles) ? source.profiles.slice(0, MAX_POLICY_PROFILES).map(normalizeProfile) : [];
+  source.profiles = Array.isArray(source.profiles) ? source.profiles.map(normalizeProfile) : [];
   source.securityPatch = normalizeSecurityPatch(source.securityPatch);
   source.activeProfile = typeof source.activeProfile === 'string' ? source.activeProfile.slice(0, MAX_PROFILE_VALUE_LENGTH) : null;
   return source;

--- a/module/template/webroot/policy.js
+++ b/module/template/webroot/policy.js
@@ -63,8 +63,9 @@ const REBOOT_POLICY_FEATURES = new Set(['buildIdentity', 'regionIdentity', 'iden
 const MAX_REFERENCE_PACKAGES = 10000;
 const MAX_REFERENCE_KEYBOXES = 4096;
 const MAX_REFERENCE_TEMPLATES = 256;
-const MAX_POLICY_PROFILES = 256;
-const MAX_PROFILE_APPLICATIONS = 64;
+const MAX_POLICY_PROFILES = 64;
+const MAX_PROFILE_APPLICATIONS = 256;
+const MAX_TOTAL_ASSIGNMENTS = 2048;
 const MAX_PROFILE_VALUE_LENGTH = 256;
 
 function onReady(fn) {
@@ -171,13 +172,32 @@ function normalizeSecurityPatch(value) {
   return normalized;
 }
 
+function validatePolicyLimits(source) {
+  const profiles = Array.isArray(source && source.profiles) ? source.profiles : [];
+  if (profiles.length > MAX_POLICY_PROFILES) {
+    throw new Error(`Policy supports at most ${MAX_POLICY_PROFILES} profiles`);
+  }
+  let totalAssignments = 0;
+  profiles.forEach(profile => {
+    const applications = Array.isArray(profile && profile.applications) ? profile.applications : [];
+    if (applications.length > MAX_PROFILE_APPLICATIONS) {
+      throw new Error(`A profile supports at most ${MAX_PROFILE_APPLICATIONS} application assignments`);
+    }
+    totalAssignments += applications.length;
+    if (totalAssignments > MAX_TOTAL_ASSIGNMENTS) {
+      throw new Error(`Policy supports at most ${MAX_TOTAL_ASSIGNMENTS} total application assignments`);
+    }
+  });
+}
+
 function stateForSave(source) {
+  validatePolicyLimits(source);
   const normalizedPatch = normalizeSecurityPatch(source.securityPatch);
   return {
     version: Number(source.version) || 2,
     features: normalizePolicyFeatures(source.features),
     securityPatch: normalizedPatch,
-    profiles: Array.isArray(source.profiles) ? source.profiles.slice(0, MAX_POLICY_PROFILES).map(normalizeProfile) : [],
+    profiles: Array.isArray(source.profiles) ? source.profiles.map(normalizeProfile) : [],
     activeProfile: typeof source.activeProfile === 'string' ? source.activeProfile.slice(0, MAX_PROFILE_VALUE_LENGTH) : null
   };
 }
@@ -1079,7 +1099,7 @@ function fillSelect(select, values, selected, emptyLabel) {
 
 function profileAppsFromEditor() {
   const source = document.getElementById('ct_profile_apps');
-  return source ? [...new Set(source.value.split(/\r?\n/).map(value => value.trim()).filter(value => value && value.length <= MAX_PROFILE_VALUE_LENGTH))].slice(0, MAX_PROFILE_APPLICATIONS) : [];
+  return source ? [...new Set(source.value.split(/\r?\n/).map(value => value.trim()).filter(value => value && value.length <= MAX_PROFILE_VALUE_LENGTH))] : [];
 }
 
 function renderAppChips() {
@@ -1101,7 +1121,13 @@ function addProfileApp() {
   const value = picker.value.trim();
   if (!value) return;
   const apps = profileAppsFromEditor();
-  if (!apps.includes(value)) apps.push(value);
+  if (!apps.includes(value)) {
+    if (apps.length >= MAX_PROFILE_APPLICATIONS) {
+      notify(`A profile supports at most ${MAX_PROFILE_APPLICATIONS} application assignments`, 'error');
+      return;
+    }
+    apps.push(value);
+  }
   document.getElementById('ct_profile_apps').value = apps.join('\n');
   picker.value = '';
   renderAppChips();
@@ -1154,6 +1180,10 @@ function collectProfile() {
   const existing = selectedProfileIndex >= 0 ? normalizeProfile(policyState.profiles[selectedProfileIndex]) : emptyProfile();
   const name = document.getElementById('ct_profile_name').value.trim();
   if (!/^[A-Za-z0-9][A-Za-z0-9 _.-]{0,63}$/.test(name)) throw new Error('Profile name is invalid');
+  const applications = profileAppsFromEditor();
+  if (applications.length > MAX_PROFILE_APPLICATIONS) {
+    throw new Error(`A profile supports at most ${MAX_PROFILE_APPLICATIONS} application assignments`);
+  }
   const features = {};
   FEATURE_KEYS.forEach(([key]) => {
     const value = boolOrInherit(`ct_pf_${key}`);
@@ -1168,7 +1198,7 @@ function collectProfile() {
   });
   return {
     name,
-    applications: profileAppsFromEditor(),
+    applications,
     template: document.getElementById('ct_profile_template').value || null,
     keybox: document.getElementById('ct_profile_keybox').value || null,
     privacy: document.getElementById('ct_profile_privacy').value,
@@ -1183,6 +1213,10 @@ function saveProfile() {
   let profile;
   try { profile = collectProfile(); } catch (error) { notify(error.message,'error'); return; }
   const index = selectedProfileIndex;
+  if (index < 0 && Array.isArray(policyState.profiles) && policyState.profiles.length >= MAX_POLICY_PROFILES) {
+    notify(`Policy supports at most ${MAX_POLICY_PROFILES} profiles`, 'error');
+    return;
+  }
   savePolicy(next => {
     const profiles = Array.isArray(next.profiles) ? next.profiles : (next.profiles = []);
     const conflict = profiles.findIndex((item,itemIndex) => itemIndex !== index && String(item.name).toLowerCase() === profile.name.toLowerCase());
@@ -1200,6 +1234,10 @@ function saveProfile() {
 function cloneProfile() {
   let profile;
   try { profile = collectProfile(); } catch (error) { notify(error.message,'error'); return; }
+  if (Array.isArray(policyState.profiles) && policyState.profiles.length >= MAX_POLICY_PROFILES) {
+    notify(`Policy supports at most ${MAX_POLICY_PROFILES} profiles`, 'error');
+    return;
+  }
   const base = profile.name || 'Profile';
   let name = `${base} Copy`;
   let number = 2;

--- a/module/webui-tests/policy-limit-contract.test.js
+++ b/module/webui-tests/policy-limit-contract.test.js
@@ -1,0 +1,110 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+const source = fs.readFileSync('module/template/webroot/policy.js', 'utf8');
+
+assert.match(source, /const MAX_POLICY_PROFILES = 64;/, 'WebUI profile limit must match PolicyState');
+assert.match(source, /const MAX_PROFILE_APPLICATIONS = 256;/, 'WebUI per-profile assignment limit must match PolicyState');
+assert.match(source, /const MAX_TOTAL_ASSIGNMENTS = 2048;/, 'WebUI total assignment limit must match PolicyState');
+assert.match(source, /validatePolicyLimits\(source\);/, 'policy saves must reject over-limit state before normalization');
+
+const start = source.indexOf('function safeClone(value)');
+const end = source.indexOf('function transitionRequiresReboot', start);
+assert.ok(start >= 0 && end > start, 'policy normalization implementation is missing');
+const implementation = source.slice(start, end);
+
+const context = { console };
+vm.createContext(context);
+vm.runInContext(`
+  const PROFILE_FEATURES = [
+    ['buildIdentity'], ['attestationIdentity'], ['telephonyIdentity'],
+    ['regionIdentity'], ['identityRefresh'], ['securityPatch']
+  ];
+  const PATCH_COMPONENTS = [['system', 'System'], ['vendor', 'Vendor'], ['boot', 'Boot']];
+  const PATCH_MODES = [
+    ['device_default', 'Device default'], ['prop', 'ROM property'], ['manual', 'Manual date'],
+    ['automatic', 'Automatic'], ['no', 'Omit']
+  ];
+  const MAX_POLICY_PROFILES = 64;
+  const MAX_PROFILE_APPLICATIONS = 256;
+  const MAX_TOTAL_ASSIGNMENTS = 2048;
+  const MAX_PROFILE_VALUE_LENGTH = 256;
+  ${implementation}
+  this.normalizePolicyState = normalizePolicyState;
+  this.stateForSave = stateForSave;
+`, context, { filename: 'policy.js#limit-contract' });
+
+function features() {
+  return {
+    buildIdentity: false,
+    attestationIdentity: false,
+    telephonyIdentity: false,
+    regionIdentity: false,
+    identityRefresh: false,
+    securityPatch: false
+  };
+}
+
+function securityPatch() {
+  return {
+    automaticThresholdMonths: 6,
+    system: { mode: 'device_default' },
+    vendor: { mode: 'device_default' },
+    boot: { mode: 'device_default' }
+  };
+}
+
+function profile(name, applicationCount) {
+  return {
+    name,
+    applications: Array.from({ length: applicationCount }, (_, index) => `com.example.${name}.${index}`),
+    template: null,
+    keybox: null,
+    privacy: 'inherit',
+    features: {},
+    securityPatch: {},
+    rkpPassthrough: null,
+    drmPassthrough: null
+  };
+}
+
+function policy(profiles) {
+  return {
+    version: 2,
+    features: features(),
+    securityPatch: securityPatch(),
+    profiles,
+    activeProfile: null
+  };
+}
+
+const assignments = Array.from({ length: 256 }, (_, index) => `com.example.roundtrip.${index}`);
+const canonical = policy([{ ...profile('roundtrip', 0), applications: assignments }]);
+const normalized = context.normalizePolicyState(canonical);
+assert.equal(normalized.profiles[0].applications.length, 256, 'canonical 256-assignment profile must survive WebUI normalization');
+const saved = context.stateForSave(normalized);
+assert.equal(saved.profiles[0].applications.length, 256, 'canonical 256-assignment profile must survive save normalization');
+assert.equal(saved.profiles[0].applications.join('\n'), assignments.join('\n'), 'policy round-trip must not drop assignments 65-256');
+
+assert.doesNotThrow(() => context.stateForSave(policy(Array.from({ length: 64 }, (_, index) => profile(`p${index}`, 0)))));
+assert.throws(
+  () => context.stateForSave(policy(Array.from({ length: 65 }, (_, index) => profile(`p${index}`, 0)))),
+  /at most 64 profiles/,
+  '65th profile must be rejected instead of silently discarded'
+);
+assert.throws(
+  () => context.stateForSave(policy([profile('too-many-apps', 257)])),
+  /at most 256 application assignments/,
+  '257th application assignment must be rejected instead of silently discarded'
+);
+
+const totalLimitProfiles = Array.from({ length: 8 }, (_, index) => profile(`full${index}`, 256));
+totalLimitProfiles.push(profile('overflow', 1));
+assert.throws(
+  () => context.stateForSave(policy(totalLimitProfiles)),
+  /at most 2048 total application assignments/,
+  'global assignment overflow must fail in WebUI before backend rejection'
+);
+
+console.log('Policy WebUI/backend limit contract regression checks passed');

--- a/module/webui-tests/policy-limit-contract.test.js
+++ b/module/webui-tests/policy-limit-contract.test.js
@@ -7,7 +7,7 @@ const source = fs.readFileSync('module/template/webroot/policy.js', 'utf8');
 assert.match(source, /const MAX_POLICY_PROFILES = 64;/, 'WebUI profile limit must match PolicyState');
 assert.match(source, /const MAX_PROFILE_APPLICATIONS = 256;/, 'WebUI per-profile assignment limit must match PolicyState');
 assert.match(source, /const MAX_TOTAL_ASSIGNMENTS = 2048;/, 'WebUI total assignment limit must match PolicyState');
-assert.match(source, /validatePolicyLimits\(source\);/, 'policy saves must reject over-limit state before normalization');
+assert.match(source, /validatePolicyLimits\(normalized\);/, 'policy saves must validate the complete normalized state');
 
 const start = source.indexOf('function safeClone(value)');
 const end = source.indexOf('function transitionRequiresReboot', start);
@@ -88,15 +88,28 @@ assert.equal(saved.profiles[0].applications.length, 256, 'canonical 256-assignme
 assert.equal(saved.profiles[0].applications.join('\n'), assignments.join('\n'), 'policy round-trip must not drop assignments 65-256');
 
 assert.doesNotThrow(() => context.stateForSave(policy(Array.from({ length: 64 }, (_, index) => profile(`p${index}`, 0)))));
+
+const normalized65Profiles = context.normalizePolicyState(policy(Array.from({ length: 65 }, (_, index) => profile(`p${index}`, 0))));
+assert.equal(normalized65Profiles.profiles.length, 65, 'normalization must preserve the 65th profile for limit validation');
 assert.throws(
-  () => context.stateForSave(policy(Array.from({ length: 65 }, (_, index) => profile(`p${index}`, 0)))),
+  () => context.stateForSave(normalized65Profiles),
   /at most 64 profiles/,
   '65th profile must be rejected instead of silently discarded'
 );
+
+const normalized257Assignments = context.normalizePolicyState(policy([profile('too-many-apps', 257)]));
+assert.equal(normalized257Assignments.profiles[0].applications.length, 257, 'normalization must preserve the 257th application assignment for limit validation');
 assert.throws(
-  () => context.stateForSave(policy([profile('too-many-apps', 257)])),
+  () => context.stateForSave(normalized257Assignments),
   /at most 256 application assignments/,
   '257th application assignment must be rejected instead of silently discarded'
+);
+
+const filteredBeforeValidation = profile('filtered', 256);
+filteredBeforeValidation.applications.push(filteredBeforeValidation.applications[0], 'x'.repeat(257));
+assert.doesNotThrow(
+  () => context.stateForSave(policy([filteredBeforeValidation])),
+  'save validation must run after assignment deduplication and value filtering'
 );
 
 const totalLimitProfiles = Array.from({ length: 8 }, (_, index) => profile(`full${index}`, 256));

--- a/module/webui-tests/webui-runtime-contract.test.js
+++ b/module/webui-tests/webui-runtime-contract.test.js
@@ -225,8 +225,8 @@ async function testPolicyNormalizationRejectsMalformedAndOversizedState() {
     assert.strictEqual(normalized.securityPatch.system.mode, 'manual', 'valid patch modes must be retained');
     assert.strictEqual(normalized.securityPatch.system.value, '2026-08-27', 'manual dates must be bounded');
     assert.strictEqual(normalized.securityPatch.vendor.mode, 'device_default', 'unknown patch modes must fall back safely');
-    assert.strictEqual(normalized.profiles.length, 64, 'policy profiles must be capped to the backend contract');
-    assert.strictEqual(normalized.profiles[0].applications.length, 256, 'profile assignments must be capped to the backend contract');
+    assert.strictEqual(normalized.profiles.length, 300, 'normalization must preserve profiles for later limit validation');
+    assert.strictEqual(normalized.profiles[0].applications.length, 300, 'normalization must preserve assignments for later limit validation');
     assert.strictEqual(normalized.profiles[0].template, null, 'oversized profile template references must be rejected');
     assert.strictEqual(normalized.profiles[0].keybox, null, 'oversized profile keybox references must be rejected');
     assert.strictEqual(normalized.profiles[0].privacy, 'inherit', 'unknown privacy modes must fall back safely');

--- a/module/webui-tests/webui-runtime-contract.test.js
+++ b/module/webui-tests/webui-runtime-contract.test.js
@@ -202,7 +202,7 @@ async function testPolicyNormalizationRejectsMalformedAndOversizedState() {
         },
         profiles: Array.from({ length: 300 }, (_, index) => ({
             name: `<profile-${index}>`,
-            applications: Array.from({ length: 100 }, (_, appIndex) => `com.example.${index}.${appIndex}`),
+            applications: Array.from({ length: 300 }, (_, appIndex) => `com.example.${index}.${appIndex}`),
             template: 't'.repeat(300),
             keybox: 'k'.repeat(300),
             privacy: 'unknown',
@@ -225,8 +225,8 @@ async function testPolicyNormalizationRejectsMalformedAndOversizedState() {
     assert.strictEqual(normalized.securityPatch.system.mode, 'manual', 'valid patch modes must be retained');
     assert.strictEqual(normalized.securityPatch.system.value, '2026-08-27', 'manual dates must be bounded');
     assert.strictEqual(normalized.securityPatch.vendor.mode, 'device_default', 'unknown patch modes must fall back safely');
-    assert.strictEqual(normalized.profiles.length, 256, 'policy profiles must be capped');
-    assert.strictEqual(normalized.profiles[0].applications.length, 64, 'profile assignments must be capped');
+    assert.strictEqual(normalized.profiles.length, 64, 'policy profiles must be capped to the backend contract');
+    assert.strictEqual(normalized.profiles[0].applications.length, 256, 'profile assignments must be capped to the backend contract');
     assert.strictEqual(normalized.profiles[0].template, null, 'oversized profile template references must be rejected');
     assert.strictEqual(normalized.profiles[0].keybox, null, 'oversized profile keybox references must be rejected');
     assert.strictEqual(normalized.profiles[0].privacy, 'inherit', 'unknown privacy modes must fall back safely');


### PR DESCRIPTION
## Summary

Fix the two WebUI/backend policy-limit mismatches found during the manual bug sweep.

- align the WebUI profile limit with `PolicyState` at 64 profiles
- align per-profile application assignments with `PolicyState` at 256
- enforce the backend-wide 2048 total-assignment bound before sending a save/import
- stop silently slicing over-limit profile/application data during save paths
- reject creating/cloning a 65th profile and adding/saving a 257th application assignment with a user-visible error

## Regression coverage

Adds `module/webui-tests/policy-limit-contract.test.js` covering:

- 256 application assignments survive WebUI normalize -> save round-trip unchanged
- 64 profiles are accepted and the 65th is rejected rather than silently discarded
- the 257th per-profile assignment is rejected
- total assignments above 2048 are rejected before backend submission

## Verification

Manually reviewed the resulting diff against current `master`; the branch is one commit ahead and not behind. No workflow/Actions results were used for this review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Policy Updates**
  - Policy limits now support up to 64 profiles, 256 applications per profile, and 2,048 total application assignments.
  - The editor blocks adding applications, creating or saving profiles, and cloning profiles when limits would be exceeded.
  - Clear error notifications explain when an operation exceeds a limit.
  - Policy data is preserved during saving instead of being silently truncated.

- **Tests**
  - Added coverage to verify policy limits and prevent overflow regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->