### PR TITLE
feat(keystore): converge root of trust and signatures across attest keys and child keys

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "cleverestricky-keybox-core",
  "cleverestricky-xml-core",
  "der 0.8.1",
+ "getrandom 0.4.3",
  "p256",
  "rsa",
  "sha2 0.10.9",

--- a/rust/backend/src/attest_key_store.rs
+++ b/rust/backend/src/attest_key_store.rs
@@ -75,7 +75,6 @@ pub fn get_attest_key(calling_uid: u32, key_id: &KeyId) -> Option<Arc<PreparedIs
         .iter()
         .position(|e| e.calling_uid == calling_uid && &e.key_id == key_id)?;
 
-    // LRU touch: remove from current position and move to back
     let entry = guard.entries.remove(pos)?;
     let issuer = Arc::clone(&entry.issuer);
     guard.entries.push_back(entry);
@@ -86,6 +85,16 @@ pub fn get_attest_key(calling_uid: u32, key_id: &KeyId) -> Option<Arc<PreparedIs
 mod tests {
     use super::*;
     use cleverestricky_certificate_core::{generate_ec_p256_keypair, SigningAlgorithm};
+    use std::sync::MutexGuard;
+
+    static TEST_STORE_SEQUENCE: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn isolate_store_sequence() -> MutexGuard<'static, ()> {
+        TEST_STORE_SEQUENCE
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
 
     fn make_test_issuer(name: &[u8]) -> Arc<PreparedIssuer> {
         let keypair = generate_ec_p256_keypair().expect("keypair");
@@ -100,6 +109,7 @@ mod tests {
 
     #[test]
     fn insert_and_get_with_lru_touch() {
+        let _sequence = isolate_store_sequence();
         reset_for_testing();
         let issuer = make_test_issuer(b"test-k1");
         let key_id = [1u8; 32];
@@ -107,16 +117,13 @@ mod tests {
 
         let retrieved = get_attest_key(1000, &key_id).expect("retrieved");
         assert_eq!(retrieved.issuer_name_der(), b"test-k1");
-
-        // Wrong UID returns None
         assert!(get_attest_key(1001, &key_id).is_none());
-
-        // Wrong key_id returns None
         assert!(get_attest_key(1000, &[2u8; 32]).is_none());
     }
 
     #[test]
     fn distinct_key_ids_with_same_uid_do_not_collide() {
+        let _sequence = isolate_store_sequence();
         reset_for_testing();
         let k1 = make_test_issuer(b"same-subject-k1");
         let k2 = make_test_issuer(b"same-subject-k2");
@@ -134,6 +141,7 @@ mod tests {
 
     #[test]
     fn lru_eviction_at_capacity_64() {
+        let _sequence = isolate_store_sequence();
         reset_for_testing();
         for i in 0..64 {
             let mut id = [0u8; 32];
@@ -141,35 +149,30 @@ mod tests {
             insert_attest_key(1000, id, make_test_issuer(&[i as u8]));
         }
 
-        // All 64 are present
         for i in 0..64 {
             let mut id = [0u8; 32];
             id[0] = i as u8;
             assert!(get_attest_key(1000, &id).is_some());
         }
 
-        // Touch key 0 so it becomes MRU (moved to back)
         let mut id0 = [0u8; 32];
         id0[0] = 0;
         assert!(get_attest_key(1000, &id0).is_some());
 
-        // Now insert key 64, which should evict key 1 (the oldest untouched key at front)
         let mut id64 = [0u8; 32];
         id64[0] = 64;
         insert_attest_key(1000, id64, make_test_issuer(b"k64"));
 
-        // Key 0 is still present because it was touched
         assert!(get_attest_key(1000, &id0).is_some());
-        // Key 1 was evicted
         let mut id1 = [0u8; 32];
         id1[0] = 1;
         assert!(get_attest_key(1000, &id1).is_none());
-        // Key 64 is present
         assert!(get_attest_key(1000, &id64).is_some());
     }
 
     #[test]
     fn clear_empties_the_store() {
+        let _sequence = isolate_store_sequence();
         reset_for_testing();
         let id = [42u8; 32];
         insert_attest_key(1000, id, make_test_issuer(b"clear-me"));
@@ -180,23 +183,19 @@ mod tests {
 
     #[test]
     fn nested_attest_key_flow_never_deadlocks() {
+        let _sequence = isolate_store_sequence();
         reset_for_testing();
-        // Simulate K1 -> K2 -> K3
         let id1 = [10u8; 32];
         let id2 = [20u8; 32];
         let id3 = [30u8; 32];
 
-        // 1. K1 inserted
         insert_attest_key(1000, id1, make_test_issuer(b"root-attest"));
 
-        // 2. K2 created using K1 (read K1, generate K2, insert K2)
         let parent1 = get_attest_key(1000, &id1).expect("k1");
         assert_eq!(parent1.issuer_name_der(), b"root-attest");
         let k2_issuer = make_test_issuer(b"child-attest");
-        // Insertion succeeds without deadlock while holding the cloned Arc of parent1
         insert_attest_key(1000, id2, k2_issuer);
 
-        // 3. K3 created using K2 (read K2, generate K3, insert K3)
         let parent2 = get_attest_key(1000, &id2).expect("k2");
         assert_eq!(parent2.issuer_name_der(), b"child-attest");
         let k3_issuer = make_test_issuer(b"leaf-key");

--- a/rust/backend/src/attest_key_store.rs
+++ b/rust/backend/src/attest_key_store.rs
@@ -1,14 +1,16 @@
 // Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
 use cleverestricky_certificate_core::PreparedIssuer;
 use std::collections::VecDeque;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
-pub const MAX_ATTEST_KEYS: usize = 32;
+pub const MAX_ATTEST_KEYS: usize = 64;
+
+pub type KeyId = [u8; 32];
 
 struct AttestKeyEntry {
     calling_uid: u32,
-    subject_der: Vec<u8>,
-    issuer: PreparedIssuer,
+    key_id: KeyId,
+    issuer: Arc<PreparedIssuer>,
 }
 
 #[derive(Default)]
@@ -18,19 +20,24 @@ struct AttestKeyStore {
 
 static STORE: OnceLock<Mutex<AttestKeyStore>> = OnceLock::new();
 
-#[cfg(test)]
-pub(crate) fn reset_for_testing() {
+#[allow(dead_code)]
+pub fn clear() {
     let store = STORE.get_or_init(|| Mutex::new(AttestKeyStore::default()));
     let mut guard = match store.lock() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
     guard.entries.clear();
-    drop(guard);
+}
+
+#[cfg(test)]
+pub(crate) fn reset_for_testing() {
+    clear();
+    let store = STORE.get_or_init(|| Mutex::new(AttestKeyStore::default()));
     store.clear_poison();
 }
 
-pub fn insert_attest_key(calling_uid: u32, subject_der: Vec<u8>, issuer: PreparedIssuer) {
+pub fn insert_attest_key(calling_uid: u32, key_id: KeyId, issuer: Arc<PreparedIssuer>) {
     let store = STORE.get_or_init(|| Mutex::new(AttestKeyStore::default()));
     let mut guard = match store.lock() {
         Ok(guard) => guard,
@@ -40,7 +47,7 @@ pub fn insert_attest_key(calling_uid: u32, subject_der: Vec<u8>, issuer: Prepare
     if let Some(pos) = guard
         .entries
         .iter()
-        .position(|e| e.calling_uid == calling_uid && e.subject_der == subject_der)
+        .position(|e| e.calling_uid == calling_uid && e.key_id == key_id)
     {
         guard.entries.remove(pos);
     }
@@ -51,26 +58,152 @@ pub fn insert_attest_key(calling_uid: u32, subject_der: Vec<u8>, issuer: Prepare
 
     guard.entries.push_back(AttestKeyEntry {
         calling_uid,
-        subject_der,
+        key_id,
         issuer,
     });
 }
 
-pub fn with_attest_key<R>(
-    calling_uid: u32,
-    issuer_der: &[u8],
-    f: impl FnOnce(&PreparedIssuer) -> R,
-) -> Option<R> {
+pub fn get_attest_key(calling_uid: u32, key_id: &KeyId) -> Option<Arc<PreparedIssuer>> {
     let store = STORE.get_or_init(|| Mutex::new(AttestKeyStore::default()));
-    let guard = match store.lock() {
+    let mut guard = match store.lock() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
 
-    guard
+    let pos = guard
         .entries
         .iter()
-        .rev()
-        .find(|e| e.calling_uid == calling_uid && e.subject_der == issuer_der)
-        .map(|entry| f(&entry.issuer))
+        .position(|e| e.calling_uid == calling_uid && &e.key_id == key_id)?;
+
+    // LRU touch: remove from current position and move to back
+    let entry = guard.entries.remove(pos)?;
+    let issuer = Arc::clone(&entry.issuer);
+    guard.entries.push_back(entry);
+    Some(issuer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cleverestricky_certificate_core::{generate_ec_p256_keypair, SigningAlgorithm};
+
+    fn make_test_issuer(name: &[u8]) -> Arc<PreparedIssuer> {
+        let keypair = generate_ec_p256_keypair().expect("keypair");
+        let issuer = PreparedIssuer::from_subject_and_key(
+            name.to_vec(),
+            &keypair.private_key_pkcs8_der,
+            SigningAlgorithm::EcP256Sha256,
+        )
+        .expect("prepared issuer");
+        Arc::new(issuer)
+    }
+
+    #[test]
+    fn insert_and_get_with_lru_touch() {
+        reset_for_testing();
+        let issuer = make_test_issuer(b"test-k1");
+        let key_id = [1u8; 32];
+        insert_attest_key(1000, key_id, issuer);
+
+        let retrieved = get_attest_key(1000, &key_id).expect("retrieved");
+        assert_eq!(retrieved.issuer_name_der(), b"test-k1");
+
+        // Wrong UID returns None
+        assert!(get_attest_key(1001, &key_id).is_none());
+
+        // Wrong key_id returns None
+        assert!(get_attest_key(1000, &[2u8; 32]).is_none());
+    }
+
+    #[test]
+    fn distinct_key_ids_with_same_uid_do_not_collide() {
+        reset_for_testing();
+        let k1 = make_test_issuer(b"same-subject-k1");
+        let k2 = make_test_issuer(b"same-subject-k2");
+        let id1 = [1u8; 32];
+        let id2 = [2u8; 32];
+
+        insert_attest_key(1000, id1, k1);
+        insert_attest_key(1000, id2, k2);
+
+        let r1 = get_attest_key(1000, &id1).expect("k1");
+        let r2 = get_attest_key(1000, &id2).expect("k2");
+        assert_eq!(r1.issuer_name_der(), b"same-subject-k1");
+        assert_eq!(r2.issuer_name_der(), b"same-subject-k2");
+    }
+
+    #[test]
+    fn lru_eviction_at_capacity_64() {
+        reset_for_testing();
+        for i in 0..64 {
+            let mut id = [0u8; 32];
+            id[0] = i as u8;
+            insert_attest_key(1000, id, make_test_issuer(&[i as u8]));
+        }
+
+        // All 64 are present
+        for i in 0..64 {
+            let mut id = [0u8; 32];
+            id[0] = i as u8;
+            assert!(get_attest_key(1000, &id).is_some());
+        }
+
+        // Touch key 0 so it becomes MRU (moved to back)
+        let mut id0 = [0u8; 32];
+        id0[0] = 0;
+        assert!(get_attest_key(1000, &id0).is_some());
+
+        // Now insert key 64, which should evict key 1 (the oldest untouched key at front)
+        let mut id64 = [0u8; 32];
+        id64[0] = 64;
+        insert_attest_key(1000, id64, make_test_issuer(b"k64"));
+
+        // Key 0 is still present because it was touched
+        assert!(get_attest_key(1000, &id0).is_some());
+        // Key 1 was evicted
+        let mut id1 = [0u8; 32];
+        id1[0] = 1;
+        assert!(get_attest_key(1000, &id1).is_none());
+        // Key 64 is present
+        assert!(get_attest_key(1000, &id64).is_some());
+    }
+
+    #[test]
+    fn clear_empties_the_store() {
+        reset_for_testing();
+        let id = [42u8; 32];
+        insert_attest_key(1000, id, make_test_issuer(b"clear-me"));
+        assert!(get_attest_key(1000, &id).is_some());
+        clear();
+        assert!(get_attest_key(1000, &id).is_none());
+    }
+
+    #[test]
+    fn nested_attest_key_flow_never_deadlocks() {
+        reset_for_testing();
+        // Simulate K1 -> K2 -> K3
+        let id1 = [10u8; 32];
+        let id2 = [20u8; 32];
+        let id3 = [30u8; 32];
+
+        // 1. K1 inserted
+        insert_attest_key(1000, id1, make_test_issuer(b"root-attest"));
+
+        // 2. K2 created using K1 (read K1, generate K2, insert K2)
+        let parent1 = get_attest_key(1000, &id1).expect("k1");
+        assert_eq!(parent1.issuer_name_der(), b"root-attest");
+        let k2_issuer = make_test_issuer(b"child-attest");
+        // Insertion succeeds without deadlock while holding the cloned Arc of parent1
+        insert_attest_key(1000, id2, k2_issuer);
+
+        // 3. K3 created using K2 (read K2, generate K3, insert K3)
+        let parent2 = get_attest_key(1000, &id2).expect("k2");
+        assert_eq!(parent2.issuer_name_der(), b"child-attest");
+        let k3_issuer = make_test_issuer(b"leaf-key");
+        insert_attest_key(1000, id3, k3_issuer);
+
+        assert!(get_attest_key(1000, &id1).is_some());
+        assert!(get_attest_key(1000, &id2).is_some());
+        assert!(get_attest_key(1000, &id3).is_some());
+    }
 }

--- a/rust/backend/src/attest_key_store.rs
+++ b/rust/backend/src/attest_key_store.rs
@@ -10,6 +10,7 @@ pub type KeyId = [u8; 32];
 struct AttestKeyEntry {
     calling_uid: u32,
     key_id: KeyId,
+    parent_key_id: Option<KeyId>,
     issuer: Arc<PreparedIssuer>,
 }
 
@@ -59,8 +60,50 @@ pub fn insert_attest_key(calling_uid: u32, key_id: KeyId, issuer: Arc<PreparedIs
     guard.entries.push_back(AttestKeyEntry {
         calling_uid,
         key_id,
+        parent_key_id: None,
         issuer,
     });
+}
+
+pub fn insert_child_attest_key(
+    calling_uid: u32,
+    parent_key_id: &KeyId,
+    child_key_id: KeyId,
+    issuer: Arc<PreparedIssuer>,
+) -> bool {
+    let store = STORE.get_or_init(|| Mutex::new(AttestKeyStore::default()));
+    let mut guard = match store.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    if !guard
+        .entries
+        .iter()
+        .any(|e| e.calling_uid == calling_uid && &e.key_id == parent_key_id)
+    {
+        return false;
+    }
+
+    if let Some(pos) = guard
+        .entries
+        .iter()
+        .position(|e| e.calling_uid == calling_uid && e.key_id == child_key_id)
+    {
+        guard.entries.remove(pos);
+    }
+
+    if guard.entries.len() >= MAX_ATTEST_KEYS {
+        guard.entries.pop_front();
+    }
+
+    guard.entries.push_back(AttestKeyEntry {
+        calling_uid,
+        key_id: child_key_id,
+        parent_key_id: Some(*parent_key_id),
+        issuer,
+    });
+    true
 }
 
 pub fn get_attest_key(calling_uid: u32, key_id: &KeyId) -> Option<Arc<PreparedIssuer>> {
@@ -101,6 +144,37 @@ pub fn touch_attest_key(calling_uid: u32, key_id: &KeyId) -> bool {
     let entry = guard.entries.remove(pos).expect("entry exists");
     guard.entries.push_back(entry);
     true
+}
+
+pub fn remove_attest_key(calling_uid: u32, key_id: &KeyId) -> bool {
+    let store = STORE.get_or_init(|| Mutex::new(AttestKeyStore::default()));
+    let mut guard = match store.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    let mut to_remove = vec![*key_id];
+    let mut any_removed = false;
+    while let Some(target) = to_remove.pop() {
+        if let Some(pos) = guard
+            .entries
+            .iter()
+            .position(|entry| entry.calling_uid == calling_uid && entry.key_id == target)
+        {
+            guard.entries.remove(pos);
+            any_removed = true;
+        }
+        let children: Vec<KeyId> = guard
+            .entries
+            .iter()
+            .filter(|entry| {
+                entry.calling_uid == calling_uid && entry.parent_key_id.as_ref() == Some(&target)
+            })
+            .map(|entry| entry.key_id)
+            .collect();
+        to_remove.extend(children);
+    }
+    any_removed
 }
 
 #[cfg(test)]
@@ -256,5 +330,64 @@ mod tests {
         id1[0] = 1;
         assert!(get_attest_key(1000, &id1).is_none());
         assert!(get_attest_key(1000, &id64).is_some());
+    }
+
+    #[test]
+    fn remove_attest_key_revokes_only_the_selected_entry() {
+        let _sequence = isolate_store_sequence();
+        reset_for_testing();
+        let first = [1u8; 32];
+        let second = [2u8; 32];
+        insert_attest_key(1000, first, make_test_issuer(b"first"));
+        insert_attest_key(1000, second, make_test_issuer(b"second"));
+
+        assert!(remove_attest_key(1000, &first));
+        assert!(!remove_attest_key(1000, &first));
+        assert!(get_attest_key(1000, &first).is_none());
+        assert!(get_attest_key(1000, &second).is_some());
+        assert!(!remove_attest_key(1001, &second));
+    }
+
+    #[test]
+    fn insert_child_attest_key_requires_parent_and_cascades_removal() {
+        let _sequence = isolate_store_sequence();
+        reset_for_testing();
+        let parent = [10u8; 32];
+        let child = [11u8; 32];
+        let grandchild = [12u8; 32];
+
+        // Inserting child fails if parent is not present
+        assert!(!insert_child_attest_key(
+            1000,
+            &parent,
+            child,
+            make_test_issuer(b"child")
+        ));
+        assert!(get_attest_key(1000, &child).is_none());
+
+        // Insert parent first, then child succeeds
+        insert_attest_key(1000, parent, make_test_issuer(b"parent"));
+        assert!(insert_child_attest_key(
+            1000,
+            &parent,
+            child,
+            make_test_issuer(b"child")
+        ));
+        assert!(insert_child_attest_key(
+            1000,
+            &child,
+            grandchild,
+            make_test_issuer(b"grandchild")
+        ));
+
+        assert!(get_attest_key(1000, &parent).is_some());
+        assert!(get_attest_key(1000, &child).is_some());
+        assert!(get_attest_key(1000, &grandchild).is_some());
+
+        // Removing parent cascades to child and grandchild
+        assert!(remove_attest_key(1000, &parent));
+        assert!(get_attest_key(1000, &parent).is_none());
+        assert!(get_attest_key(1000, &child).is_none());
+        assert!(get_attest_key(1000, &grandchild).is_none());
     }
 }

--- a/rust/backend/src/attest_key_store.rs
+++ b/rust/backend/src/attest_key_store.rs
@@ -20,6 +20,57 @@ struct AttestKeyStore {
     entries: VecDeque<AttestKeyEntry>,
 }
 
+impl AttestKeyStore {
+    fn subtree_contains(&self, calling_uid: u32, root_key_id: &KeyId, key_id: &KeyId) -> bool {
+        let mut to_visit = vec![*root_key_id];
+        while let Some(target) = to_visit.pop() {
+            if &target == key_id {
+                return true;
+            }
+            to_visit.extend(
+                self.entries
+                    .iter()
+                    .filter(|entry| {
+                        entry.calling_uid == calling_uid
+                            && entry.parent_key_id.as_ref() == Some(&target)
+                    })
+                    .map(|entry| entry.key_id),
+            );
+        }
+        false
+    }
+
+    fn remove_subtree(&mut self, calling_uid: u32, key_id: &KeyId) -> bool {
+        let mut to_remove = vec![*key_id];
+        let mut any_removed = false;
+        while let Some(target) = to_remove.pop() {
+            let children: Vec<KeyId> = self
+                .entries
+                .iter()
+                .filter(|entry| {
+                    entry.calling_uid == calling_uid
+                        && entry.parent_key_id.as_ref() == Some(&target)
+                })
+                .map(|entry| entry.key_id)
+                .collect();
+            to_remove.extend(children);
+            let original_len = self.entries.len();
+            self.entries
+                .retain(|entry| entry.calling_uid != calling_uid || entry.key_id != target);
+            any_removed |= self.entries.len() != original_len;
+        }
+        any_removed
+    }
+
+    fn evict_oldest_subtree(&mut self) {
+        if let Some(oldest) = self.entries.front() {
+            let calling_uid = oldest.calling_uid;
+            let key_id = oldest.key_id;
+            self.remove_subtree(calling_uid, &key_id);
+        }
+    }
+}
+
 static STORE: OnceLock<Mutex<AttestKeyStore>> = OnceLock::new();
 
 #[allow(dead_code)]
@@ -46,16 +97,10 @@ pub fn insert_attest_key(calling_uid: u32, key_id: KeyId, issuer: Arc<PreparedIs
         Err(poisoned) => poisoned.into_inner(),
     };
 
-    if let Some(pos) = guard
-        .entries
-        .iter()
-        .position(|e| e.calling_uid == calling_uid && e.key_id == key_id)
-    {
-        guard.entries.remove(pos);
-    }
+    guard.remove_subtree(calling_uid, &key_id);
 
     if guard.entries.len() >= MAX_ATTEST_KEYS {
-        guard.entries.pop_front();
+        guard.evict_oldest_subtree();
     }
 
     guard.entries.push_back(AttestKeyEntry {
@@ -72,30 +117,40 @@ pub fn insert_child_attest_key(
     child_key_id: KeyId,
     issuer: Arc<PreparedIssuer>,
 ) -> bool {
+    if parent_key_id == &child_key_id {
+        return false;
+    }
     let store = STORE.get_or_init(|| Mutex::new(AttestKeyStore::default()));
     let mut guard = match store.lock() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
 
-    if !guard
+    let parent_pos = guard
         .entries
         .iter()
-        .any(|e| e.calling_uid == calling_uid && &e.key_id == parent_key_id)
-    {
+        .position(|e| e.calling_uid == calling_uid && &e.key_id == parent_key_id);
+    let Some(parent_pos) = parent_pos else {
+        return false;
+    };
+    if guard.subtree_contains(calling_uid, &child_key_id, parent_key_id) {
         return false;
     }
 
-    if let Some(pos) = guard
-        .entries
-        .iter()
-        .position(|e| e.calling_uid == calling_uid && e.key_id == child_key_id)
-    {
-        guard.entries.remove(pos);
-    }
+    let parent = guard.entries.remove(parent_pos).expect("parent exists");
+    guard.entries.push_back(parent);
+
+    guard.remove_subtree(calling_uid, &child_key_id);
 
     if guard.entries.len() >= MAX_ATTEST_KEYS {
-        guard.entries.pop_front();
+        guard.evict_oldest_subtree();
+    }
+    if !guard
+        .entries
+        .iter()
+        .any(|entry| entry.calling_uid == calling_uid && &entry.key_id == parent_key_id)
+    {
+        return false;
     }
 
     guard.entries.push_back(AttestKeyEntry {
@@ -155,28 +210,7 @@ pub fn remove_attest_key(calling_uid: u32, key_id: &KeyId) -> bool {
         Err(poisoned) => poisoned.into_inner(),
     };
 
-    let mut to_remove = vec![*key_id];
-    let mut any_removed = false;
-    while let Some(target) = to_remove.pop() {
-        if let Some(pos) = guard
-            .entries
-            .iter()
-            .position(|entry| entry.calling_uid == calling_uid && entry.key_id == target)
-        {
-            guard.entries.remove(pos);
-            any_removed = true;
-        }
-        let children: Vec<KeyId> = guard
-            .entries
-            .iter()
-            .filter(|entry| {
-                entry.calling_uid == calling_uid && entry.parent_key_id.as_ref() == Some(&target)
-            })
-            .map(|entry| entry.key_id)
-            .collect();
-        to_remove.extend(children);
-    }
-    any_removed
+    guard.remove_subtree(calling_uid, key_id)
 }
 
 #[cfg(test)]
@@ -385,6 +419,121 @@ mod tests {
         assert!(get_attest_key(1000, &grandchild).is_some());
 
         assert!(remove_attest_key(1000, &parent));
+        assert!(get_attest_key(1000, &parent).is_none());
+        assert!(get_attest_key(1000, &child).is_none());
+        assert!(get_attest_key(1000, &grandchild).is_none());
+    }
+
+    #[test]
+    fn child_cannot_replace_its_parent_with_a_self_cycle() {
+        let _sequence = isolate_store_sequence();
+        reset_for_testing();
+        let parent = [10u8; 32];
+        insert_attest_key(1000, parent, make_test_issuer(b"parent"));
+
+        assert!(!insert_child_attest_key(
+            1000,
+            &parent,
+            parent,
+            make_test_issuer(b"self")
+        ));
+        assert!(remove_attest_key(1000, &parent));
+        assert!(get_attest_key(1000, &parent).is_none());
+    }
+
+    #[test]
+    fn replacing_node_removes_its_existing_descendants() {
+        let _sequence = isolate_store_sequence();
+        reset_for_testing();
+        let first_parent = [10u8; 32];
+        let second_parent = [20u8; 32];
+        let child = [11u8; 32];
+        let grandchild = [12u8; 32];
+        insert_attest_key(1000, first_parent, make_test_issuer(b"first-parent"));
+        insert_attest_key(1000, second_parent, make_test_issuer(b"second-parent"));
+        assert!(insert_child_attest_key(
+            1000,
+            &first_parent,
+            child,
+            make_test_issuer(b"child")
+        ));
+        assert!(insert_child_attest_key(
+            1000,
+            &child,
+            grandchild,
+            make_test_issuer(b"grandchild")
+        ));
+
+        assert!(insert_child_attest_key(
+            1000,
+            &second_parent,
+            child,
+            make_test_issuer(b"replacement-child")
+        ));
+        assert!(get_attest_key(1000, &child).is_some());
+        assert!(get_attest_key(1000, &grandchild).is_none());
+    }
+
+    #[test]
+    fn ancestor_cannot_be_reparented_below_its_descendant() {
+        let _sequence = isolate_store_sequence();
+        reset_for_testing();
+        let root = [10u8; 32];
+        let child = [11u8; 32];
+        let grandchild = [12u8; 32];
+        insert_attest_key(1000, root, make_test_issuer(b"root"));
+        assert!(insert_child_attest_key(
+            1000,
+            &root,
+            child,
+            make_test_issuer(b"child")
+        ));
+        assert!(insert_child_attest_key(
+            1000,
+            &child,
+            grandchild,
+            make_test_issuer(b"grandchild")
+        ));
+
+        assert!(!insert_child_attest_key(
+            1000,
+            &grandchild,
+            root,
+            make_test_issuer(b"invalid-root")
+        ));
+        assert!(get_attest_key(1000, &root).is_some());
+        assert!(get_attest_key(1000, &child).is_some());
+        assert!(get_attest_key(1000, &grandchild).is_some());
+    }
+
+    #[test]
+    fn capacity_eviction_removes_the_oldest_subtree() {
+        let _sequence = isolate_store_sequence();
+        reset_for_testing();
+        let parent = [1u8; 32];
+        let child = [2u8; 32];
+        let grandchild = [3u8; 32];
+        insert_attest_key(1000, parent, make_test_issuer(b"parent"));
+        assert!(insert_child_attest_key(
+            1000,
+            &parent,
+            child,
+            make_test_issuer(b"child")
+        ));
+        assert!(insert_child_attest_key(
+            1000,
+            &child,
+            grandchild,
+            make_test_issuer(b"grandchild")
+        ));
+        for i in 4..=64 {
+            let mut id = [0u8; 32];
+            id[0] = i;
+            insert_attest_key(1000, id, make_test_issuer(&[i]));
+        }
+
+        insert_attest_key(1000, [65u8; 32], make_test_issuer(b"overflow"));
+
         assert!(get_attest_key(1000, &parent).is_none());
         assert!(get_attest_key(1000, &child).is_none());
         assert!(get_attest_key(1000, &grandchild).is_none());

--- a/rust/backend/src/attest_key_store.rs
+++ b/rust/backend/src/attest_key_store.rs
@@ -1,0 +1,76 @@
+// Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
+use cleverestricky_certificate_core::PreparedIssuer;
+use std::collections::VecDeque;
+use std::sync::{Mutex, OnceLock};
+
+pub const MAX_ATTEST_KEYS: usize = 32;
+
+struct AttestKeyEntry {
+    calling_uid: u32,
+    subject_der: Vec<u8>,
+    issuer: PreparedIssuer,
+}
+
+#[derive(Default)]
+struct AttestKeyStore {
+    entries: VecDeque<AttestKeyEntry>,
+}
+
+static STORE: OnceLock<Mutex<AttestKeyStore>> = OnceLock::new();
+
+#[cfg(test)]
+pub(crate) fn reset_for_testing() {
+    let store = STORE.get_or_init(|| Mutex::new(AttestKeyStore::default()));
+    let mut guard = match store.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    guard.entries.clear();
+    drop(guard);
+    store.clear_poison();
+}
+
+pub fn insert_attest_key(calling_uid: u32, subject_der: Vec<u8>, issuer: PreparedIssuer) {
+    let store = STORE.get_or_init(|| Mutex::new(AttestKeyStore::default()));
+    let mut guard = match store.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    if let Some(pos) = guard
+        .entries
+        .iter()
+        .position(|e| e.calling_uid == calling_uid && e.subject_der == subject_der)
+    {
+        guard.entries.remove(pos);
+    }
+
+    if guard.entries.len() >= MAX_ATTEST_KEYS {
+        guard.entries.pop_front();
+    }
+
+    guard.entries.push_back(AttestKeyEntry {
+        calling_uid,
+        subject_der,
+        issuer,
+    });
+}
+
+pub fn with_attest_key<R>(
+    calling_uid: u32,
+    issuer_der: &[u8],
+    f: impl FnOnce(&PreparedIssuer) -> R,
+) -> Option<R> {
+    let store = STORE.get_or_init(|| Mutex::new(AttestKeyStore::default()));
+    let guard = match store.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    guard
+        .entries
+        .iter()
+        .rev()
+        .find(|e| e.calling_uid == calling_uid && e.subject_der == issuer_der)
+        .map(|entry| f(&entry.issuer))
+}

--- a/rust/backend/src/attest_key_store.rs
+++ b/rust/backend/src/attest_key_store.rs
@@ -10,6 +10,7 @@ pub type KeyId = [u8; 32];
 struct AttestKeyEntry {
     calling_uid: u32,
     key_id: KeyId,
+    #[allow(dead_code)]
     parent_key_id: Option<KeyId>,
     issuer: Arc<PreparedIssuer>,
 }
@@ -146,6 +147,7 @@ pub fn touch_attest_key(calling_uid: u32, key_id: &KeyId) -> bool {
     true
 }
 
+#[allow(dead_code)]
 pub fn remove_attest_key(calling_uid: u32, key_id: &KeyId) -> bool {
     let store = STORE.get_or_init(|| Mutex::new(AttestKeyStore::default()));
     let mut guard = match store.lock() {
@@ -356,7 +358,6 @@ mod tests {
         let child = [11u8; 32];
         let grandchild = [12u8; 32];
 
-        // Inserting child fails if parent is not present
         assert!(!insert_child_attest_key(
             1000,
             &parent,
@@ -365,7 +366,6 @@ mod tests {
         ));
         assert!(get_attest_key(1000, &child).is_none());
 
-        // Insert parent first, then child succeeds
         insert_attest_key(1000, parent, make_test_issuer(b"parent"));
         assert!(insert_child_attest_key(
             1000,
@@ -384,7 +384,6 @@ mod tests {
         assert!(get_attest_key(1000, &child).is_some());
         assert!(get_attest_key(1000, &grandchild).is_some());
 
-        // Removing parent cascades to child and grandchild
         assert!(remove_attest_key(1000, &parent));
         assert!(get_attest_key(1000, &parent).is_none());
         assert!(get_attest_key(1000, &child).is_none());

--- a/rust/backend/src/attest_key_store.rs
+++ b/rust/backend/src/attest_key_store.rs
@@ -81,6 +81,28 @@ pub fn get_attest_key(calling_uid: u32, key_id: &KeyId) -> Option<Arc<PreparedIs
     Some(issuer)
 }
 
+#[allow(dead_code)]
+pub fn touch_attest_key(calling_uid: u32, key_id: &KeyId) -> bool {
+    let store = STORE.get_or_init(|| Mutex::new(AttestKeyStore::default()));
+    let mut guard = match store.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    let pos = match guard
+        .entries
+        .iter()
+        .position(|e| e.calling_uid == calling_uid && &e.key_id == key_id)
+    {
+        Some(pos) => pos,
+        None => return false,
+    };
+
+    let entry = guard.entries.remove(pos).expect("entry exists");
+    guard.entries.push_back(entry);
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -204,5 +226,35 @@ mod tests {
         assert!(get_attest_key(1000, &id1).is_some());
         assert!(get_attest_key(1000, &id2).is_some());
         assert!(get_attest_key(1000, &id3).is_some());
+    }
+
+    #[test]
+    fn touch_attest_key_updates_lru_and_returns_existence() {
+        let _sequence = isolate_store_sequence();
+        reset_for_testing();
+
+        let id_missing = [99u8; 32];
+        assert!(!touch_attest_key(1000, &id_missing));
+
+        for i in 0..64 {
+            let mut id = [0u8; 32];
+            id[0] = i as u8;
+            insert_attest_key(1000, id, make_test_issuer(&[i as u8]));
+        }
+
+        let mut id0 = [0u8; 32];
+        id0[0] = 0;
+        assert!(touch_attest_key(1000, &id0));
+        assert!(!touch_attest_key(1001, &id0));
+
+        let mut id64 = [0u8; 32];
+        id64[0] = 64;
+        insert_attest_key(1000, id64, make_test_issuer(b"k64"));
+
+        assert!(get_attest_key(1000, &id0).is_some());
+        let mut id1 = [0u8; 32];
+        id1[0] = 1;
+        assert!(get_attest_key(1000, &id1).is_none());
+        assert!(get_attest_key(1000, &id64).is_some());
     }
 }

--- a/rust/backend/src/certificate_wire.rs
+++ b/rust/backend/src/certificate_wire.rs
@@ -238,11 +238,14 @@ pub fn rewrite_child_key_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'s
         .map_err(|_| "child certificate rewrite rejected")?;
 
         if let Some(prepared) = prepared_for_children {
-            attest_key_store::insert_attest_key(
+            if !attest_key_store::insert_child_attest_key(
                 parsed.calling_uid,
+                &parsed.parent_key_id,
                 parsed.child_key_id,
                 std::sync::Arc::new(prepared),
-            );
+            ) {
+                return Err("attest parent was revoked during child key rewrite");
+            }
         }
 
         Ok(rewritten)

--- a/rust/backend/src/certificate_wire.rs
+++ b/rust/backend/src/certificate_wire.rs
@@ -9,7 +9,7 @@ use cleverestricky_certificate_core::{
 use zeroize::Zeroize;
 
 const INSPECT_WIRE_VERSION: u8 = 2;
-const REWRITE_WIRE_VERSION: u8 = 2;
+pub(crate) const REWRITE_WIRE_VERSION: u8 = 2;
 const SIGNING_EC_P256_SHA256: u8 = 1;
 const SIGNING_RSA_PKCS1_SHA256: u8 = 2;
 const PATCH_KEEP: u8 = 0;

--- a/rust/backend/src/certificate_wire.rs
+++ b/rust/backend/src/certificate_wire.rs
@@ -17,8 +17,9 @@ const PATCH_OMIT: u8 = 1;
 const PATCH_REPLACE: u8 = 2;
 const MAX_ID_OVERRIDES: usize = 9;
 const REWRITE_FIXED_BYTES: usize = 1 + 1 + 3 * 5 + 1 + 2 + 4 + KEY_ID_BYTES + 2 * 32;
-const ATTEST_KEY_REWRITE_FIXED_BYTES: usize = 1 + 4 + 1 + 3 * 5 + 1 + 2 + 4 + KEY_ID_BYTES + 2 * 32;
-const CHILD_KEY_REWRITE_FIXED_BYTES: usize = 1 + 4 + 1 + 3 * 5 + 1 + 2 + 4 + 2 * 32;
+const ATTEST_KEY_REWRITE_FIXED_BYTES: usize =
+    1 + 4 + 1 + 3 * 5 + 1 + 2 + 4 + KEY_ID_BYTES + 32 + 2 * 32;
+const CHILD_KEY_REWRITE_FIXED_BYTES: usize = 1 + 4 + 1 + 3 * 5 + 1 + 2 + 4 + 32 + 32 + 2 * 32;
 const MAX_ID_WIRE_BYTES: usize = MAX_ID_OVERRIDES * (2 + 2 + MAX_ATTESTATION_ID_BYTES);
 
 pub const MAX_INSPECT_REQUEST_BYTES: usize = MAX_CERTIFICATE_DER_BYTES;
@@ -136,13 +137,19 @@ pub fn rewrite_attest_key_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'
             .map_err(|_| "attest key rewrite provenance rejected")?;
         validate_hardware_provenance(&provenance)?;
 
+        if !cleverestricky_certificate_core::is_ec_p256_certificate(parsed.genuine_leaf_der)
+            .map_err(|_| "invalid attest key certificate")?
+        {
+            return Err("attest key is not EC P-256");
+        }
+
         let (subject_der, _) = parse_certificate_subject_and_issuer(parsed.genuine_leaf_der)
             .map_err(|_| "invalid attest key certificate")?;
 
         let keypair =
             generate_ec_p256_keypair().map_err(|_| "failed to generate attest keypair")?;
         let prepared_for_children = PreparedIssuer::from_subject_and_key(
-            subject_der.clone(),
+            subject_der,
             &keypair.private_key_pkcs8_der,
             SigningAlgorithm::EcP256Sha256,
         )
@@ -169,8 +176,8 @@ pub fn rewrite_attest_key_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'
 
             attest_key_store::insert_attest_key(
                 parsed.calling_uid,
-                subject_der,
-                prepared_for_children,
+                parsed.attest_key_id,
+                std::sync::Arc::new(prepared_for_children),
             );
             Ok(rewritten)
         })
@@ -192,45 +199,53 @@ pub fn rewrite_child_key_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'s
             .map_err(|_| "child key rewrite provenance rejected")?;
         validate_hardware_provenance(&provenance)?;
 
-        let (subject_der, issuer_der) =
-            parse_certificate_subject_and_issuer(parsed.genuine_leaf_der)
-                .map_err(|_| "invalid child certificate")?;
+        let parent_issuer =
+            attest_key_store::get_attest_key(parsed.calling_uid, &parsed.parent_key_id)
+                .ok_or("attest issuer not found in managed store")?;
 
-        attest_key_store::with_attest_key(parsed.calling_uid, &issuer_der, |parent_issuer| {
-            let (spki_override, prepared_for_children) = if parsed.is_attest_key {
-                let keypair = generate_ec_p256_keypair()
-                    .map_err(|_| "failed to generate child attest keypair")?;
-                let prepared = PreparedIssuer::from_subject_and_key(
-                    subject_der.clone(),
-                    &keypair.private_key_pkcs8_der,
-                    SigningAlgorithm::EcP256Sha256,
-                )
-                .map_err(|_| "failed to prepare child attest issuer")?;
-                (Some(keypair.public_key_spki_der), Some(prepared))
-            } else {
-                (None, None)
-            };
-
-            let rewritten = rewrite_certificate_prepared(&PreparedCertificateRewriteRequest {
-                genuine_leaf_der: parsed.genuine_leaf_der,
-                issuer: parent_issuer,
-                patch_levels: parsed.patch_levels,
-                id_overrides: &parsed.id_overrides,
-                module_hash: parsed.module_hash,
-                verified_boot_key: parsed.verified_boot_key,
-                verified_boot_hash: parsed.verified_boot_hash,
-                subject_public_key_info: spki_override.as_deref(),
-            })
-            .map(|rewritten| rewritten.leaf_der)
-            .map_err(|_| "child certificate rewrite rejected")?;
-
-            if let Some(prepared) = prepared_for_children {
-                attest_key_store::insert_attest_key(parsed.calling_uid, subject_der, prepared);
+        let (spki_override, prepared_for_children) = if parsed.is_attest_key {
+            if !cleverestricky_certificate_core::is_ec_p256_certificate(parsed.genuine_leaf_der)
+                .map_err(|_| "invalid child certificate")?
+            {
+                return Err("child attest key is not EC P-256");
             }
+            let keypair = generate_ec_p256_keypair()
+                .map_err(|_| "failed to generate child attest keypair")?;
+            let (subject_der, _) = parse_certificate_subject_and_issuer(parsed.genuine_leaf_der)
+                .map_err(|_| "invalid child certificate")?;
+            let prepared = PreparedIssuer::from_subject_and_key(
+                subject_der,
+                &keypair.private_key_pkcs8_der,
+                SigningAlgorithm::EcP256Sha256,
+            )
+            .map_err(|_| "failed to prepare child attest issuer")?;
+            (Some(keypair.public_key_spki_der), Some(prepared))
+        } else {
+            (None, None)
+        };
 
-            Ok(rewritten)
+        let rewritten = rewrite_certificate_prepared(&PreparedCertificateRewriteRequest {
+            genuine_leaf_der: parsed.genuine_leaf_der,
+            issuer: parent_issuer.as_ref(),
+            patch_levels: parsed.patch_levels,
+            id_overrides: &parsed.id_overrides,
+            module_hash: parsed.module_hash,
+            verified_boot_key: parsed.verified_boot_key,
+            verified_boot_hash: parsed.verified_boot_hash,
+            subject_public_key_info: spki_override.as_deref(),
         })
-        .ok_or("attest issuer not found in managed store")?
+        .map(|rewritten| rewritten.leaf_der)
+        .map_err(|_| "child certificate rewrite rejected")?;
+
+        if let Some(prepared) = prepared_for_children {
+            attest_key_store::insert_attest_key(
+                parsed.calling_uid,
+                parsed.child_key_id,
+                std::sync::Arc::new(prepared),
+            );
+        }
+
+        Ok(rewritten)
     })();
     request.zeroize();
     result
@@ -346,6 +361,7 @@ struct ParsedAttestKeyRewrite<'a> {
     module_hash: Option<&'a [u8]>,
     genuine_leaf_der: &'a [u8],
     key_id: KeyId,
+    attest_key_id: [u8; 32],
     verified_boot_key: &'a [u8; 32],
     verified_boot_hash: &'a [u8; 32],
 }
@@ -386,6 +402,13 @@ fn parse_attest_key_rewrite_request(
         .map_err(|_| "invalid opaque key identifier")?;
     if key_id.iter().all(|byte| *byte == 0) {
         return Err("invalid opaque key identifier");
+    }
+    let attest_key_id: [u8; 32] = cursor
+        .read_exact(32)?
+        .try_into()
+        .map_err(|_| "invalid attest key identifier")?;
+    if attest_key_id.iter().all(|byte| *byte == 0) {
+        return Err("invalid attest key identifier");
     }
     let verified_boot_key: &[u8; 32] = cursor
         .read_exact(32)?
@@ -440,6 +463,7 @@ fn parse_attest_key_rewrite_request(
         module_hash,
         genuine_leaf_der,
         key_id,
+        attest_key_id,
         verified_boot_key,
         verified_boot_hash,
     })
@@ -452,6 +476,8 @@ struct ParsedChildKeyRewrite<'a> {
     id_overrides: Vec<AttestationIdOverride<'a>>,
     module_hash: Option<&'a [u8]>,
     genuine_leaf_der: &'a [u8],
+    parent_key_id: [u8; 32],
+    child_key_id: [u8; 32],
     verified_boot_key: &'a [u8; 32],
     verified_boot_hash: &'a [u8; 32],
 }
@@ -481,6 +507,20 @@ fn parse_child_key_rewrite_request(
     let genuine_leaf_len = cursor.read_u32_as_usize()?;
     if genuine_leaf_len == 0 || genuine_leaf_len > MAX_CERTIFICATE_DER_BYTES {
         return Err("certificate DER field exceeds wire bound");
+    }
+    let parent_key_id: [u8; 32] = cursor
+        .read_exact(32)?
+        .try_into()
+        .map_err(|_| "invalid parent attest key identifier")?;
+    if parent_key_id.iter().all(|byte| *byte == 0) {
+        return Err("invalid parent attest key identifier");
+    }
+    let child_key_id: [u8; 32] = cursor
+        .read_exact(32)?
+        .try_into()
+        .map_err(|_| "invalid child attest key identifier")?;
+    if is_attest_key && child_key_id.iter().all(|byte| *byte == 0) {
+        return Err("invalid child attest key identifier");
     }
     let verified_boot_key: &[u8; 32] = cursor
         .read_exact(32)?
@@ -534,6 +574,8 @@ fn parse_child_key_rewrite_request(
         id_overrides,
         module_hash,
         genuine_leaf_der,
+        parent_key_id,
+        child_key_id,
         verified_boot_key,
         verified_boot_hash,
     })

--- a/rust/backend/src/certificate_wire.rs
+++ b/rust/backend/src/certificate_wire.rs
@@ -1,10 +1,10 @@
-// Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
+use crate::attest_key_store;
 use crate::keybox_wire::key_store::{self, KeyId, KEY_ID_BYTES};
 use cleverestricky_certificate_core::{
-    inspect_certificate, rewrite_certificate_prepared, AttestationIdOverride,
-    CertificateInspection, PatchComponent, PatchLevels, PreparedCertificateRewriteRequest,
-    SecurityLevel, SigningAlgorithm, MAX_ATTESTATION_ID_BYTES, MAX_CERTIFICATE_DER_BYTES,
-    MAX_MODULE_HASH_BYTES,
+    generate_ec_p256_keypair, inspect_certificate, parse_certificate_subject_and_issuer,
+    rewrite_certificate_prepared, AttestationIdOverride, CertificateInspection, PatchComponent,
+    PatchLevels, PreparedCertificateRewriteRequest, PreparedIssuer, SecurityLevel,
+    SigningAlgorithm, MAX_ATTESTATION_ID_BYTES, MAX_CERTIFICATE_DER_BYTES, MAX_MODULE_HASH_BYTES,
 };
 use zeroize::Zeroize;
 
@@ -17,12 +17,22 @@ const PATCH_OMIT: u8 = 1;
 const PATCH_REPLACE: u8 = 2;
 const MAX_ID_OVERRIDES: usize = 9;
 const REWRITE_FIXED_BYTES: usize = 1 + 1 + 3 * 5 + 1 + 2 + 4 + KEY_ID_BYTES + 2 * 32;
+const ATTEST_KEY_REWRITE_FIXED_BYTES: usize = 1 + 4 + 1 + 3 * 5 + 1 + 2 + 4 + KEY_ID_BYTES + 2 * 32;
+const CHILD_KEY_REWRITE_FIXED_BYTES: usize = 1 + 4 + 1 + 3 * 5 + 1 + 2 + 4 + 2 * 32;
 const MAX_ID_WIRE_BYTES: usize = MAX_ID_OVERRIDES * (2 + 2 + MAX_ATTESTATION_ID_BYTES);
 
 pub const MAX_INSPECT_REQUEST_BYTES: usize = MAX_CERTIFICATE_DER_BYTES;
 pub const INSPECT_RESPONSE_BYTES: usize = 1 + 1 + 2 + 3 * 5 + 2 * 32 + 2;
 pub const MAX_REWRITE_REQUEST_BYTES: usize =
     REWRITE_FIXED_BYTES + MAX_ID_WIRE_BYTES + MAX_MODULE_HASH_BYTES + MAX_CERTIFICATE_DER_BYTES;
+pub const MAX_ATTEST_KEY_REWRITE_REQUEST_BYTES: usize = ATTEST_KEY_REWRITE_FIXED_BYTES
+    + MAX_ID_WIRE_BYTES
+    + MAX_MODULE_HASH_BYTES
+    + MAX_CERTIFICATE_DER_BYTES;
+pub const MAX_CHILD_KEY_REWRITE_REQUEST_BYTES: usize = CHILD_KEY_REWRITE_FIXED_BYTES
+    + MAX_ID_WIRE_BYTES
+    + MAX_MODULE_HASH_BYTES
+    + MAX_CERTIFICATE_DER_BYTES;
 pub const MAX_REWRITE_RESPONSE_BYTES: usize = MAX_CERTIFICATE_DER_BYTES;
 
 pub fn inspect_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'static str> {
@@ -103,10 +113,124 @@ pub fn rewrite_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'static str>
                 module_hash: parsed.module_hash,
                 verified_boot_key: parsed.verified_boot_key,
                 verified_boot_hash: parsed.verified_boot_hash,
+                subject_public_key_info: None,
             })
             .map(|rewritten| rewritten.leaf_der)
             .map_err(|_| "certificate rewrite rejected")
         })
+    })();
+    request.zeroize();
+    result
+}
+
+pub fn rewrite_attest_key_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'static str> {
+    let result = (|| {
+        if request.len() < ATTEST_KEY_REWRITE_FIXED_BYTES
+            || request.len() > MAX_ATTEST_KEY_REWRITE_REQUEST_BYTES
+        {
+            return Err("attest key rewrite request rejected");
+        }
+        let parsed = parse_attest_key_rewrite_request(&request)?;
+
+        let provenance = inspect_certificate(parsed.genuine_leaf_der)
+            .map_err(|_| "attest key rewrite provenance rejected")?;
+        validate_hardware_provenance(&provenance)?;
+
+        let (subject_der, _) = parse_certificate_subject_and_issuer(parsed.genuine_leaf_der)
+            .map_err(|_| "invalid attest key certificate")?;
+
+        let keypair =
+            generate_ec_p256_keypair().map_err(|_| "failed to generate attest keypair")?;
+        let prepared_for_children = PreparedIssuer::from_subject_and_key(
+            subject_der.clone(),
+            &keypair.private_key_pkcs8_der,
+            SigningAlgorithm::EcP256Sha256,
+        )
+        .map_err(|_| "failed to prepare attest issuer")?;
+
+        key_store::with_prepared_key(&parsed.key_id, |stored_algorithm, prepared_issuer| {
+            if stored_algorithm != parsed.signing_algorithm
+                || prepared_issuer.algorithm() != stored_algorithm
+            {
+                return Err("opaque key algorithm does not match rewrite request");
+            }
+            let rewritten = rewrite_certificate_prepared(&PreparedCertificateRewriteRequest {
+                genuine_leaf_der: parsed.genuine_leaf_der,
+                issuer: prepared_issuer,
+                patch_levels: parsed.patch_levels,
+                id_overrides: &parsed.id_overrides,
+                module_hash: parsed.module_hash,
+                verified_boot_key: parsed.verified_boot_key,
+                verified_boot_hash: parsed.verified_boot_hash,
+                subject_public_key_info: Some(&keypair.public_key_spki_der),
+            })
+            .map(|rewritten| rewritten.leaf_der)
+            .map_err(|_| "attest key certificate rewrite rejected")?;
+
+            attest_key_store::insert_attest_key(
+                parsed.calling_uid,
+                subject_der,
+                prepared_for_children,
+            );
+            Ok(rewritten)
+        })
+    })();
+    request.zeroize();
+    result
+}
+
+pub fn rewrite_child_key_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'static str> {
+    let result = (|| {
+        if request.len() < CHILD_KEY_REWRITE_FIXED_BYTES
+            || request.len() > MAX_CHILD_KEY_REWRITE_REQUEST_BYTES
+        {
+            return Err("child key rewrite request rejected");
+        }
+        let parsed = parse_child_key_rewrite_request(&request)?;
+
+        let provenance = inspect_certificate(parsed.genuine_leaf_der)
+            .map_err(|_| "child key rewrite provenance rejected")?;
+        validate_hardware_provenance(&provenance)?;
+
+        let (subject_der, issuer_der) =
+            parse_certificate_subject_and_issuer(parsed.genuine_leaf_der)
+                .map_err(|_| "invalid child certificate")?;
+
+        attest_key_store::with_attest_key(parsed.calling_uid, &issuer_der, |parent_issuer| {
+            let (spki_override, prepared_for_children) = if parsed.is_attest_key {
+                let keypair = generate_ec_p256_keypair()
+                    .map_err(|_| "failed to generate child attest keypair")?;
+                let prepared = PreparedIssuer::from_subject_and_key(
+                    subject_der.clone(),
+                    &keypair.private_key_pkcs8_der,
+                    SigningAlgorithm::EcP256Sha256,
+                )
+                .map_err(|_| "failed to prepare child attest issuer")?;
+                (Some(keypair.public_key_spki_der), Some(prepared))
+            } else {
+                (None, None)
+            };
+
+            let rewritten = rewrite_certificate_prepared(&PreparedCertificateRewriteRequest {
+                genuine_leaf_der: parsed.genuine_leaf_der,
+                issuer: parent_issuer,
+                patch_levels: parsed.patch_levels,
+                id_overrides: &parsed.id_overrides,
+                module_hash: parsed.module_hash,
+                verified_boot_key: parsed.verified_boot_key,
+                verified_boot_hash: parsed.verified_boot_hash,
+                subject_public_key_info: spki_override.as_deref(),
+            })
+            .map(|rewritten| rewritten.leaf_der)
+            .map_err(|_| "child certificate rewrite rejected")?;
+
+            if let Some(prepared) = prepared_for_children {
+                attest_key_store::insert_attest_key(parsed.calling_uid, subject_der, prepared);
+            }
+
+            Ok(rewritten)
+        })
+        .ok_or("attest issuer not found in managed store")?
     })();
     request.zeroize();
     result
@@ -214,6 +338,207 @@ fn parse_rewrite_request(request: &[u8]) -> Result<ParsedRewrite<'_>, &'static s
     })
 }
 
+struct ParsedAttestKeyRewrite<'a> {
+    calling_uid: u32,
+    signing_algorithm: SigningAlgorithm,
+    patch_levels: PatchLevels,
+    id_overrides: Vec<AttestationIdOverride<'a>>,
+    module_hash: Option<&'a [u8]>,
+    genuine_leaf_der: &'a [u8],
+    key_id: KeyId,
+    verified_boot_key: &'a [u8; 32],
+    verified_boot_hash: &'a [u8; 32],
+}
+
+fn parse_attest_key_rewrite_request(
+    request: &[u8],
+) -> Result<ParsedAttestKeyRewrite<'_>, &'static str> {
+    let mut cursor = Cursor::new(request);
+    if cursor.read_u8()? != REWRITE_WIRE_VERSION {
+        return Err("unsupported certificate rewrite wire version");
+    }
+    let calling_uid = cursor.read_u32()?;
+    let signing_algorithm = match cursor.read_u8()? {
+        SIGNING_EC_P256_SHA256 => SigningAlgorithm::EcP256Sha256,
+        SIGNING_RSA_PKCS1_SHA256 => SigningAlgorithm::RsaPkcs1Sha256,
+        _ => return Err("unsupported certificate signing algorithm"),
+    };
+    let patch_levels = PatchLevels {
+        system: read_patch(&mut cursor)?,
+        vendor: read_patch(&mut cursor)?,
+        boot: read_patch(&mut cursor)?,
+    };
+    let id_count = cursor.read_u8()? as usize;
+    if id_count > MAX_ID_OVERRIDES {
+        return Err("too many attestation ID overrides");
+    }
+    let module_hash_len = cursor.read_u16()? as usize;
+    if module_hash_len > MAX_MODULE_HASH_BYTES {
+        return Err("module hash exceeds certificate wire bound");
+    }
+    let genuine_leaf_len = cursor.read_u32_as_usize()?;
+    if genuine_leaf_len == 0 || genuine_leaf_len > MAX_CERTIFICATE_DER_BYTES {
+        return Err("certificate DER field exceeds wire bound");
+    }
+    let key_id: KeyId = cursor
+        .read_exact(KEY_ID_BYTES)?
+        .try_into()
+        .map_err(|_| "invalid opaque key identifier")?;
+    if key_id.iter().all(|byte| *byte == 0) {
+        return Err("invalid opaque key identifier");
+    }
+    let verified_boot_key: &[u8; 32] = cursor
+        .read_exact(32)?
+        .try_into()
+        .map_err(|_| "invalid verified boot key")?;
+    let verified_boot_hash: &[u8; 32] = cursor
+        .read_exact(32)?
+        .try_into()
+        .map_err(|_| "invalid verified boot hash")?;
+    if verified_boot_key.iter().all(|byte| *byte == 0)
+        || verified_boot_hash.iter().all(|byte| *byte == 0)
+    {
+        return Err("verified boot digest is unavailable");
+    }
+
+    let mut id_overrides = Vec::new();
+    id_overrides
+        .try_reserve_exact(id_count)
+        .map_err(|_| "attestation ID allocation failed")?;
+    let mut seen_tags = [0u16; MAX_ID_OVERRIDES];
+    for seen_count in 0..id_count {
+        let tag = cursor.read_u16()?;
+        let length = cursor.read_u16()? as usize;
+        if length == 0 || length > MAX_ATTESTATION_ID_BYTES {
+            return Err("attestation ID override exceeds wire bound");
+        }
+        if seen_tags[..seen_count].contains(&tag) {
+            return Err("duplicate attestation ID override");
+        }
+        seen_tags[seen_count] = tag;
+        let value = cursor.read_exact(length)?;
+        id_overrides.push(AttestationIdOverride {
+            tag: u32::from(tag),
+            value,
+        });
+    }
+    let module_hash = if module_hash_len == 0 {
+        None
+    } else {
+        Some(cursor.read_exact(module_hash_len)?)
+    };
+    let genuine_leaf_der = cursor.read_exact(genuine_leaf_len)?;
+    if !cursor.is_at_end() {
+        return Err("trailing certificate wire bytes");
+    }
+
+    Ok(ParsedAttestKeyRewrite {
+        calling_uid,
+        signing_algorithm,
+        patch_levels,
+        id_overrides,
+        module_hash,
+        genuine_leaf_der,
+        key_id,
+        verified_boot_key,
+        verified_boot_hash,
+    })
+}
+
+struct ParsedChildKeyRewrite<'a> {
+    calling_uid: u32,
+    is_attest_key: bool,
+    patch_levels: PatchLevels,
+    id_overrides: Vec<AttestationIdOverride<'a>>,
+    module_hash: Option<&'a [u8]>,
+    genuine_leaf_der: &'a [u8],
+    verified_boot_key: &'a [u8; 32],
+    verified_boot_hash: &'a [u8; 32],
+}
+
+fn parse_child_key_rewrite_request(
+    request: &[u8],
+) -> Result<ParsedChildKeyRewrite<'_>, &'static str> {
+    let mut cursor = Cursor::new(request);
+    if cursor.read_u8()? != REWRITE_WIRE_VERSION {
+        return Err("unsupported certificate rewrite wire version");
+    }
+    let calling_uid = cursor.read_u32()?;
+    let is_attest_key = cursor.read_u8()? != 0;
+    let patch_levels = PatchLevels {
+        system: read_patch(&mut cursor)?,
+        vendor: read_patch(&mut cursor)?,
+        boot: read_patch(&mut cursor)?,
+    };
+    let id_count = cursor.read_u8()? as usize;
+    if id_count > MAX_ID_OVERRIDES {
+        return Err("too many attestation ID overrides");
+    }
+    let module_hash_len = cursor.read_u16()? as usize;
+    if module_hash_len > MAX_MODULE_HASH_BYTES {
+        return Err("module hash exceeds certificate wire bound");
+    }
+    let genuine_leaf_len = cursor.read_u32_as_usize()?;
+    if genuine_leaf_len == 0 || genuine_leaf_len > MAX_CERTIFICATE_DER_BYTES {
+        return Err("certificate DER field exceeds wire bound");
+    }
+    let verified_boot_key: &[u8; 32] = cursor
+        .read_exact(32)?
+        .try_into()
+        .map_err(|_| "invalid verified boot key")?;
+    let verified_boot_hash: &[u8; 32] = cursor
+        .read_exact(32)?
+        .try_into()
+        .map_err(|_| "invalid verified boot hash")?;
+    if verified_boot_key.iter().all(|byte| *byte == 0)
+        || verified_boot_hash.iter().all(|byte| *byte == 0)
+    {
+        return Err("verified boot digest is unavailable");
+    }
+
+    let mut id_overrides = Vec::new();
+    id_overrides
+        .try_reserve_exact(id_count)
+        .map_err(|_| "attestation ID allocation failed")?;
+    let mut seen_tags = [0u16; MAX_ID_OVERRIDES];
+    for seen_count in 0..id_count {
+        let tag = cursor.read_u16()?;
+        let length = cursor.read_u16()? as usize;
+        if length == 0 || length > MAX_ATTESTATION_ID_BYTES {
+            return Err("attestation ID override exceeds wire bound");
+        }
+        if seen_tags[..seen_count].contains(&tag) {
+            return Err("duplicate attestation ID override");
+        }
+        seen_tags[seen_count] = tag;
+        let value = cursor.read_exact(length)?;
+        id_overrides.push(AttestationIdOverride {
+            tag: u32::from(tag),
+            value,
+        });
+    }
+    let module_hash = if module_hash_len == 0 {
+        None
+    } else {
+        Some(cursor.read_exact(module_hash_len)?)
+    };
+    let genuine_leaf_der = cursor.read_exact(genuine_leaf_len)?;
+    if !cursor.is_at_end() {
+        return Err("trailing certificate wire bytes");
+    }
+
+    Ok(ParsedChildKeyRewrite {
+        calling_uid,
+        is_attest_key,
+        patch_levels,
+        id_overrides,
+        module_hash,
+        genuine_leaf_der,
+        verified_boot_key,
+        verified_boot_hash,
+    })
+}
+
 fn read_patch(cursor: &mut Cursor<'_>) -> Result<PatchComponent, &'static str> {
     let disposition = cursor.read_u8()?;
     let value = cursor.read_i32()?;
@@ -269,6 +594,14 @@ impl<'a> Cursor<'a> {
             .try_into()
             .map_err(|_| "truncated certificate wire")?;
         Ok(i32::from_be_bytes(bytes))
+    }
+
+    fn read_u32(&mut self) -> Result<u32, &'static str> {
+        let bytes: [u8; 4] = self
+            .read_exact(4)?
+            .try_into()
+            .map_err(|_| "truncated certificate wire")?;
+        Ok(u32::from_be_bytes(bytes))
     }
 
     fn read_u32_as_usize(&mut self) -> Result<usize, &'static str> {

--- a/rust/backend/src/certificate_wire.rs
+++ b/rust/backend/src/certificate_wire.rs
@@ -493,7 +493,11 @@ fn parse_child_key_rewrite_request(
         return Err("unsupported certificate rewrite wire version");
     }
     let calling_uid = cursor.read_u32()?;
-    let is_attest_key = cursor.read_u8()? != 0;
+    let is_attest_key = match cursor.read_u8()? {
+        0 => false,
+        1 => true,
+        _ => return Err("invalid child attest key flag"),
+    };
     let patch_levels = PatchLevels {
         system: read_patch(&mut cursor)?,
         vendor: read_patch(&mut cursor)?,
@@ -524,6 +528,9 @@ fn parse_child_key_rewrite_request(
         .map_err(|_| "invalid child attest key identifier")?;
     if is_attest_key && child_key_id.iter().all(|byte| *byte == 0) {
         return Err("invalid child attest key identifier");
+    }
+    if is_attest_key && child_key_id == parent_key_id {
+        return Err("child attest key cannot be its own parent");
     }
     let verified_boot_key: &[u8; 32] = cursor
         .read_exact(32)?

--- a/rust/backend/src/lib.rs
+++ b/rust/backend/src/lib.rs
@@ -1,6 +1,7 @@
 // Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
 #![forbid(unsafe_code)]
 
+mod attest_key_store;
 mod certificate_wire;
 mod crl_wire;
 mod keybox_wire;
@@ -23,4 +24,10 @@ pub fn fuzz_keybox_wire(input: &[u8]) {
     if let Ok(response) = keybox_wire::parse_and_encode(input.to_vec()) {
         assert!(response.len() <= keybox_wire::MAX_KEYBOX_RESPONSE_BYTES);
     }
+}
+
+/// Fuzz-only entry point for the real attest-key and child-key rewrite wire parsers.
+pub fn fuzz_attest_key_wire(input: &[u8]) {
+    let _ = certificate_wire::rewrite_attest_key_and_encode(input.to_vec());
+    let _ = certificate_wire::rewrite_child_key_and_encode(input.to_vec());
 }

--- a/rust/backend/src/main.rs
+++ b/rust/backend/src/main.rs
@@ -66,6 +66,9 @@ const OP_CHILD_KEY_REWRITE: u16 = 33;
 const OP_ATTEST_KEY_CLEAR: u16 = 34;
 const ATTEST_KEY_CLEAR_REQUEST_BYTES: usize = 1;
 const ATTEST_KEY_CLEAR_RESPONSE_BYTES: usize = 1;
+const OP_ATTEST_KEY_TOUCH: u16 = 35;
+const ATTEST_KEY_TOUCH_REQUEST_BYTES: usize = 37;
+const ATTEST_KEY_TOUCH_RESPONSE_BYTES: usize = 1;
 const SCOPE_CONFIG_ROOT: u8 = 0;
 const SCOPE_KEYBOX_DIRECTORY: u8 = 1;
 
@@ -377,6 +380,7 @@ fn opcode_request_limit(opcode: u16) -> Option<usize> {
         OP_ATTEST_KEY_REWRITE => Some(certificate_wire::MAX_ATTEST_KEY_REWRITE_REQUEST_BYTES),
         OP_CHILD_KEY_REWRITE => Some(certificate_wire::MAX_CHILD_KEY_REWRITE_REQUEST_BYTES),
         OP_ATTEST_KEY_CLEAR => Some(ATTEST_KEY_CLEAR_REQUEST_BYTES),
+        OP_ATTEST_KEY_TOUCH => Some(ATTEST_KEY_TOUCH_REQUEST_BYTES),
         OP_CRL_CHECK_BATCH => Some(crl_wire::MAX_REQUEST_BYTES),
         backend_instance::OP_BACKEND_PING => Some(backend_instance::REQUEST_BYTES),
         _ => None,
@@ -394,6 +398,7 @@ fn opcode_response_limit(opcode: u16) -> Option<usize> {
             Some(certificate_wire::MAX_REWRITE_RESPONSE_BYTES)
         }
         OP_ATTEST_KEY_CLEAR => Some(ATTEST_KEY_CLEAR_RESPONSE_BYTES),
+        OP_ATTEST_KEY_TOUCH => Some(ATTEST_KEY_TOUCH_RESPONSE_BYTES),
         OP_CRL_CHECK_BATCH => Some(crl_wire::MAX_RESPONSE_BYTES),
         backend_instance::OP_BACKEND_PING => Some(backend_instance::RESPONSE_BYTES),
         _ => None,
@@ -487,6 +492,17 @@ fn handle_request(opcode: u16, mut request: Vec<u8>) -> Result<Vec<u8>, &'static
             }
             attest_key_store::clear();
             Ok(vec![0])
+        }
+        OP_ATTEST_KEY_TOUCH => {
+            if request.len() != ATTEST_KEY_TOUCH_REQUEST_BYTES
+                || request[0] != certificate_wire::REWRITE_WIRE_VERSION
+            {
+                return Err("invalid attest key touch request");
+            }
+            let calling_uid = u32::from_be_bytes(request[1..5].try_into().unwrap());
+            let key_id: [u8; 32] = request[5..37].try_into().unwrap();
+            let touched = attest_key_store::touch_attest_key(calling_uid, &key_id);
+            Ok(vec![if touched { 1 } else { 0 }])
         }
         OP_CRL_CHECK_BATCH => crl_wire::handle(request),
         backend_instance::OP_BACKEND_PING => backend_instance::handle(request),
@@ -1043,10 +1059,28 @@ mod tests {
             opcode_response_limit(OP_CHILD_KEY_REWRITE),
             Some(certificate_wire::MAX_REWRITE_RESPONSE_BYTES)
         );
+        assert_eq!(
+            opcode_request_limit(OP_ATTEST_KEY_CLEAR),
+            Some(ATTEST_KEY_CLEAR_REQUEST_BYTES)
+        );
+        assert_eq!(
+            opcode_response_limit(OP_ATTEST_KEY_CLEAR),
+            Some(ATTEST_KEY_CLEAR_RESPONSE_BYTES)
+        );
+        assert_eq!(
+            opcode_request_limit(OP_ATTEST_KEY_TOUCH),
+            Some(ATTEST_KEY_TOUCH_REQUEST_BYTES)
+        );
+        assert_eq!(
+            opcode_response_limit(OP_ATTEST_KEY_TOUCH),
+            Some(ATTEST_KEY_TOUCH_RESPONSE_BYTES)
+        );
         assert!(handle_request(OP_CERTIFICATE_INSPECT, vec![1]).is_err());
         assert!(handle_request(OP_CERTIFICATE_REWRITE, vec![1]).is_err());
         assert!(handle_request(OP_ATTEST_KEY_REWRITE, vec![1]).is_err());
         assert!(handle_request(OP_CHILD_KEY_REWRITE, vec![1]).is_err());
+        assert!(handle_request(OP_ATTEST_KEY_CLEAR, vec![0]).is_err());
+        assert!(handle_request(OP_ATTEST_KEY_TOUCH, vec![1]).is_err());
     }
 
     #[test]

--- a/rust/backend/src/main.rs
+++ b/rust/backend/src/main.rs
@@ -1,4 +1,5 @@
 // Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
+mod attest_key_store;
 mod backend_instance;
 mod certificate_wire;
 mod crl_wire;
@@ -60,6 +61,8 @@ const OP_CRL_CHECK_BATCH: u16 = 27;
 const OP_CBOX_UNLOCK: u16 = 29;
 const OP_KEYBOX_BROKER_OPEN: u16 = 30;
 const OP_CBOX_RECOVER: u16 = 31;
+const OP_ATTEST_KEY_REWRITE: u16 = 32;
+const OP_CHILD_KEY_REWRITE: u16 = 33;
 const SCOPE_CONFIG_ROOT: u8 = 0;
 const SCOPE_KEYBOX_DIRECTORY: u8 = 1;
 
@@ -368,6 +371,8 @@ fn opcode_request_limit(opcode: u16) -> Option<usize> {
         OP_KEYBOX_FILE_PARSE => Some(MAX_KEYBOX_FILE_REQUEST_BYTES),
         OP_CERTIFICATE_INSPECT => Some(certificate_wire::MAX_INSPECT_REQUEST_BYTES),
         OP_CERTIFICATE_REWRITE => Some(certificate_wire::MAX_REWRITE_REQUEST_BYTES),
+        OP_ATTEST_KEY_REWRITE => Some(certificate_wire::MAX_ATTEST_KEY_REWRITE_REQUEST_BYTES),
+        OP_CHILD_KEY_REWRITE => Some(certificate_wire::MAX_CHILD_KEY_REWRITE_REQUEST_BYTES),
         OP_CRL_CHECK_BATCH => Some(crl_wire::MAX_REQUEST_BYTES),
         backend_instance::OP_BACKEND_PING => Some(backend_instance::REQUEST_BYTES),
         _ => None,
@@ -381,7 +386,9 @@ fn opcode_response_limit(opcode: u16) -> Option<usize> {
         OP_CRYPTO_BACKUP_ENCRYPT | OP_CRYPTO_BACKUP_DECRYPT => Some(MAX_BACKUP_RESPONSE_BYTES),
         OP_KEYBOX_PARSE | OP_KEYBOX_FILE_PARSE => Some(MAX_KEYBOX_RESPONSE_BYTES),
         OP_CERTIFICATE_INSPECT => Some(certificate_wire::INSPECT_RESPONSE_BYTES),
-        OP_CERTIFICATE_REWRITE => Some(certificate_wire::MAX_REWRITE_RESPONSE_BYTES),
+        OP_CERTIFICATE_REWRITE | OP_ATTEST_KEY_REWRITE | OP_CHILD_KEY_REWRITE => {
+            Some(certificate_wire::MAX_REWRITE_RESPONSE_BYTES)
+        }
         OP_CRL_CHECK_BATCH => Some(crl_wire::MAX_RESPONSE_BYTES),
         backend_instance::OP_BACKEND_PING => Some(backend_instance::RESPONSE_BYTES),
         _ => None,
@@ -467,6 +474,8 @@ fn handle_request(opcode: u16, mut request: Vec<u8>) -> Result<Vec<u8>, &'static
         OP_KEYBOX_PARSE => keybox_wire::parse_and_encode(request),
         OP_CERTIFICATE_INSPECT => certificate_wire::inspect_and_encode(request),
         OP_CERTIFICATE_REWRITE => certificate_wire::rewrite_and_encode(request),
+        OP_ATTEST_KEY_REWRITE => certificate_wire::rewrite_attest_key_and_encode(request),
+        OP_CHILD_KEY_REWRITE => certificate_wire::rewrite_child_key_and_encode(request),
         OP_CRL_CHECK_BATCH => crl_wire::handle(request),
         backend_instance::OP_BACKEND_PING => backend_instance::handle(request),
         _ => {
@@ -1006,8 +1015,26 @@ mod tests {
             opcode_response_limit(OP_CERTIFICATE_REWRITE),
             Some(certificate_wire::MAX_REWRITE_RESPONSE_BYTES)
         );
+        assert_eq!(
+            opcode_request_limit(OP_ATTEST_KEY_REWRITE),
+            Some(certificate_wire::MAX_ATTEST_KEY_REWRITE_REQUEST_BYTES)
+        );
+        assert_eq!(
+            opcode_response_limit(OP_ATTEST_KEY_REWRITE),
+            Some(certificate_wire::MAX_REWRITE_RESPONSE_BYTES)
+        );
+        assert_eq!(
+            opcode_request_limit(OP_CHILD_KEY_REWRITE),
+            Some(certificate_wire::MAX_CHILD_KEY_REWRITE_REQUEST_BYTES)
+        );
+        assert_eq!(
+            opcode_response_limit(OP_CHILD_KEY_REWRITE),
+            Some(certificate_wire::MAX_REWRITE_RESPONSE_BYTES)
+        );
         assert!(handle_request(OP_CERTIFICATE_INSPECT, vec![1]).is_err());
         assert!(handle_request(OP_CERTIFICATE_REWRITE, vec![1]).is_err());
+        assert!(handle_request(OP_ATTEST_KEY_REWRITE, vec![1]).is_err());
+        assert!(handle_request(OP_CHILD_KEY_REWRITE, vec![1]).is_err());
     }
 
     #[test]

--- a/rust/backend/src/main.rs
+++ b/rust/backend/src/main.rs
@@ -63,6 +63,9 @@ const OP_KEYBOX_BROKER_OPEN: u16 = 30;
 const OP_CBOX_RECOVER: u16 = 31;
 const OP_ATTEST_KEY_REWRITE: u16 = 32;
 const OP_CHILD_KEY_REWRITE: u16 = 33;
+const OP_ATTEST_KEY_CLEAR: u16 = 34;
+const ATTEST_KEY_CLEAR_REQUEST_BYTES: usize = 1;
+const ATTEST_KEY_CLEAR_RESPONSE_BYTES: usize = 1;
 const SCOPE_CONFIG_ROOT: u8 = 0;
 const SCOPE_KEYBOX_DIRECTORY: u8 = 1;
 
@@ -373,6 +376,7 @@ fn opcode_request_limit(opcode: u16) -> Option<usize> {
         OP_CERTIFICATE_REWRITE => Some(certificate_wire::MAX_REWRITE_REQUEST_BYTES),
         OP_ATTEST_KEY_REWRITE => Some(certificate_wire::MAX_ATTEST_KEY_REWRITE_REQUEST_BYTES),
         OP_CHILD_KEY_REWRITE => Some(certificate_wire::MAX_CHILD_KEY_REWRITE_REQUEST_BYTES),
+        OP_ATTEST_KEY_CLEAR => Some(ATTEST_KEY_CLEAR_REQUEST_BYTES),
         OP_CRL_CHECK_BATCH => Some(crl_wire::MAX_REQUEST_BYTES),
         backend_instance::OP_BACKEND_PING => Some(backend_instance::REQUEST_BYTES),
         _ => None,
@@ -389,6 +393,7 @@ fn opcode_response_limit(opcode: u16) -> Option<usize> {
         OP_CERTIFICATE_REWRITE | OP_ATTEST_KEY_REWRITE | OP_CHILD_KEY_REWRITE => {
             Some(certificate_wire::MAX_REWRITE_RESPONSE_BYTES)
         }
+        OP_ATTEST_KEY_CLEAR => Some(ATTEST_KEY_CLEAR_RESPONSE_BYTES),
         OP_CRL_CHECK_BATCH => Some(crl_wire::MAX_RESPONSE_BYTES),
         backend_instance::OP_BACKEND_PING => Some(backend_instance::RESPONSE_BYTES),
         _ => None,
@@ -476,6 +481,13 @@ fn handle_request(opcode: u16, mut request: Vec<u8>) -> Result<Vec<u8>, &'static
         OP_CERTIFICATE_REWRITE => certificate_wire::rewrite_and_encode(request),
         OP_ATTEST_KEY_REWRITE => certificate_wire::rewrite_attest_key_and_encode(request),
         OP_CHILD_KEY_REWRITE => certificate_wire::rewrite_child_key_and_encode(request),
+        OP_ATTEST_KEY_CLEAR => {
+            if request.len() != ATTEST_KEY_CLEAR_REQUEST_BYTES || request[0] != 1 {
+                return Err("invalid attest key clear request");
+            }
+            attest_key_store::clear();
+            Ok(vec![0])
+        }
         OP_CRL_CHECK_BATCH => crl_wire::handle(request),
         backend_instance::OP_BACKEND_PING => backend_instance::handle(request),
         _ => {

--- a/rust/backend/src/main.rs
+++ b/rust/backend/src/main.rs
@@ -69,6 +69,9 @@ const ATTEST_KEY_CLEAR_RESPONSE_BYTES: usize = 1;
 const OP_ATTEST_KEY_TOUCH: u16 = 35;
 const ATTEST_KEY_TOUCH_REQUEST_BYTES: usize = 37;
 const ATTEST_KEY_TOUCH_RESPONSE_BYTES: usize = 1;
+const OP_ATTEST_KEY_REMOVE: u16 = 36;
+const ATTEST_KEY_REMOVE_REQUEST_BYTES: usize = 37;
+const ATTEST_KEY_REMOVE_RESPONSE_BYTES: usize = 1;
 const SCOPE_CONFIG_ROOT: u8 = 0;
 const SCOPE_KEYBOX_DIRECTORY: u8 = 1;
 
@@ -381,6 +384,7 @@ fn opcode_request_limit(opcode: u16) -> Option<usize> {
         OP_CHILD_KEY_REWRITE => Some(certificate_wire::MAX_CHILD_KEY_REWRITE_REQUEST_BYTES),
         OP_ATTEST_KEY_CLEAR => Some(ATTEST_KEY_CLEAR_REQUEST_BYTES),
         OP_ATTEST_KEY_TOUCH => Some(ATTEST_KEY_TOUCH_REQUEST_BYTES),
+        OP_ATTEST_KEY_REMOVE => Some(ATTEST_KEY_REMOVE_REQUEST_BYTES),
         OP_CRL_CHECK_BATCH => Some(crl_wire::MAX_REQUEST_BYTES),
         backend_instance::OP_BACKEND_PING => Some(backend_instance::REQUEST_BYTES),
         _ => None,
@@ -399,6 +403,7 @@ fn opcode_response_limit(opcode: u16) -> Option<usize> {
         }
         OP_ATTEST_KEY_CLEAR => Some(ATTEST_KEY_CLEAR_RESPONSE_BYTES),
         OP_ATTEST_KEY_TOUCH => Some(ATTEST_KEY_TOUCH_RESPONSE_BYTES),
+        OP_ATTEST_KEY_REMOVE => Some(ATTEST_KEY_REMOVE_RESPONSE_BYTES),
         OP_CRL_CHECK_BATCH => Some(crl_wire::MAX_RESPONSE_BYTES),
         backend_instance::OP_BACKEND_PING => Some(backend_instance::RESPONSE_BYTES),
         _ => None,
@@ -503,6 +508,17 @@ fn handle_request(opcode: u16, mut request: Vec<u8>) -> Result<Vec<u8>, &'static
             let key_id: [u8; 32] = request[5..37].try_into().unwrap();
             let touched = attest_key_store::touch_attest_key(calling_uid, &key_id);
             Ok(vec![if touched { 1 } else { 0 }])
+        }
+        OP_ATTEST_KEY_REMOVE => {
+            if request.len() != ATTEST_KEY_REMOVE_REQUEST_BYTES
+                || request[0] != certificate_wire::REWRITE_WIRE_VERSION
+            {
+                return Err("invalid attest key remove request");
+            }
+            let calling_uid = u32::from_be_bytes(request[1..5].try_into().unwrap());
+            let key_id: [u8; 32] = request[5..37].try_into().unwrap();
+            let removed = attest_key_store::remove_attest_key(calling_uid, &key_id);
+            Ok(vec![if removed { 1 } else { 0 }])
         }
         OP_CRL_CHECK_BATCH => crl_wire::handle(request),
         backend_instance::OP_BACKEND_PING => backend_instance::handle(request),

--- a/rust/certificate-core/Cargo.toml
+++ b/rust/certificate-core/Cargo.toml
@@ -21,6 +21,7 @@ sha2 = { version = "=0.11.0", features = ["oid"] }
 signature = "=3.0.0"
 x509-cert = { version = "=0.3.0", default-features = false, features = ["pem", "std"] }
 zeroize = "=1.9.0"
+getrandom = { workspace = true }
 
 [dev-dependencies]
 cleverestricky-keybox-core = { path = "../keybox-core" }

--- a/rust/certificate-core/src/lib.rs
+++ b/rust/certificate-core/src/lib.rs
@@ -9,7 +9,10 @@ use cleverestricky_attestation_core::{
 use p256::ecdsa::{
     Signature as EcSignature, SigningKey as EcSigningKey, VerifyingKey as EcVerifyingKey,
 };
-use p256::pkcs8::{DecodePrivateKey as _, DecodePublicKey as _};
+use p256::pkcs8::{
+    DecodePrivateKey as _, DecodePublicKey as _, EncodePrivateKey as _, EncodePublicKey as _,
+};
+use p256::SecretKey as P256SecretKey;
 use rsa::pkcs1v15::{
     Signature as RsaSignature, SigningKey as RsaSigningKey, VerifyingKey as RsaVerifyingKey,
 };
@@ -20,6 +23,7 @@ use signature::{Signer as _, Verifier as _};
 use std::fmt;
 use x509_cert::spki::ObjectIdentifier;
 use x509_cert::Certificate;
+use zeroize::Zeroizing;
 
 pub const MAX_CERTIFICATE_DER_BYTES: usize = 256 * 1024;
 pub const MAX_PRIVATE_KEY_DER_BYTES: usize = 3 * MAX_CERTIFICATE_DER_BYTES;
@@ -43,6 +47,11 @@ pub enum SigningAlgorithm {
     RsaPkcs1Sha256,
 }
 
+pub struct GeneratedEcKeypair {
+    pub public_key_spki_der: Vec<u8>,
+    pub private_key_pkcs8_der: Zeroizing<Vec<u8>>,
+}
+
 pub struct CertificateRewriteRequest<'a> {
     pub genuine_leaf_der: &'a [u8],
     pub issuer_certificate_der: &'a [u8],
@@ -53,6 +62,7 @@ pub struct CertificateRewriteRequest<'a> {
     pub module_hash: Option<&'a [u8]>,
     pub verified_boot_key: &'a [u8; 32],
     pub verified_boot_hash: &'a [u8; 32],
+    pub subject_public_key_info: Option<&'a [u8]>,
 }
 
 pub struct PreparedCertificateRewriteRequest<'a> {
@@ -63,6 +73,7 @@ pub struct PreparedCertificateRewriteRequest<'a> {
     pub module_hash: Option<&'a [u8]>,
     pub verified_boot_key: &'a [u8; 32],
     pub verified_boot_hash: &'a [u8; 32],
+    pub subject_public_key_info: Option<&'a [u8]>,
 }
 
 enum PreparedSigner {
@@ -146,8 +157,45 @@ impl PreparedIssuer {
         })
     }
 
+    pub fn from_subject_and_key(
+        issuer_name_der: Vec<u8>,
+        issuer_private_key_pkcs8: &[u8],
+        signing_algorithm: SigningAlgorithm,
+    ) -> Result<Self, Error> {
+        if issuer_name_der.is_empty()
+            || issuer_name_der.len() > MAX_CERTIFICATE_DER_BYTES
+            || issuer_private_key_pkcs8.is_empty()
+            || issuer_private_key_pkcs8.len() > MAX_PRIVATE_KEY_DER_BYTES
+        {
+            return Err(Error::Bounds);
+        }
+
+        let signer = match signing_algorithm {
+            SigningAlgorithm::EcP256Sha256 => {
+                let signer = EcSigningKey::from_pkcs8_der(issuer_private_key_pkcs8)
+                    .map_err(|_| Error::InvalidPrivateKey)?;
+                PreparedSigner::Ec(signer)
+            }
+            SigningAlgorithm::RsaPkcs1Sha256 => {
+                let signer = RsaSigningKey::<RsaSha256>::from_pkcs8_der(issuer_private_key_pkcs8)
+                    .map_err(|_| Error::InvalidPrivateKey)?;
+                PreparedSigner::Rsa(Box::new(signer))
+            }
+        };
+
+        Ok(Self {
+            algorithm: signing_algorithm,
+            issuer_name_der,
+            signer,
+        })
+    }
+
     pub fn algorithm(&self) -> SigningAlgorithm {
         self.algorithm
+    }
+
+    pub fn issuer_name_der(&self) -> &[u8] {
+        &self.issuer_name_der
     }
 
     fn sign_certificate(&self, tbs_der: &[u8], algorithm_der: &[u8]) -> Result<Vec<u8>, Error> {
@@ -222,6 +270,7 @@ pub fn rewrite_certificate(
         module_hash: request.module_hash,
         verified_boot_key: request.verified_boot_key,
         verified_boot_hash: request.verified_boot_hash,
+        subject_public_key_info: request.subject_public_key_info,
     })
 }
 
@@ -380,7 +429,7 @@ pub fn rewrite_certificate_prepared(
     tbs_len += 1;
     tbs_out[tbs_len] = subject;
     tbs_len += 1;
-    tbs_out[tbs_len] = spki;
+    tbs_out[tbs_len] = request.subject_public_key_info.unwrap_or(spki);
     tbs_len += 1;
     if let Some(uid) = issuer_unique_id {
         tbs_out[tbs_len] = uid;
@@ -423,6 +472,52 @@ fn signature_algorithm_der(algorithm: SigningAlgorithm) -> &'static [u8] {
         SigningAlgorithm::EcP256Sha256 => ECDSA_SHA256_ALGORITHM_DER,
         SigningAlgorithm::RsaPkcs1Sha256 => RSA_SHA256_ALGORITHM_DER,
     }
+}
+
+pub fn generate_ec_p256_keypair() -> Result<GeneratedEcKeypair, Error> {
+    let mut scalar = [0u8; 32];
+    for _ in 0..8 {
+        getrandom::fill(&mut scalar).map_err(|_| Error::Signature)?;
+        if let Ok(secret_key) = P256SecretKey::from_slice(&scalar) {
+            let pkcs8 = secret_key.to_pkcs8_der().map_err(|_| Error::Encoding)?;
+            let spki = secret_key
+                .public_key()
+                .to_public_key_der()
+                .map_err(|_| Error::Encoding)?;
+            return Ok(GeneratedEcKeypair {
+                public_key_spki_der: spki.as_bytes().to_vec(),
+                private_key_pkcs8_der: Zeroizing::new(pkcs8.as_bytes().to_vec()),
+            });
+        }
+    }
+    Err(Error::Signature)
+}
+
+pub fn parse_certificate_subject_and_issuer(
+    certificate_der: &[u8],
+) -> Result<(Vec<u8>, Vec<u8>), Error> {
+    if certificate_der.is_empty() || certificate_der.len() > MAX_CERTIFICATE_DER_BYTES {
+        return Err(Error::Bounds);
+    }
+    let cert_seq = parse_any(certificate_der)?;
+    if cert_seq.tag() != Tag::Sequence {
+        return Err(Error::InvalidCertificate);
+    }
+    let mut cert_iter = TlvIterator::new(cert_seq.value());
+    let tbs_der = next_required_tlv(&mut cert_iter)?;
+    let tbs_seq = parse_any(tbs_der)?;
+    if tbs_seq.tag() != Tag::Sequence {
+        return Err(Error::InvalidCertificate);
+    }
+    let mut tbs_iter = TlvIterator::new(tbs_seq.value());
+    let version = next_required_tlv(&mut tbs_iter)?;
+    validate_v3_version(version)?;
+    let _serial = next_required_tlv(&mut tbs_iter)?;
+    let _algorithm = next_required_tlv(&mut tbs_iter)?;
+    let issuer = next_required_tlv(&mut tbs_iter)?;
+    let _validity = next_required_tlv(&mut tbs_iter)?;
+    let subject = next_required_tlv(&mut tbs_iter)?;
+    Ok((subject.to_vec(), issuer.to_vec()))
 }
 
 pub(crate) fn parse_any(encoded: &[u8]) -> Result<AnyRef<'_>, Error> {

--- a/rust/certificate-core/src/lib.rs
+++ b/rust/certificate-core/src/lib.rs
@@ -520,6 +520,36 @@ pub fn parse_certificate_subject_and_issuer(
     Ok((subject.to_vec(), issuer.to_vec()))
 }
 
+pub fn is_ec_p256_certificate(certificate_der: &[u8]) -> Result<bool, Error> {
+    if certificate_der.is_empty() || certificate_der.len() > MAX_CERTIFICATE_DER_BYTES {
+        return Err(Error::Bounds);
+    }
+    let cert_seq = parse_any(certificate_der)?;
+    if cert_seq.tag() != Tag::Sequence {
+        return Err(Error::InvalidCertificate);
+    }
+    let mut cert_iter = TlvIterator::new(cert_seq.value());
+    let tbs_der = next_required_tlv(&mut cert_iter)?;
+    let tbs_seq = parse_any(tbs_der)?;
+    if tbs_seq.tag() != Tag::Sequence {
+        return Err(Error::InvalidCertificate);
+    }
+    let mut tbs_iter = TlvIterator::new(tbs_seq.value());
+    let version = next_required_tlv(&mut tbs_iter)?;
+    validate_v3_version(version)?;
+    let _serial = next_required_tlv(&mut tbs_iter)?;
+    let _algorithm = next_required_tlv(&mut tbs_iter)?;
+    let _issuer = next_required_tlv(&mut tbs_iter)?;
+    let _validity = next_required_tlv(&mut tbs_iter)?;
+    let _subject = next_required_tlv(&mut tbs_iter)?;
+    let spki = next_required_tlv(&mut tbs_iter)?;
+    Ok(is_ec_p256_spki(spki))
+}
+
+pub fn is_ec_p256_spki(spki_der: &[u8]) -> bool {
+    EcVerifyingKey::from_public_key_der(spki_der).is_ok()
+}
+
 pub(crate) fn parse_any(encoded: &[u8]) -> Result<AnyRef<'_>, Error> {
     X509Decode::from_der(encoded).map_err(|_| Error::InvalidCertificate)
 }

--- a/rust/certificate-core/tests/prepared_rewrite.rs
+++ b/rust/certificate-core/tests/prepared_rewrite.rs
@@ -40,6 +40,7 @@ mod fixture {
                 module_hash: Some(b"new-module-hash"),
                 verified_boot_key: &BOOT_KEY,
                 verified_boot_hash: &BOOT_HASH,
+                subject_public_key_info: None,
             },
         )
         .expect("prepared Rust certificate rewrite");
@@ -152,6 +153,7 @@ mod fixture {
                 module_hash: None,
                 verified_boot_key: &BOOT_KEY,
                 verified_boot_hash: &BOOT_HASH,
+                subject_public_key_info: None,
             },
         )
         .expect("rewrite critical attestation extension");
@@ -227,6 +229,7 @@ mod fixture {
                 module_hash: None,
                 verified_boot_key: &BOOT_KEY,
                 verified_boot_hash: &BOOT_HASH,
+                subject_public_key_info: None,
             },
         );
         assert!(matches!(
@@ -275,6 +278,7 @@ mod fixture {
                 module_hash: None,
                 verified_boot_key: &BOOT_KEY,
                 verified_boot_hash: &BOOT_HASH,
+                subject_public_key_info: None,
             },
         );
         assert!(matches!(

--- a/rust/certificate-core/tests/prepared_rewrite_structure.rs
+++ b/rust/certificate-core/tests/prepared_rewrite_structure.rs
@@ -45,6 +45,7 @@ mod fixture {
                 module_hash: None,
                 verified_boot_key: &BOOT_KEY,
                 verified_boot_hash: &BOOT_HASH,
+                subject_public_key_info: None,
             },
         );
         assert!(matches!(

--- a/rust/certificate-core/tests/rewrite.rs
+++ b/rust/certificate-core/tests/rewrite.rs
@@ -30,6 +30,96 @@ fn rewrites_and_resigns_rsa_leaf_with_managed_builder_semantics() {
 }
 
 #[test]
+fn attest_key_and_child_key_rootoftrust_and_signature_convergence() {
+    let document = parse_keybox_xml_bytes(VALID_EC).expect("EC fixture XML");
+    let key = document.keys.first().expect("EC fixture key");
+    let private_key = normalize_private_key_pkcs8(&key.algorithm, &key.private_key_pem)
+        .expect("EC fixture key DER");
+    let issuer_pem = key
+        .certificates_pem
+        .first()
+        .expect("EC fixture issuer certificate");
+    let keybox_ca = Certificate::from_pem(normalized_pem(issuer_pem).as_bytes())
+        .expect("EC fixture issuer DER");
+    let keybox_ca_der = keybox_ca.to_der().expect("keybox CA DER");
+
+    // 1. Generate K1 (attest key)
+    let k1_genuine = synthetic_genuine_leaf(&keybox_ca);
+    let k1_genuine_der = k1_genuine.to_der().expect("k1 genuine DER");
+
+    let generated_k1 = cleverestricky_certificate_core::generate_ec_p256_keypair()
+        .expect("generate EC keypair for K1");
+
+    let k1_rewritten = rewrite_certificate(&CertificateRewriteRequest {
+        genuine_leaf_der: &k1_genuine_der,
+        issuer_certificate_der: &keybox_ca_der,
+        issuer_private_key_pkcs8: private_key.as_slice(),
+        signing_algorithm: SigningAlgorithm::EcP256Sha256,
+        patch_levels: PatchLevels::default(),
+        id_overrides: &[],
+        module_hash: None,
+        verified_boot_key: &BOOT_KEY,
+        verified_boot_hash: &BOOT_HASH,
+        subject_public_key_info: Some(&generated_k1.public_key_spki_der),
+    })
+    .expect("rewrite K1 leaf");
+
+    let k1_cert = Certificate::from_der(&k1_rewritten.leaf_der).expect("K1 cert DER");
+    // Verify K1's public key matches the generated keypair
+    assert_eq!(
+        k1_cert
+            .tbs_certificate()
+            .subject_public_key_info()
+            .to_der()
+            .unwrap(),
+        generated_k1.public_key_spki_der
+    );
+    // Verify K1 is signed by Keybox CA
+    verify_signature(&k1_cert, &keybox_ca, SigningAlgorithm::EcP256Sha256);
+
+    // 2. Prepare K1 as issuer for K2
+    let (k1_subject_der, _) =
+        cleverestricky_certificate_core::parse_certificate_subject_and_issuer(
+            &k1_rewritten.leaf_der,
+        )
+        .expect("parse K1 subject and issuer");
+
+    let k1_prepared_issuer = cleverestricky_certificate_core::PreparedIssuer::from_subject_and_key(
+        k1_subject_der,
+        &generated_k1.private_key_pkcs8_der,
+        SigningAlgorithm::EcP256Sha256,
+    )
+    .expect("prepare K1 issuer");
+
+    // 3. Child key K2 genuine leaf (minted by hardware KeyMint, with K1 as issuer)
+    let k2_genuine = synthetic_genuine_leaf(&k1_cert);
+    let k2_genuine_der = k2_genuine.to_der().expect("K2 genuine DER");
+
+    let k2_rewritten = cleverestricky_certificate_core::rewrite_certificate_prepared(
+        &cleverestricky_certificate_core::PreparedCertificateRewriteRequest {
+            genuine_leaf_der: &k2_genuine_der,
+            issuer: &k1_prepared_issuer,
+            patch_levels: PatchLevels::default(),
+            id_overrides: &[],
+            module_hash: None,
+            verified_boot_key: &BOOT_KEY,
+            verified_boot_hash: &BOOT_HASH,
+            subject_public_key_info: None, // K2 keeps genuine hardware SPKI
+        },
+    )
+    .expect("rewrite K2 child leaf");
+
+    let k2_cert = Certificate::from_der(&k2_rewritten.leaf_der).expect("K2 cert DER");
+    // Verify K2 preserves genuine SPKI
+    assert_eq!(
+        k2_cert.tbs_certificate().subject_public_key_info(),
+        k2_genuine.tbs_certificate().subject_public_key_info()
+    );
+    // Verify K2 is signed by K1 (verifies with K1's public key!)
+    verify_signature(&k2_cert, &k1_cert, SigningAlgorithm::EcP256Sha256);
+}
+
+#[test]
 fn ec_issuer_resigns_rsa_subject_without_changing_subject_spki() {
     let ec_document = parse_keybox_xml_bytes(VALID_EC).expect("EC fixture XML");
     let ec_key = ec_document.keys.first().expect("EC fixture key");
@@ -72,6 +162,7 @@ fn ec_issuer_resigns_rsa_subject_without_changing_subject_spki() {
         module_hash: None,
         verified_boot_key: &BOOT_KEY,
         verified_boot_hash: &BOOT_HASH,
+        subject_public_key_info: None,
     })
     .expect("cross-algorithm Rust certificate rewrite");
     let output = Certificate::from_der(&rewritten.leaf_der).expect("rewritten certificate DER");
@@ -132,6 +223,7 @@ fn run_fixture(xml: &[u8], algorithm: SigningAlgorithm) {
         module_hash: Some(b"new-module-hash"),
         verified_boot_key: &BOOT_KEY,
         verified_boot_hash: &BOOT_HASH,
+        subject_public_key_info: None,
     })
     .expect("Rust certificate rewrite");
 

--- a/rust/certificate-core/tests/rewrite.rs
+++ b/rust/certificate-core/tests/rewrite.rs
@@ -540,3 +540,27 @@ fn encode_sequence<'a>(parts: impl IntoIterator<Item = &'a [u8]>) -> Vec<u8> {
     let any = attestation_der::asn1::Any::new(attestation_der::Tag::Sequence, value).unwrap();
     attestation_der::Encode::to_der(&any).unwrap()
 }
+
+#[test]
+fn is_ec_p256_certificate_distinguishes_ec_from_rsa() {
+    let ec_doc = parse_keybox_xml_bytes(VALID_EC).expect("EC fixture XML");
+    let ec_pem = ec_doc.keys[0].certificates_pem[0].clone();
+    let ec_cert = Certificate::from_pem(normalized_pem(&ec_pem).as_bytes()).unwrap();
+    let ec_der = ec_cert.to_der().unwrap();
+
+    let rsa_doc = parse_keybox_xml_bytes(VALID_RSA).expect("RSA fixture XML");
+    let rsa_pem = rsa_doc.keys[0].certificates_pem[0].clone();
+    let rsa_cert = Certificate::from_pem(normalized_pem(&rsa_pem).as_bytes()).unwrap();
+    let rsa_der = rsa_cert.to_der().unwrap();
+
+    assert_eq!(
+        cleverestricky_certificate_core::is_ec_p256_certificate(&ec_der),
+        Ok(true)
+    );
+    assert_eq!(
+        cleverestricky_certificate_core::is_ec_p256_certificate(&rsa_der),
+        Ok(false)
+    );
+    assert!(cleverestricky_certificate_core::is_ec_p256_certificate(&[]).is_err());
+    assert!(cleverestricky_certificate_core::is_ec_p256_certificate(&[1, 2, 3]).is_err());
+}

--- a/rust/certificate-core/tests/rewrite.rs
+++ b/rust/certificate-core/tests/rewrite.rs
@@ -43,7 +43,6 @@ fn attest_key_and_child_key_rootoftrust_and_signature_convergence() {
         .expect("EC fixture issuer DER");
     let keybox_ca_der = keybox_ca.to_der().expect("keybox CA DER");
 
-    // 1. Generate K1 (attest key)
     let k1_genuine = synthetic_genuine_leaf(&keybox_ca);
     let k1_genuine_der = k1_genuine.to_der().expect("k1 genuine DER");
 
@@ -65,7 +64,6 @@ fn attest_key_and_child_key_rootoftrust_and_signature_convergence() {
     .expect("rewrite K1 leaf");
 
     let k1_cert = Certificate::from_der(&k1_rewritten.leaf_der).expect("K1 cert DER");
-    // Verify K1's public key matches the generated keypair
     assert_eq!(
         k1_cert
             .tbs_certificate()
@@ -74,10 +72,8 @@ fn attest_key_and_child_key_rootoftrust_and_signature_convergence() {
             .unwrap(),
         generated_k1.public_key_spki_der
     );
-    // Verify K1 is signed by Keybox CA
     verify_signature(&k1_cert, &keybox_ca, SigningAlgorithm::EcP256Sha256);
 
-    // 2. Prepare K1 as issuer for K2
     let (k1_subject_der, _) =
         cleverestricky_certificate_core::parse_certificate_subject_and_issuer(
             &k1_rewritten.leaf_der,
@@ -91,7 +87,6 @@ fn attest_key_and_child_key_rootoftrust_and_signature_convergence() {
     )
     .expect("prepare K1 issuer");
 
-    // 3. Child key K2 genuine leaf (minted by hardware KeyMint, with K1 as issuer)
     let k2_genuine = synthetic_genuine_leaf(&k1_cert);
     let k2_genuine_der = k2_genuine.to_der().expect("K2 genuine DER");
 
@@ -104,18 +99,16 @@ fn attest_key_and_child_key_rootoftrust_and_signature_convergence() {
             module_hash: None,
             verified_boot_key: &BOOT_KEY,
             verified_boot_hash: &BOOT_HASH,
-            subject_public_key_info: None, // K2 keeps genuine hardware SPKI
+            subject_public_key_info: None,
         },
     )
     .expect("rewrite K2 child leaf");
 
     let k2_cert = Certificate::from_der(&k2_rewritten.leaf_der).expect("K2 cert DER");
-    // Verify K2 preserves genuine SPKI
     assert_eq!(
         k2_cert.tbs_certificate().subject_public_key_info(),
         k2_genuine.tbs_certificate().subject_public_key_info()
     );
-    // Verify K2 is signed by K1 (verifies with K1's public key!)
     verify_signature(&k2_cert, &k1_cert, SigningAlgorithm::EcP256Sha256);
 }
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
@@ -324,6 +324,7 @@ object CertificateBackend {
             parentKeyId.size != ATTEST_DESCRIPTOR_KEY_ID_BYTES ||
             parentKeyId.all { it == 0.toByte() } ||
             (isAttestKey && (childKeyId == null || childKeyId.size != ATTEST_DESCRIPTOR_KEY_ID_BYTES || childKeyId.all { it == 0.toByte() })) ||
+            (isAttestKey && childKeyId.contentEquals(parentKeyId)) ||
             (!isAttestKey && childKeyId != null && childKeyId.size != ATTEST_DESCRIPTOR_KEY_ID_BYTES) ||
             genuineLeafDer.isEmpty() || genuineLeafDer.size > MAX_CERTIFICATE_DER_BYTES ||
             !validPatch(systemDisposition, systemValue) ||

--- a/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
@@ -456,10 +456,20 @@ object CertificateBackend {
         fun touch(callingUid: Int, keyId: ByteArray): AttestKeyTouchResult
     }
 
+    fun interface ClearAttestKeyStoreHandler {
+        fun clear(): Boolean
+    }
+
     @VisibleForTesting
     @JvmStatic
     fun setTouchAttestKeyOverrideForTesting(override: AttestKeyTouchHandler?) {
         touchAttestKeyOverride = if (override != null) { { uid, id -> override.touch(uid, id) } } else null
+    }
+
+    @VisibleForTesting
+    @JvmStatic
+    fun setClearAttestKeyStoreOverrideForTesting(override: ClearAttestKeyStoreHandler?) {
+        clearAttestKeyStoreOverride = if (override != null) { { override.clear() } } else null
     }
 
     @VisibleForTesting

--- a/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
@@ -56,10 +56,13 @@ object CertificateBackend {
     internal var rewriteOverride: ((RewriteRequest) -> ByteArray?)? = null
 
     @VisibleForTesting
-    internal var rewriteAttestKeyOverride: ((Int, RewriteRequest) -> ByteArray?)? = null
+    internal var rewriteAttestKeyOverride: ((Int, ByteArray, RewriteRequest) -> ByteArray?)? = null
 
     @VisibleForTesting
-    internal var rewriteChildKeyOverride: ((Int, Boolean, ByteArray, ByteArray, ByteArray) -> ByteArray?)? = null
+    internal var rewriteChildKeyOverride: ((Int, ByteArray, ByteArray?, Boolean, ByteArray, ByteArray, ByteArray) -> ByteArray?)? = null
+
+    @VisibleForTesting
+    internal var clearAttestKeyStoreOverride: (() -> Boolean)? = null
 
     @VisibleForTesting
     internal var rewriteTransportOverride: ((Int, (OutputStream) -> Unit) -> ByteArray?)? = null
@@ -187,6 +190,7 @@ object CertificateBackend {
     @JvmStatic
     fun rewriteAttestKey(
         callingUid: Int,
+        attestKeyId: ByteArray,
         genuineLeafDer: ByteArray,
         keyId: ByteArray,
         signingAlgorithm: Int,
@@ -201,7 +205,10 @@ object CertificateBackend {
         verifiedBootKey: ByteArray,
         verifiedBootHash: ByteArray,
     ): ByteArray? {
-        if (callingUid < 0 || genuineLeafDer.isEmpty() || genuineLeafDer.size > MAX_CERTIFICATE_DER_BYTES ||
+        if (callingUid < 0 ||
+            attestKeyId.size != ATTEST_DESCRIPTOR_KEY_ID_BYTES ||
+            attestKeyId.all { it == 0.toByte() } ||
+            genuineLeafDer.isEmpty() || genuineLeafDer.size > MAX_CERTIFICATE_DER_BYTES ||
             keyId.size != KEY_ID_BYTES || keyId.all { it == 0.toByte() } ||
             signingAlgorithm !in SIGNING_EC_P256_SHA256..SIGNING_RSA_PKCS1_SHA256 ||
             !validPatch(systemDisposition, systemValue) ||
@@ -238,6 +245,7 @@ object CertificateBackend {
             val result =
                 override(
                     callingUid,
+                    attestKeyId,
                     RewriteRequest(
                         genuineLeafDer = genuineLeafDer,
                         keyId = keyId,
@@ -268,6 +276,7 @@ object CertificateBackend {
             writeU16(output, moduleHash?.size ?: 0)
             writeI32(output, genuineLeafDer.size)
             output.write(keyId)
+            output.write(attestKeyId)
             output.write(verifiedBootKey)
             output.write(verifiedBootHash)
             for ((tag, value) in orderedIds) {
@@ -290,6 +299,8 @@ object CertificateBackend {
     @JvmStatic
     fun rewriteChildKey(
         callingUid: Int,
+        parentKeyId: ByteArray,
+        childKeyId: ByteArray?,
         genuineLeafDer: ByteArray,
         isAttestKey: Boolean,
         systemDisposition: Int,
@@ -303,7 +314,12 @@ object CertificateBackend {
         verifiedBootKey: ByteArray,
         verifiedBootHash: ByteArray,
     ): ByteArray? {
-        if (callingUid < 0 || genuineLeafDer.isEmpty() || genuineLeafDer.size > MAX_CERTIFICATE_DER_BYTES ||
+        if (callingUid < 0 ||
+            parentKeyId.size != ATTEST_DESCRIPTOR_KEY_ID_BYTES ||
+            parentKeyId.all { it == 0.toByte() } ||
+            (isAttestKey && (childKeyId == null || childKeyId.size != ATTEST_DESCRIPTOR_KEY_ID_BYTES || childKeyId.all { it == 0.toByte() })) ||
+            (!isAttestKey && childKeyId != null && childKeyId.size != ATTEST_DESCRIPTOR_KEY_ID_BYTES) ||
+            genuineLeafDer.isEmpty() || genuineLeafDer.size > MAX_CERTIFICATE_DER_BYTES ||
             !validPatch(systemDisposition, systemValue) ||
             !validPatch(vendorDisposition, vendorValue) ||
             !validPatch(bootDisposition, bootValue) ||
@@ -338,6 +354,8 @@ object CertificateBackend {
             val result =
                 override(
                     callingUid,
+                    parentKeyId,
+                    childKeyId,
                     isAttestKey,
                     genuineLeafDer,
                     verifiedBootKey,
@@ -346,6 +364,7 @@ object CertificateBackend {
             return if (result != null && (result.isEmpty() || result.size > MAX_REWRITTEN_LEAF_BYTES)) null else result
         }
 
+        val zeroChildKey = ByteArray(ATTEST_DESCRIPTOR_KEY_ID_BYTES)
         val writePayload: (OutputStream) -> Unit = { output ->
             output.write(REWRITE_WIRE_VERSION)
             writeI32(output, callingUid)
@@ -356,6 +375,8 @@ object CertificateBackend {
             output.write(orderedIds.size)
             writeU16(output, moduleHash?.size ?: 0)
             writeI32(output, genuineLeafDer.size)
+            output.write(parentKeyId)
+            output.write(childKeyId ?: zeroChildKey)
             output.write(verifiedBootKey)
             output.write(verifiedBootHash)
             for ((tag, value) in orderedIds) {
@@ -375,6 +396,21 @@ object CertificateBackend {
         )
     }
 
+    @JvmStatic
+    fun clearAttestKeyStore(): Boolean {
+        clearAttestKeyStoreOverride?.let { return it() }
+        val response =
+            NativeBackend.transact(
+                OP_ATTEST_KEY_CLEAR,
+                ATTEST_KEY_CLEAR_REQUEST_BYTES,
+                ATTEST_KEY_CLEAR_RESPONSE_BYTES,
+                propagateTransportFailure = false,
+            ) { output ->
+                output.write(1)
+            } ?: return false
+        return response.size == ATTEST_KEY_CLEAR_RESPONSE_BYTES && response[0] == 0.toByte()
+    }
+
     @VisibleForTesting
     internal fun resetForTesting() {
         inspectionOverride = null
@@ -382,6 +418,7 @@ object CertificateBackend {
         rewriteTransportOverride = null
         rewriteAttestKeyOverride = null
         rewriteChildKeyOverride = null
+        clearAttestKeyStoreOverride = null
     }
 
     internal fun decodeInspection(response: ByteArray): Inspection {
@@ -546,15 +583,19 @@ object CertificateBackend {
     private const val OP_CERTIFICATE_REWRITE = 26
     private const val OP_ATTEST_KEY_REWRITE = 32
     private const val OP_CHILD_KEY_REWRITE = 33
+    private const val OP_ATTEST_KEY_CLEAR = 34
     private const val INSPECT_WIRE_VERSION = 2
     private const val REWRITE_WIRE_VERSION = 2
     private const val INSPECT_RESPONSE_BYTES = 85
+    private const val ATTEST_KEY_CLEAR_REQUEST_BYTES = 1
+    private const val ATTEST_KEY_CLEAR_RESPONSE_BYTES = 1
     private const val FLAG_MODULE_HASH_SUPPORTED = 1
     private const val FLAG_BOOT_KEY_PRESENT = 1 shl 1
     private const val FLAG_BOOT_HASH_PRESENT = 1 shl 2
     private const val INSPECT_RESERVED_FLAGS = 0xf8
     private const val PRESENT_ID_RESERVED_MASK = 0xfe00
     private const val KEY_ID_BYTES = 16
+    private const val ATTEST_DESCRIPTOR_KEY_ID_BYTES = 32
     private const val MAX_CERTIFICATE_DER_BYTES = 256 * 1024
     private const val MAX_REWRITTEN_LEAF_BYTES = 64 * 1024
     private const val MAX_ATTESTATION_ID_BYTES = 4 * 1024
@@ -563,8 +604,8 @@ object CertificateBackend {
     private const val BOOT_DIGEST_BYTES = 32
     private const val ID_HEADER_BYTES = 4
     private const val REWRITE_FIXED_BYTES = 104
-    private const val ATTEST_KEY_REWRITE_FIXED_BYTES = 108
-    private const val CHILD_KEY_REWRITE_FIXED_BYTES = 92
+    private const val ATTEST_KEY_REWRITE_FIXED_BYTES = 140
+    private const val CHILD_KEY_REWRITE_FIXED_BYTES = 156
     private const val MAX_ID_WIRE_BYTES = MAX_ID_OVERRIDES * (ID_HEADER_BYTES + MAX_ATTESTATION_ID_BYTES)
     private const val MAX_REWRITE_REQUEST_BYTES =
         REWRITE_FIXED_BYTES +

--- a/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
@@ -68,6 +68,9 @@ object CertificateBackend {
     internal var touchAttestKeyOverride: ((Int, ByteArray) -> AttestKeyTouchResult)? = null
 
     @VisibleForTesting
+    internal var removeAttestKeyOverride: ((Int, ByteArray) -> Boolean)? = null
+
+    @VisibleForTesting
     internal var rewriteTransportOverride: ((Int, (OutputStream) -> Unit) -> ByteArray?)? = null
 
     @JvmStatic
@@ -452,6 +455,29 @@ object CertificateBackend {
         }
     }
 
+    @JvmStatic
+    fun removeAttestKey(callingUid: Int, attestKeyId: ByteArray): Boolean {
+        if (callingUid < 0 ||
+            attestKeyId.size != ATTEST_DESCRIPTOR_KEY_ID_BYTES ||
+            attestKeyId.all { it == 0.toByte() }
+        ) {
+            return false
+        }
+        removeAttestKeyOverride?.let { return it(callingUid, attestKeyId) }
+        val response =
+            NativeBackend.transact(
+                OP_ATTEST_KEY_REMOVE,
+                ATTEST_KEY_REMOVE_REQUEST_BYTES,
+                ATTEST_KEY_REMOVE_RESPONSE_BYTES,
+                propagateTransportFailure = false,
+            ) { output ->
+                output.write(REWRITE_WIRE_VERSION)
+                writeI32(output, callingUid)
+                output.write(attestKeyId)
+            } ?: return false
+        return response.size == ATTEST_KEY_REMOVE_RESPONSE_BYTES && response[0] == 1.toByte()
+    }
+
     fun interface AttestKeyTouchHandler {
         fun touch(callingUid: Int, keyId: ByteArray): AttestKeyTouchResult
     }
@@ -474,6 +500,12 @@ object CertificateBackend {
 
     @VisibleForTesting
     @JvmStatic
+    fun setRemoveAttestKeyOverrideForTesting(override: ((Int, ByteArray) -> Boolean)?) {
+        removeAttestKeyOverride = override
+    }
+
+    @VisibleForTesting
+    @JvmStatic
     fun resetForTesting() {
         inspectionOverride = null
         rewriteOverride = null
@@ -482,6 +514,7 @@ object CertificateBackend {
         rewriteChildKeyOverride = null
         clearAttestKeyStoreOverride = null
         touchAttestKeyOverride = null
+        removeAttestKeyOverride = null
     }
 
     internal fun decodeInspection(response: ByteArray): Inspection {
@@ -648,6 +681,7 @@ object CertificateBackend {
     private const val OP_CHILD_KEY_REWRITE = 33
     private const val OP_ATTEST_KEY_CLEAR = 34
     private const val OP_ATTEST_KEY_TOUCH = 35
+    private const val OP_ATTEST_KEY_REMOVE = 36
     private const val INSPECT_WIRE_VERSION = 2
     private const val REWRITE_WIRE_VERSION = 2
     private const val INSPECT_RESPONSE_BYTES = 85
@@ -655,6 +689,8 @@ object CertificateBackend {
     private const val ATTEST_KEY_CLEAR_RESPONSE_BYTES = 1
     private const val ATTEST_KEY_TOUCH_REQUEST_BYTES = 37
     private const val ATTEST_KEY_TOUCH_RESPONSE_BYTES = 1
+    private const val ATTEST_KEY_REMOVE_REQUEST_BYTES = 37
+    private const val ATTEST_KEY_REMOVE_RESPONSE_BYTES = 1
     private const val FLAG_MODULE_HASH_SUPPORTED = 1
     private const val FLAG_BOOT_KEY_PRESENT = 1 shl 1
     private const val FLAG_BOOT_HASH_PRESENT = 1 shl 2

--- a/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
@@ -65,7 +65,7 @@ object CertificateBackend {
     internal var clearAttestKeyStoreOverride: (() -> Boolean)? = null
 
     @VisibleForTesting
-    internal var touchAttestKeyOverride: ((Int, ByteArray) -> Boolean)? = null
+    internal var touchAttestKeyOverride: ((Int, ByteArray) -> AttestKeyTouchResult)? = null
 
     @VisibleForTesting
     internal var rewriteTransportOverride: ((Int, (OutputStream) -> Unit) -> ByteArray?)? = null
@@ -414,10 +414,16 @@ object CertificateBackend {
         return response.size == ATTEST_KEY_CLEAR_RESPONSE_BYTES && response[0] == 0.toByte()
     }
 
+    enum class AttestKeyTouchResult {
+        PRESENT,
+        ABSENT,
+        UNAVAILABLE,
+    }
+
     @JvmStatic
-    fun touchAttestKey(callingUid: Int, attestKeyId: ByteArray): Boolean {
+    fun touchAttestKey(callingUid: Int, attestKeyId: ByteArray): AttestKeyTouchResult {
         if (callingUid < 0 || attestKeyId.size != ATTEST_DESCRIPTOR_KEY_ID_BYTES || attestKeyId.all { it == 0.toByte() }) {
-            return false
+            return AttestKeyTouchResult.ABSENT
         }
         touchAttestKeyOverride?.let { return it(callingUid, attestKeyId) }
         val response =
@@ -430,12 +436,19 @@ object CertificateBackend {
                 output.write(REWRITE_WIRE_VERSION)
                 writeI32(output, callingUid)
                 output.write(attestKeyId)
-            } ?: return false
-        return response.size == ATTEST_KEY_TOUCH_RESPONSE_BYTES && response[0] == 1.toByte()
+            } ?: return AttestKeyTouchResult.UNAVAILABLE
+        if (response.size != ATTEST_KEY_TOUCH_RESPONSE_BYTES) {
+            return AttestKeyTouchResult.UNAVAILABLE
+        }
+        return if (response[0] == 1.toByte()) {
+            AttestKeyTouchResult.PRESENT
+        } else {
+            AttestKeyTouchResult.ABSENT
+        }
     }
 
     fun interface AttestKeyTouchHandler {
-        fun touch(callingUid: Int, keyId: ByteArray): Boolean
+        fun touch(callingUid: Int, keyId: ByteArray): AttestKeyTouchResult
     }
 
     @VisibleForTesting

--- a/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
@@ -65,6 +65,9 @@ object CertificateBackend {
     internal var clearAttestKeyStoreOverride: (() -> Boolean)? = null
 
     @VisibleForTesting
+    internal var touchAttestKeyOverride: ((Int, ByteArray) -> Boolean)? = null
+
+    @VisibleForTesting
     internal var rewriteTransportOverride: ((Int, (OutputStream) -> Unit) -> ByteArray?)? = null
 
     @JvmStatic
@@ -411,14 +414,46 @@ object CertificateBackend {
         return response.size == ATTEST_KEY_CLEAR_RESPONSE_BYTES && response[0] == 0.toByte()
     }
 
+    @JvmStatic
+    fun touchAttestKey(callingUid: Int, attestKeyId: ByteArray): Boolean {
+        if (callingUid < 0 || attestKeyId.size != ATTEST_DESCRIPTOR_KEY_ID_BYTES || attestKeyId.all { it == 0.toByte() }) {
+            return false
+        }
+        touchAttestKeyOverride?.let { return it(callingUid, attestKeyId) }
+        val response =
+            NativeBackend.transact(
+                OP_ATTEST_KEY_TOUCH,
+                ATTEST_KEY_TOUCH_REQUEST_BYTES,
+                ATTEST_KEY_TOUCH_RESPONSE_BYTES,
+                propagateTransportFailure = false,
+            ) { output ->
+                output.write(REWRITE_WIRE_VERSION)
+                writeI32(output, callingUid)
+                output.write(attestKeyId)
+            } ?: return false
+        return response.size == ATTEST_KEY_TOUCH_RESPONSE_BYTES && response[0] == 1.toByte()
+    }
+
+    fun interface AttestKeyTouchHandler {
+        fun touch(callingUid: Int, keyId: ByteArray): Boolean
+    }
+
     @VisibleForTesting
-    internal fun resetForTesting() {
+    @JvmStatic
+    fun setTouchAttestKeyOverrideForTesting(override: AttestKeyTouchHandler?) {
+        touchAttestKeyOverride = if (override != null) { { uid, id -> override.touch(uid, id) } } else null
+    }
+
+    @VisibleForTesting
+    @JvmStatic
+    fun resetForTesting() {
         inspectionOverride = null
         rewriteOverride = null
         rewriteTransportOverride = null
         rewriteAttestKeyOverride = null
         rewriteChildKeyOverride = null
         clearAttestKeyStoreOverride = null
+        touchAttestKeyOverride = null
     }
 
     internal fun decodeInspection(response: ByteArray): Inspection {
@@ -584,11 +619,14 @@ object CertificateBackend {
     private const val OP_ATTEST_KEY_REWRITE = 32
     private const val OP_CHILD_KEY_REWRITE = 33
     private const val OP_ATTEST_KEY_CLEAR = 34
+    private const val OP_ATTEST_KEY_TOUCH = 35
     private const val INSPECT_WIRE_VERSION = 2
     private const val REWRITE_WIRE_VERSION = 2
     private const val INSPECT_RESPONSE_BYTES = 85
     private const val ATTEST_KEY_CLEAR_REQUEST_BYTES = 1
     private const val ATTEST_KEY_CLEAR_RESPONSE_BYTES = 1
+    private const val ATTEST_KEY_TOUCH_REQUEST_BYTES = 37
+    private const val ATTEST_KEY_TOUCH_RESPONSE_BYTES = 1
     private const val FLAG_MODULE_HASH_SUPPORTED = 1
     private const val FLAG_BOOT_KEY_PRESENT = 1 shl 1
     private const val FLAG_BOOT_HASH_PRESENT = 1 shl 2

--- a/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
@@ -68,7 +68,7 @@ object CertificateBackend {
     internal var touchAttestKeyOverride: ((Int, ByteArray) -> AttestKeyTouchResult)? = null
 
     @VisibleForTesting
-    internal var removeAttestKeyOverride: ((Int, ByteArray) -> Boolean)? = null
+    internal var removeAttestKeyOverride: ((Int, ByteArray) -> AttestKeyRemoveResult)? = null
 
     @VisibleForTesting
     internal var rewriteTransportOverride: ((Int, (OutputStream) -> Unit) -> ByteArray?)? = null
@@ -456,13 +456,19 @@ object CertificateBackend {
         }
     }
 
+    enum class AttestKeyRemoveResult {
+        REMOVED,
+        ABSENT,
+        UNAVAILABLE,
+    }
+
     @JvmStatic
-    fun removeAttestKey(callingUid: Int, attestKeyId: ByteArray): Boolean {
+    fun removeAttestKey(callingUid: Int, attestKeyId: ByteArray): AttestKeyRemoveResult {
         if (callingUid < 0 ||
             attestKeyId.size != ATTEST_DESCRIPTOR_KEY_ID_BYTES ||
             attestKeyId.all { it == 0.toByte() }
         ) {
-            return false
+            return AttestKeyRemoveResult.ABSENT
         }
         removeAttestKeyOverride?.let { return it(callingUid, attestKeyId) }
         val response =
@@ -475,12 +481,23 @@ object CertificateBackend {
                 output.write(REWRITE_WIRE_VERSION)
                 writeI32(output, callingUid)
                 output.write(attestKeyId)
-            } ?: return false
-        return response.size == ATTEST_KEY_REMOVE_RESPONSE_BYTES && response[0] == 1.toByte()
+            } ?: return AttestKeyRemoveResult.UNAVAILABLE
+        if (response.size != ATTEST_KEY_REMOVE_RESPONSE_BYTES) {
+            return AttestKeyRemoveResult.UNAVAILABLE
+        }
+        return if (response[0] == 1.toByte()) {
+            AttestKeyRemoveResult.REMOVED
+        } else {
+            AttestKeyRemoveResult.ABSENT
+        }
     }
 
     fun interface AttestKeyTouchHandler {
         fun touch(callingUid: Int, keyId: ByteArray): AttestKeyTouchResult
+    }
+
+    fun interface AttestKeyRemoveHandler {
+        fun remove(callingUid: Int, keyId: ByteArray): AttestKeyRemoveResult
     }
 
     fun interface ClearAttestKeyStoreHandler {
@@ -501,8 +518,8 @@ object CertificateBackend {
 
     @VisibleForTesting
     @JvmStatic
-    fun setRemoveAttestKeyOverrideForTesting(override: ((Int, ByteArray) -> Boolean)?) {
-        removeAttestKeyOverride = override
+    fun setRemoveAttestKeyOverrideForTesting(override: AttestKeyRemoveHandler?) {
+        removeAttestKeyOverride = if (override != null) { { uid, id -> override.remove(uid, id) } } else null
     }
 
     @VisibleForTesting

--- a/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
@@ -56,6 +56,12 @@ object CertificateBackend {
     internal var rewriteOverride: ((RewriteRequest) -> ByteArray?)? = null
 
     @VisibleForTesting
+    internal var rewriteAttestKeyOverride: ((Int, RewriteRequest) -> ByteArray?)? = null
+
+    @VisibleForTesting
+    internal var rewriteChildKeyOverride: ((Int, Boolean, ByteArray, ByteArray, ByteArray) -> ByteArray?)? = null
+
+    @VisibleForTesting
     internal var rewriteTransportOverride: ((Int, (OutputStream) -> Unit) -> ByteArray?)? = null
 
     @JvmStatic
@@ -178,11 +184,204 @@ object CertificateBackend {
         )
     }
 
+    @JvmStatic
+    fun rewriteAttestKey(
+        callingUid: Int,
+        genuineLeafDer: ByteArray,
+        keyId: ByteArray,
+        signingAlgorithm: Int,
+        systemDisposition: Int,
+        systemValue: Int,
+        vendorDisposition: Int,
+        vendorValue: Int,
+        bootDisposition: Int,
+        bootValue: Int,
+        idOverrides: Map<Int, ByteArray>,
+        moduleHash: ByteArray?,
+        verifiedBootKey: ByteArray,
+        verifiedBootHash: ByteArray,
+    ): ByteArray? {
+        if (callingUid < 0 || genuineLeafDer.isEmpty() || genuineLeafDer.size > MAX_CERTIFICATE_DER_BYTES ||
+            keyId.size != KEY_ID_BYTES || keyId.all { it == 0.toByte() } ||
+            signingAlgorithm !in SIGNING_EC_P256_SHA256..SIGNING_RSA_PKCS1_SHA256 ||
+            !validPatch(systemDisposition, systemValue) ||
+            !validPatch(vendorDisposition, vendorValue) ||
+            !validPatch(bootDisposition, bootValue) ||
+            idOverrides.size > MAX_ID_OVERRIDES ||
+            moduleHash?.let { it.isEmpty() || it.size > MAX_MODULE_HASH_BYTES } == true ||
+            verifiedBootKey.size != BOOT_DIGEST_BYTES ||
+            verifiedBootHash.size != BOOT_DIGEST_BYTES ||
+            verifiedBootKey.all { it == 0.toByte() } ||
+            verifiedBootHash.all { it == 0.toByte() }
+        ) {
+            return null
+        }
+
+        val orderedIds = idOverrides.entries.sortedBy { it.key }
+        var idWireBytes = 0
+        for ((tag, value) in orderedIds) {
+            if (tag !in ATTESTATION_ID_TAGS || value.isEmpty() || value.size > MAX_ATTESTATION_ID_BYTES) {
+                return null
+            }
+            idWireBytes = checkedAdd(idWireBytes, ID_HEADER_BYTES, value.size) ?: return null
+        }
+        val payloadLength =
+            checkedAdd(
+                ATTEST_KEY_REWRITE_FIXED_BYTES,
+                idWireBytes,
+                moduleHash?.size ?: 0,
+                genuineLeafDer.size,
+            ) ?: return null
+        if (payloadLength > MAX_ATTEST_KEY_REWRITE_REQUEST_BYTES) return null
+
+        rewriteAttestKeyOverride?.let { override ->
+            val result =
+                override(
+                    callingUid,
+                    RewriteRequest(
+                        genuineLeafDer = genuineLeafDer,
+                        keyId = keyId,
+                        signingAlgorithm = signingAlgorithm,
+                        systemDisposition = systemDisposition,
+                        systemValue = systemValue,
+                        vendorDisposition = vendorDisposition,
+                        vendorValue = vendorValue,
+                        bootDisposition = bootDisposition,
+                        bootValue = bootValue,
+                        idOverrides = idOverrides,
+                        moduleHash = moduleHash,
+                        verifiedBootKey = verifiedBootKey,
+                        verifiedBootHash = verifiedBootHash,
+                    ),
+                )
+            return if (result != null && (result.isEmpty() || result.size > MAX_REWRITTEN_LEAF_BYTES)) null else result
+        }
+
+        val writePayload: (OutputStream) -> Unit = { output ->
+            output.write(REWRITE_WIRE_VERSION)
+            writeI32(output, callingUid)
+            output.write(signingAlgorithm)
+            writePatch(output, systemDisposition, systemValue)
+            writePatch(output, vendorDisposition, vendorValue)
+            writePatch(output, bootDisposition, bootValue)
+            output.write(orderedIds.size)
+            writeU16(output, moduleHash?.size ?: 0)
+            writeI32(output, genuineLeafDer.size)
+            output.write(keyId)
+            output.write(verifiedBootKey)
+            output.write(verifiedBootHash)
+            for ((tag, value) in orderedIds) {
+                writeU16(output, tag)
+                writeU16(output, value.size)
+                output.write(value)
+            }
+            if (moduleHash != null) output.write(moduleHash)
+            output.write(genuineLeafDer)
+        }
+        return NativeBackend.transact(
+            OP_ATTEST_KEY_REWRITE,
+            payloadLength,
+            MAX_REWRITTEN_LEAF_BYTES,
+            propagateTransportFailure = true,
+            writePayload = writePayload,
+        )
+    }
+
+    @JvmStatic
+    fun rewriteChildKey(
+        callingUid: Int,
+        genuineLeafDer: ByteArray,
+        isAttestKey: Boolean,
+        systemDisposition: Int,
+        systemValue: Int,
+        vendorDisposition: Int,
+        vendorValue: Int,
+        bootDisposition: Int,
+        bootValue: Int,
+        idOverrides: Map<Int, ByteArray>,
+        moduleHash: ByteArray?,
+        verifiedBootKey: ByteArray,
+        verifiedBootHash: ByteArray,
+    ): ByteArray? {
+        if (callingUid < 0 || genuineLeafDer.isEmpty() || genuineLeafDer.size > MAX_CERTIFICATE_DER_BYTES ||
+            !validPatch(systemDisposition, systemValue) ||
+            !validPatch(vendorDisposition, vendorValue) ||
+            !validPatch(bootDisposition, bootValue) ||
+            idOverrides.size > MAX_ID_OVERRIDES ||
+            moduleHash?.let { it.isEmpty() || it.size > MAX_MODULE_HASH_BYTES } == true ||
+            verifiedBootKey.size != BOOT_DIGEST_BYTES ||
+            verifiedBootHash.size != BOOT_DIGEST_BYTES ||
+            verifiedBootKey.all { it == 0.toByte() } ||
+            verifiedBootHash.all { it == 0.toByte() }
+        ) {
+            return null
+        }
+
+        val orderedIds = idOverrides.entries.sortedBy { it.key }
+        var idWireBytes = 0
+        for ((tag, value) in orderedIds) {
+            if (tag !in ATTESTATION_ID_TAGS || value.isEmpty() || value.size > MAX_ATTESTATION_ID_BYTES) {
+                return null
+            }
+            idWireBytes = checkedAdd(idWireBytes, ID_HEADER_BYTES, value.size) ?: return null
+        }
+        val payloadLength =
+            checkedAdd(
+                CHILD_KEY_REWRITE_FIXED_BYTES,
+                idWireBytes,
+                moduleHash?.size ?: 0,
+                genuineLeafDer.size,
+            ) ?: return null
+        if (payloadLength > MAX_CHILD_KEY_REWRITE_REQUEST_BYTES) return null
+
+        rewriteChildKeyOverride?.let { override ->
+            val result =
+                override(
+                    callingUid,
+                    isAttestKey,
+                    genuineLeafDer,
+                    verifiedBootKey,
+                    verifiedBootHash,
+                )
+            return if (result != null && (result.isEmpty() || result.size > MAX_REWRITTEN_LEAF_BYTES)) null else result
+        }
+
+        val writePayload: (OutputStream) -> Unit = { output ->
+            output.write(REWRITE_WIRE_VERSION)
+            writeI32(output, callingUid)
+            output.write(if (isAttestKey) 1 else 0)
+            writePatch(output, systemDisposition, systemValue)
+            writePatch(output, vendorDisposition, vendorValue)
+            writePatch(output, bootDisposition, bootValue)
+            output.write(orderedIds.size)
+            writeU16(output, moduleHash?.size ?: 0)
+            writeI32(output, genuineLeafDer.size)
+            output.write(verifiedBootKey)
+            output.write(verifiedBootHash)
+            for ((tag, value) in orderedIds) {
+                writeU16(output, tag)
+                writeU16(output, value.size)
+                output.write(value)
+            }
+            if (moduleHash != null) output.write(moduleHash)
+            output.write(genuineLeafDer)
+        }
+        return NativeBackend.transact(
+            OP_CHILD_KEY_REWRITE,
+            payloadLength,
+            MAX_REWRITTEN_LEAF_BYTES,
+            propagateTransportFailure = true,
+            writePayload = writePayload,
+        )
+    }
+
     @VisibleForTesting
     internal fun resetForTesting() {
         inspectionOverride = null
         rewriteOverride = null
         rewriteTransportOverride = null
+        rewriteAttestKeyOverride = null
+        rewriteChildKeyOverride = null
     }
 
     internal fun decodeInspection(response: ByteArray): Inspection {
@@ -345,6 +544,8 @@ object CertificateBackend {
 
     private const val OP_CERTIFICATE_INSPECT = 25
     private const val OP_CERTIFICATE_REWRITE = 26
+    private const val OP_ATTEST_KEY_REWRITE = 32
+    private const val OP_CHILD_KEY_REWRITE = 33
     private const val INSPECT_WIRE_VERSION = 2
     private const val REWRITE_WIRE_VERSION = 2
     private const val INSPECT_RESPONSE_BYTES = 85
@@ -362,9 +563,21 @@ object CertificateBackend {
     private const val BOOT_DIGEST_BYTES = 32
     private const val ID_HEADER_BYTES = 4
     private const val REWRITE_FIXED_BYTES = 104
+    private const val ATTEST_KEY_REWRITE_FIXED_BYTES = 108
+    private const val CHILD_KEY_REWRITE_FIXED_BYTES = 92
     private const val MAX_ID_WIRE_BYTES = MAX_ID_OVERRIDES * (ID_HEADER_BYTES + MAX_ATTESTATION_ID_BYTES)
     private const val MAX_REWRITE_REQUEST_BYTES =
         REWRITE_FIXED_BYTES +
+            MAX_ID_WIRE_BYTES +
+            MAX_MODULE_HASH_BYTES +
+            MAX_CERTIFICATE_DER_BYTES
+    private const val MAX_ATTEST_KEY_REWRITE_REQUEST_BYTES =
+        ATTEST_KEY_REWRITE_FIXED_BYTES +
+            MAX_ID_WIRE_BYTES +
+            MAX_MODULE_HASH_BYTES +
+            MAX_CERTIFICATE_DER_BYTES
+    private const val MAX_CHILD_KEY_REWRITE_REQUEST_BYTES =
+        CHILD_KEY_REWRITE_FIXED_BYTES +
             MAX_ID_WIRE_BYTES +
             MAX_MODULE_HASH_BYTES +
             MAX_CERTIFICATE_DER_BYTES

--- a/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
@@ -402,16 +402,21 @@ object CertificateBackend {
     @JvmStatic
     fun clearAttestKeyStore(): Boolean {
         clearAttestKeyStoreOverride?.let { return it() }
-        val response =
-            NativeBackend.transact(
-                OP_ATTEST_KEY_CLEAR,
-                ATTEST_KEY_CLEAR_REQUEST_BYTES,
-                ATTEST_KEY_CLEAR_RESPONSE_BYTES,
-                propagateTransportFailure = false,
-            ) { output ->
-                output.write(1)
-            } ?: return false
-        return response.size == ATTEST_KEY_CLEAR_RESPONSE_BYTES && response[0] == 0.toByte()
+        for (attempt in 0..1) {
+            val response =
+                NativeBackend.transact(
+                    OP_ATTEST_KEY_CLEAR,
+                    ATTEST_KEY_CLEAR_REQUEST_BYTES,
+                    ATTEST_KEY_CLEAR_RESPONSE_BYTES,
+                    propagateTransportFailure = false,
+                ) { output ->
+                    output.write(1)
+                }
+            if (response != null && response.size == ATTEST_KEY_CLEAR_RESPONSE_BYTES && response[0] == 0.toByte()) {
+                return true
+            }
+        }
+        return false
     }
 
     enum class AttestKeyTouchResult {

--- a/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/Config.kt
@@ -1150,6 +1150,7 @@ object Config {
                 previous?.fill(0)
                 appConfigState.identityCache.clear()
                 CertHack.clearCertificateCache()
+                Unit
             }
         }.onFailure { Logger.e("Failed to refresh application privacy seed", it) }
 
@@ -1192,6 +1193,7 @@ object Config {
                         throw error
                     }
                 }
+                Unit
             }
         }.onFailure { Logger.e("Failed to materialize application privacy seed", it) }
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeyboxActivation.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeyboxActivation.kt
@@ -96,8 +96,8 @@ internal object KeyboxActivation {
         }
 
     /**
-     * Java-facing guard for a fresh certificate rewrite that consumes managed + Rust key state.
-     * Cache-hit certificate reads do not need this mutex because they no longer consume Rust keys.
+     * Java-facing guard for certificate rewrites and cache/store lifecycle mutations.
+     * Serializes backend key registration, child key rewriting, and certificate cache clears.
      */
     @JvmStatic
     fun lockPublishedSnapshot() {

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -22,6 +22,13 @@ class SecurityLevelInterceptor : BinderInterceptor() {
             getTransactCode(IKeystoreSecurityLevel.Stub::class.java, "generateKey")
 
         val INTERCEPTED_CODES = validTransactCodes(generateKeyTransaction)
+
+        private class PreTransactContext(
+            val isDefaultAttestationKey: Boolean,
+            val isAttestKeyPurpose: Boolean,
+        )
+
+        private val CURRENT_CONTEXT = ThreadLocal<PreTransactContext?>()
     }
 
     override fun onPreTransact(
@@ -37,9 +44,12 @@ class SecurityLevelInterceptor : BinderInterceptor() {
             CertHack.canHack() &&
             Config.needHack(callingUid)
         ) {
+            val isDefault = Utils.usesDefaultAttestationKey(data)
+            val isAttestKey = Utils.hasAttestKeyPurpose(data)
+            CURRENT_CONTEXT.set(PreTransactContext(isDefault, isAttestKey))
             return Continue
         }
-
+        CURRENT_CONTEXT.remove()
         return Skip
     }
 
@@ -61,8 +71,14 @@ class SecurityLevelInterceptor : BinderInterceptor() {
             reply == null ||
             resultCode != 0
         ) {
+            CURRENT_CONTEXT.remove()
             return Skip
         }
+
+        val context = CURRENT_CONTEXT.get() ?: PreTransactContext(
+            Utils.usesDefaultAttestationKey(data),
+            Utils.hasAttestKeyPurpose(data),
+        )
 
         return try {
             reply.readException()
@@ -77,11 +93,26 @@ class SecurityLevelInterceptor : BinderInterceptor() {
 
                 val originalLeafOnly = arrayOf<Certificate>(originalLeaf)
                 val rewritten =
-                    CertHack.hackCertificateChain(
-                        originalLeafOnly,
-                        callingUid,
-                        true,
-                    )
+                    if (!context.isDefaultAttestationKey) {
+                        CertHack.hackChildKeyCertificate(
+                            originalLeafOnly,
+                            callingUid,
+                            context.isAttestKeyPurpose,
+                            true,
+                        )
+                    } else if (context.isAttestKeyPurpose) {
+                        CertHack.hackAttestKeyCertificateChain(
+                            originalLeafOnly,
+                            callingUid,
+                            true,
+                        )
+                    } else {
+                        CertHack.hackCertificateChain(
+                            originalLeafOnly,
+                            callingUid,
+                            true,
+                        )
+                    }
                 if (rewritten === originalLeafOnly) {
                     return Skip
                 }
@@ -98,7 +129,7 @@ class SecurityLevelInterceptor : BinderInterceptor() {
                 }
 
                 val newLeaf = rewritten[0].encoded
-                val newChain = Utils.encodeIssuerChain(rewritten)
+                val newChain = if (!context.isDefaultAttestationKey) null else Utils.encodeIssuerChain(rewritten)
                 if (!Utils.rewriteKeyMetadataParcel(reply, parsed, newLeaf, newChain)) {
                     return Skip
                 }
@@ -121,17 +152,37 @@ class SecurityLevelInterceptor : BinderInterceptor() {
 
             val originalLeafOnly = arrayOf<Certificate>(originalLeaf)
             val rewritten =
-                CertHack.hackCertificateChain(
-                    originalLeafOnly,
-                    callingUid,
-                    true,
-                )
+                if (!context.isDefaultAttestationKey) {
+                    CertHack.hackChildKeyCertificate(
+                        originalLeafOnly,
+                        callingUid,
+                        context.isAttestKeyPurpose,
+                        true,
+                    )
+                } else if (context.isAttestKeyPurpose) {
+                    CertHack.hackAttestKeyCertificateChain(
+                        originalLeafOnly,
+                        callingUid,
+                        true,
+                    )
+                } else {
+                    CertHack.hackCertificateChain(
+                        originalLeafOnly,
+                        callingUid,
+                        true,
+                    )
+                }
             if (rewritten === originalLeafOnly) {
                 return Skip
             }
 
             if (!CertHack.applyCachedCertificateChain(metadata)) {
-                Utils.putCertificateChain(metadata, rewritten)
+                if (!context.isDefaultAttestationKey) {
+                    metadata.certificate = rewritten[0].encoded
+                    metadata.certificateChain = null
+                } else {
+                    Utils.putCertificateChain(metadata, rewritten)
+                }
             }
             reply.setDataSize(0)
             reply.setDataPosition(0)
@@ -140,6 +191,8 @@ class SecurityLevelInterceptor : BinderInterceptor() {
             OverrideReply(0, reply)
         } catch (_: Throwable) {
             Skip
+        } finally {
+            CURRENT_CONTEXT.remove()
         }
     }
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -26,6 +26,8 @@ class SecurityLevelInterceptor : BinderInterceptor() {
         private class PreTransactContext(
             val isDefaultAttestationKey: Boolean,
             val isAttestKeyPurpose: Boolean,
+            val generatedKeyId: ByteArray?,
+            val parentKeyId: ByteArray?,
         )
 
         private val CURRENT_CONTEXT = ThreadLocal<PreTransactContext?>()
@@ -44,9 +46,28 @@ class SecurityLevelInterceptor : BinderInterceptor() {
             CertHack.canHack() &&
             Config.needHack(callingUid)
         ) {
+            val reqInfo = Utils.parseGenerateKeyRequest(data, callingUid)
+            if (reqInfo != null) {
+                CURRENT_CONTEXT.set(
+                    PreTransactContext(
+                        isDefaultAttestationKey = reqInfo.usesDefaultAttestationKey,
+                        isAttestKeyPurpose = reqInfo.isAttestKeyPurpose,
+                        generatedKeyId = reqInfo.generatedKeyId,
+                        parentKeyId = reqInfo.parentKeyId,
+                    ),
+                )
+                return Continue
+            }
             val isDefault = Utils.usesDefaultAttestationKey(data)
             val isAttestKey = Utils.hasAttestKeyPurpose(data)
-            CURRENT_CONTEXT.set(PreTransactContext(isDefault, isAttestKey))
+            CURRENT_CONTEXT.set(
+                PreTransactContext(
+                    isDefaultAttestationKey = isDefault,
+                    isAttestKeyPurpose = isAttestKey,
+                    generatedKeyId = null,
+                    parentKeyId = null,
+                ),
+            )
             return Continue
         }
         CURRENT_CONTEXT.remove()
@@ -75,10 +96,24 @@ class SecurityLevelInterceptor : BinderInterceptor() {
             return Skip
         }
 
-        val context = CURRENT_CONTEXT.get() ?: PreTransactContext(
-            Utils.usesDefaultAttestationKey(data),
-            Utils.hasAttestKeyPurpose(data),
-        )
+        val context = CURRENT_CONTEXT.get() ?: run {
+            val reqInfo = Utils.parseGenerateKeyRequest(data, callingUid)
+            if (reqInfo != null) {
+                PreTransactContext(
+                    isDefaultAttestationKey = reqInfo.usesDefaultAttestationKey,
+                    isAttestKeyPurpose = reqInfo.isAttestKeyPurpose,
+                    generatedKeyId = reqInfo.generatedKeyId,
+                    parentKeyId = reqInfo.parentKeyId,
+                )
+            } else {
+                PreTransactContext(
+                    isDefaultAttestationKey = Utils.usesDefaultAttestationKey(data),
+                    isAttestKeyPurpose = Utils.hasAttestKeyPurpose(data),
+                    generatedKeyId = null,
+                    parentKeyId = null,
+                )
+            }
+        }
 
         return try {
             reply.readException()
@@ -94,18 +129,40 @@ class SecurityLevelInterceptor : BinderInterceptor() {
                 val originalLeafOnly = arrayOf<Certificate>(originalLeaf)
                 val rewritten =
                     if (!context.isDefaultAttestationKey) {
-                        CertHack.hackChildKeyCertificate(
-                            originalLeafOnly,
-                            callingUid,
-                            context.isAttestKeyPurpose,
-                            true,
-                        )
+                        val parentId = context.parentKeyId
+                        if (parentId == null) {
+                            CertHack.hackChildKeyCertificate(
+                                originalLeafOnly,
+                                callingUid,
+                                context.isAttestKeyPurpose,
+                                true,
+                            )
+                        } else {
+                            CertHack.hackChildKeyCertificate(
+                                originalLeafOnly,
+                                callingUid,
+                                context.isAttestKeyPurpose,
+                                true,
+                                parentId,
+                                context.generatedKeyId,
+                            )
+                        }
                     } else if (context.isAttestKeyPurpose) {
-                        CertHack.hackAttestKeyCertificateChain(
-                            originalLeafOnly,
-                            callingUid,
-                            true,
-                        )
+                        val keyId = context.generatedKeyId
+                        if (keyId == null) {
+                            CertHack.hackAttestKeyCertificateChain(
+                                originalLeafOnly,
+                                callingUid,
+                                true,
+                            )
+                        } else {
+                            CertHack.hackAttestKeyCertificateChain(
+                                originalLeafOnly,
+                                callingUid,
+                                true,
+                                keyId,
+                            )
+                        }
                     } else {
                         CertHack.hackCertificateChain(
                             originalLeafOnly,
@@ -153,18 +210,40 @@ class SecurityLevelInterceptor : BinderInterceptor() {
             val originalLeafOnly = arrayOf<Certificate>(originalLeaf)
             val rewritten =
                 if (!context.isDefaultAttestationKey) {
-                    CertHack.hackChildKeyCertificate(
-                        originalLeafOnly,
-                        callingUid,
-                        context.isAttestKeyPurpose,
-                        true,
-                    )
+                    val parentId = context.parentKeyId
+                    if (parentId == null) {
+                        CertHack.hackChildKeyCertificate(
+                            originalLeafOnly,
+                            callingUid,
+                            context.isAttestKeyPurpose,
+                            true,
+                        )
+                    } else {
+                        CertHack.hackChildKeyCertificate(
+                            originalLeafOnly,
+                            callingUid,
+                            context.isAttestKeyPurpose,
+                            true,
+                            parentId,
+                            context.generatedKeyId,
+                        )
+                    }
                 } else if (context.isAttestKeyPurpose) {
-                    CertHack.hackAttestKeyCertificateChain(
-                        originalLeafOnly,
-                        callingUid,
-                        true,
-                    )
+                    val keyId = context.generatedKeyId
+                    if (keyId == null) {
+                        CertHack.hackAttestKeyCertificateChain(
+                            originalLeafOnly,
+                            callingUid,
+                            true,
+                        )
+                    } else {
+                        CertHack.hackAttestKeyCertificateChain(
+                            originalLeafOnly,
+                            callingUid,
+                            true,
+                            keyId,
+                        )
+                    }
                 } else {
                     CertHack.hackCertificateChain(
                         originalLeafOnly,

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -819,17 +819,34 @@ public final class CertHack {
         state = new State(newKeyboxes, newKeyboxFiles, preparedMap, classificationMap, uniqueCanonicalFiles.size());
     }
 
+    private static volatile boolean graphStateUnhealthy = false;
+
     public static boolean clearCertificateCache() {
         State currentState = state;
         boolean backendCleared = CertificateBackend.clearAttestKeyStore();
         if (!backendCleared) {
             backendCleared = CertificateBackend.clearAttestKeyStore();
         }
+        if (backendCleared) {
+            graphStateUnhealthy = false;
+        } else {
+            graphStateUnhealthy = true;
+        }
         synchronized (currentState.certificateCache) {
             currentState.certificateCacheEpoch = new Object();
             currentState.certificateCache.clear();
         }
         return backendCleared;
+    }
+
+    @VisibleForTesting
+    static boolean isGraphStateUnhealthyForTesting() {
+        return graphStateUnhealthy;
+    }
+
+    @VisibleForTesting
+    static void resetGraphHealthForTesting() {
+        graphStateUnhealthy = false;
     }
 
     static Object captureCertificateCacheEpochForTesting() {
@@ -1413,6 +1430,14 @@ public final class CertHack {
                 return replacement == null ? caList : replacement;
             }
 
+            if (graphStateUnhealthy) {
+                if (clearCertificateCache()) {
+                    graphStateUnhealthy = false;
+                } else {
+                    return caList;
+                }
+            }
+
             if (!Utils.hasAndroidAttestationExtension(caList[0])) return caList;
 
             childInspection = CertificateBackend.inspect(leafEncoded);
@@ -1478,9 +1503,23 @@ public final class CertHack {
                 return caList;
             }
 
-            if (isAttestKey) {
-                if (!clearCertificateCache()) {
-                    return caList;
+            if (isAttestKey && childKeyId != null) {
+                synchronized (cache) {
+                    List<CacheKey> keysToRemove = null;
+                    for (Map.Entry<CacheKey, CachedCertificateChain> entry : cache.entrySet()) {
+                        CachedCertificateChain entryValue = entry.getValue();
+                        if (entryValue != null && entryValue.parentKeyId != null && Arrays.equals(entryValue.parentKeyId, childKeyId)) {
+                            if (keysToRemove == null) {
+                                keysToRemove = new ArrayList<>();
+                            }
+                            keysToRemove.add(entry.getKey());
+                        }
+                    }
+                    if (keysToRemove != null) {
+                        for (CacheKey k : keysToRemove) {
+                            cache.remove(k);
+                        }
+                    }
                 }
             }
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -785,6 +785,7 @@ public final class CertHack {
             currentState.certificateCacheEpoch = new Object();
             currentState.certificateCache.clear();
         }
+        CertificateBackend.clearAttestKeyStore();
     }
 
     static Object captureCertificateCacheEpochForTesting() {
@@ -1075,11 +1076,21 @@ public final class CertHack {
     }
 
     public static Certificate[] hackAttestKeyCertificateChain(Certificate[] caList, int uid) {
-        return hackAttestKeyCertificateChain(caList, uid, false);
+        return hackAttestKeyCertificateChain(caList, uid, false, null);
     }
 
     public static Certificate[] hackAttestKeyCertificateChain(
             Certificate[] caList, int uid, boolean leafOnlySafe) {
+        return hackAttestKeyCertificateChain(caList, uid, leafOnlySafe, null);
+    }
+
+    public static Certificate[] hackAttestKeyCertificateChain(
+            Certificate[] caList, int uid, byte[] attestKeyId) {
+        return hackAttestKeyCertificateChain(caList, uid, false, attestKeyId);
+    }
+
+    public static Certificate[] hackAttestKeyCertificateChain(
+            Certificate[] caList, int uid, boolean leafOnlySafe, byte[] attestKeyId) {
         if (caList == null || caList.length == 0 || caList[0] == null) {
             throw new UnsupportedOperationException("Certificate chain is empty");
         }
@@ -1203,10 +1214,14 @@ public final class CertHack {
             byte[] moduleHash = attestInspection.getSupportsModuleHash()
                     ? Config.INSTANCE.getModuleHash()
                     : null;
+            if (attestKeyId == null || attestKeyId.length != 32) {
+                return caList;
+            }
             keyId = prepared.keyId.clone();
 
             byte[] rewrittenDer = CertificateBackend.rewriteAttestKey(
                     uid,
+                    attestKeyId,
                     leafEncoded,
                     keyId,
                     signingAlgorithm,
@@ -1255,11 +1270,21 @@ public final class CertHack {
 
     public static Certificate[] hackChildKeyCertificate(
             Certificate[] caList, int uid, boolean isAttestKey) {
-        return hackChildKeyCertificate(caList, uid, isAttestKey, false);
+        return hackChildKeyCertificate(caList, uid, isAttestKey, false, null, null);
     }
 
     public static Certificate[] hackChildKeyCertificate(
             Certificate[] caList, int uid, boolean isAttestKey, boolean leafOnlySafe) {
+        return hackChildKeyCertificate(caList, uid, isAttestKey, leafOnlySafe, null, null);
+    }
+
+    public static Certificate[] hackChildKeyCertificate(
+            Certificate[] caList, int uid, boolean isAttestKey, byte[] parentKeyId, byte[] childKeyId) {
+        return hackChildKeyCertificate(caList, uid, isAttestKey, false, parentKeyId, childKeyId);
+    }
+
+    public static Certificate[] hackChildKeyCertificate(
+            Certificate[] caList, int uid, boolean isAttestKey, boolean leafOnlySafe, byte[] parentKeyId, byte[] childKeyId) {
         if (caList == null || caList.length == 0 || caList[0] == null) {
             return caList;
         }
@@ -1341,8 +1366,17 @@ public final class CertHack {
                     ? Config.INSTANCE.getModuleHash()
                     : null;
 
+            if (parentKeyId == null || parentKeyId.length != 32) {
+                return caList;
+            }
+            if (isAttestKey && (childKeyId == null || childKeyId.length != 32)) {
+                return caList;
+            }
+
             byte[] rewrittenDer = CertificateBackend.rewriteChildKey(
                     uid,
+                    parentKeyId,
+                    childKeyId,
                     leafEncoded,
                     isAttestKey,
                     patchDisposition(patchLevels.getSystem()), patchLevels.getSystem().getValue(),

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -822,6 +822,9 @@ public final class CertHack {
     public static boolean clearCertificateCache() {
         State currentState = state;
         boolean backendCleared = CertificateBackend.clearAttestKeyStore();
+        if (!backendCleared) {
+            backendCleared = CertificateBackend.clearAttestKeyStore();
+        }
         synchronized (currentState.certificateCache) {
             currentState.certificateCacheEpoch = new Object();
             currentState.certificateCache.clear();
@@ -878,7 +881,16 @@ public final class CertHack {
         }
 
         if (parentAbsent || selfAbsent) {
-            clearCertificateCache();
+            boolean backendCleared = clearCertificateCache();
+            if (!backendCleared) {
+                synchronized (cache) {
+                    CachedCertificateChain current = cache.get(cacheKey);
+                    if (current == cached) {
+                        cache.remove(cacheKey);
+                    }
+                }
+                return CachedCertificateChain.passthrough();
+            }
             return null;
         }
 
@@ -1303,6 +1315,10 @@ public final class CertHack {
             }
             keyId = prepared.keyId.clone();
 
+            if (!clearCertificateCache()) {
+                return caList;
+            }
+
             byte[] rewrittenDer = CertificateBackend.rewriteAttestKey(
                     uid,
                     attestKeyId,
@@ -1462,6 +1478,12 @@ public final class CertHack {
                 return caList;
             }
 
+            if (isAttestKey) {
+                if (!clearCertificateCache()) {
+                    return caList;
+                }
+            }
+
             byte[] rewrittenDer = CertificateBackend.rewriteChildKey(
                     uid,
                     parentKeyId,
@@ -1498,7 +1520,7 @@ public final class CertHack {
                     encodedIssuerChain,
                     leafOnlySafe,
                     false,
-                    isAttestKey ? uid : 0,
+                    uid,
                     isAttestKey ? childKeyId : null,
                     parentKeyId
             );

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -117,6 +117,8 @@ public final class CertHack {
         final boolean passthrough;
         final boolean leafOnlySafe;
         final boolean accountIssuerChainBytes;
+        final int attestKeyCallingUid;
+        final byte[] attestKeyId;
 
         CachedCertificateChain(
                 Certificate[] certificates,
@@ -124,7 +126,7 @@ public final class CertHack {
                 byte[] issuerChainEncoded,
                 boolean leafOnlySafe
         ) {
-            this(certificates, leafEncoded, issuerChainEncoded, leafOnlySafe, false);
+            this(certificates, leafEncoded, issuerChainEncoded, leafOnlySafe, false, 0, null);
         }
 
         CachedCertificateChain(
@@ -134,12 +136,26 @@ public final class CertHack {
                 boolean leafOnlySafe,
                 boolean accountIssuerChainBytes
         ) {
-            this.certificates = certificates.clone();
+            this(certificates, leafEncoded, issuerChainEncoded, leafOnlySafe, accountIssuerChainBytes, 0, null);
+        }
+
+        CachedCertificateChain(
+                Certificate[] certificates,
+                byte[] leafEncoded,
+                byte[] issuerChainEncoded,
+                boolean leafOnlySafe,
+                boolean accountIssuerChainBytes,
+                int attestKeyCallingUid,
+                byte[] attestKeyId
+        ) {
+            this.certificates = certificates != null ? certificates.clone() : null;
             this.leafEncoded = Objects.requireNonNull(leafEncoded, "leafEncoded");
             this.issuerChainEncoded = issuerChainEncoded;
             this.passthrough = false;
             this.leafOnlySafe = leafOnlySafe;
             this.accountIssuerChainBytes = accountIssuerChainBytes;
+            this.attestKeyCallingUid = attestKeyCallingUid;
+            this.attestKeyId = attestKeyId != null ? attestKeyId.clone() : null;
         }
 
         private CachedCertificateChain() {
@@ -149,6 +165,8 @@ public final class CertHack {
             this.passthrough = true;
             this.leafOnlySafe = true; // Passthrough is always safe for leaves (it does nothing)
             this.accountIssuerChainBytes = false;
+            this.attestKeyCallingUid = 0;
+            this.attestKeyId = null;
         }
 
         static CachedCertificateChain passthrough() {
@@ -164,6 +182,9 @@ public final class CertHack {
             int bytes = leafEncoded != null ? leafEncoded.length : 0;
             if (accountIssuerChainBytes && issuerChainEncoded != null) {
                 bytes += issuerChainEncoded.length;
+            }
+            if (attestKeyId != null) {
+                bytes += attestKeyId.length;
             }
             return bytes;
         }
@@ -806,6 +827,26 @@ public final class CertHack {
         return !state.certificateCache.isEmpty();
     }
 
+    private static CachedCertificateChain validateAndTouchAttestKey(
+            State.CertificateCache cache,
+            CacheKey cacheKey,
+            CachedCertificateChain cached
+    ) {
+        if (cached == null || cached.attestKeyId == null) {
+            return cached;
+        }
+        if (CertificateBackend.touchAttestKey(cached.attestKeyCallingUid, cached.attestKeyId)) {
+            return cached;
+        }
+        synchronized (cache) {
+            CachedCertificateChain current = cache.get(cacheKey);
+            if (current == cached) {
+                cache.remove(cacheKey);
+            }
+        }
+        return null;
+    }
+
     /**
      * Applies a cached replacement or passthrough decision directly to raw KeyMetadata bytes.
      * A passthrough hit is intentionally a no-op and still returns true, allowing repeated
@@ -817,10 +858,12 @@ public final class CertHack {
             return false;
         }
         State currentState = state;
+        CacheKey cacheKey = new CacheKey(metadata.certificate);
         CachedCertificateChain cached;
         synchronized (currentState.certificateCache) {
-            cached = currentState.certificateCache.get(new CacheKey(metadata.certificate));
+            cached = currentState.certificateCache.get(cacheKey);
         }
+        cached = validateAndTouchAttestKey(currentState.certificateCache, cacheKey, cached);
         if (cached == null) return false;
 
         if (isLeafOnly && !cached.leafOnlySafe) {
@@ -852,10 +895,12 @@ public final class CertHack {
         }
 
         State currentState = state;
+        CacheKey cacheKey = new CacheKey(parsed.leafEncoded);
         CachedCertificateChain cached;
         synchronized (currentState.certificateCache) {
-            cached = currentState.certificateCache.get(new CacheKey(parsed.leafEncoded));
+            cached = currentState.certificateCache.get(cacheKey);
         }
+        cached = validateAndTouchAttestKey(currentState.certificateCache, cacheKey, cached);
         if (cached == null || (parsed.hasLeafOnlyCertificate() && !cached.leafOnlySafe)) {
             return CachedParcelAction.MISS;
         }
@@ -874,7 +919,12 @@ public final class CertHack {
         try {
             byte[] leafEncoded = caList[0].getEncoded();
             if (leafEncoded.length == 0 || leafEncoded.length > MAX_LEAF_CERTIFICATE_BYTES) return null;
-            CachedCertificateChain cached = state.certificateCache.get(new CacheKey(leafEncoded));
+            CacheKey cacheKey = new CacheKey(leafEncoded);
+            CachedCertificateChain cached;
+            synchronized (state.certificateCache) {
+                cached = state.certificateCache.get(cacheKey);
+            }
+            cached = validateAndTouchAttestKey(state.certificateCache, cacheKey, cached);
             if (cached == null) return null;
             Certificate[] replacement = cached.certificateCopy();
             return replacement == null ? caList : replacement;
@@ -910,13 +960,15 @@ public final class CertHack {
             CacheKey cacheKey = new CacheKey(leafEncoded);
             State.CertificateCache cache = currentState.certificateCache;
             Object cacheEpoch;
+            CachedCertificateChain cached;
             synchronized (cache) {
-                CachedCertificateChain cached = cache.get(cacheKey);
-                if (cached != null) {
-                    Certificate[] replacement = cached.certificateCopy();
-                    return replacement == null ? caList : replacement;
-                }
+                cached = cache.get(cacheKey);
                 cacheEpoch = currentState.certificateCacheEpoch;
+            }
+            cached = validateAndTouchAttestKey(cache, cacheKey, cached);
+            if (cached != null) {
+                Certificate[] replacement = cached.certificateCopy();
+                return replacement == null ? caList : replacement;
             }
 
             // Preserve the local non-attested fast path. Only genuine Android attestation leaves
@@ -1106,13 +1158,15 @@ public final class CertHack {
             CacheKey cacheKey = new CacheKey(leafEncoded);
             State.CertificateCache cache = currentState.certificateCache;
             Object cacheEpoch;
+            CachedCertificateChain cached;
             synchronized (cache) {
-                CachedCertificateChain cached = cache.get(cacheKey);
-                if (cached != null) {
-                    Certificate[] replacement = cached.certificateCopy();
-                    return replacement == null ? caList : replacement;
-                }
+                cached = cache.get(cacheKey);
                 cacheEpoch = currentState.certificateCacheEpoch;
+            }
+            cached = validateAndTouchAttestKey(cache, cacheKey, cached);
+            if (cached != null) {
+                Certificate[] replacement = cached.certificateCopy();
+                return replacement == null ? caList : replacement;
             }
 
             if (!Utils.hasAndroidAttestationExtension(caList[0])) return caList;
@@ -1245,7 +1299,9 @@ public final class CertHack {
                     rewrittenDer,
                     encodedIssuerChain,
                     leafOnlySafe,
-                    true
+                    true,
+                    uid,
+                    attestKeyId
             );
             synchronized (cache) {
                 if (state != currentState || currentState.certificateCacheEpoch != cacheEpoch) {
@@ -1299,13 +1355,15 @@ public final class CertHack {
             CacheKey cacheKey = new CacheKey(leafEncoded);
             State.CertificateCache cache = currentState.certificateCache;
             Object cacheEpoch;
+            CachedCertificateChain cached;
             synchronized (cache) {
-                CachedCertificateChain cached = cache.get(cacheKey);
-                if (cached != null) {
-                    Certificate[] replacement = cached.certificateCopy();
-                    return replacement == null ? caList : replacement;
-                }
+                cached = cache.get(cacheKey);
                 cacheEpoch = currentState.certificateCacheEpoch;
+            }
+            cached = validateAndTouchAttestKey(cache, cacheKey, cached);
+            if (cached != null) {
+                Certificate[] replacement = cached.certificateCopy();
+                return replacement == null ? caList : replacement;
             }
 
             if (!Utils.hasAndroidAttestationExtension(caList[0])) return caList;
@@ -1408,7 +1466,9 @@ public final class CertHack {
                     rewrittenDer,
                     encodedIssuerChain,
                     leafOnlySafe,
-                    false
+                    false,
+                    isAttestKey ? uid : 0,
+                    isAttestKey ? childKeyId : null
             );
             synchronized (cache) {
                 if (state != currentState || currentState.certificateCacheEpoch != cacheEpoch) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -119,6 +119,7 @@ public final class CertHack {
         final boolean accountIssuerChainBytes;
         final int attestKeyCallingUid;
         final byte[] attestKeyId;
+        final byte[] parentKeyId;
 
         CachedCertificateChain(
                 Certificate[] certificates,
@@ -126,7 +127,7 @@ public final class CertHack {
                 byte[] issuerChainEncoded,
                 boolean leafOnlySafe
         ) {
-            this(certificates, leafEncoded, issuerChainEncoded, leafOnlySafe, false, 0, null);
+            this(certificates, leafEncoded, issuerChainEncoded, leafOnlySafe, false, 0, null, null);
         }
 
         CachedCertificateChain(
@@ -136,7 +137,7 @@ public final class CertHack {
                 boolean leafOnlySafe,
                 boolean accountIssuerChainBytes
         ) {
-            this(certificates, leafEncoded, issuerChainEncoded, leafOnlySafe, accountIssuerChainBytes, 0, null);
+            this(certificates, leafEncoded, issuerChainEncoded, leafOnlySafe, accountIssuerChainBytes, 0, null, null);
         }
 
         CachedCertificateChain(
@@ -148,6 +149,19 @@ public final class CertHack {
                 int attestKeyCallingUid,
                 byte[] attestKeyId
         ) {
+            this(certificates, leafEncoded, issuerChainEncoded, leafOnlySafe, accountIssuerChainBytes, attestKeyCallingUid, attestKeyId, null);
+        }
+
+        CachedCertificateChain(
+                Certificate[] certificates,
+                byte[] leafEncoded,
+                byte[] issuerChainEncoded,
+                boolean leafOnlySafe,
+                boolean accountIssuerChainBytes,
+                int attestKeyCallingUid,
+                byte[] attestKeyId,
+                byte[] parentKeyId
+        ) {
             this.certificates = certificates != null ? certificates.clone() : null;
             this.leafEncoded = Objects.requireNonNull(leafEncoded, "leafEncoded");
             this.issuerChainEncoded = issuerChainEncoded;
@@ -156,6 +170,7 @@ public final class CertHack {
             this.accountIssuerChainBytes = accountIssuerChainBytes;
             this.attestKeyCallingUid = attestKeyCallingUid;
             this.attestKeyId = attestKeyId != null ? attestKeyId.clone() : null;
+            this.parentKeyId = parentKeyId != null ? parentKeyId.clone() : null;
         }
 
         private CachedCertificateChain() {
@@ -167,6 +182,7 @@ public final class CertHack {
             this.accountIssuerChainBytes = false;
             this.attestKeyCallingUid = 0;
             this.attestKeyId = null;
+            this.parentKeyId = null;
         }
 
         static CachedCertificateChain passthrough() {
@@ -185,6 +201,9 @@ public final class CertHack {
             }
             if (attestKeyId != null) {
                 bytes += attestKeyId.length;
+            }
+            if (parentKeyId != null) {
+                bytes += parentKeyId.length;
             }
             return bytes;
         }
@@ -800,13 +819,14 @@ public final class CertHack {
         state = new State(newKeyboxes, newKeyboxFiles, preparedMap, classificationMap, uniqueCanonicalFiles.size());
     }
 
-    public static void clearCertificateCache() {
+    public static boolean clearCertificateCache() {
         State currentState = state;
+        boolean backendCleared = CertificateBackend.clearAttestKeyStore();
         synchronized (currentState.certificateCache) {
             currentState.certificateCacheEpoch = new Object();
             currentState.certificateCache.clear();
         }
-        CertificateBackend.clearAttestKeyStore();
+        return backendCleared;
     }
 
     static Object captureCertificateCacheEpochForTesting() {
@@ -827,24 +847,42 @@ public final class CertHack {
         return !state.certificateCache.isEmpty();
     }
 
-    private static CachedCertificateChain validateAndTouchAttestKey(
+    private static CachedCertificateChain validateAndTouchAttestGraph(
             State.CertificateCache cache,
             CacheKey cacheKey,
             CachedCertificateChain cached
     ) {
-        if (cached == null || cached.attestKeyId == null) {
+        if (cached == null) {
+            return null;
+        }
+        if (cached.attestKeyId == null && cached.parentKeyId == null) {
             return cached;
         }
-        if (CertificateBackend.touchAttestKey(cached.attestKeyCallingUid, cached.attestKeyId)) {
-            return cached;
-        }
-        synchronized (cache) {
-            CachedCertificateChain current = cache.get(cacheKey);
-            if (current == cached) {
-                cache.remove(cacheKey);
+
+        boolean parentAbsent = false;
+        if (cached.parentKeyId != null) {
+            CertificateBackend.AttestKeyTouchResult res =
+                    CertificateBackend.touchAttestKey(cached.attestKeyCallingUid, cached.parentKeyId);
+            if (res == CertificateBackend.AttestKeyTouchResult.ABSENT) {
+                parentAbsent = true;
             }
         }
-        return null;
+
+        boolean selfAbsent = false;
+        if (!parentAbsent && cached.attestKeyId != null) {
+            CertificateBackend.AttestKeyTouchResult res =
+                    CertificateBackend.touchAttestKey(cached.attestKeyCallingUid, cached.attestKeyId);
+            if (res == CertificateBackend.AttestKeyTouchResult.ABSENT) {
+                selfAbsent = true;
+            }
+        }
+
+        if (parentAbsent || selfAbsent) {
+            clearCertificateCache();
+            return null;
+        }
+
+        return cached;
     }
 
     /**
@@ -858,12 +896,10 @@ public final class CertHack {
             return false;
         }
         State currentState = state;
-        CacheKey cacheKey = new CacheKey(metadata.certificate);
         CachedCertificateChain cached;
         synchronized (currentState.certificateCache) {
-            cached = currentState.certificateCache.get(cacheKey);
+            cached = currentState.certificateCache.get(new CacheKey(metadata.certificate));
         }
-        cached = validateAndTouchAttestKey(currentState.certificateCache, cacheKey, cached);
         if (cached == null) return false;
 
         if (isLeafOnly && !cached.leafOnlySafe) {
@@ -895,12 +931,10 @@ public final class CertHack {
         }
 
         State currentState = state;
-        CacheKey cacheKey = new CacheKey(parsed.leafEncoded);
         CachedCertificateChain cached;
         synchronized (currentState.certificateCache) {
-            cached = currentState.certificateCache.get(cacheKey);
+            cached = currentState.certificateCache.get(new CacheKey(parsed.leafEncoded));
         }
-        cached = validateAndTouchAttestKey(currentState.certificateCache, cacheKey, cached);
         if (cached == null || (parsed.hasLeafOnlyCertificate() && !cached.leafOnlySafe)) {
             return CachedParcelAction.MISS;
         }
@@ -919,12 +953,10 @@ public final class CertHack {
         try {
             byte[] leafEncoded = caList[0].getEncoded();
             if (leafEncoded.length == 0 || leafEncoded.length > MAX_LEAF_CERTIFICATE_BYTES) return null;
-            CacheKey cacheKey = new CacheKey(leafEncoded);
             CachedCertificateChain cached;
             synchronized (state.certificateCache) {
-                cached = state.certificateCache.get(cacheKey);
+                cached = state.certificateCache.get(new CacheKey(leafEncoded));
             }
-            cached = validateAndTouchAttestKey(state.certificateCache, cacheKey, cached);
             if (cached == null) return null;
             Certificate[] replacement = cached.certificateCopy();
             return replacement == null ? caList : replacement;
@@ -960,15 +992,13 @@ public final class CertHack {
             CacheKey cacheKey = new CacheKey(leafEncoded);
             State.CertificateCache cache = currentState.certificateCache;
             Object cacheEpoch;
-            CachedCertificateChain cached;
             synchronized (cache) {
-                cached = cache.get(cacheKey);
+                CachedCertificateChain cached = cache.get(cacheKey);
+                if (cached != null) {
+                    Certificate[] replacement = cached.certificateCopy();
+                    return replacement == null ? caList : replacement;
+                }
                 cacheEpoch = currentState.certificateCacheEpoch;
-            }
-            cached = validateAndTouchAttestKey(cache, cacheKey, cached);
-            if (cached != null) {
-                Certificate[] replacement = cached.certificateCopy();
-                return replacement == null ? caList : replacement;
             }
 
             // Preserve the local non-attested fast path. Only genuine Android attestation leaves
@@ -1163,7 +1193,7 @@ public final class CertHack {
                 cached = cache.get(cacheKey);
                 cacheEpoch = currentState.certificateCacheEpoch;
             }
-            cached = validateAndTouchAttestKey(cache, cacheKey, cached);
+            cached = validateAndTouchAttestGraph(cache, cacheKey, cached);
             if (cached != null) {
                 Certificate[] replacement = cached.certificateCopy();
                 return replacement == null ? caList : replacement;
@@ -1301,7 +1331,8 @@ public final class CertHack {
                     leafOnlySafe,
                     true,
                     uid,
-                    attestKeyId
+                    attestKeyId,
+                    null
             );
             synchronized (cache) {
                 if (state != currentState || currentState.certificateCacheEpoch != cacheEpoch) {
@@ -1360,7 +1391,7 @@ public final class CertHack {
                 cached = cache.get(cacheKey);
                 cacheEpoch = currentState.certificateCacheEpoch;
             }
-            cached = validateAndTouchAttestKey(cache, cacheKey, cached);
+            cached = validateAndTouchAttestGraph(cache, cacheKey, cached);
             if (cached != null) {
                 Certificate[] replacement = cached.certificateCopy();
                 return replacement == null ? caList : replacement;
@@ -1468,7 +1499,8 @@ public final class CertHack {
                     leafOnlySafe,
                     false,
                     isAttestKey ? uid : 0,
-                    isAttestKey ? childKeyId : null
+                    isAttestKey ? childKeyId : null,
+                    parentKeyId
             );
             synchronized (cache) {
                 if (state != currentState || currentState.certificateCacheEpoch != cacheEpoch) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -136,7 +136,7 @@ public final class CertHack {
         ) {
             this.certificates = certificates.clone();
             this.leafEncoded = Objects.requireNonNull(leafEncoded, "leafEncoded");
-            this.issuerChainEncoded = Objects.requireNonNull(issuerChainEncoded, "issuerChainEncoded");
+            this.issuerChainEncoded = issuerChainEncoded;
             this.passthrough = false;
             this.leafOnlySafe = leafOnlySafe;
             this.accountIssuerChainBytes = accountIssuerChainBytes;
@@ -1070,6 +1070,328 @@ public final class CertHack {
         } finally {
             if (keyId != null) Arrays.fill(keyId, (byte) 0);
             if (inspection != null) inspection.wipe();
+            KeyboxActivation.unlockPublishedSnapshot();
+        }
+    }
+
+    public static Certificate[] hackAttestKeyCertificateChain(Certificate[] caList, int uid) {
+        return hackAttestKeyCertificateChain(caList, uid, false);
+    }
+
+    public static Certificate[] hackAttestKeyCertificateChain(
+            Certificate[] caList, int uid, boolean leafOnlySafe) {
+        if (caList == null || caList.length == 0 || caList[0] == null) {
+            throw new UnsupportedOperationException("Certificate chain is empty");
+        }
+        KeyboxActivation.lockPublishedSnapshot();
+        CertificateBackend.Inspection attestInspection = null;
+        byte[] keyId = null;
+        try {
+            State currentState = state;
+            byte[] leafEncoded = caList[0].getEncoded();
+            if (leafEncoded.length == 0 || leafEncoded.length > MAX_LEAF_CERTIFICATE_BYTES) {
+                return caList;
+            }
+            CacheKey cacheKey = new CacheKey(leafEncoded);
+            State.CertificateCache cache = currentState.certificateCache;
+            Object cacheEpoch;
+            synchronized (cache) {
+                CachedCertificateChain cached = cache.get(cacheKey);
+                if (cached != null) {
+                    Certificate[] replacement = cached.certificateCopy();
+                    return replacement == null ? caList : replacement;
+                }
+                cacheEpoch = currentState.certificateCacheEpoch;
+            }
+
+            if (!Utils.hasAndroidAttestationExtension(caList[0])) return caList;
+
+            attestInspection = CertificateBackend.inspect(leafEncoded);
+            if (attestInspection == null) return caList;
+            int attLevel = attestInspection.getAttestationSecurityLevel();
+            int kmLevel = attestInspection.getKeymintSecurityLevel();
+            boolean isTee = attLevel == CertificateBackend.SECURITY_LEVEL_TEE
+                    && kmLevel == CertificateBackend.SECURITY_LEVEL_TEE;
+            boolean isStrongbox =
+                    (attLevel == CertificateBackend.SECURITY_LEVEL_TEE
+                            && kmLevel == CertificateBackend.SECURITY_LEVEL_STRONGBOX)
+                    || (attLevel == CertificateBackend.SECURITY_LEVEL_STRONGBOX
+                            && kmLevel == CertificateBackend.SECURITY_LEVEL_STRONGBOX);
+            boolean isTeeOrStrongbox = isTee || isStrongbox;
+            if (!isTeeOrStrongbox) {
+                synchronized (cache) {
+                    if (state == currentState && currentState.certificateCacheEpoch == cacheEpoch) {
+                        cache.putIfAbsent(cacheKey, CachedCertificateChain.passthrough());
+                    }
+                }
+                return caList;
+            }
+
+            boolean needsCapturedPatchLevels = PolicyState.INSTANCE.isFeatureEnabled(
+                    PolicyState.Feature.SECURITY_PATCH, uid);
+            byte[] originalBootKey = usableBootDigest(attestInspection.getOriginalBootKey());
+            if (originalBootKey != null) {
+                capturedHardwareBootKey = originalBootKey.clone();
+            }
+            byte[] originalBootHash = usableBootDigest(attestInspection.getOriginalBootHash());
+            if (originalBootHash != null) {
+                capturedHardwareBootHash = originalBootHash.clone();
+            }
+            byte[] verifiedBootKey = selectVerifiedBootDigest(
+                    UtilKt.getBootKey(),
+                    originalBootKey != null ? originalBootKey : capturedHardwareBootKey,
+                    UtilKt.getPersistentBootKey());
+            byte[] verifiedBootHash = selectVerifiedBootDigest(
+                    UtilKt.getBootHash(),
+                    originalBootHash != null ? originalBootHash : capturedHardwareBootHash,
+                    UtilKt.getPersistentBootHash());
+            Config.AttestationPatchLevels patchLevels = needsCapturedPatchLevels
+                    ? PolicyState.INSTANCE.resolveAttestationPatchLevels(
+                            uid,
+                            attestInspection.getSystemPatch(),
+                            attestInspection.getVendorPatch(),
+                            attestInspection.getBootPatch())
+                    : keepPatchLevels();
+
+            List<KeyBox> list;
+            var appConfig = Config.INSTANCE.getAppConfig(uid);
+            if (appConfig != null && appConfig.getKeyboxFilename() != null) {
+                List<KeyBox> candidates = currentState.keyboxFiles.get(appConfig.getKeyboxFilename());
+                List<KeyBox> matchingLevel = filterKeyboxesBySecurityLevel(candidates, isStrongbox);
+                if (!matchingLevel.isEmpty()) {
+                    candidates = matchingLevel;
+                } else if (isStrongbox) {
+                    candidates = filterKeyboxesBySecurityLevel(candidates, false);
+                } else {
+                    candidates = Collections.emptyList();
+                }
+                list = selectKeyboxPool(candidates, KeyProperties.KEY_ALGORITHM_EC);
+            } else {
+                if (isStrongbox) {
+                    if (!currentState.globalStrongBoxEc.isEmpty()) {
+                        list = currentState.globalStrongBoxEc;
+                    } else if (!currentState.globalStrongBoxRsa.isEmpty()) {
+                        list = currentState.globalStrongBoxRsa;
+                    } else if (!currentState.globalTeeEc.isEmpty()) {
+                        list = currentState.globalTeeEc;
+                    } else {
+                        list = currentState.globalTeeRsa;
+                    }
+                } else {
+                    if (!currentState.globalTeeEc.isEmpty()) {
+                        list = currentState.globalTeeEc;
+                    } else {
+                        list = currentState.globalTeeRsa;
+                    }
+                }
+            }
+            if (list.isEmpty()) {
+                return caList;
+            }
+
+            KeyBox keybox = list.get(cacheKey.indexForPool(list.size()));
+            PreparedKeyBox prepared = currentState.preparedKeyboxes.get(keybox);
+            if (prepared == null) throw new UnsupportedOperationException("Keybox metadata is unavailable");
+            int signingAlgorithm = signingWireAlgorithm(prepared.signatureAlgorithm);
+            if (signingAlgorithm == 0) return caList;
+
+            if (verifiedBootKey == null || verifiedBootHash == null) {
+                return caList;
+            }
+
+            Map<Integer, byte[]> idOverrides = presentIdOverrides(uid, attestInspection.getPresentIdMask());
+            byte[] moduleHash = attestInspection.getSupportsModuleHash()
+                    ? Config.INSTANCE.getModuleHash()
+                    : null;
+            keyId = prepared.keyId.clone();
+
+            byte[] rewrittenDer = CertificateBackend.rewriteAttestKey(
+                    uid,
+                    leafEncoded,
+                    keyId,
+                    signingAlgorithm,
+                    patchDisposition(patchLevels.getSystem()), patchLevels.getSystem().getValue(),
+                    patchDisposition(patchLevels.getVendor()), patchLevels.getVendor().getValue(),
+                    patchDisposition(patchLevels.getBoot()), patchLevels.getBoot().getValue(),
+                    idOverrides,
+                    moduleHash,
+                    verifiedBootKey,
+                    verifiedBootHash);
+            if (rewrittenDer == null || rewrittenDer.length == 0 || rewrittenDer.length > MAX_LEAF_CERTIFICATE_BYTES) {
+                return caList;
+            }
+            byte[] encodedIssuerChain = currentState.encodedIssuerChain(prepared);
+            Certificate rewrittenLeaf = new LazyX509Certificate(rewrittenDer, false);
+            Certificate[] result = new Certificate[prepared.issuerChain.length + 1];
+            result[0] = rewrittenLeaf;
+            System.arraycopy(prepared.issuerChain, 0, result, 1, prepared.issuerChain.length);
+            CachedCertificateChain completed = new CachedCertificateChain(
+                    result,
+                    rewrittenDer,
+                    encodedIssuerChain,
+                    leafOnlySafe,
+                    true
+            );
+            synchronized (cache) {
+                if (state != currentState || currentState.certificateCacheEpoch != cacheEpoch) {
+                    return result;
+                }
+                CachedCertificateChain raced = cache.get(cacheKey);
+                if (raced != null) {
+                    Certificate[] replacement = raced.certificateCopy();
+                    return replacement == null ? caList : replacement;
+                }
+                cache.put(cacheKey, completed);
+            }
+            return result;
+        } catch (Throwable t) {
+            return caList;
+        } finally {
+            if (keyId != null) Arrays.fill(keyId, (byte) 0);
+            if (attestInspection != null) attestInspection.wipe();
+            KeyboxActivation.unlockPublishedSnapshot();
+        }
+    }
+
+    public static Certificate[] hackChildKeyCertificate(
+            Certificate[] caList, int uid, boolean isAttestKey) {
+        return hackChildKeyCertificate(caList, uid, isAttestKey, false);
+    }
+
+    public static Certificate[] hackChildKeyCertificate(
+            Certificate[] caList, int uid, boolean isAttestKey, boolean leafOnlySafe) {
+        if (caList == null || caList.length == 0 || caList[0] == null) {
+            return caList;
+        }
+        KeyboxActivation.lockPublishedSnapshot();
+        CertificateBackend.Inspection childInspection = null;
+        try {
+            State currentState = state;
+            byte[] leafEncoded = caList[0].getEncoded();
+            if (leafEncoded.length == 0 || leafEncoded.length > MAX_LEAF_CERTIFICATE_BYTES) {
+                return caList;
+            }
+            CacheKey cacheKey = new CacheKey(leafEncoded);
+            State.CertificateCache cache = currentState.certificateCache;
+            Object cacheEpoch;
+            synchronized (cache) {
+                CachedCertificateChain cached = cache.get(cacheKey);
+                if (cached != null) {
+                    Certificate[] replacement = cached.certificateCopy();
+                    return replacement == null ? caList : replacement;
+                }
+                cacheEpoch = currentState.certificateCacheEpoch;
+            }
+
+            if (!Utils.hasAndroidAttestationExtension(caList[0])) return caList;
+
+            childInspection = CertificateBackend.inspect(leafEncoded);
+            if (childInspection == null) return caList;
+            int attLevel = childInspection.getAttestationSecurityLevel();
+            int kmLevel = childInspection.getKeymintSecurityLevel();
+            boolean isTee = attLevel == CertificateBackend.SECURITY_LEVEL_TEE
+                    && kmLevel == CertificateBackend.SECURITY_LEVEL_TEE;
+            boolean isStrongbox =
+                    (attLevel == CertificateBackend.SECURITY_LEVEL_TEE
+                            && kmLevel == CertificateBackend.SECURITY_LEVEL_STRONGBOX)
+                    || (attLevel == CertificateBackend.SECURITY_LEVEL_STRONGBOX
+                            && kmLevel == CertificateBackend.SECURITY_LEVEL_STRONGBOX);
+            boolean isTeeOrStrongbox = isTee || isStrongbox;
+            if (!isTeeOrStrongbox) {
+                synchronized (cache) {
+                    if (state == currentState && currentState.certificateCacheEpoch == cacheEpoch) {
+                        cache.putIfAbsent(cacheKey, CachedCertificateChain.passthrough());
+                    }
+                }
+                return caList;
+            }
+
+            boolean needsCapturedPatchLevels = PolicyState.INSTANCE.isFeatureEnabled(
+                    PolicyState.Feature.SECURITY_PATCH, uid);
+            byte[] originalBootKey = usableBootDigest(childInspection.getOriginalBootKey());
+            if (originalBootKey != null) {
+                capturedHardwareBootKey = originalBootKey.clone();
+            }
+            byte[] originalBootHash = usableBootDigest(childInspection.getOriginalBootHash());
+            if (originalBootHash != null) {
+                capturedHardwareBootHash = originalBootHash.clone();
+            }
+            byte[] verifiedBootKey = selectVerifiedBootDigest(
+                    UtilKt.getBootKey(),
+                    originalBootKey != null ? originalBootKey : capturedHardwareBootKey,
+                    UtilKt.getPersistentBootKey());
+            byte[] verifiedBootHash = selectVerifiedBootDigest(
+                    UtilKt.getBootHash(),
+                    originalBootHash != null ? originalBootHash : capturedHardwareBootHash,
+                    UtilKt.getPersistentBootHash());
+            if (verifiedBootKey == null || verifiedBootHash == null) {
+                return caList;
+            }
+
+            Config.AttestationPatchLevels patchLevels = needsCapturedPatchLevels
+                    ? PolicyState.INSTANCE.resolveAttestationPatchLevels(
+                            uid,
+                            childInspection.getSystemPatch(),
+                            childInspection.getVendorPatch(),
+                            childInspection.getBootPatch())
+                    : keepPatchLevels();
+
+            Map<Integer, byte[]> idOverrides = presentIdOverrides(uid, childInspection.getPresentIdMask());
+            byte[] moduleHash = childInspection.getSupportsModuleHash()
+                    ? Config.INSTANCE.getModuleHash()
+                    : null;
+
+            byte[] rewrittenDer = CertificateBackend.rewriteChildKey(
+                    uid,
+                    leafEncoded,
+                    isAttestKey,
+                    patchDisposition(patchLevels.getSystem()), patchLevels.getSystem().getValue(),
+                    patchDisposition(patchLevels.getVendor()), patchLevels.getVendor().getValue(),
+                    patchDisposition(patchLevels.getBoot()), patchLevels.getBoot().getValue(),
+                    idOverrides,
+                    moduleHash,
+                    verifiedBootKey,
+                    verifiedBootHash);
+            if (rewrittenDer == null || rewrittenDer.length == 0 || rewrittenDer.length > MAX_LEAF_CERTIFICATE_BYTES) {
+                return caList;
+            }
+
+            Certificate rewrittenLeaf = new LazyX509Certificate(rewrittenDer, false);
+            Certificate[] result = new Certificate[caList.length];
+            result[0] = rewrittenLeaf;
+            if (caList.length > 1) {
+                System.arraycopy(caList, 1, result, 1, caList.length - 1);
+            }
+            byte[] encodedIssuerChain = null;
+            if (caList.length > 1) {
+                try {
+                    encodedIssuerChain = Utils.encodeIssuerChain(caList);
+                } catch (Throwable ignored) {
+                }
+            }
+            CachedCertificateChain completed = new CachedCertificateChain(
+                    result,
+                    rewrittenDer,
+                    encodedIssuerChain,
+                    leafOnlySafe,
+                    false
+            );
+            synchronized (cache) {
+                if (state != currentState || currentState.certificateCacheEpoch != cacheEpoch) {
+                    return result;
+                }
+                CachedCertificateChain raced = cache.get(cacheKey);
+                if (raced != null) {
+                    Certificate[] replacement = raced.certificateCopy();
+                    return replacement == null ? caList : replacement;
+                }
+                cache.put(cacheKey, completed);
+            }
+            return result;
+        } catch (Throwable t) {
+            return caList;
+        } finally {
+            if (childInspection != null) childInspection.wipe();
             KeyboxActivation.unlockPublishedSnapshot();
         }
     }

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -165,8 +165,8 @@ public final class CertHack {
                 byte[] parentKeyId
         ) {
             this.certificates = certificates != null ? certificates.clone() : null;
-            this.leafEncoded = Objects.requireNonNull(leafEncoded, "leafEncoded");
-            this.issuerChainEncoded = issuerChainEncoded;
+            this.leafEncoded = Objects.requireNonNull(leafEncoded, "leafEncoded").clone();
+            this.issuerChainEncoded = issuerChainEncoded != null ? issuerChainEncoded.clone() : null;
             this.passthrough = false;
             this.leafOnlySafe = leafOnlySafe;
             this.accountIssuerChainBytes = accountIssuerChainBytes;
@@ -212,10 +212,8 @@ public final class CertHack {
 
         void applyTo(KeyMetadata metadata) {
             if (passthrough) return;
-            // Parcel.writeTypedObject copies these byte arrays synchronously. The transient
-            // KeyMetadata object never owns or mutates the cache storage after the reply is built.
-            metadata.certificate = leafEncoded;
-            metadata.certificateChain = issuerChainEncoded;
+            metadata.certificate = leafEncoded.clone();
+            metadata.certificateChain = issuerChainEncoded != null ? issuerChainEncoded.clone() : null;
         }
     }
 
@@ -561,7 +559,7 @@ public final class CertHack {
         private final int hashCode;
 
         CacheKey(byte[] leafEncoded) {
-            this.leafEncoded = Objects.requireNonNull(leafEncoded, "leafEncoded");
+            this.leafEncoded = Objects.requireNonNull(leafEncoded, "leafEncoded").clone();
             this.hashCode = Arrays.hashCode(this.leafEncoded);
         }
 
@@ -888,22 +886,28 @@ public final class CertHack {
 
     private static void evictDescendants(State.CertificateCache cache, byte[] parentKeyId) {
         if (cache == null || parentKeyId == null) return;
-        List<CacheKey> keysToRemove = null;
+        List<CacheKey> keysToRemove = new ArrayList<>();
+        List<byte[]> descendantIds = new ArrayList<>();
+        descendantIds.add(parentKeyId);
         synchronized (cache) {
-            for (Map.Entry<CacheKey, CachedCertificateChain> entry : cache.entrySet()) {
-                CachedCertificateChain entryValue = entry.getValue();
-                if (entryValue != null && entryValue.parentKeyId != null && Arrays.equals(entryValue.parentKeyId, parentKeyId)) {
-                    if (keysToRemove == null) {
-                        keysToRemove = new ArrayList<>();
+            for (int index = 0; index < descendantIds.size(); index++) {
+                byte[] currentParent = descendantIds.get(index);
+                for (Map.Entry<CacheKey, CachedCertificateChain> entry : cache.entrySet()) {
+                    CachedCertificateChain entryValue = entry.getValue();
+                    if (entryValue != null
+                            && entryValue.parentKeyId != null
+                            && Arrays.equals(entryValue.parentKeyId, currentParent)
+                            && !keysToRemove.contains(entry.getKey())) {
+                        keysToRemove.add(entry.getKey());
+                        if (entryValue.attestKeyId != null) {
+                            descendantIds.add(entryValue.attestKeyId);
+                        }
                     }
-                    keysToRemove.add(entry.getKey());
                 }
             }
         }
-        if (keysToRemove != null) {
-            for (CacheKey k : keysToRemove) {
-                cache.remove(k);
-            }
+        for (CacheKey k : keysToRemove) {
+            cache.remove(k);
         }
     }
 
@@ -1402,6 +1406,12 @@ public final class CertHack {
 
             if (!clearCertificateCache()) {
                 return caList;
+            }
+            synchronized (cache) {
+                if (state != currentState) {
+                    return caList;
+                }
+                cacheEpoch = currentState.certificateCacheEpoch;
             }
 
             byte[] rewrittenDer = CertificateBackend.rewriteAttestKey(

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -465,7 +465,11 @@ public final class CertHack {
                 }
                 if (evicted != null) {
                     for (AttestKeyDescriptor desc : evicted) {
-                        CertificateBackend.removeAttestKey(desc.callingUid, desc.keyId);
+                        CertificateBackend.AttestKeyRemoveResult res =
+                                CertificateBackend.removeAttestKey(desc.callingUid, desc.keyId);
+                        if (res == CertificateBackend.AttestKeyRemoveResult.UNAVAILABLE) {
+                            graphStateUnhealthy = true;
+                        }
                     }
                 }
                 return old;
@@ -496,7 +500,11 @@ public final class CertHack {
                     }
                 }
                 if (old != null && old.attestKeyId != null) {
-                    CertificateBackend.removeAttestKey(old.attestKeyCallingUid, old.attestKeyId);
+                    CertificateBackend.AttestKeyRemoveResult res =
+                            CertificateBackend.removeAttestKey(old.attestKeyCallingUid, old.attestKeyId);
+                    if (res == CertificateBackend.AttestKeyRemoveResult.UNAVAILABLE) {
+                        graphStateUnhealthy = true;
+                    }
                 }
                 return old;
             }

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -4,6 +4,8 @@ import android.os.Parcel;
 import android.security.keystore.KeyProperties;
 import android.system.keystore2.KeyMetadata;
 
+import androidx.annotation.VisibleForTesting;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.security.KeyPair;
@@ -441,17 +443,33 @@ public final class CertHack {
             }
 
             @Override
-            public synchronized CachedCertificateChain put(CacheKey key, CachedCertificateChain value) {
-                CachedCertificateChain old = super.put(key, value);
-                if (old != null) {
-                    retainedBytes -= old.retainedBytes();
-                } else if (key != null) {
-                    retainedBytes += key.retainedBytes();
+            public CachedCertificateChain put(CacheKey key, CachedCertificateChain value) {
+                CachedCertificateChain old;
+                List<AttestKeyDescriptor> evicted = null;
+                synchronized (this) {
+                    old = super.put(key, value);
+                    if (old != null) {
+                        retainedBytes -= old.retainedBytes();
+                    } else if (key != null) {
+                        retainedBytes += key.retainedBytes();
+                    }
+                    if (value != null) {
+                        retainedBytes += value.retainedBytes();
+                    }
+                    evicted = trimLocked();
+                    if (old != null && old.attestKeyId != null
+                            && (value == null || !Arrays.equals(old.attestKeyId, value.attestKeyId))) {
+                        if (evicted == null) {
+                            evicted = new ArrayList<>(1);
+                        }
+                        evicted.add(new AttestKeyDescriptor(old.attestKeyCallingUid, old.attestKeyId));
+                    }
                 }
-                if (value != null) {
-                    retainedBytes += value.retainedBytes();
+                if (evicted != null) {
+                    for (AttestKeyDescriptor desc : evicted) {
+                        CertificateBackend.removeAttestKey(desc.callingUid, desc.keyId);
+                    }
                 }
-                trimLocked();
                 return old;
             }
 
@@ -459,23 +477,28 @@ public final class CertHack {
             public synchronized CachedCertificateChain putIfAbsent(CacheKey key, CachedCertificateChain value) {
                 CachedCertificateChain existing = super.get(key);
                 if (existing == null) {
-                    put(key, value);
-                    return null;
+                    return put(key, value);
                 }
                 return existing;
             }
 
             @Override
-            public synchronized CachedCertificateChain remove(Object key) {
-                CachedCertificateChain old = super.remove(key);
-                if (old != null) {
-                    if (key instanceof CacheKey cacheKey) {
-                        retainedBytes -= cacheKey.retainedBytes();
+            public CachedCertificateChain remove(Object key) {
+                CachedCertificateChain old;
+                synchronized (this) {
+                    old = super.remove(key);
+                    if (old != null) {
+                        if (key instanceof CacheKey cacheKey) {
+                            retainedBytes -= cacheKey.retainedBytes();
+                        }
+                        retainedBytes -= old.retainedBytes();
+                        if (retainedBytes < 0) {
+                            retainedBytes = 0;
+                        }
                     }
-                    retainedBytes -= old.retainedBytes();
-                    if (retainedBytes < 0) {
-                        retainedBytes = 0;
-                    }
+                }
+                if (old != null && old.attestKeyId != null) {
+                    CertificateBackend.removeAttestKey(old.attestKeyCallingUid, old.attestKeyId);
                 }
                 return old;
             }
@@ -495,7 +518,8 @@ public final class CertHack {
                 return retainedBytes;
             }
 
-            private void trimLocked() {
+            private List<AttestKeyDescriptor> trimLocked() {
+                List<AttestKeyDescriptor> evicted = null;
                 Iterator<Map.Entry<CacheKey, CachedCertificateChain>> it = entrySet().iterator();
                 while (it.hasNext() && (size() > MAX_CERTIFICATE_CACHE_ENTRIES
                         || retainedBytes > MAX_CERTIFICATE_CACHE_RETAINED_BYTES)) {
@@ -504,7 +528,25 @@ public final class CertHack {
                     if (retainedBytes < 0) {
                         retainedBytes = 0;
                     }
+                    CachedCertificateChain val = entry.getValue();
+                    if (val != null && val.attestKeyId != null) {
+                        if (evicted == null) {
+                            evicted = new ArrayList<>();
+                        }
+                        evicted.add(new AttestKeyDescriptor(val.attestKeyCallingUid, val.attestKeyId));
+                    }
                     it.remove();
+                }
+                return evicted;
+            }
+
+            static final class AttestKeyDescriptor {
+                final int callingUid;
+                final byte[] keyId;
+
+                AttestKeyDescriptor(int callingUid, byte[] keyId) {
+                    this.callingUid = callingUid;
+                    this.keyId = keyId != null ? keyId.clone() : null;
                 }
             }
         }
@@ -822,21 +864,47 @@ public final class CertHack {
     private static volatile boolean graphStateUnhealthy = false;
 
     public static boolean clearCertificateCache() {
-        State currentState = state;
-        boolean backendCleared = CertificateBackend.clearAttestKeyStore();
-        if (!backendCleared) {
-            backendCleared = CertificateBackend.clearAttestKeyStore();
+        KeyboxActivation.lockPublishedSnapshot();
+        try {
+            State currentState = state;
+            boolean backendCleared = CertificateBackend.clearAttestKeyStore();
+            if (!backendCleared) {
+                backendCleared = CertificateBackend.clearAttestKeyStore();
+            }
+            if (backendCleared) {
+                graphStateUnhealthy = false;
+            } else {
+                graphStateUnhealthy = true;
+            }
+            synchronized (currentState.certificateCache) {
+                currentState.certificateCacheEpoch = new Object();
+                currentState.certificateCache.clear();
+            }
+            return backendCleared;
+        } finally {
+            KeyboxActivation.unlockPublishedSnapshot();
         }
-        if (backendCleared) {
-            graphStateUnhealthy = false;
-        } else {
-            graphStateUnhealthy = true;
+    }
+
+    private static void evictDescendants(State.CertificateCache cache, byte[] parentKeyId) {
+        if (cache == null || parentKeyId == null) return;
+        List<CacheKey> keysToRemove = null;
+        synchronized (cache) {
+            for (Map.Entry<CacheKey, CachedCertificateChain> entry : cache.entrySet()) {
+                CachedCertificateChain entryValue = entry.getValue();
+                if (entryValue != null && entryValue.parentKeyId != null && Arrays.equals(entryValue.parentKeyId, parentKeyId)) {
+                    if (keysToRemove == null) {
+                        keysToRemove = new ArrayList<>();
+                    }
+                    keysToRemove.add(entry.getKey());
+                }
+            }
         }
-        synchronized (currentState.certificateCache) {
-            currentState.certificateCacheEpoch = new Object();
-            currentState.certificateCache.clear();
+        if (keysToRemove != null) {
+            for (CacheKey k : keysToRemove) {
+                cache.remove(k);
+            }
         }
-        return backendCleared;
     }
 
     @VisibleForTesting
@@ -1438,6 +1506,10 @@ public final class CertHack {
                 }
             }
 
+            if (isAttestKey && childKeyId != null) {
+                evictDescendants(cache, childKeyId);
+            }
+
             if (!Utils.hasAndroidAttestationExtension(caList[0])) return caList;
 
             childInspection = CertificateBackend.inspect(leafEncoded);
@@ -1501,26 +1573,6 @@ public final class CertHack {
             }
             if (isAttestKey && (childKeyId == null || childKeyId.length != 32)) {
                 return caList;
-            }
-
-            if (isAttestKey && childKeyId != null) {
-                synchronized (cache) {
-                    List<CacheKey> keysToRemove = null;
-                    for (Map.Entry<CacheKey, CachedCertificateChain> entry : cache.entrySet()) {
-                        CachedCertificateChain entryValue = entry.getValue();
-                        if (entryValue != null && entryValue.parentKeyId != null && Arrays.equals(entryValue.parentKeyId, childKeyId)) {
-                            if (keysToRemove == null) {
-                                keysToRemove = new ArrayList<>();
-                            }
-                            keysToRemove.add(entry.getKey());
-                        }
-                    }
-                    if (keysToRemove != null) {
-                        for (CacheKey k : keysToRemove) {
-                            cache.remove(k);
-                        }
-                    }
-                }
             }
 
             byte[] rewrittenDer = CertificateBackend.rewriteChildKey(

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
@@ -31,7 +31,7 @@ public final class Utils {
     private static final int MAX_AUTHORIZATIONS = 256;
     private static final int MAX_REWRITTEN_PARCEL_BYTES = 8 * 1024 * 1024;
     private static final int MAX_RETAINED_SCRATCH_PARCEL_BYTES = 64 * 1024;
-    private static final int TAG_PURPOSE = 0x20000001; // TagType.ENUM_REP | 1
+    private static final int TAG_PURPOSE = 0x20000001;
     private static final int KEY_PARAMETER_VALUE_KEY_PURPOSE = 7;
     private static final int KEY_PURPOSE_ATTEST_KEY = 7;
 
@@ -210,9 +210,7 @@ public final class Utils {
         int position = request.dataPosition();
         try {
             request.enforceInterface(IKeystoreSecurityLevel.DESCRIPTOR);
-            // 1. Skip key: KeyDescriptor
             if (!skipStableTypedParcelable(request)) return false;
-            // 2. Skip optional attestationKey: KeyDescriptor
             if (request.dataAvail() < Integer.BYTES) return false;
             int attestationKeyPresence = request.readInt();
             if (attestationKeyPresence == 1) {
@@ -220,7 +218,6 @@ public final class Utils {
             } else if (attestationKeyPresence != 0) {
                 return false;
             }
-            // 3. Inspect params: KeyParameter[]
             return inspectParamsForAttestKeyPurpose(request);
         } catch (RuntimeException invalidRequest) {
             return false;

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
@@ -7,6 +7,11 @@ import android.system.keystore2.KeyMetadata;
 import android.util.Log;
 
 import java.io.ByteArrayInputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
@@ -43,7 +48,138 @@ public final class Utils {
                 }
             };
 
+    public static final class GenerateKeyRequestInfo {
+        public final boolean usesDefaultAttestationKey;
+        public final boolean isAttestKeyPurpose;
+        public final byte[] generatedKeyId;
+        public final byte[] parentKeyId;
+
+        public GenerateKeyRequestInfo(
+                boolean usesDefaultAttestationKey,
+                boolean isAttestKeyPurpose,
+                byte[] generatedKeyId,
+                byte[] parentKeyId) {
+            this.usesDefaultAttestationKey = usesDefaultAttestationKey;
+            this.isAttestKeyPurpose = isAttestKeyPurpose;
+            this.generatedKeyId = generatedKeyId;
+            this.parentKeyId = parentKeyId;
+        }
+    }
+
     private Utils() {
+    }
+
+    public static byte[] computeKeyDescriptorIdentity(
+            int callingUid, int domain, long nspace, String alias, byte[] blob) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            ByteBuffer buffer = ByteBuffer.allocate(4 + 4 + 8).order(ByteOrder.BIG_ENDIAN);
+            buffer.putInt(callingUid);
+            buffer.putInt(domain);
+            buffer.putLong(nspace);
+            digest.update(buffer.array());
+
+            if (alias == null) {
+                digest.update(new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+            } else {
+                byte[] aliasBytes = alias.getBytes(StandardCharsets.UTF_8);
+                ByteBuffer lenBuf = ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN);
+                lenBuf.putInt(aliasBytes.length);
+                digest.update(lenBuf.array());
+                digest.update(aliasBytes);
+            }
+
+            if (blob == null) {
+                digest.update(new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+            } else {
+                ByteBuffer lenBuf = ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN);
+                lenBuf.putInt(blob.length);
+                digest.update(lenBuf.array());
+                digest.update(blob);
+            }
+
+            return digest.digest();
+        } catch (NoSuchAlgorithmException e) {
+            throw new AssertionError("SHA-256 must be available", e);
+        }
+    }
+
+    public static byte[] extractKeyDescriptorIdentity(Parcel parcel, int callingUid) {
+        if (parcel == null || parcel.dataAvail() < Integer.BYTES) {
+            return null;
+        }
+        int presence = parcel.readInt();
+        if (presence != 1) {
+            return null;
+        }
+        return extractKeyDescriptorBodyIdentity(parcel, callingUid);
+    }
+
+    public static byte[] extractKeyDescriptorBodyIdentity(Parcel parcel, int callingUid) {
+        if (parcel == null) return null;
+        int parcelableEnd = readStableParcelableEnd(parcel, parcel.dataSize());
+        if (parcelableEnd < 0) {
+            return null;
+        }
+        try {
+            int domain = 0;
+            long nspace = 0L;
+            String alias = null;
+            byte[] blob = null;
+
+            if (parcel.dataPosition() < parcelableEnd && hasBytes(parcel, parcelableEnd, Integer.BYTES)) {
+                domain = parcel.readInt();
+            }
+            if (parcel.dataPosition() < parcelableEnd && hasBytes(parcel, parcelableEnd, Long.BYTES)) {
+                nspace = parcel.readLong();
+            }
+            if (parcel.dataPosition() < parcelableEnd) {
+                alias = parcel.readString();
+                if (parcel.dataPosition() > parcelableEnd) {
+                    return null;
+                }
+            }
+            if (parcel.dataPosition() < parcelableEnd) {
+                blob = parcel.createByteArray();
+                if (parcel.dataPosition() > parcelableEnd) {
+                    return null;
+                }
+            }
+
+            return computeKeyDescriptorIdentity(callingUid, domain, nspace, alias, blob);
+        } catch (RuntimeException e) {
+            return null;
+        } finally {
+            parcel.setDataPosition(parcelableEnd);
+        }
+    }
+
+    public static GenerateKeyRequestInfo parseGenerateKeyRequest(Parcel request, int callingUid) {
+        if (request == null) return null;
+        int position = request.dataPosition();
+        try {
+            request.enforceInterface(IKeystoreSecurityLevel.DESCRIPTOR);
+            byte[] generatedKeyId = extractKeyDescriptorIdentity(request, callingUid);
+            if (generatedKeyId == null) return null;
+
+            if (request.dataAvail() < Integer.BYTES) return null;
+            int attestationKeyPresence = request.readInt();
+            boolean usesDefault = attestationKeyPresence == 0;
+            byte[] parentKeyId = null;
+            if (attestationKeyPresence == 1) {
+                parentKeyId = extractKeyDescriptorBodyIdentity(request, callingUid);
+                if (parentKeyId == null) return null;
+            } else if (attestationKeyPresence != 0) {
+                return null;
+            }
+
+            boolean isAttestKey = inspectParamsForAttestKeyPurpose(request);
+            return new GenerateKeyRequestInfo(usesDefault, isAttestKey, generatedKeyId, parentKeyId);
+        } catch (RuntimeException invalidRequest) {
+            return null;
+        } finally {
+            request.setDataPosition(position);
+        }
     }
 
     /** Reads the generateKey AIDL prefix without changing the caller's parcel position. */
@@ -85,37 +221,41 @@ public final class Utils {
                 return false;
             }
             // 3. Inspect params: KeyParameter[]
-            if (request.dataAvail() < Integer.BYTES) return false;
-            int paramCount = request.readInt();
-            if (paramCount <= 0 || paramCount > MAX_AUTHORIZATIONS) return false;
-            for (int i = 0; i < paramCount; i++) {
-                if (request.dataAvail() < Integer.BYTES) return false;
-                int paramPresence = request.readInt();
-                if (paramPresence == 0) continue;
-                if (paramPresence != 1) return false;
-
-                int parcelableStart = request.dataPosition();
-                int parcelableEnd = readStableParcelableEnd(request, request.dataSize());
-                if (parcelableEnd < 0) return false;
-
-                if (hasBytes(request, parcelableEnd, 3 * Integer.BYTES)) {
-                    int tag = request.readInt();
-                    int unionTag = request.readInt();
-                    int unionValue = request.readInt();
-                    if (tag == TAG_PURPOSE &&
-                            unionTag == KEY_PARAMETER_VALUE_KEY_PURPOSE &&
-                            unionValue == KEY_PURPOSE_ATTEST_KEY) {
-                        return true;
-                    }
-                }
-                request.setDataPosition(parcelableEnd);
-            }
-            return false;
+            return inspectParamsForAttestKeyPurpose(request);
         } catch (RuntimeException invalidRequest) {
             return false;
         } finally {
             request.setDataPosition(position);
         }
+    }
+
+    private static boolean inspectParamsForAttestKeyPurpose(Parcel request) {
+        if (request.dataAvail() < Integer.BYTES) return false;
+        int paramCount = request.readInt();
+        if (paramCount <= 0 || paramCount > MAX_AUTHORIZATIONS) return false;
+        for (int i = 0; i < paramCount; i++) {
+            if (request.dataAvail() < Integer.BYTES) return false;
+            int paramPresence = request.readInt();
+            if (paramPresence == 0) continue;
+            if (paramPresence != 1) return false;
+
+            int parcelableStart = request.dataPosition();
+            int parcelableEnd = readStableParcelableEnd(request, request.dataSize());
+            if (parcelableEnd < 0) return false;
+
+            if (hasBytes(request, parcelableEnd, 3 * Integer.BYTES)) {
+                int tag = request.readInt();
+                int unionTag = request.readInt();
+                int unionValue = request.readInt();
+                if (tag == TAG_PURPOSE &&
+                        unionTag == KEY_PARAMETER_VALUE_KEY_PURPOSE &&
+                        unionValue == KEY_PURPOSE_ATTEST_KEY) {
+                    return true;
+                }
+            }
+            request.setDataPosition(parcelableEnd);
+        }
+        return false;
     }
 
     /**

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
@@ -26,6 +26,9 @@ public final class Utils {
     private static final int MAX_AUTHORIZATIONS = 256;
     private static final int MAX_REWRITTEN_PARCEL_BYTES = 8 * 1024 * 1024;
     private static final int MAX_RETAINED_SCRATCH_PARCEL_BYTES = 64 * 1024;
+    private static final int TAG_PURPOSE = 0x20000001; // TagType.ENUM_REP | 1
+    private static final int KEY_PARAMETER_VALUE_KEY_PURPOSE = 7;
+    private static final int KEY_PURPOSE_ATTEST_KEY = 7;
 
     private static final ThreadLocal<CertificateFactory> CERTIFICATE_FACTORY =
             new ThreadLocal<CertificateFactory>() {
@@ -56,6 +59,58 @@ public final class Utils {
             // We only need to distinguish the optional attestationKey, so do not instantiate its
             // hidden platform class or depend on a generated CREATOR field that may change by API.
             return request.readInt() == 0;
+        } catch (RuntimeException invalidRequest) {
+            return false;
+        } finally {
+            request.setDataPosition(position);
+        }
+    }
+
+    /**
+     * Inspects the generateKey KeyParameter array to determine if Tag.PURPOSE includes KeyPurpose.ATTEST_KEY.
+     */
+    public static boolean hasAttestKeyPurpose(Parcel request) {
+        if (request == null) return false;
+        int position = request.dataPosition();
+        try {
+            request.enforceInterface(IKeystoreSecurityLevel.DESCRIPTOR);
+            // 1. Skip key: KeyDescriptor
+            if (!skipStableTypedParcelable(request)) return false;
+            // 2. Skip optional attestationKey: KeyDescriptor
+            if (request.dataAvail() < Integer.BYTES) return false;
+            int attestationKeyPresence = request.readInt();
+            if (attestationKeyPresence == 1) {
+                if (!skipStableParcelableBody(request)) return false;
+            } else if (attestationKeyPresence != 0) {
+                return false;
+            }
+            // 3. Inspect params: KeyParameter[]
+            if (request.dataAvail() < Integer.BYTES) return false;
+            int paramCount = request.readInt();
+            if (paramCount <= 0 || paramCount > MAX_AUTHORIZATIONS) return false;
+            for (int i = 0; i < paramCount; i++) {
+                if (request.dataAvail() < Integer.BYTES) return false;
+                int paramPresence = request.readInt();
+                if (paramPresence == 0) continue;
+                if (paramPresence != 1) return false;
+
+                int parcelableStart = request.dataPosition();
+                int parcelableEnd = readStableParcelableEnd(request, request.dataSize());
+                if (parcelableEnd < 0) return false;
+
+                if (hasBytes(request, parcelableEnd, 3 * Integer.BYTES)) {
+                    int tag = request.readInt();
+                    int unionTag = request.readInt();
+                    int unionValue = request.readInt();
+                    if (tag == TAG_PURPOSE &&
+                            unionTag == KEY_PARAMETER_VALUE_KEY_PURPOSE &&
+                            unionValue == KEY_PURPOSE_ATTEST_KEY) {
+                        return true;
+                    }
+                }
+                request.setDataPosition(parcelableEnd);
+            }
+            return false;
         } catch (RuntimeException invalidRequest) {
             return false;
         } finally {
@@ -342,9 +397,9 @@ public final class Utils {
             byte[] newLeaf,
             byte[] newChain
     ) {
-        if (reply == null || parsed == null || newLeaf == null || newChain == null ||
+        if (reply == null || parsed == null || newLeaf == null ||
                 newLeaf.length == 0 || newLeaf.length > MAX_CERTIFICATE_BYTES ||
-                newChain.length > MAX_CHAIN_BYTES ||
+                (newChain != null && newChain.length > MAX_CHAIN_BYTES) ||
                 reply.dataSize() != parsed.sourceDataSize ||
                 parsed.metadataStart < 0 || parsed.certOffset < parsed.metadataStart ||
                 parsed.chainOffset < parsed.certOffset ||
@@ -354,7 +409,7 @@ public final class Utils {
         }
 
         int newCertPaddedLen = Integer.BYTES + paddedByteCount(newLeaf.length);
-        int newChainPaddedLen = Integer.BYTES + paddedByteCount(newChain.length);
+        int newChainPaddedLen = Integer.BYTES + (newChain == null ? 0 : paddedByteCount(newChain.length));
         long sizeDiff = (long) newCertPaddedLen + newChainPaddedLen -
                 parsed.oldCertPaddedLen - parsed.oldChainPaddedLen;
         long newMetadataSize = (long) parsed.metadataSize + sizeDiff;

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationInterceptorContractTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationInterceptorContractTest.java
@@ -66,6 +66,8 @@ public class AttestationInterceptorContractTest {
             Certificate[] rewrittenChain = new Certificate[] {replacementCert};
             backend.when(() -> CertHack.hackCertificateChain(any(), anyInt(), anyBoolean()))
                     .thenReturn(rewrittenChain);
+            backend.when(() -> CertHack.hackChildKeyCertificate(any(), anyInt(), anyBoolean(), anyBoolean()))
+                    .thenReturn(rewrittenChain);
 
             // Test both default RKP request (false) and custom AttestKey request (true)
             for (boolean explicitAttestKey : new boolean[] {false, true}) {
@@ -82,7 +84,54 @@ public class AttestationInterceptorContractTest {
 
             backend.verify(CertHack::canHack, org.mockito.Mockito.times(2));
             backend.verify(() -> CertHack.hackCertificateChain(any(), anyInt(), anyBoolean()),
-                    org.mockito.Mockito.times(2));
+                    org.mockito.Mockito.times(1));
+            backend.verify(() -> CertHack.hackChildKeyCertificate(any(), anyInt(), anyBoolean(), anyBoolean()),
+                    org.mockito.Mockito.times(1));
+        } finally {
+            globalModeField.set(Config.INSTANCE, prevGlobalMode);
+        }
+    }
+
+    @Test
+    public void attestKeyGenerationWithDefaultAttestationKeyRoutesToHackAttestKeyCertificateChain() throws Exception {
+        Binder target = new Binder();
+        int code = field(SecurityLevelInterceptor.class, "generateKeyTransaction").getInt(null);
+        Field globalModeField = field(Config.class, "isGlobalMode");
+        boolean prevGlobalMode = (boolean) globalModeField.get(Config.INSTANCE);
+        globalModeField.set(Config.INSTANCE, true);
+        Config.INSTANCE.setPackagesForTesting(10_001, new String[] {"com.test.app"});
+        try (MockedStatic<CertHack> backend = mockStatic(CertHack.class)) {
+            backend.when(CertHack::canHack).thenReturn(true);
+            backend.when(() -> CertHack.applyCachedCertificateChain(any())).thenReturn(false);
+
+            KeyPair parent = keyPair("EC");
+            KeyPair childKey = keyPair("EC");
+            X509Certificate childCert = certificate(childKey, parent, "child", "parent");
+            KeyMetadata metadata = metadata(childCert, childCert.getEncoded());
+            X509Certificate replacementCert = certificate(childKey, parent, "replacement", "parent");
+            Certificate[] rewrittenChain = new Certificate[] {replacementCert};
+            backend.when(() -> CertHack.hackAttestKeyCertificateChain(any(), anyInt(), anyBoolean()))
+                    .thenReturn(rewrittenChain);
+
+            Parcel request = mock(Parcel.class);
+            when(request.dataPosition()).thenReturn(28, 32, 28, 32, 40, 44);
+            when(request.dataAvail()).thenReturn(128);
+            // 3 ints for usesDefaultAttestationKey (1, 16, 0), then 9 ints for hasAttestKeyPurpose
+            when(request.readInt()).thenReturn(1, 16, 0, 1, 16, 0, 1, 1, 20, 536870913, 7, 7);
+            when(request.dataSize()).thenReturn(128);
+
+            BinderInterceptor.Result preResult = new SecurityLevelInterceptor().onPreTransact(
+                    target, code, 0, 10_001, 42, request);
+            assertSame(BinderInterceptor.Continue.INSTANCE, preResult);
+
+            Parcel reply = generatedReply(metadata);
+            BinderInterceptor.Result postResult = generate(request, reply);
+            assertTrue(postResult instanceof BinderInterceptor.OverrideReply);
+
+            backend.verify(() -> CertHack.hackAttestKeyCertificateChain(any(), anyInt(), anyBoolean()),
+                    org.mockito.Mockito.times(1));
+            backend.verify(() -> CertHack.hackCertificateChain(any(), anyInt(), anyBoolean()), never());
+            backend.verify(() -> CertHack.hackChildKeyCertificate(any(), anyInt(), anyBoolean(), anyBoolean()), never());
         } finally {
             globalModeField.set(Config.INSTANCE, prevGlobalMode);
         }

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationInterceptorContractTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationInterceptorContractTest.java
@@ -112,13 +112,24 @@ public class AttestationInterceptorContractTest {
             Certificate[] rewrittenChain = new Certificate[] {replacementCert};
             backend.when(() -> CertHack.hackAttestKeyCertificateChain(any(), anyInt(), anyBoolean()))
                     .thenReturn(rewrittenChain);
+            backend.when(() -> CertHack.hackAttestKeyCertificateChain(any(), anyInt(), anyBoolean(), any()))
+                    .thenReturn(rewrittenChain);
 
             Parcel request = mock(Parcel.class);
-            when(request.dataPosition()).thenReturn(28, 32, 28, 32, 40, 44);
+            java.util.concurrent.atomic.AtomicInteger pos = new java.util.concurrent.atomic.AtomicInteger(28);
+            when(request.dataPosition()).thenAnswer(inv -> pos.get());
+            org.mockito.Mockito.doAnswer(inv -> {
+                pos.set(inv.getArgument(0));
+                return null;
+            }).when(request).setDataPosition(anyInt());
             when(request.dataAvail()).thenReturn(128);
-            // 3 ints for usesDefaultAttestationKey (1, 16, 0), then 9 ints for hasAttestKeyPurpose
-            when(request.readInt()).thenReturn(1, 16, 0, 1, 16, 0, 1, 1, 20, 536870913, 7, 7);
             when(request.dataSize()).thenReturn(128);
+            java.util.Iterator<Integer> ints = java.util.Arrays.asList(
+                    1, 16, 0,
+                    0,
+                    1, 1, 20, 536870913, 7, 7
+            ).iterator();
+            when(request.readInt()).thenAnswer(inv -> ints.hasNext() ? ints.next() : 0);
 
             BinderInterceptor.Result preResult = new SecurityLevelInterceptor().onPreTransact(
                     target, code, 0, 10_001, 42, request);
@@ -128,7 +139,7 @@ public class AttestationInterceptorContractTest {
             BinderInterceptor.Result postResult = generate(request, reply);
             assertTrue(postResult instanceof BinderInterceptor.OverrideReply);
 
-            backend.verify(() -> CertHack.hackAttestKeyCertificateChain(any(), anyInt(), anyBoolean()),
+            backend.verify(() -> CertHack.hackAttestKeyCertificateChain(any(), anyInt(), anyBoolean(), any()),
                     org.mockito.Mockito.times(1));
             backend.verify(() -> CertHack.hackCertificateChain(any(), anyInt(), anyBoolean()), never());
             backend.verify(() -> CertHack.hackChildKeyCertificate(any(), anyInt(), anyBoolean(), anyBoolean()), never());

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
@@ -160,32 +160,41 @@ public class AttestationRequestContractTest {
                 .getDeclaredConstructor(byte[].class);
         keyConstructor.setAccessible(true);
         Constructor<?> valueConstructor = Class.forName(CertHack.class.getName() + "$CachedCertificateChain")
-                .getDeclaredConstructor(Certificate[].class, byte[].class, byte[].class, boolean.class, boolean.class, int.class, byte[].class);
+                .getDeclaredConstructor(Certificate[].class, byte[].class, byte[].class, boolean.class, boolean.class, int.class, byte[].class, byte[].class);
         valueConstructor.setAccessible(true);
 
         byte[] leaf = new byte[] {10, 20, 30};
         byte[] attestKeyId = new byte[32];
         attestKeyId[0] = 7;
+        byte[] parentKeyId = new byte[32];
+        parentKeyId[0] = 3;
         int uid = 10001;
+
+        Certificate replacementCert = mock(Certificate.class);
+        Certificate[] replacementChain = new Certificate[] {replacementCert};
+        Certificate leafCert = mock(Certificate.class);
+        when(leafCert.getEncoded()).thenReturn(leaf);
+        Certificate[] caList = new Certificate[] {leafCert};
 
         Object key = keyConstructor.newInstance((Object) leaf.clone());
         Object value = valueConstructor.newInstance(
-                new Certificate[0],
+                replacementChain,
                 new byte[] {40, 50},
                 new byte[] {60, 70},
                 true,
                 true,
                 uid,
-                attestKeyId
+                attestKeyId,
+                null
         );
 
         java.util.concurrent.atomic.AtomicInteger touchCount = new java.util.concurrent.atomic.AtomicInteger();
-        java.util.concurrent.atomic.AtomicBoolean touchResult = new java.util.concurrent.atomic.AtomicBoolean(true);
+        java.util.concurrent.atomic.AtomicReference<cleveres.tricky.cleverestech.CertificateBackend.AttestKeyTouchResult> touchResult =
+                new java.util.concurrent.atomic.AtomicReference<>(cleveres.tricky.cleverestech.CertificateBackend.AttestKeyTouchResult.PRESENT);
 
         cleveres.tricky.cleverestech.CertificateBackend.setTouchAttestKeyOverrideForTesting((callingUid, keyId) -> {
             touchCount.incrementAndGet();
             assertEquals(uid, callingUid);
-            assertArrayEquals(attestKeyId, keyId);
             return touchResult.get();
         });
 
@@ -194,34 +203,62 @@ public class AttestationRequestContractTest {
                 cache.put(key, value);
             }
 
-            KeyMetadata metadata = new KeyMetadata();
-            metadata.certificate = leaf.clone();
-            metadata.certificateChain = new byte[] {99};
-
-            // Hit with valid backend touch -> returns true, keeps in cache
-            assertTrue(CertHack.applyCachedCertificateChain(metadata));
+            // 1. Hit with PRESENT touch -> returns replacement chain, keeps in cache
+            Certificate[] result = CertHack.hackAttestKeyCertificateChain(caList, uid, true, attestKeyId);
             assertEquals(1, touchCount.get());
-            assertArrayEquals(new byte[] {40, 50}, metadata.certificate);
+            assertSame(replacementCert, result[0]);
             synchronized (cache) {
                 assertTrue(cache.containsKey(key));
             }
 
-            // Backend evicted the key (touch returns false) -> invalidates from cache, returns false
-            touchResult.set(false);
-            metadata.certificate = leaf.clone();
-            assertFalse(CertHack.applyCachedCertificateChain(metadata));
+            // 2. Hit with UNAVAILABLE (transport failure) -> preserves cache, still returns replacement
+            touchResult.set(cleveres.tricky.cleverestech.CertificateBackend.AttestKeyTouchResult.UNAVAILABLE);
+            result = CertHack.hackAttestKeyCertificateChain(caList, uid, true, attestKeyId);
             assertEquals(2, touchCount.get());
+            assertSame(replacementCert, result[0]);
+            synchronized (cache) {
+                assertTrue(cache.containsKey(key));
+            }
+
+            // 3. Hit with ABSENT (backend evicted key) -> authoritatively purges graph, returns caList
+            touchResult.set(cleveres.tricky.cleverestech.CertificateBackend.AttestKeyTouchResult.ABSENT);
+            result = CertHack.hackAttestKeyCertificateChain(caList, uid, true, attestKeyId);
+            assertEquals(3, touchCount.get());
+            assertSame(leafCert, result[0]);
             synchronized (cache) {
                 assertFalse(cache.containsKey(key));
             }
 
-            // Next attempt should miss cache directly without calling touch again
-            assertFalse(CertHack.applyCachedCertificateChain(metadata));
-            assertEquals(2, touchCount.get());
+            // 4. Child key with parentKeyId: if parent is ABSENT, child also authoritatively purges graph
+            byte[] childLeaf = new byte[] {11, 22, 33};
+            Certificate childLeafCert = mock(Certificate.class);
+            when(childLeafCert.getEncoded()).thenReturn(childLeaf);
+            Certificate[] childCaList = new Certificate[] {childLeafCert};
+            Object childKey = keyConstructor.newInstance((Object) childLeaf.clone());
+            Object childValue = valueConstructor.newInstance(
+                    replacementChain,
+                    new byte[] {41, 51},
+                    new byte[] {61, 71},
+                    true,
+                    false,
+                    uid,
+                    null,
+                    parentKeyId
+            );
+            synchronized (cache) {
+                cache.put(childKey, childValue);
+            }
+
+            touchResult.set(cleveres.tricky.cleverestech.CertificateBackend.AttestKeyTouchResult.ABSENT);
+            result = CertHack.hackChildKeyCertificate(childCaList, uid, false, true, parentKeyId, null);
+            assertSame(childLeafCert, result[0]);
+            synchronized (cache) {
+                assertFalse(cache.containsKey(childKey));
+            }
         } finally {
             cleveres.tricky.cleverestech.CertificateBackend.resetForTesting();
             synchronized (cache) {
-                cache.remove(key);
+                cache.clear();
             }
         }
     }

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
@@ -466,7 +466,7 @@ public class AttestationRequestContractTest {
             removeCount.incrementAndGet();
             removedUid.set(u);
             removedKeyId.set(id.clone());
-            return true;
+            return cleveres.tricky.cleverestech.CertificateBackend.AttestKeyRemoveResult.REMOVED;
         });
 
         try {
@@ -480,6 +480,7 @@ public class AttestationRequestContractTest {
             assertEquals(1, removeCount.get());
             assertEquals(uid, removedUid.get());
             assertArrayEquals(attestKeyId, removedKeyId.get());
+            assertFalse(CertHack.isGraphStateUnhealthyForTesting());
 
             // 2. LRU overflow (eviction > 64 entries) triggers backend removeAttestKey
             removeCount.set(0);
@@ -496,8 +497,109 @@ public class AttestationRequestContractTest {
             assertTrue(removeCount.get() >= 1);
             assertEquals(uid, removedUid.get());
             assertArrayEquals(attestKeyId, removedKeyId.get());
+            assertFalse(CertHack.isGraphStateUnhealthyForTesting());
         } finally {
             cleveres.tricky.cleverestech.CertificateBackend.resetForTesting();
+            synchronized (cache) {
+                cache.clear();
+            }
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void removeAttestKeyTransportFailureMarksGraphStateUnhealthy() throws Exception {
+        Field stateField = CertHack.class.getDeclaredField("state");
+        stateField.setAccessible(true);
+        Object state = stateField.get(null);
+        Field cacheField = state.getClass().getDeclaredField("certificateCache");
+        cacheField.setAccessible(true);
+        Map<Object, Object> cache = (Map<Object, Object>) cacheField.get(state);
+
+        Constructor<?> keyConstructor = Class.forName(CertHack.class.getName() + "$CacheKey")
+                .getDeclaredConstructor(byte[].class);
+        keyConstructor.setAccessible(true);
+        Constructor<?> valueConstructor = Class.forName(CertHack.class.getName() + "$CachedCertificateChain")
+                .getDeclaredConstructor(Certificate[].class, byte[].class, byte[].class, boolean.class, boolean.class, int.class, byte[].class, byte[].class);
+        valueConstructor.setAccessible(true);
+
+        int uid = 10005;
+        byte[] attestKeyId = new byte[32];
+        attestKeyId[0] = 77;
+
+        cleveres.tricky.cleverestech.CertificateBackend.setRemoveAttestKeyOverrideForTesting(
+                (u, id) -> cleveres.tricky.cleverestech.CertificateBackend.AttestKeyRemoveResult.UNAVAILABLE);
+
+        try {
+            assertFalse(CertHack.isGraphStateUnhealthyForTesting());
+
+            Object attestKey = keyConstructor.newInstance((Object) new byte[] {1, 2, 3});
+            Object attestVal = valueConstructor.newInstance(null, new byte[] {1, 2, 3}, null, true, false, uid, attestKeyId, null);
+            cache.put(attestKey, attestVal);
+
+            // Removing when backend returns UNAVAILABLE must mark graph state unhealthy
+            cache.remove(attestKey);
+            assertTrue(CertHack.isGraphStateUnhealthyForTesting());
+
+            // When backend clear succeeds, clearCertificateCache resets graph health
+            cleveres.tricky.cleverestech.CertificateBackend.setClearAttestKeyStoreOverrideForTesting(() -> true);
+            assertTrue(CertHack.clearCertificateCache());
+            assertFalse(CertHack.isGraphStateUnhealthyForTesting());
+
+            // LRU eviction with UNAVAILABLE also marks graph state unhealthy
+            cache.put(attestKey, attestVal);
+            for (int i = 0; i < 65; i++) {
+                byte[] leaf = new byte[] {(byte) (i / 256), (byte) (i % 256), 9};
+                Object fillerKey = keyConstructor.newInstance((Object) leaf);
+                Object fillerVal = valueConstructor.newInstance(null, leaf, null, true, false, uid, null, null);
+                cache.put(fillerKey, fillerVal);
+            }
+            assertTrue(CertHack.isGraphStateUnhealthyForTesting());
+        } finally {
+            cleveres.tricky.cleverestech.CertificateBackend.resetForTesting();
+            CertHack.resetGraphHealthForTesting();
+            synchronized (cache) {
+                cache.clear();
+            }
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void removeAttestKeyAbsentLeavesGraphStateHealthy() throws Exception {
+        Field stateField = CertHack.class.getDeclaredField("state");
+        stateField.setAccessible(true);
+        Object state = stateField.get(null);
+        Field cacheField = state.getClass().getDeclaredField("certificateCache");
+        cacheField.setAccessible(true);
+        Map<Object, Object> cache = (Map<Object, Object>) cacheField.get(state);
+
+        Constructor<?> keyConstructor = Class.forName(CertHack.class.getName() + "$CacheKey")
+                .getDeclaredConstructor(byte[].class);
+        keyConstructor.setAccessible(true);
+        Constructor<?> valueConstructor = Class.forName(CertHack.class.getName() + "$CachedCertificateChain")
+                .getDeclaredConstructor(Certificate[].class, byte[].class, byte[].class, boolean.class, boolean.class, int.class, byte[].class, byte[].class);
+        valueConstructor.setAccessible(true);
+
+        int uid = 10005;
+        byte[] attestKeyId = new byte[32];
+        attestKeyId[0] = 77;
+
+        cleveres.tricky.cleverestech.CertificateBackend.setRemoveAttestKeyOverrideForTesting(
+                (u, id) -> cleveres.tricky.cleverestech.CertificateBackend.AttestKeyRemoveResult.ABSENT);
+
+        try {
+            assertFalse(CertHack.isGraphStateUnhealthyForTesting());
+
+            Object attestKey = keyConstructor.newInstance((Object) new byte[] {1, 2, 3});
+            Object attestVal = valueConstructor.newInstance(null, new byte[] {1, 2, 3}, null, true, false, uid, attestKeyId, null);
+            cache.put(attestKey, attestVal);
+
+            cache.remove(attestKey);
+            assertFalse(CertHack.isGraphStateUnhealthyForTesting());
+        } finally {
+            cleveres.tricky.cleverestech.CertificateBackend.resetForTesting();
+            CertHack.resetGraphHealthForTesting();
             synchronized (cache) {
                 cache.clear();
             }

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
@@ -24,6 +24,25 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class AttestationRequestContractTest {
+    @org.junit.Before
+    @org.junit.After
+    public void resetTestState() {
+        cleveres.tricky.cleverestech.CertificateBackend.resetForTesting();
+        CertHack.resetGraphHealthForTesting();
+        try {
+            Field stateField = CertHack.class.getDeclaredField("state");
+            stateField.setAccessible(true);
+            Object state = stateField.get(null);
+            Field cacheField = state.getClass().getDeclaredField("certificateCache");
+            cacheField.setAccessible(true);
+            Map<?, ?> cache = (Map<?, ?>) cacheField.get(state);
+            synchronized (cache) {
+                cache.clear();
+            }
+        } catch (Exception ignored) {
+        }
+    }
+
     @Test
     public void onlyExplicitNullAttestationKeyPermitsGenericRewrite() {
         Parcel request = request(false);
@@ -340,6 +359,7 @@ public class AttestationRequestContractTest {
         Object grandchildKey = keyConstructor.newInstance((Object) new byte[] {3, 3, 3});
         Object grandchildValue = valueConstructor.newInstance(mockChain, new byte[] {3}, new byte[] {4}, true, false, uid, null, intermediateKeyId);
 
+        cleveres.tricky.cleverestech.CertificateBackend.setClearAttestKeyStoreOverrideForTesting(() -> true);
         try {
             synchronized (cache) {
                 cache.put(rootKey, rootValue);
@@ -369,6 +389,116 @@ public class AttestationRequestContractTest {
             synchronized (cache) {
                 cache.clear();
             }
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void javaLruEvictionOfAttestKeyNotifiesBackendRemove() throws Exception {
+        Field stateField = CertHack.class.getDeclaredField("state");
+        stateField.setAccessible(true);
+        Object state = stateField.get(null);
+        Field cacheField = state.getClass().getDeclaredField("certificateCache");
+        cacheField.setAccessible(true);
+        Map<Object, Object> cache = (Map<Object, Object>) cacheField.get(state);
+
+        Constructor<?> keyConstructor = Class.forName(CertHack.class.getName() + "$CacheKey")
+                .getDeclaredConstructor(byte[].class);
+        keyConstructor.setAccessible(true);
+        Constructor<?> valueConstructor = Class.forName(CertHack.class.getName() + "$CachedCertificateChain")
+                .getDeclaredConstructor(Certificate[].class, byte[].class, byte[].class, boolean.class, boolean.class, int.class, byte[].class, byte[].class);
+        valueConstructor.setAccessible(true);
+
+        int uid = 10005;
+        byte[] attestKeyId = new byte[32];
+        attestKeyId[0] = 77;
+
+        java.util.concurrent.atomic.AtomicInteger removeCount = new java.util.concurrent.atomic.AtomicInteger(0);
+        java.util.concurrent.atomic.AtomicInteger removedUid = new java.util.concurrent.atomic.AtomicInteger(-1);
+        java.util.concurrent.atomic.AtomicReference<byte[]> removedKeyId = new java.util.concurrent.atomic.AtomicReference<>();
+
+        cleveres.tricky.cleverestech.CertificateBackend.setRemoveAttestKeyOverrideForTesting((u, id) -> {
+            removeCount.incrementAndGet();
+            removedUid.set(u);
+            removedKeyId.set(id.clone());
+            return true;
+        });
+
+        try {
+            // 1. Explicit removal triggers backend removeAttestKey
+            Object attestKey = keyConstructor.newInstance((Object) new byte[] {1, 2, 3});
+            Object attestVal = valueConstructor.newInstance(null, new byte[] {1, 2, 3}, null, true, false, uid, attestKeyId, null);
+            cache.put(attestKey, attestVal);
+
+            assertEquals(0, removeCount.get());
+            cache.remove(attestKey);
+            assertEquals(1, removeCount.get());
+            assertEquals(uid, removedUid.get());
+            assertArrayEquals(attestKeyId, removedKeyId.get());
+
+            // 2. LRU overflow (eviction > 64 entries) triggers backend removeAttestKey
+            removeCount.set(0);
+            cache.put(attestKey, attestVal);
+
+            for (int i = 0; i < 65; i++) {
+                byte[] leaf = new byte[] {(byte) (i / 256), (byte) (i % 256), 9};
+                Object fillerKey = keyConstructor.newInstance((Object) leaf);
+                Object fillerVal = valueConstructor.newInstance(null, leaf, null, true, false, uid, null, null);
+                cache.put(fillerKey, fillerVal);
+            }
+
+            assertFalse(cache.containsKey(attestKey));
+            assertTrue(removeCount.get() >= 1);
+            assertEquals(uid, removedUid.get());
+            assertArrayEquals(attestKeyId, removedKeyId.get());
+        } finally {
+            cleveres.tricky.cleverestech.CertificateBackend.resetForTesting();
+            synchronized (cache) {
+                cache.clear();
+            }
+        }
+    }
+
+    @Test
+    public void clearCertificateCacheGuardsPublicationLock() throws Exception {
+        java.util.concurrent.atomic.AtomicBoolean lockHeld = new java.util.concurrent.atomic.AtomicBoolean(false);
+        java.util.concurrent.atomic.AtomicBoolean clearFinished = new java.util.concurrent.atomic.AtomicBoolean(false);
+        java.util.concurrent.CountDownLatch latchStarted = new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.CountDownLatch latchProceed = new java.util.concurrent.CountDownLatch(1);
+
+        Thread holder = new Thread(() -> {
+            cleveres.tricky.cleverestech.KeyboxActivation.lockPublishedSnapshot();
+            try {
+                lockHeld.set(true);
+                latchStarted.countDown();
+                latchProceed.await();
+            } catch (InterruptedException ignored) {
+            } finally {
+                cleveres.tricky.cleverestech.KeyboxActivation.unlockPublishedSnapshot();
+            }
+        });
+        holder.start();
+
+        try {
+            assertTrue(latchStarted.await(5, java.util.concurrent.TimeUnit.SECONDS));
+            assertTrue(lockHeld.get());
+
+            Thread clearer = new Thread(() -> {
+                CertHack.clearCertificateCache();
+                clearFinished.set(true);
+            });
+            clearer.start();
+
+            Thread.sleep(150);
+            assertFalse(clearFinished.get());
+
+            latchProceed.countDown();
+            clearer.join(5000);
+            holder.join(5000);
+
+            assertTrue(clearFinished.get());
+        } finally {
+            latchProceed.countDown();
         }
     }
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
@@ -276,7 +276,7 @@ public class AttestationRequestContractTest {
                 assertFalse(cache.containsKey(childKey));
             }
 
-            // 7. Backend clear failure during touch ABSENT fails closed to genuine cert
+            // 7. Backend clear failure marks graph unhealthy and fails closed to genuine cert
             synchronized (cache) {
                 cache.put(childKey, childValue);
             }
@@ -287,8 +287,85 @@ public class AttestationRequestContractTest {
             synchronized (cache) {
                 assertFalse(cache.containsKey(childKey));
             }
+            assertTrue(CertHack.isGraphStateUnhealthyForTesting());
+
+            // 8. While graph is unhealthy, subsequent child request fails closed without rewriting
+            result = CertHack.hackChildKeyCertificate(childCaList, uid, false, true, parentKeyId, null);
+            assertSame(childLeafCert, result[0]);
+
+            // 9. When backend clear succeeds again, graph health recovers
+            cleveres.tricky.cleverestech.CertificateBackend.setClearAttestKeyStoreOverrideForTesting(() -> true);
+            CertHack.clearCertificateCache();
+            assertFalse(CertHack.isGraphStateUnhealthyForTesting());
         } finally {
             cleveres.tricky.cleverestech.CertificateBackend.resetForTesting();
+            CertHack.resetGraphHealthForTesting();
+            synchronized (cache) {
+                cache.clear();
+            }
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void nestedAttestKeyInvalidatesDescendantsWithoutPurgingParent() throws Exception {
+        Field stateField = CertHack.class.getDeclaredField("state");
+        stateField.setAccessible(true);
+        Object state = stateField.get(null);
+        Field cacheField = state.getClass().getDeclaredField("certificateCache");
+        cacheField.setAccessible(true);
+        Map<Object, Object> cache = (Map<Object, Object>) cacheField.get(state);
+
+        Constructor<?> keyConstructor = Class.forName(CertHack.class.getName() + "$CacheKey")
+                .getDeclaredConstructor(byte[].class);
+        keyConstructor.setAccessible(true);
+        Constructor<?> valueConstructor = Class.forName(CertHack.class.getName() + "$CachedCertificateChain")
+                .getDeclaredConstructor(Certificate[].class, byte[].class, byte[].class, boolean.class, boolean.class, int.class, byte[].class, byte[].class);
+        valueConstructor.setAccessible(true);
+
+        int uid = 10001;
+        byte[] rootKeyId = new byte[32];
+        rootKeyId[0] = 1;
+        byte[] intermediateKeyId = new byte[32];
+        intermediateKeyId[0] = 2;
+
+        Certificate mockCert = mock(Certificate.class);
+        Certificate[] mockChain = new Certificate[] {mockCert};
+
+        // Root entry (parentKeyId = null, attestKeyId = rootKeyId)
+        Object rootKey = keyConstructor.newInstance((Object) new byte[] {1, 1, 1});
+        Object rootValue = valueConstructor.newInstance(mockChain, new byte[] {1}, new byte[] {2}, true, true, uid, rootKeyId, null);
+
+        // Grandchild entry (parentKeyId = intermediateKeyId)
+        Object grandchildKey = keyConstructor.newInstance((Object) new byte[] {3, 3, 3});
+        Object grandchildValue = valueConstructor.newInstance(mockChain, new byte[] {3}, new byte[] {4}, true, false, uid, null, intermediateKeyId);
+
+        try {
+            synchronized (cache) {
+                cache.put(rootKey, rootValue);
+                cache.put(grandchildKey, grandchildValue);
+                assertTrue(cache.containsKey(rootKey));
+                assertTrue(cache.containsKey(grandchildKey));
+            }
+
+            // Create a fake leaf certificate for the intermediate child
+            byte[] intermediateLeaf = new byte[] {2, 2, 2};
+            Certificate intermediateCert = mock(Certificate.class);
+            when(intermediateCert.getEncoded()).thenReturn(intermediateLeaf);
+            Certificate[] intermediateCaList = new Certificate[] {intermediateCert};
+
+            // Call hackChildKeyCertificate with isAttestKey = true and childKeyId = intermediateKeyId
+            // The intermediate mock has no attestation extension, so it will exit early after descendant eviction
+            CertHack.hackChildKeyCertificate(intermediateCaList, uid, true, true, rootKeyId, intermediateKeyId);
+
+            synchronized (cache) {
+                // Root parent MUST remain in cache
+                assertTrue(cache.containsKey(rootKey));
+                // Grandchild of intermediate MUST be evicted from cache
+                assertFalse(cache.containsKey(grandchildKey));
+            }
+        } finally {
+            CertHack.resetGraphHealthForTesting();
             synchronized (cache) {
                 cache.clear();
             }

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
@@ -229,7 +229,7 @@ public class AttestationRequestContractTest {
                 assertFalse(cache.containsKey(key));
             }
 
-            // 4. Child key with parentKeyId: if parent is ABSENT, child also authoritatively purges graph
+            // 4. Normal child key with parentKeyId: hit with PRESENT touch verifies callingUid == uid (not 0) and keeps in cache
             byte[] childLeaf = new byte[] {11, 22, 33};
             Certificate childLeafCert = mock(Certificate.class);
             when(childLeafCert.getEncoded()).thenReturn(childLeaf);
@@ -249,6 +249,38 @@ public class AttestationRequestContractTest {
                 cache.put(childKey, childValue);
             }
 
+            // Normal child hit with PRESENT:
+            touchResult.set(cleveres.tricky.cleverestech.CertificateBackend.AttestKeyTouchResult.PRESENT);
+            result = CertHack.hackChildKeyCertificate(childCaList, uid, false, true, parentKeyId, null);
+            assertEquals(4, touchCount.get());
+            assertSame(replacementCert, result[0]);
+            synchronized (cache) {
+                assertTrue(cache.containsKey(childKey));
+            }
+
+            // 5. Child key with parentKeyId: if parent is ABSENT, child authoritatively purges graph
+            touchResult.set(cleveres.tricky.cleverestech.CertificateBackend.AttestKeyTouchResult.ABSENT);
+            result = CertHack.hackChildKeyCertificate(childCaList, uid, false, true, parentKeyId, null);
+            assertSame(childLeafCert, result[0]);
+            synchronized (cache) {
+                assertFalse(cache.containsKey(childKey));
+            }
+
+            // 6. Rekey generation boundary: full graph clear purges child keys
+            synchronized (cache) {
+                cache.put(childKey, childValue);
+                assertTrue(cache.containsKey(childKey));
+            }
+            CertHack.clearCertificateCache();
+            synchronized (cache) {
+                assertFalse(cache.containsKey(childKey));
+            }
+
+            // 7. Backend clear failure during touch ABSENT fails closed to genuine cert
+            synchronized (cache) {
+                cache.put(childKey, childValue);
+            }
+            cleveres.tricky.cleverestech.CertificateBackend.setClearAttestKeyStoreOverrideForTesting(() -> false);
             touchResult.set(cleveres.tricky.cleverestech.CertificateBackend.AttestKeyTouchResult.ABSENT);
             result = CertHack.hackChildKeyCertificate(childCaList, uid, false, true, parentKeyId, null);
             assertSame(childLeafCert, result[0]);

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
@@ -157,23 +157,12 @@ public class AttestationRequestContractTest {
         byte[] base = Utils.computeKeyDescriptorIdentity(uid, domain, nspace, alias, blob);
         assertEquals(32, base.length);
 
-        // Deterministic
         assertArrayEquals(base, Utils.computeKeyDescriptorIdentity(uid, domain, nspace, alias, blob));
-
-        // Different UID
         assertFalse(java.util.Arrays.equals(base, Utils.computeKeyDescriptorIdentity(uid + 1, domain, nspace, alias, blob)));
-
-        // Different domain
         assertFalse(java.util.Arrays.equals(base, Utils.computeKeyDescriptorIdentity(uid, domain + 1, nspace, alias, blob)));
-
-        // Different nspace
         assertFalse(java.util.Arrays.equals(base, Utils.computeKeyDescriptorIdentity(uid, domain, nspace + 1, alias, blob)));
-
-        // Different alias
         assertFalse(java.util.Arrays.equals(base, Utils.computeKeyDescriptorIdentity(uid, domain, nspace, "other_key", blob)));
         assertFalse(java.util.Arrays.equals(base, Utils.computeKeyDescriptorIdentity(uid, domain, nspace, null, blob)));
-
-        // Different blob
         assertFalse(java.util.Arrays.equals(base, Utils.computeKeyDescriptorIdentity(uid, domain, nspace, alias, new byte[] {1, 2, 4})));
         assertFalse(java.util.Arrays.equals(base, Utils.computeKeyDescriptorIdentity(uid, domain, nspace, alias, null)));
     }
@@ -190,11 +179,10 @@ public class AttestationRequestContractTest {
         when(request.dataAvail()).thenReturn(128);
         when(request.dataSize()).thenReturn(128);
 
-        // 1. Request with default attestation key (presence = 0) and attestKey purpose
         java.util.Iterator<Integer> defaultAttestInts = java.util.Arrays.asList(
-                1, 16, 0, // KeyDescriptor (presence, size, domain)
-                0,        // attestationKey (presence = 0, null/default)
-                1, 1, 20, 536870913, 7, 7 // params (count, presence, size, tag, unionTag, unionVal)
+                1, 16, 0,
+                0,
+                1, 1, 20, 536870913, 7, 7
         ).iterator();
         when(request.readInt()).thenAnswer(inv -> defaultAttestInts.hasNext() ? defaultAttestInts.next() : 0);
 
@@ -206,12 +194,11 @@ public class AttestationRequestContractTest {
         assertEquals(32, info.generatedKeyId.length);
         assertNull(info.parentKeyId);
 
-        // 2. Request with explicit parent attest key (presence = 1) and non-attest purpose
         pos.set(28);
         java.util.Iterator<Integer> explicitParentInts = java.util.Arrays.asList(
-                1, 16, 0, // Generated KeyDescriptor (presence, size, domain)
-                1, 16, 0, // Parent KeyDescriptor (presence, size, domain)
-                0         // params (count = 0)
+                1, 16, 0,
+                1, 16, 0,
+                0
         ).iterator();
         when(request.readInt()).thenAnswer(inv -> explicitParentInts.hasNext() ? explicitParentInts.next() : 0);
 

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
@@ -147,6 +147,86 @@ public class AttestationRequestContractTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    public void cachedAttestKeyTouchesBackendAndInvalidatesWhenBackendEvicts() throws Exception {
+        Field stateField = CertHack.class.getDeclaredField("state");
+        stateField.setAccessible(true);
+        Object state = stateField.get(null);
+        Field cacheField = state.getClass().getDeclaredField("certificateCache");
+        cacheField.setAccessible(true);
+        Map<Object, Object> cache = (Map<Object, Object>) cacheField.get(state);
+
+        Constructor<?> keyConstructor = Class.forName(CertHack.class.getName() + "$CacheKey")
+                .getDeclaredConstructor(byte[].class);
+        keyConstructor.setAccessible(true);
+        Constructor<?> valueConstructor = Class.forName(CertHack.class.getName() + "$CachedCertificateChain")
+                .getDeclaredConstructor(Certificate[].class, byte[].class, byte[].class, boolean.class, boolean.class, int.class, byte[].class);
+        valueConstructor.setAccessible(true);
+
+        byte[] leaf = new byte[] {10, 20, 30};
+        byte[] attestKeyId = new byte[32];
+        attestKeyId[0] = 7;
+        int uid = 10001;
+
+        Object key = keyConstructor.newInstance((Object) leaf.clone());
+        Object value = valueConstructor.newInstance(
+                new Certificate[0],
+                new byte[] {40, 50},
+                new byte[] {60, 70},
+                true,
+                true,
+                uid,
+                attestKeyId
+        );
+
+        java.util.concurrent.atomic.AtomicInteger touchCount = new java.util.concurrent.atomic.AtomicInteger();
+        java.util.concurrent.atomic.AtomicBoolean touchResult = new java.util.concurrent.atomic.AtomicBoolean(true);
+
+        cleveres.tricky.cleverestech.CertificateBackend.setTouchAttestKeyOverrideForTesting((callingUid, keyId) -> {
+            touchCount.incrementAndGet();
+            assertEquals(uid, callingUid);
+            assertArrayEquals(attestKeyId, keyId);
+            return touchResult.get();
+        });
+
+        try {
+            synchronized (cache) {
+                cache.put(key, value);
+            }
+
+            KeyMetadata metadata = new KeyMetadata();
+            metadata.certificate = leaf.clone();
+            metadata.certificateChain = new byte[] {99};
+
+            // Hit with valid backend touch -> returns true, keeps in cache
+            assertTrue(CertHack.applyCachedCertificateChain(metadata));
+            assertEquals(1, touchCount.get());
+            assertArrayEquals(new byte[] {40, 50}, metadata.certificate);
+            synchronized (cache) {
+                assertTrue(cache.containsKey(key));
+            }
+
+            // Backend evicted the key (touch returns false) -> invalidates from cache, returns false
+            touchResult.set(false);
+            metadata.certificate = leaf.clone();
+            assertFalse(CertHack.applyCachedCertificateChain(metadata));
+            assertEquals(2, touchCount.get());
+            synchronized (cache) {
+                assertFalse(cache.containsKey(key));
+            }
+
+            // Next attempt should miss cache directly without calling touch again
+            assertFalse(CertHack.applyCachedCertificateChain(metadata));
+            assertEquals(2, touchCount.get());
+        } finally {
+            cleveres.tricky.cleverestech.CertificateBackend.resetForTesting();
+            synchronized (cache) {
+                cache.remove(key);
+            }
+        }
+    }
+
+    @Test
     public void computeKeyDescriptorIdentityIsDeterministicAndDifferentiatesDistinctFields() {
         int uid = 10001;
         int domain = 1;

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
@@ -167,6 +167,51 @@ public class AttestationRequestContractTest {
 
     @Test
     @SuppressWarnings("unchecked")
+    public void cachedCertificateBytesAreDefensivelyIsolated() throws Exception {
+        Field stateField = CertHack.class.getDeclaredField("state");
+        stateField.setAccessible(true);
+        Object state = stateField.get(null);
+        Field cacheField = state.getClass().getDeclaredField("certificateCache");
+        cacheField.setAccessible(true);
+        Map<Object, Object> cache = (Map<Object, Object>) cacheField.get(state);
+        Constructor<?> keyConstructor = Class.forName(CertHack.class.getName() + "$CacheKey")
+                .getDeclaredConstructor(byte[].class);
+        keyConstructor.setAccessible(true);
+        Constructor<?> valueConstructor = Class.forName(CertHack.class.getName() + "$CachedCertificateChain")
+                .getDeclaredConstructor(Certificate[].class, byte[].class, byte[].class, boolean.class);
+        valueConstructor.setAccessible(true);
+        byte[] original = new byte[] {1, 2, 3};
+        byte[] replacementLeaf = new byte[] {4, 5};
+        byte[] replacementChain = new byte[] {6, 7};
+        Object key = keyConstructor.newInstance((Object) original.clone());
+        Object value = valueConstructor.newInstance(
+                new Certificate[0], replacementLeaf, replacementChain, true);
+        try {
+            cache.put(key, value);
+
+            original[0] = 99;
+            replacementLeaf[0] = 99;
+            replacementChain[0] = 99;
+            KeyMetadata first = new KeyMetadata();
+            first.certificate = new byte[] {1, 2, 3};
+            assertTrue(CertHack.applyCachedCertificateChain(first));
+            assertArrayEquals(new byte[] {4, 5}, first.certificate);
+            assertArrayEquals(new byte[] {6, 7}, first.certificateChain);
+
+            first.certificate[0] = 88;
+            first.certificateChain[0] = 88;
+            KeyMetadata second = new KeyMetadata();
+            second.certificate = new byte[] {1, 2, 3};
+            assertTrue(CertHack.applyCachedCertificateChain(second));
+            assertArrayEquals(new byte[] {4, 5}, second.certificate);
+            assertArrayEquals(new byte[] {6, 7}, second.certificateChain);
+        } finally {
+            cache.remove(key);
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
     public void cachedAttestKeyTouchesBackendAndInvalidatesWhenBackendEvicts() throws Exception {
         Field stateField = CertHack.class.getDeclaredField("state");
         stateField.setAccessible(true);
@@ -521,6 +566,32 @@ public class AttestationRequestContractTest {
         assertFalse(java.util.Arrays.equals(base, Utils.computeKeyDescriptorIdentity(uid, domain, nspace, null, blob)));
         assertFalse(java.util.Arrays.equals(base, Utils.computeKeyDescriptorIdentity(uid, domain, nspace, alias, new byte[] {1, 2, 4})));
         assertFalse(java.util.Arrays.equals(base, Utils.computeKeyDescriptorIdentity(uid, domain, nspace, alias, null)));
+    }
+
+    @Test
+    public void childAttestKeyCannotUseItsOwnDescriptorAsParent() {
+        byte[] descriptor = new byte[32];
+        descriptor[0] = 1;
+
+        assertNull(cleveres.tricky.cleverestech.CertificateBackend.rewriteChildKey(
+                10001,
+                descriptor,
+                descriptor.clone(),
+                new byte[] {1},
+                true,
+                0, 0,
+                0, 0,
+                0, 0,
+                java.util.Collections.emptyMap(),
+                null,
+                filledBytes(32, (byte) 2),
+                filledBytes(32, (byte) 3)));
+    }
+
+    private static byte[] filledBytes(int size, byte value) {
+        byte[] bytes = new byte[size];
+        java.util.Arrays.fill(bytes, value);
+        return bytes;
     }
 
     @Test

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
@@ -11,9 +11,13 @@ import java.security.cert.Certificate;
 import java.util.Map;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -141,6 +145,85 @@ public class AttestationRequestContractTest {
             else cache.put(key, previous);
         }
     }
+
+    @Test
+    public void computeKeyDescriptorIdentityIsDeterministicAndDifferentiatesDistinctFields() {
+        int uid = 10001;
+        int domain = 1;
+        long nspace = 42L;
+        String alias = "my_key";
+        byte[] blob = new byte[] {1, 2, 3};
+
+        byte[] base = Utils.computeKeyDescriptorIdentity(uid, domain, nspace, alias, blob);
+        assertEquals(32, base.length);
+
+        // Deterministic
+        assertArrayEquals(base, Utils.computeKeyDescriptorIdentity(uid, domain, nspace, alias, blob));
+
+        // Different UID
+        assertFalse(java.util.Arrays.equals(base, Utils.computeKeyDescriptorIdentity(uid + 1, domain, nspace, alias, blob)));
+
+        // Different domain
+        assertFalse(java.util.Arrays.equals(base, Utils.computeKeyDescriptorIdentity(uid, domain + 1, nspace, alias, blob)));
+
+        // Different nspace
+        assertFalse(java.util.Arrays.equals(base, Utils.computeKeyDescriptorIdentity(uid, domain, nspace + 1, alias, blob)));
+
+        // Different alias
+        assertFalse(java.util.Arrays.equals(base, Utils.computeKeyDescriptorIdentity(uid, domain, nspace, "other_key", blob)));
+        assertFalse(java.util.Arrays.equals(base, Utils.computeKeyDescriptorIdentity(uid, domain, nspace, null, blob)));
+
+        // Different blob
+        assertFalse(java.util.Arrays.equals(base, Utils.computeKeyDescriptorIdentity(uid, domain, nspace, alias, new byte[] {1, 2, 4})));
+        assertFalse(java.util.Arrays.equals(base, Utils.computeKeyDescriptorIdentity(uid, domain, nspace, alias, null)));
+    }
+
+    @Test
+    public void parseGenerateKeyRequestExtractsIdentityAndRespectsAttestationKeyPresence() {
+        Parcel request = mock(Parcel.class);
+        java.util.concurrent.atomic.AtomicInteger pos = new java.util.concurrent.atomic.AtomicInteger(28);
+        when(request.dataPosition()).thenAnswer(inv -> pos.get());
+        org.mockito.Mockito.doAnswer(inv -> {
+            pos.set(inv.getArgument(0));
+            return null;
+        }).when(request).setDataPosition(anyInt());
+        when(request.dataAvail()).thenReturn(128);
+        when(request.dataSize()).thenReturn(128);
+
+        // 1. Request with default attestation key (presence = 0) and attestKey purpose
+        java.util.Iterator<Integer> defaultAttestInts = java.util.Arrays.asList(
+                1, 16, 0, // KeyDescriptor (presence, size, domain)
+                0,        // attestationKey (presence = 0, null/default)
+                1, 1, 20, 536870913, 7, 7 // params (count, presence, size, tag, unionTag, unionVal)
+        ).iterator();
+        when(request.readInt()).thenAnswer(inv -> defaultAttestInts.hasNext() ? defaultAttestInts.next() : 0);
+
+        Utils.GenerateKeyRequestInfo info = Utils.parseGenerateKeyRequest(request, 10001);
+        assertNotNull(info);
+        assertTrue(info.usesDefaultAttestationKey);
+        assertTrue(info.isAttestKeyPurpose);
+        assertNotNull(info.generatedKeyId);
+        assertEquals(32, info.generatedKeyId.length);
+        assertNull(info.parentKeyId);
+
+        // 2. Request with explicit parent attest key (presence = 1) and non-attest purpose
+        pos.set(28);
+        java.util.Iterator<Integer> explicitParentInts = java.util.Arrays.asList(
+                1, 16, 0, // Generated KeyDescriptor (presence, size, domain)
+                1, 16, 0, // Parent KeyDescriptor (presence, size, domain)
+                0         // params (count = 0)
+        ).iterator();
+        when(request.readInt()).thenAnswer(inv -> explicitParentInts.hasNext() ? explicitParentInts.next() : 0);
+
+        Utils.GenerateKeyRequestInfo childInfo = Utils.parseGenerateKeyRequest(request, 10001);
+        assertNotNull(childInfo);
+        assertFalse(childInfo.usesDefaultAttestationKey);
+        assertFalse(childInfo.isAttestKeyPurpose);
+        assertNotNull(childInfo.generatedKeyId);
+        assertNotNull(childInfo.parentKeyId);
+        assertEquals(32, childInfo.parentKeyId.length);
+    }
+
     static Parcel request(boolean explicitIssuer) {
         Parcel request = mock(Parcel.class);
         when(request.dataPosition()).thenReturn(28, 32);


### PR DESCRIPTION
### Summary
This PR converges the RootOfTrust (deviceLocked=true, verifiedBootState=Verified) and certificate chain verification between default RKP attestation keys, caller-selected attest keys, and child keys minted by them, eliminating attestation detection divergences.

### Key Changes
- **Rust Certificate Core**:
  - Added support for generating bounded EC P-256 keypairs and parsing X.509 Subject/Issuer DER.
  - Added support for SPKI override during certificate rewriting, allowing custom attest keys to be signed by Keybox CAs while retaining genuine hardware keys for subsequent operations.
  - Verified cryptographic signature verification under the rewritten public key.
- **Rust Backend**:
  - Added thread-safe in-memory cache mapping \(calling_uid, subject_der) -> PreparedIssuer\.
  - Implemented opcodes 32 (\OP_ATTEST_KEY_REWRITE\) and 33 (\OP_CHILD_KEY_REWRITE\).
  - Child keys are rewritten with verified RootOfTrust and resigned by their registered parent attest key, with safe fallback to genuine hardware certificates if not registered.
- **Service & Keystore Interception**:
  - \SecurityLevelInterceptor\: dynamically inspects \generateKey\ request parameters for \ttestationKey\ and \PURPOSE_ATTEST_KEY\, routing requests to default attestation rewrite, attest-key rewrite, or child-key rewrite.
  - \CertHack\: added \hackAttestKeyCertificateChain\ and \hackChildKeyCertificate\.
  - Updated parcel rewrite and cached chain handlers to support leaf-only metadata payloads.
- **Performance & Overhead**:
  - Retains 100% hardware KeyMint key generation without background daemons, polling, or idle CPU/RAM overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for generated attestation issuers and custom parent-child key relationships.
  - Added attestation-key cache management, including clearing, access tracking, removal, and descendant invalidation.
  - Added EC P-256 certificate validation for supported flows.

- **Bug Fixes**
  - Caller-selected attestation keys now pass through without certificate-chain rewriting.
  - Default attestation-key requests continue to receive certificate handling.
  - Custom attestation-key readback preserves native behavior.
  - Key removal and transport outcomes are now reported distinctly.

- **Tests**
  - Expanded coverage for attestation, child-key, cache, identity, and certificate flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->