### PR TITLE
perf(keystore): eliminate post-transact payload copying and streamline attested rewrite

### DIFF
--- a/module/src/main/cpp/binder_interceptor.cpp
+++ b/module/src/main/cpp/binder_interceptor.cpp
@@ -218,11 +218,16 @@ private:
     OVERRIDE_REPLY,
     OVERRIDE_DATA,
   };
+  enum Capabilities : uint32_t {
+    CAP_NONE = 0,
+    CAP_OMIT_POST_REQUEST_PAYLOAD = 1 << 0,
+  };
 
   struct InterceptItem {
     wp<IBinder> target{};
     sp<IBinder> interceptor;
     std::vector<uint32_t> filtered_codes;
+    uint32_t capabilities = 0;
   };
 
   using RwLock = std::shared_mutex;
@@ -771,6 +776,12 @@ status_t BinderInterceptor::onTransact(uint32_t code,
       }
       codes.push_back(filtered_code);
     }
+    uint32_t capabilities = 0;
+    if (data.dataAvail() >= sizeof(uint32_t)) {
+      if (data.readUint32(&capabilities) != OK) {
+        return BAD_VALUE;
+      }
+    }
     if (data.dataAvail() != 0)
       return BAD_VALUE;
     std::sort(codes.begin(), codes.end());
@@ -798,6 +809,7 @@ status_t BinderInterceptor::onTransact(uint32_t code,
       }
       it->second.interceptor = interceptor;
       it->second.filtered_codes = std::move(codes);
+      it->second.capabilities = capabilities;
     }
     if (replaced_interceptor != nullptr) {
       Parcel notification;
@@ -893,6 +905,7 @@ bool BinderInterceptor::handleIntercept(sp<BBinder> target, uint32_t code,
     }                                                                          \
   })
   sp<IBinder> interceptor;
+  uint32_t capabilities = 0;
   {
     ReadGuard rg{lock};
     auto it = items.find(target);
@@ -901,6 +914,7 @@ bool BinderInterceptor::handleIntercept(sp<BBinder> target, uint32_t code,
       return false;
     }
     interceptor = it->second.interceptor;
+    capabilities = it->second.capabilities;
   }
   if (interceptor == nullptr)
     return false;
@@ -984,10 +998,13 @@ bool BinderInterceptor::handleIntercept(sp<BBinder> target, uint32_t code,
   CHECK_POST(tmpData.writeInt32(static_cast<int32_t>(calling_uid)));
   CHECK_POST(tmpData.writeInt32(static_cast<int32_t>(calling_pid)));
   CHECK_POST(tmpData.writeInt32(result));
-  CHECK_POST(tmpData.writeUint64(data.dataSize()));
-  CHECK_POST(tmpData.appendFrom(&data, 0, data.dataSize()));
+  const bool omit_request = (capabilities & CAP_OMIT_POST_REQUEST_PAYLOAD) != 0;
+  CHECK_POST(tmpData.writeUint64(omit_request ? 0 : data.dataSize()));
+  if (!omit_request) {
+    CHECK_POST(tmpData.appendFrom(&data, 0, data.dataSize()));
+  }
   CHECK_POST(tmpData.writeUint64(reply == nullptr ? 0 : reply->dataSize()));
-  LOGD("data size %zu reply size %zu", data.dataSize(),
+  LOGD("data size %zu reply size %zu", omit_request ? 0 : data.dataSize(),
        reply == nullptr ? 0 : reply->dataSize());
   if (reply) {
     CHECK_POST(tmpData.appendFrom(reply, 0, reply->dataSize()));

--- a/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
@@ -106,7 +106,7 @@ object CertificateBackend {
             return null
         }
 
-        val orderedIds = idOverrides.entries.sortedBy { it.key }
+        val orderedIds = if (idOverrides.isEmpty()) emptyList() else idOverrides.entries.sortedBy { it.key }
         var idWireBytes = 0
         for ((tag, value) in orderedIds) {
             if (tag !in ATTESTATION_ID_TAGS || value.isEmpty() || value.size > MAX_ATTESTATION_ID_BYTES) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -394,7 +394,14 @@ object KeystoreInterceptor : BinderInterceptor() {
 
         val expectedEpoch = synchronized(this) { lifecycleEpoch }
 
-        val registeredHook = registerBinderInterceptor(bd, b, this, interceptedCodes)
+        val registeredHook =
+            registerBinderInterceptor(
+                bd,
+                b,
+                this,
+                interceptedCodes,
+                CAP_OMIT_POST_REQUEST_PAYLOAD,
+            )
         if (!registeredHook) {
             Logger.e("Failed to register the Keystore Binder interceptor")
             parkBinderHook(bd)
@@ -426,6 +433,7 @@ object KeystoreInterceptor : BinderInterceptor() {
                     tee.asBinder(),
                     interceptor,
                     SecurityLevelInterceptor.INTERCEPTED_CODES,
+                    CAP_OMIT_POST_REQUEST_PAYLOAD,
                 )
             ) {
                 Logger.e("Failed to register the TEE SecurityLevel interceptor")
@@ -473,6 +481,7 @@ object KeystoreInterceptor : BinderInterceptor() {
                     strongbox.asBinder(),
                     interceptor,
                     SecurityLevelInterceptor.INTERCEPTED_CODES,
+                    CAP_OMIT_POST_REQUEST_PAYLOAD,
                 )
             ) {
                 Logger.e("Failed to register the StrongBox SecurityLevel interceptor")

--- a/service/src/main/java/cleveres/tricky/cleverestech/binder/BinderInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/binder/BinderInterceptor.kt
@@ -28,6 +28,8 @@ open class BinderInterceptor : Binder() {
         private const val MAX_FILTERED_CODES = 1024
         private const val MAX_INTERCEPT_PARCEL_BYTES = 8L * 1024 * 1024
 
+        const val CAP_OMIT_POST_REQUEST_PAYLOAD = 1
+
         fun getBinderControlEndpoint(remote: IBinder): IBinder? {
             val data = Parcel.obtain()
             val reply = Parcel.obtain()
@@ -52,6 +54,7 @@ open class BinderInterceptor : Binder() {
             target: IBinder,
             interceptor: BinderInterceptor,
             filteredCodes: IntArray,
+            capabilities: Int = 0,
         ): Boolean {
             val codes = filteredCodes.filter { it > 0 }.distinct()
             if (codes.isEmpty() || codes.size > MAX_FILTERED_CODES) {
@@ -66,6 +69,9 @@ open class BinderInterceptor : Binder() {
                 data.writeStrongBinder(interceptor)
                 data.writeInt(codes.size)
                 codes.forEach(data::writeInt)
+                if (capabilities != 0) {
+                    data.writeInt(capabilities)
+                }
                 val handled = controlEndpoint.transact(REGISTER_INTERCEPTOR, data, reply, 0)
                 val status = if (reply.dataAvail() >= Int.SIZE_BYTES) reply.readInt() else -1
                 handled && status == 0
@@ -241,9 +247,11 @@ open class BinderInterceptor : Binder() {
         val result =
             try {
                 val requestSize = requireNotNull(readBoundedSize(data)) { "Invalid request size" }
-                request.appendFrom(data, data.dataPosition(), requestSize)
-                request.setDataPosition(0)
-                data.setDataPosition(data.dataPosition() + requestSize)
+                if (requestSize > 0) {
+                    request.appendFrom(data, data.dataPosition(), requestSize)
+                    request.setDataPosition(0)
+                    data.setDataPosition(data.dataPosition() + requestSize)
+                }
 
                 val responseSize = requireNotNull(readBoundedSize(data)) { "Invalid response size" }
                 require(responseSize == data.dataAvail()) { "Trailing response data" }

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -60,6 +60,7 @@ public final class CertHack {
     private static final class PreparedKeyBox {
         final String signatureAlgorithm;
         final Certificate[] issuerChain;
+        final byte[] keyId;
 
         PreparedKeyBox(KeyBox keybox) throws Exception {
             if (keybox.certificates.isEmpty()) throw new IOException("Keybox has no certificates");
@@ -70,16 +71,17 @@ public final class CertHack {
                 throw new IOException("Production keybox does not use an opaque backend key handle");
             }
             byte[] encoded = keybox.keyPair.getPrivate().getEncoded();
-            try {
-                if (encoded == null || encoded.length != BACKEND_KEY_ID_BYTES) {
-                    throw new IOException("Opaque backend key identifier is invalid");
-                }
-                int aggregate = 0;
-                for (byte value : encoded) aggregate |= value & 0xFF;
-                if (aggregate == 0) throw new IOException("Opaque backend key identifier is zero");
-            } finally {
+            if (encoded == null || encoded.length != BACKEND_KEY_ID_BYTES) {
                 if (encoded != null) Arrays.fill(encoded, (byte) 0);
+                throw new IOException("Opaque backend key identifier is invalid");
             }
+            int aggregate = 0;
+            for (byte value : encoded) aggregate |= value & 0xFF;
+            if (aggregate == 0) {
+                Arrays.fill(encoded, (byte) 0);
+                throw new IOException("Opaque backend key identifier is zero");
+            }
+            this.keyId = encoded;
         }
 
         private static byte[] encodeKeyboxIssuers(Certificate[] issuers) throws CertificateException {
@@ -1023,8 +1025,7 @@ public final class CertHack {
             byte[] moduleHash = inspection.getSupportsModuleHash()
                     ? Config.INSTANCE.getModuleHash()
                     : null;
-            keyId = keybox.keyPair.getPrivate().getEncoded();
-            if (keyId == null || keyId.length != BACKEND_KEY_ID_BYTES) return caList;
+            keyId = prepared.keyId.clone();
 
             byte[] rewrittenDer = CertificateBackend.rewrite(
                     leafEncoded,
@@ -1073,21 +1074,28 @@ public final class CertHack {
         }
     }
 
+    private static final Config.AttestationPatchLevels KEEP_PATCH_LEVELS =
+            new Config.AttestationPatchLevels(
+                    new Config.AttestationPatchComponent(Config.PatchDisposition.KEEP, 0),
+                    new Config.AttestationPatchComponent(Config.PatchDisposition.KEEP, 0),
+                    new Config.AttestationPatchComponent(Config.PatchDisposition.KEEP, 0));
+
     private static Config.AttestationPatchLevels keepPatchLevels() {
-        Config.AttestationPatchComponent keep =
-                new Config.AttestationPatchComponent(Config.PatchDisposition.KEEP, 0);
-        return new Config.AttestationPatchLevels(keep, keep, keep);
+        return KEEP_PATCH_LEVELS;
     }
 
     private static Map<Integer, byte[]> presentIdOverrides(int uid, int mask) {
         if (mask == 0) return Collections.emptyMap();
-        Map<Integer, byte[]> overrides = new HashMap<>();
+        Map<Integer, byte[]> overrides = null;
         for (int index = 0; index < ATTESTATION_ID_TAGS.length; index++) {
             if ((mask & (1 << index)) == 0) continue;
             byte[] value = Config.INSTANCE.getAttestationId(ATTESTATION_ID_NAMES[index], uid);
-            if (value != null) overrides.put(ATTESTATION_ID_TAGS[index], value);
+            if (value != null) {
+                if (overrides == null) overrides = new HashMap<>();
+                overrides.put(ATTESTATION_ID_TAGS[index], value);
+            }
         }
-        return overrides;
+        return overrides == null ? Collections.emptyMap() : overrides;
     }
 
     private static int patchDisposition(Config.AttestationPatchComponent component) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/binder/BinderInterceptorTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/binder/BinderInterceptorTest.kt
@@ -99,4 +99,39 @@ class BinderInterceptorTest {
         assertTrue(BinderInterceptor.clearAndParkBinderHook(control))
         assertEquals(listOf(2, 3, 4), seenCodes)
     }
+
+    @Test
+    fun testRegisterBinderInterceptorWithCapabilities() {
+        var writtenCapabilities = -1
+        val control =
+            object : Binder() {
+                override fun onTransact(
+                    code: Int,
+                    data: Parcel,
+                    reply: Parcel?,
+                    flags: Int,
+                ): Boolean {
+                    data.readStrongBinder()
+                    data.readStrongBinder()
+                    val count = data.readInt()
+                    for (i in 0 until count) data.readInt()
+                    if (data.dataAvail() >= Int.SIZE_BYTES) {
+                        writtenCapabilities = data.readInt()
+                    }
+                    reply?.writeInt(0)
+                    return true
+                }
+            }
+        val interceptor = BinderInterceptor()
+        val ok =
+            BinderInterceptor.registerBinderInterceptor(
+                control,
+                Binder(),
+                interceptor,
+                intArrayOf(1, 2),
+                BinderInterceptor.CAP_OMIT_POST_REQUEST_PAYLOAD,
+            )
+        assertTrue(ok)
+        assertEquals(BinderInterceptor.CAP_OMIT_POST_REQUEST_PAYLOAD, writtenCapabilities)
+    }
 }


### PR DESCRIPTION
### Summary
Streamlines the keystore attestation and key generation hot path to minimize timing divergence and IPC overhead:

1. **Native Binder Transport**:
   - Introduce \CAP_OMIT_POST_REQUEST_PAYLOAD\ capability allowing post-transaction interceptors that only inspect replies to omit request parcel replication across Binder IPC.
   - Register Keystore and SecurityLevel child interceptors with this capability to eliminate redundant request buffer copying.

2. **Streamlined Attestation Path**:
   - Cache opaque backend key handles on \PreparedKeyBox\ and clone locally to avoid repeated JCA private key queries.
   - Use a pre-allocated constant for default attestation patch levels and lazily allocate ID override structures.
   - Avoid collection sorting and allocation in \CertificateBackend.rewrite\ when attestation ID overrides are empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selectively omitting original request payloads from post-transaction interception notifications.
  * Keystore, TEE, and StrongBox interception now use payload omission to reduce unnecessary sensitive data exposure.

* **Bug Fixes**
  * Corrected certificate processing when no identifier overrides are provided.
  * Improved handling and cleanup of validated key identifiers during certificate operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->