### PR TITLE
feat(keystore): converge root of trust and signatures across attest keys and child keys

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "cleverestricky-keybox-core",
  "cleverestricky-xml-core",
  "der 0.8.1",
+ "getrandom 0.4.3",
  "p256",
  "rsa",
  "sha2 0.10.9",

--- a/rust/backend/src/attest_key_store.rs
+++ b/rust/backend/src/attest_key_store.rs
@@ -1,0 +1,76 @@
+// Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
+use cleverestricky_certificate_core::PreparedIssuer;
+use std::collections::VecDeque;
+use std::sync::{Mutex, OnceLock};
+
+pub const MAX_ATTEST_KEYS: usize = 32;
+
+struct AttestKeyEntry {
+    calling_uid: u32,
+    subject_der: Vec<u8>,
+    issuer: PreparedIssuer,
+}
+
+#[derive(Default)]
+struct AttestKeyStore {
+    entries: VecDeque<AttestKeyEntry>,
+}
+
+static STORE: OnceLock<Mutex<AttestKeyStore>> = OnceLock::new();
+
+#[cfg(test)]
+pub(crate) fn reset_for_testing() {
+    let store = STORE.get_or_init(|| Mutex::new(AttestKeyStore::default()));
+    let mut guard = match store.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    guard.entries.clear();
+    drop(guard);
+    store.clear_poison();
+}
+
+pub fn insert_attest_key(calling_uid: u32, subject_der: Vec<u8>, issuer: PreparedIssuer) {
+    let store = STORE.get_or_init(|| Mutex::new(AttestKeyStore::default()));
+    let mut guard = match store.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    if let Some(pos) = guard
+        .entries
+        .iter()
+        .position(|e| e.calling_uid == calling_uid && e.subject_der == subject_der)
+    {
+        guard.entries.remove(pos);
+    }
+
+    if guard.entries.len() >= MAX_ATTEST_KEYS {
+        guard.entries.pop_front();
+    }
+
+    guard.entries.push_back(AttestKeyEntry {
+        calling_uid,
+        subject_der,
+        issuer,
+    });
+}
+
+pub fn with_attest_key<R>(
+    calling_uid: u32,
+    issuer_der: &[u8],
+    f: impl FnOnce(&PreparedIssuer) -> R,
+) -> Option<R> {
+    let store = STORE.get_or_init(|| Mutex::new(AttestKeyStore::default()));
+    let guard = match store.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    guard
+        .entries
+        .iter()
+        .rev()
+        .find(|e| e.calling_uid == calling_uid && e.subject_der == issuer_der)
+        .map(|entry| f(&entry.issuer))
+}

--- a/rust/backend/src/certificate_wire.rs
+++ b/rust/backend/src/certificate_wire.rs
@@ -1,10 +1,10 @@
-// Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
+use crate::attest_key_store;
 use crate::keybox_wire::key_store::{self, KeyId, KEY_ID_BYTES};
 use cleverestricky_certificate_core::{
-    inspect_certificate, rewrite_certificate_prepared, AttestationIdOverride,
-    CertificateInspection, PatchComponent, PatchLevels, PreparedCertificateRewriteRequest,
-    SecurityLevel, SigningAlgorithm, MAX_ATTESTATION_ID_BYTES, MAX_CERTIFICATE_DER_BYTES,
-    MAX_MODULE_HASH_BYTES,
+    generate_ec_p256_keypair, inspect_certificate, parse_certificate_subject_and_issuer,
+    rewrite_certificate_prepared, AttestationIdOverride, CertificateInspection, PatchComponent,
+    PatchLevels, PreparedCertificateRewriteRequest, PreparedIssuer, SecurityLevel,
+    SigningAlgorithm, MAX_ATTESTATION_ID_BYTES, MAX_CERTIFICATE_DER_BYTES, MAX_MODULE_HASH_BYTES,
 };
 use zeroize::Zeroize;
 
@@ -17,12 +17,22 @@ const PATCH_OMIT: u8 = 1;
 const PATCH_REPLACE: u8 = 2;
 const MAX_ID_OVERRIDES: usize = 9;
 const REWRITE_FIXED_BYTES: usize = 1 + 1 + 3 * 5 + 1 + 2 + 4 + KEY_ID_BYTES + 2 * 32;
+const ATTEST_KEY_REWRITE_FIXED_BYTES: usize = 1 + 4 + 1 + 3 * 5 + 1 + 2 + 4 + KEY_ID_BYTES + 2 * 32;
+const CHILD_KEY_REWRITE_FIXED_BYTES: usize = 1 + 4 + 1 + 3 * 5 + 1 + 2 + 4 + 2 * 32;
 const MAX_ID_WIRE_BYTES: usize = MAX_ID_OVERRIDES * (2 + 2 + MAX_ATTESTATION_ID_BYTES);
 
 pub const MAX_INSPECT_REQUEST_BYTES: usize = MAX_CERTIFICATE_DER_BYTES;
 pub const INSPECT_RESPONSE_BYTES: usize = 1 + 1 + 2 + 3 * 5 + 2 * 32 + 2;
 pub const MAX_REWRITE_REQUEST_BYTES: usize =
     REWRITE_FIXED_BYTES + MAX_ID_WIRE_BYTES + MAX_MODULE_HASH_BYTES + MAX_CERTIFICATE_DER_BYTES;
+pub const MAX_ATTEST_KEY_REWRITE_REQUEST_BYTES: usize = ATTEST_KEY_REWRITE_FIXED_BYTES
+    + MAX_ID_WIRE_BYTES
+    + MAX_MODULE_HASH_BYTES
+    + MAX_CERTIFICATE_DER_BYTES;
+pub const MAX_CHILD_KEY_REWRITE_REQUEST_BYTES: usize = CHILD_KEY_REWRITE_FIXED_BYTES
+    + MAX_ID_WIRE_BYTES
+    + MAX_MODULE_HASH_BYTES
+    + MAX_CERTIFICATE_DER_BYTES;
 pub const MAX_REWRITE_RESPONSE_BYTES: usize = MAX_CERTIFICATE_DER_BYTES;
 
 pub fn inspect_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'static str> {
@@ -103,10 +113,124 @@ pub fn rewrite_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'static str>
                 module_hash: parsed.module_hash,
                 verified_boot_key: parsed.verified_boot_key,
                 verified_boot_hash: parsed.verified_boot_hash,
+                subject_public_key_info: None,
             })
             .map(|rewritten| rewritten.leaf_der)
             .map_err(|_| "certificate rewrite rejected")
         })
+    })();
+    request.zeroize();
+    result
+}
+
+pub fn rewrite_attest_key_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'static str> {
+    let result = (|| {
+        if request.len() < ATTEST_KEY_REWRITE_FIXED_BYTES
+            || request.len() > MAX_ATTEST_KEY_REWRITE_REQUEST_BYTES
+        {
+            return Err("attest key rewrite request rejected");
+        }
+        let parsed = parse_attest_key_rewrite_request(&request)?;
+
+        let provenance = inspect_certificate(parsed.genuine_leaf_der)
+            .map_err(|_| "attest key rewrite provenance rejected")?;
+        validate_hardware_provenance(&provenance)?;
+
+        let (subject_der, _) = parse_certificate_subject_and_issuer(parsed.genuine_leaf_der)
+            .map_err(|_| "invalid attest key certificate")?;
+
+        let keypair =
+            generate_ec_p256_keypair().map_err(|_| "failed to generate attest keypair")?;
+        let prepared_for_children = PreparedIssuer::from_subject_and_key(
+            subject_der.clone(),
+            &keypair.private_key_pkcs8_der,
+            SigningAlgorithm::EcP256Sha256,
+        )
+        .map_err(|_| "failed to prepare attest issuer")?;
+
+        key_store::with_prepared_key(&parsed.key_id, |stored_algorithm, prepared_issuer| {
+            if stored_algorithm != parsed.signing_algorithm
+                || prepared_issuer.algorithm() != stored_algorithm
+            {
+                return Err("opaque key algorithm does not match rewrite request");
+            }
+            let rewritten = rewrite_certificate_prepared(&PreparedCertificateRewriteRequest {
+                genuine_leaf_der: parsed.genuine_leaf_der,
+                issuer: prepared_issuer,
+                patch_levels: parsed.patch_levels,
+                id_overrides: &parsed.id_overrides,
+                module_hash: parsed.module_hash,
+                verified_boot_key: parsed.verified_boot_key,
+                verified_boot_hash: parsed.verified_boot_hash,
+                subject_public_key_info: Some(&keypair.public_key_spki_der),
+            })
+            .map(|rewritten| rewritten.leaf_der)
+            .map_err(|_| "attest key certificate rewrite rejected")?;
+
+            attest_key_store::insert_attest_key(
+                parsed.calling_uid,
+                subject_der,
+                prepared_for_children,
+            );
+            Ok(rewritten)
+        })
+    })();
+    request.zeroize();
+    result
+}
+
+pub fn rewrite_child_key_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'static str> {
+    let result = (|| {
+        if request.len() < CHILD_KEY_REWRITE_FIXED_BYTES
+            || request.len() > MAX_CHILD_KEY_REWRITE_REQUEST_BYTES
+        {
+            return Err("child key rewrite request rejected");
+        }
+        let parsed = parse_child_key_rewrite_request(&request)?;
+
+        let provenance = inspect_certificate(parsed.genuine_leaf_der)
+            .map_err(|_| "child key rewrite provenance rejected")?;
+        validate_hardware_provenance(&provenance)?;
+
+        let (subject_der, issuer_der) =
+            parse_certificate_subject_and_issuer(parsed.genuine_leaf_der)
+                .map_err(|_| "invalid child certificate")?;
+
+        attest_key_store::with_attest_key(parsed.calling_uid, &issuer_der, |parent_issuer| {
+            let (spki_override, prepared_for_children) = if parsed.is_attest_key {
+                let keypair = generate_ec_p256_keypair()
+                    .map_err(|_| "failed to generate child attest keypair")?;
+                let prepared = PreparedIssuer::from_subject_and_key(
+                    subject_der.clone(),
+                    &keypair.private_key_pkcs8_der,
+                    SigningAlgorithm::EcP256Sha256,
+                )
+                .map_err(|_| "failed to prepare child attest issuer")?;
+                (Some(keypair.public_key_spki_der), Some(prepared))
+            } else {
+                (None, None)
+            };
+
+            let rewritten = rewrite_certificate_prepared(&PreparedCertificateRewriteRequest {
+                genuine_leaf_der: parsed.genuine_leaf_der,
+                issuer: parent_issuer,
+                patch_levels: parsed.patch_levels,
+                id_overrides: &parsed.id_overrides,
+                module_hash: parsed.module_hash,
+                verified_boot_key: parsed.verified_boot_key,
+                verified_boot_hash: parsed.verified_boot_hash,
+                subject_public_key_info: spki_override.as_deref(),
+            })
+            .map(|rewritten| rewritten.leaf_der)
+            .map_err(|_| "child certificate rewrite rejected")?;
+
+            if let Some(prepared) = prepared_for_children {
+                attest_key_store::insert_attest_key(parsed.calling_uid, subject_der, prepared);
+            }
+
+            Ok(rewritten)
+        })
+        .ok_or("attest issuer not found in managed store")?
     })();
     request.zeroize();
     result
@@ -214,6 +338,207 @@ fn parse_rewrite_request(request: &[u8]) -> Result<ParsedRewrite<'_>, &'static s
     })
 }
 
+struct ParsedAttestKeyRewrite<'a> {
+    calling_uid: u32,
+    signing_algorithm: SigningAlgorithm,
+    patch_levels: PatchLevels,
+    id_overrides: Vec<AttestationIdOverride<'a>>,
+    module_hash: Option<&'a [u8]>,
+    genuine_leaf_der: &'a [u8],
+    key_id: KeyId,
+    verified_boot_key: &'a [u8; 32],
+    verified_boot_hash: &'a [u8; 32],
+}
+
+fn parse_attest_key_rewrite_request(
+    request: &[u8],
+) -> Result<ParsedAttestKeyRewrite<'_>, &'static str> {
+    let mut cursor = Cursor::new(request);
+    if cursor.read_u8()? != REWRITE_WIRE_VERSION {
+        return Err("unsupported certificate rewrite wire version");
+    }
+    let calling_uid = cursor.read_u32()?;
+    let signing_algorithm = match cursor.read_u8()? {
+        SIGNING_EC_P256_SHA256 => SigningAlgorithm::EcP256Sha256,
+        SIGNING_RSA_PKCS1_SHA256 => SigningAlgorithm::RsaPkcs1Sha256,
+        _ => return Err("unsupported certificate signing algorithm"),
+    };
+    let patch_levels = PatchLevels {
+        system: read_patch(&mut cursor)?,
+        vendor: read_patch(&mut cursor)?,
+        boot: read_patch(&mut cursor)?,
+    };
+    let id_count = cursor.read_u8()? as usize;
+    if id_count > MAX_ID_OVERRIDES {
+        return Err("too many attestation ID overrides");
+    }
+    let module_hash_len = cursor.read_u16()? as usize;
+    if module_hash_len > MAX_MODULE_HASH_BYTES {
+        return Err("module hash exceeds certificate wire bound");
+    }
+    let genuine_leaf_len = cursor.read_u32_as_usize()?;
+    if genuine_leaf_len == 0 || genuine_leaf_len > MAX_CERTIFICATE_DER_BYTES {
+        return Err("certificate DER field exceeds wire bound");
+    }
+    let key_id: KeyId = cursor
+        .read_exact(KEY_ID_BYTES)?
+        .try_into()
+        .map_err(|_| "invalid opaque key identifier")?;
+    if key_id.iter().all(|byte| *byte == 0) {
+        return Err("invalid opaque key identifier");
+    }
+    let verified_boot_key: &[u8; 32] = cursor
+        .read_exact(32)?
+        .try_into()
+        .map_err(|_| "invalid verified boot key")?;
+    let verified_boot_hash: &[u8; 32] = cursor
+        .read_exact(32)?
+        .try_into()
+        .map_err(|_| "invalid verified boot hash")?;
+    if verified_boot_key.iter().all(|byte| *byte == 0)
+        || verified_boot_hash.iter().all(|byte| *byte == 0)
+    {
+        return Err("verified boot digest is unavailable");
+    }
+
+    let mut id_overrides = Vec::new();
+    id_overrides
+        .try_reserve_exact(id_count)
+        .map_err(|_| "attestation ID allocation failed")?;
+    let mut seen_tags = [0u16; MAX_ID_OVERRIDES];
+    for seen_count in 0..id_count {
+        let tag = cursor.read_u16()?;
+        let length = cursor.read_u16()? as usize;
+        if length == 0 || length > MAX_ATTESTATION_ID_BYTES {
+            return Err("attestation ID override exceeds wire bound");
+        }
+        if seen_tags[..seen_count].contains(&tag) {
+            return Err("duplicate attestation ID override");
+        }
+        seen_tags[seen_count] = tag;
+        let value = cursor.read_exact(length)?;
+        id_overrides.push(AttestationIdOverride {
+            tag: u32::from(tag),
+            value,
+        });
+    }
+    let module_hash = if module_hash_len == 0 {
+        None
+    } else {
+        Some(cursor.read_exact(module_hash_len)?)
+    };
+    let genuine_leaf_der = cursor.read_exact(genuine_leaf_len)?;
+    if !cursor.is_at_end() {
+        return Err("trailing certificate wire bytes");
+    }
+
+    Ok(ParsedAttestKeyRewrite {
+        calling_uid,
+        signing_algorithm,
+        patch_levels,
+        id_overrides,
+        module_hash,
+        genuine_leaf_der,
+        key_id,
+        verified_boot_key,
+        verified_boot_hash,
+    })
+}
+
+struct ParsedChildKeyRewrite<'a> {
+    calling_uid: u32,
+    is_attest_key: bool,
+    patch_levels: PatchLevels,
+    id_overrides: Vec<AttestationIdOverride<'a>>,
+    module_hash: Option<&'a [u8]>,
+    genuine_leaf_der: &'a [u8],
+    verified_boot_key: &'a [u8; 32],
+    verified_boot_hash: &'a [u8; 32],
+}
+
+fn parse_child_key_rewrite_request(
+    request: &[u8],
+) -> Result<ParsedChildKeyRewrite<'_>, &'static str> {
+    let mut cursor = Cursor::new(request);
+    if cursor.read_u8()? != REWRITE_WIRE_VERSION {
+        return Err("unsupported certificate rewrite wire version");
+    }
+    let calling_uid = cursor.read_u32()?;
+    let is_attest_key = cursor.read_u8()? != 0;
+    let patch_levels = PatchLevels {
+        system: read_patch(&mut cursor)?,
+        vendor: read_patch(&mut cursor)?,
+        boot: read_patch(&mut cursor)?,
+    };
+    let id_count = cursor.read_u8()? as usize;
+    if id_count > MAX_ID_OVERRIDES {
+        return Err("too many attestation ID overrides");
+    }
+    let module_hash_len = cursor.read_u16()? as usize;
+    if module_hash_len > MAX_MODULE_HASH_BYTES {
+        return Err("module hash exceeds certificate wire bound");
+    }
+    let genuine_leaf_len = cursor.read_u32_as_usize()?;
+    if genuine_leaf_len == 0 || genuine_leaf_len > MAX_CERTIFICATE_DER_BYTES {
+        return Err("certificate DER field exceeds wire bound");
+    }
+    let verified_boot_key: &[u8; 32] = cursor
+        .read_exact(32)?
+        .try_into()
+        .map_err(|_| "invalid verified boot key")?;
+    let verified_boot_hash: &[u8; 32] = cursor
+        .read_exact(32)?
+        .try_into()
+        .map_err(|_| "invalid verified boot hash")?;
+    if verified_boot_key.iter().all(|byte| *byte == 0)
+        || verified_boot_hash.iter().all(|byte| *byte == 0)
+    {
+        return Err("verified boot digest is unavailable");
+    }
+
+    let mut id_overrides = Vec::new();
+    id_overrides
+        .try_reserve_exact(id_count)
+        .map_err(|_| "attestation ID allocation failed")?;
+    let mut seen_tags = [0u16; MAX_ID_OVERRIDES];
+    for seen_count in 0..id_count {
+        let tag = cursor.read_u16()?;
+        let length = cursor.read_u16()? as usize;
+        if length == 0 || length > MAX_ATTESTATION_ID_BYTES {
+            return Err("attestation ID override exceeds wire bound");
+        }
+        if seen_tags[..seen_count].contains(&tag) {
+            return Err("duplicate attestation ID override");
+        }
+        seen_tags[seen_count] = tag;
+        let value = cursor.read_exact(length)?;
+        id_overrides.push(AttestationIdOverride {
+            tag: u32::from(tag),
+            value,
+        });
+    }
+    let module_hash = if module_hash_len == 0 {
+        None
+    } else {
+        Some(cursor.read_exact(module_hash_len)?)
+    };
+    let genuine_leaf_der = cursor.read_exact(genuine_leaf_len)?;
+    if !cursor.is_at_end() {
+        return Err("trailing certificate wire bytes");
+    }
+
+    Ok(ParsedChildKeyRewrite {
+        calling_uid,
+        is_attest_key,
+        patch_levels,
+        id_overrides,
+        module_hash,
+        genuine_leaf_der,
+        verified_boot_key,
+        verified_boot_hash,
+    })
+}
+
 fn read_patch(cursor: &mut Cursor<'_>) -> Result<PatchComponent, &'static str> {
     let disposition = cursor.read_u8()?;
     let value = cursor.read_i32()?;
@@ -269,6 +594,14 @@ impl<'a> Cursor<'a> {
             .try_into()
             .map_err(|_| "truncated certificate wire")?;
         Ok(i32::from_be_bytes(bytes))
+    }
+
+    fn read_u32(&mut self) -> Result<u32, &'static str> {
+        let bytes: [u8; 4] = self
+            .read_exact(4)?
+            .try_into()
+            .map_err(|_| "truncated certificate wire")?;
+        Ok(u32::from_be_bytes(bytes))
     }
 
     fn read_u32_as_usize(&mut self) -> Result<usize, &'static str> {

--- a/rust/backend/src/lib.rs
+++ b/rust/backend/src/lib.rs
@@ -1,6 +1,7 @@
 // Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
 #![forbid(unsafe_code)]
 
+mod attest_key_store;
 mod certificate_wire;
 mod crl_wire;
 mod keybox_wire;
@@ -23,4 +24,10 @@ pub fn fuzz_keybox_wire(input: &[u8]) {
     if let Ok(response) = keybox_wire::parse_and_encode(input.to_vec()) {
         assert!(response.len() <= keybox_wire::MAX_KEYBOX_RESPONSE_BYTES);
     }
+}
+
+/// Fuzz-only entry point for the real attest-key and child-key rewrite wire parsers.
+pub fn fuzz_attest_key_wire(input: &[u8]) {
+    let _ = certificate_wire::rewrite_attest_key_and_encode(input.to_vec());
+    let _ = certificate_wire::rewrite_child_key_and_encode(input.to_vec());
 }

--- a/rust/backend/src/main.rs
+++ b/rust/backend/src/main.rs
@@ -1,4 +1,5 @@
 // Additional GPLv3 section 7(b) attribution term for tryigit-owned material: see ../../NOTICE.
+mod attest_key_store;
 mod backend_instance;
 mod certificate_wire;
 mod crl_wire;
@@ -60,6 +61,8 @@ const OP_CRL_CHECK_BATCH: u16 = 27;
 const OP_CBOX_UNLOCK: u16 = 29;
 const OP_KEYBOX_BROKER_OPEN: u16 = 30;
 const OP_CBOX_RECOVER: u16 = 31;
+const OP_ATTEST_KEY_REWRITE: u16 = 32;
+const OP_CHILD_KEY_REWRITE: u16 = 33;
 const SCOPE_CONFIG_ROOT: u8 = 0;
 const SCOPE_KEYBOX_DIRECTORY: u8 = 1;
 
@@ -368,6 +371,8 @@ fn opcode_request_limit(opcode: u16) -> Option<usize> {
         OP_KEYBOX_FILE_PARSE => Some(MAX_KEYBOX_FILE_REQUEST_BYTES),
         OP_CERTIFICATE_INSPECT => Some(certificate_wire::MAX_INSPECT_REQUEST_BYTES),
         OP_CERTIFICATE_REWRITE => Some(certificate_wire::MAX_REWRITE_REQUEST_BYTES),
+        OP_ATTEST_KEY_REWRITE => Some(certificate_wire::MAX_ATTEST_KEY_REWRITE_REQUEST_BYTES),
+        OP_CHILD_KEY_REWRITE => Some(certificate_wire::MAX_CHILD_KEY_REWRITE_REQUEST_BYTES),
         OP_CRL_CHECK_BATCH => Some(crl_wire::MAX_REQUEST_BYTES),
         backend_instance::OP_BACKEND_PING => Some(backend_instance::REQUEST_BYTES),
         _ => None,
@@ -381,7 +386,9 @@ fn opcode_response_limit(opcode: u16) -> Option<usize> {
         OP_CRYPTO_BACKUP_ENCRYPT | OP_CRYPTO_BACKUP_DECRYPT => Some(MAX_BACKUP_RESPONSE_BYTES),
         OP_KEYBOX_PARSE | OP_KEYBOX_FILE_PARSE => Some(MAX_KEYBOX_RESPONSE_BYTES),
         OP_CERTIFICATE_INSPECT => Some(certificate_wire::INSPECT_RESPONSE_BYTES),
-        OP_CERTIFICATE_REWRITE => Some(certificate_wire::MAX_REWRITE_RESPONSE_BYTES),
+        OP_CERTIFICATE_REWRITE | OP_ATTEST_KEY_REWRITE | OP_CHILD_KEY_REWRITE => {
+            Some(certificate_wire::MAX_REWRITE_RESPONSE_BYTES)
+        }
         OP_CRL_CHECK_BATCH => Some(crl_wire::MAX_RESPONSE_BYTES),
         backend_instance::OP_BACKEND_PING => Some(backend_instance::RESPONSE_BYTES),
         _ => None,
@@ -467,6 +474,8 @@ fn handle_request(opcode: u16, mut request: Vec<u8>) -> Result<Vec<u8>, &'static
         OP_KEYBOX_PARSE => keybox_wire::parse_and_encode(request),
         OP_CERTIFICATE_INSPECT => certificate_wire::inspect_and_encode(request),
         OP_CERTIFICATE_REWRITE => certificate_wire::rewrite_and_encode(request),
+        OP_ATTEST_KEY_REWRITE => certificate_wire::rewrite_attest_key_and_encode(request),
+        OP_CHILD_KEY_REWRITE => certificate_wire::rewrite_child_key_and_encode(request),
         OP_CRL_CHECK_BATCH => crl_wire::handle(request),
         backend_instance::OP_BACKEND_PING => backend_instance::handle(request),
         _ => {
@@ -1006,8 +1015,26 @@ mod tests {
             opcode_response_limit(OP_CERTIFICATE_REWRITE),
             Some(certificate_wire::MAX_REWRITE_RESPONSE_BYTES)
         );
+        assert_eq!(
+            opcode_request_limit(OP_ATTEST_KEY_REWRITE),
+            Some(certificate_wire::MAX_ATTEST_KEY_REWRITE_REQUEST_BYTES)
+        );
+        assert_eq!(
+            opcode_response_limit(OP_ATTEST_KEY_REWRITE),
+            Some(certificate_wire::MAX_REWRITE_RESPONSE_BYTES)
+        );
+        assert_eq!(
+            opcode_request_limit(OP_CHILD_KEY_REWRITE),
+            Some(certificate_wire::MAX_CHILD_KEY_REWRITE_REQUEST_BYTES)
+        );
+        assert_eq!(
+            opcode_response_limit(OP_CHILD_KEY_REWRITE),
+            Some(certificate_wire::MAX_REWRITE_RESPONSE_BYTES)
+        );
         assert!(handle_request(OP_CERTIFICATE_INSPECT, vec![1]).is_err());
         assert!(handle_request(OP_CERTIFICATE_REWRITE, vec![1]).is_err());
+        assert!(handle_request(OP_ATTEST_KEY_REWRITE, vec![1]).is_err());
+        assert!(handle_request(OP_CHILD_KEY_REWRITE, vec![1]).is_err());
     }
 
     #[test]

--- a/rust/certificate-core/Cargo.toml
+++ b/rust/certificate-core/Cargo.toml
@@ -21,6 +21,7 @@ sha2 = { version = "=0.11.0", features = ["oid"] }
 signature = "=3.0.0"
 x509-cert = { version = "=0.3.0", default-features = false, features = ["pem", "std"] }
 zeroize = "=1.9.0"
+getrandom = { workspace = true }
 
 [dev-dependencies]
 cleverestricky-keybox-core = { path = "../keybox-core" }

--- a/rust/certificate-core/src/lib.rs
+++ b/rust/certificate-core/src/lib.rs
@@ -9,7 +9,10 @@ use cleverestricky_attestation_core::{
 use p256::ecdsa::{
     Signature as EcSignature, SigningKey as EcSigningKey, VerifyingKey as EcVerifyingKey,
 };
-use p256::pkcs8::{DecodePrivateKey as _, DecodePublicKey as _};
+use p256::pkcs8::{
+    DecodePrivateKey as _, DecodePublicKey as _, EncodePrivateKey as _, EncodePublicKey as _,
+};
+use p256::SecretKey as P256SecretKey;
 use rsa::pkcs1v15::{
     Signature as RsaSignature, SigningKey as RsaSigningKey, VerifyingKey as RsaVerifyingKey,
 };
@@ -20,6 +23,7 @@ use signature::{Signer as _, Verifier as _};
 use std::fmt;
 use x509_cert::spki::ObjectIdentifier;
 use x509_cert::Certificate;
+use zeroize::Zeroizing;
 
 pub const MAX_CERTIFICATE_DER_BYTES: usize = 256 * 1024;
 pub const MAX_PRIVATE_KEY_DER_BYTES: usize = 3 * MAX_CERTIFICATE_DER_BYTES;
@@ -43,6 +47,11 @@ pub enum SigningAlgorithm {
     RsaPkcs1Sha256,
 }
 
+pub struct GeneratedEcKeypair {
+    pub public_key_spki_der: Vec<u8>,
+    pub private_key_pkcs8_der: Zeroizing<Vec<u8>>,
+}
+
 pub struct CertificateRewriteRequest<'a> {
     pub genuine_leaf_der: &'a [u8],
     pub issuer_certificate_der: &'a [u8],
@@ -53,6 +62,7 @@ pub struct CertificateRewriteRequest<'a> {
     pub module_hash: Option<&'a [u8]>,
     pub verified_boot_key: &'a [u8; 32],
     pub verified_boot_hash: &'a [u8; 32],
+    pub subject_public_key_info: Option<&'a [u8]>,
 }
 
 pub struct PreparedCertificateRewriteRequest<'a> {
@@ -63,6 +73,7 @@ pub struct PreparedCertificateRewriteRequest<'a> {
     pub module_hash: Option<&'a [u8]>,
     pub verified_boot_key: &'a [u8; 32],
     pub verified_boot_hash: &'a [u8; 32],
+    pub subject_public_key_info: Option<&'a [u8]>,
 }
 
 enum PreparedSigner {
@@ -146,8 +157,45 @@ impl PreparedIssuer {
         })
     }
 
+    pub fn from_subject_and_key(
+        issuer_name_der: Vec<u8>,
+        issuer_private_key_pkcs8: &[u8],
+        signing_algorithm: SigningAlgorithm,
+    ) -> Result<Self, Error> {
+        if issuer_name_der.is_empty()
+            || issuer_name_der.len() > MAX_CERTIFICATE_DER_BYTES
+            || issuer_private_key_pkcs8.is_empty()
+            || issuer_private_key_pkcs8.len() > MAX_PRIVATE_KEY_DER_BYTES
+        {
+            return Err(Error::Bounds);
+        }
+
+        let signer = match signing_algorithm {
+            SigningAlgorithm::EcP256Sha256 => {
+                let signer = EcSigningKey::from_pkcs8_der(issuer_private_key_pkcs8)
+                    .map_err(|_| Error::InvalidPrivateKey)?;
+                PreparedSigner::Ec(signer)
+            }
+            SigningAlgorithm::RsaPkcs1Sha256 => {
+                let signer = RsaSigningKey::<RsaSha256>::from_pkcs8_der(issuer_private_key_pkcs8)
+                    .map_err(|_| Error::InvalidPrivateKey)?;
+                PreparedSigner::Rsa(Box::new(signer))
+            }
+        };
+
+        Ok(Self {
+            algorithm: signing_algorithm,
+            issuer_name_der,
+            signer,
+        })
+    }
+
     pub fn algorithm(&self) -> SigningAlgorithm {
         self.algorithm
+    }
+
+    pub fn issuer_name_der(&self) -> &[u8] {
+        &self.issuer_name_der
     }
 
     fn sign_certificate(&self, tbs_der: &[u8], algorithm_der: &[u8]) -> Result<Vec<u8>, Error> {
@@ -222,6 +270,7 @@ pub fn rewrite_certificate(
         module_hash: request.module_hash,
         verified_boot_key: request.verified_boot_key,
         verified_boot_hash: request.verified_boot_hash,
+        subject_public_key_info: request.subject_public_key_info,
     })
 }
 
@@ -380,7 +429,7 @@ pub fn rewrite_certificate_prepared(
     tbs_len += 1;
     tbs_out[tbs_len] = subject;
     tbs_len += 1;
-    tbs_out[tbs_len] = spki;
+    tbs_out[tbs_len] = request.subject_public_key_info.unwrap_or(spki);
     tbs_len += 1;
     if let Some(uid) = issuer_unique_id {
         tbs_out[tbs_len] = uid;
@@ -423,6 +472,52 @@ fn signature_algorithm_der(algorithm: SigningAlgorithm) -> &'static [u8] {
         SigningAlgorithm::EcP256Sha256 => ECDSA_SHA256_ALGORITHM_DER,
         SigningAlgorithm::RsaPkcs1Sha256 => RSA_SHA256_ALGORITHM_DER,
     }
+}
+
+pub fn generate_ec_p256_keypair() -> Result<GeneratedEcKeypair, Error> {
+    let mut scalar = [0u8; 32];
+    for _ in 0..8 {
+        getrandom::fill(&mut scalar).map_err(|_| Error::Signature)?;
+        if let Ok(secret_key) = P256SecretKey::from_slice(&scalar) {
+            let pkcs8 = secret_key.to_pkcs8_der().map_err(|_| Error::Encoding)?;
+            let spki = secret_key
+                .public_key()
+                .to_public_key_der()
+                .map_err(|_| Error::Encoding)?;
+            return Ok(GeneratedEcKeypair {
+                public_key_spki_der: spki.as_bytes().to_vec(),
+                private_key_pkcs8_der: Zeroizing::new(pkcs8.as_bytes().to_vec()),
+            });
+        }
+    }
+    Err(Error::Signature)
+}
+
+pub fn parse_certificate_subject_and_issuer(
+    certificate_der: &[u8],
+) -> Result<(Vec<u8>, Vec<u8>), Error> {
+    if certificate_der.is_empty() || certificate_der.len() > MAX_CERTIFICATE_DER_BYTES {
+        return Err(Error::Bounds);
+    }
+    let cert_seq = parse_any(certificate_der)?;
+    if cert_seq.tag() != Tag::Sequence {
+        return Err(Error::InvalidCertificate);
+    }
+    let mut cert_iter = TlvIterator::new(cert_seq.value());
+    let tbs_der = next_required_tlv(&mut cert_iter)?;
+    let tbs_seq = parse_any(tbs_der)?;
+    if tbs_seq.tag() != Tag::Sequence {
+        return Err(Error::InvalidCertificate);
+    }
+    let mut tbs_iter = TlvIterator::new(tbs_seq.value());
+    let version = next_required_tlv(&mut tbs_iter)?;
+    validate_v3_version(version)?;
+    let _serial = next_required_tlv(&mut tbs_iter)?;
+    let _algorithm = next_required_tlv(&mut tbs_iter)?;
+    let issuer = next_required_tlv(&mut tbs_iter)?;
+    let _validity = next_required_tlv(&mut tbs_iter)?;
+    let subject = next_required_tlv(&mut tbs_iter)?;
+    Ok((subject.to_vec(), issuer.to_vec()))
 }
 
 pub(crate) fn parse_any(encoded: &[u8]) -> Result<AnyRef<'_>, Error> {

--- a/rust/certificate-core/tests/prepared_rewrite.rs
+++ b/rust/certificate-core/tests/prepared_rewrite.rs
@@ -40,6 +40,7 @@ mod fixture {
                 module_hash: Some(b"new-module-hash"),
                 verified_boot_key: &BOOT_KEY,
                 verified_boot_hash: &BOOT_HASH,
+                subject_public_key_info: None,
             },
         )
         .expect("prepared Rust certificate rewrite");
@@ -152,6 +153,7 @@ mod fixture {
                 module_hash: None,
                 verified_boot_key: &BOOT_KEY,
                 verified_boot_hash: &BOOT_HASH,
+                subject_public_key_info: None,
             },
         )
         .expect("rewrite critical attestation extension");
@@ -227,6 +229,7 @@ mod fixture {
                 module_hash: None,
                 verified_boot_key: &BOOT_KEY,
                 verified_boot_hash: &BOOT_HASH,
+                subject_public_key_info: None,
             },
         );
         assert!(matches!(
@@ -275,6 +278,7 @@ mod fixture {
                 module_hash: None,
                 verified_boot_key: &BOOT_KEY,
                 verified_boot_hash: &BOOT_HASH,
+                subject_public_key_info: None,
             },
         );
         assert!(matches!(

--- a/rust/certificate-core/tests/prepared_rewrite_structure.rs
+++ b/rust/certificate-core/tests/prepared_rewrite_structure.rs
@@ -45,6 +45,7 @@ mod fixture {
                 module_hash: None,
                 verified_boot_key: &BOOT_KEY,
                 verified_boot_hash: &BOOT_HASH,
+                subject_public_key_info: None,
             },
         );
         assert!(matches!(

--- a/rust/certificate-core/tests/rewrite.rs
+++ b/rust/certificate-core/tests/rewrite.rs
@@ -30,6 +30,96 @@ fn rewrites_and_resigns_rsa_leaf_with_managed_builder_semantics() {
 }
 
 #[test]
+fn attest_key_and_child_key_rootoftrust_and_signature_convergence() {
+    let document = parse_keybox_xml_bytes(VALID_EC).expect("EC fixture XML");
+    let key = document.keys.first().expect("EC fixture key");
+    let private_key = normalize_private_key_pkcs8(&key.algorithm, &key.private_key_pem)
+        .expect("EC fixture key DER");
+    let issuer_pem = key
+        .certificates_pem
+        .first()
+        .expect("EC fixture issuer certificate");
+    let keybox_ca = Certificate::from_pem(normalized_pem(issuer_pem).as_bytes())
+        .expect("EC fixture issuer DER");
+    let keybox_ca_der = keybox_ca.to_der().expect("keybox CA DER");
+
+    // 1. Generate K1 (attest key)
+    let k1_genuine = synthetic_genuine_leaf(&keybox_ca);
+    let k1_genuine_der = k1_genuine.to_der().expect("k1 genuine DER");
+
+    let generated_k1 = cleverestricky_certificate_core::generate_ec_p256_keypair()
+        .expect("generate EC keypair for K1");
+
+    let k1_rewritten = rewrite_certificate(&CertificateRewriteRequest {
+        genuine_leaf_der: &k1_genuine_der,
+        issuer_certificate_der: &keybox_ca_der,
+        issuer_private_key_pkcs8: private_key.as_slice(),
+        signing_algorithm: SigningAlgorithm::EcP256Sha256,
+        patch_levels: PatchLevels::default(),
+        id_overrides: &[],
+        module_hash: None,
+        verified_boot_key: &BOOT_KEY,
+        verified_boot_hash: &BOOT_HASH,
+        subject_public_key_info: Some(&generated_k1.public_key_spki_der),
+    })
+    .expect("rewrite K1 leaf");
+
+    let k1_cert = Certificate::from_der(&k1_rewritten.leaf_der).expect("K1 cert DER");
+    // Verify K1's public key matches the generated keypair
+    assert_eq!(
+        k1_cert
+            .tbs_certificate()
+            .subject_public_key_info()
+            .to_der()
+            .unwrap(),
+        generated_k1.public_key_spki_der
+    );
+    // Verify K1 is signed by Keybox CA
+    verify_signature(&k1_cert, &keybox_ca, SigningAlgorithm::EcP256Sha256);
+
+    // 2. Prepare K1 as issuer for K2
+    let (k1_subject_der, _) =
+        cleverestricky_certificate_core::parse_certificate_subject_and_issuer(
+            &k1_rewritten.leaf_der,
+        )
+        .expect("parse K1 subject and issuer");
+
+    let k1_prepared_issuer = cleverestricky_certificate_core::PreparedIssuer::from_subject_and_key(
+        k1_subject_der,
+        &generated_k1.private_key_pkcs8_der,
+        SigningAlgorithm::EcP256Sha256,
+    )
+    .expect("prepare K1 issuer");
+
+    // 3. Child key K2 genuine leaf (minted by hardware KeyMint, with K1 as issuer)
+    let k2_genuine = synthetic_genuine_leaf(&k1_cert);
+    let k2_genuine_der = k2_genuine.to_der().expect("K2 genuine DER");
+
+    let k2_rewritten = cleverestricky_certificate_core::rewrite_certificate_prepared(
+        &cleverestricky_certificate_core::PreparedCertificateRewriteRequest {
+            genuine_leaf_der: &k2_genuine_der,
+            issuer: &k1_prepared_issuer,
+            patch_levels: PatchLevels::default(),
+            id_overrides: &[],
+            module_hash: None,
+            verified_boot_key: &BOOT_KEY,
+            verified_boot_hash: &BOOT_HASH,
+            subject_public_key_info: None, // K2 keeps genuine hardware SPKI
+        },
+    )
+    .expect("rewrite K2 child leaf");
+
+    let k2_cert = Certificate::from_der(&k2_rewritten.leaf_der).expect("K2 cert DER");
+    // Verify K2 preserves genuine SPKI
+    assert_eq!(
+        k2_cert.tbs_certificate().subject_public_key_info(),
+        k2_genuine.tbs_certificate().subject_public_key_info()
+    );
+    // Verify K2 is signed by K1 (verifies with K1's public key!)
+    verify_signature(&k2_cert, &k1_cert, SigningAlgorithm::EcP256Sha256);
+}
+
+#[test]
 fn ec_issuer_resigns_rsa_subject_without_changing_subject_spki() {
     let ec_document = parse_keybox_xml_bytes(VALID_EC).expect("EC fixture XML");
     let ec_key = ec_document.keys.first().expect("EC fixture key");
@@ -72,6 +162,7 @@ fn ec_issuer_resigns_rsa_subject_without_changing_subject_spki() {
         module_hash: None,
         verified_boot_key: &BOOT_KEY,
         verified_boot_hash: &BOOT_HASH,
+        subject_public_key_info: None,
     })
     .expect("cross-algorithm Rust certificate rewrite");
     let output = Certificate::from_der(&rewritten.leaf_der).expect("rewritten certificate DER");
@@ -132,6 +223,7 @@ fn run_fixture(xml: &[u8], algorithm: SigningAlgorithm) {
         module_hash: Some(b"new-module-hash"),
         verified_boot_key: &BOOT_KEY,
         verified_boot_hash: &BOOT_HASH,
+        subject_public_key_info: None,
     })
     .expect("Rust certificate rewrite");
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/CertificateBackend.kt
@@ -56,6 +56,12 @@ object CertificateBackend {
     internal var rewriteOverride: ((RewriteRequest) -> ByteArray?)? = null
 
     @VisibleForTesting
+    internal var rewriteAttestKeyOverride: ((Int, RewriteRequest) -> ByteArray?)? = null
+
+    @VisibleForTesting
+    internal var rewriteChildKeyOverride: ((Int, Boolean, ByteArray, ByteArray, ByteArray) -> ByteArray?)? = null
+
+    @VisibleForTesting
     internal var rewriteTransportOverride: ((Int, (OutputStream) -> Unit) -> ByteArray?)? = null
 
     @JvmStatic
@@ -178,11 +184,204 @@ object CertificateBackend {
         )
     }
 
+    @JvmStatic
+    fun rewriteAttestKey(
+        callingUid: Int,
+        genuineLeafDer: ByteArray,
+        keyId: ByteArray,
+        signingAlgorithm: Int,
+        systemDisposition: Int,
+        systemValue: Int,
+        vendorDisposition: Int,
+        vendorValue: Int,
+        bootDisposition: Int,
+        bootValue: Int,
+        idOverrides: Map<Int, ByteArray>,
+        moduleHash: ByteArray?,
+        verifiedBootKey: ByteArray,
+        verifiedBootHash: ByteArray,
+    ): ByteArray? {
+        if (callingUid < 0 || genuineLeafDer.isEmpty() || genuineLeafDer.size > MAX_CERTIFICATE_DER_BYTES ||
+            keyId.size != KEY_ID_BYTES || keyId.all { it == 0.toByte() } ||
+            signingAlgorithm !in SIGNING_EC_P256_SHA256..SIGNING_RSA_PKCS1_SHA256 ||
+            !validPatch(systemDisposition, systemValue) ||
+            !validPatch(vendorDisposition, vendorValue) ||
+            !validPatch(bootDisposition, bootValue) ||
+            idOverrides.size > MAX_ID_OVERRIDES ||
+            moduleHash?.let { it.isEmpty() || it.size > MAX_MODULE_HASH_BYTES } == true ||
+            verifiedBootKey.size != BOOT_DIGEST_BYTES ||
+            verifiedBootHash.size != BOOT_DIGEST_BYTES ||
+            verifiedBootKey.all { it == 0.toByte() } ||
+            verifiedBootHash.all { it == 0.toByte() }
+        ) {
+            return null
+        }
+
+        val orderedIds = idOverrides.entries.sortedBy { it.key }
+        var idWireBytes = 0
+        for ((tag, value) in orderedIds) {
+            if (tag !in ATTESTATION_ID_TAGS || value.isEmpty() || value.size > MAX_ATTESTATION_ID_BYTES) {
+                return null
+            }
+            idWireBytes = checkedAdd(idWireBytes, ID_HEADER_BYTES, value.size) ?: return null
+        }
+        val payloadLength =
+            checkedAdd(
+                ATTEST_KEY_REWRITE_FIXED_BYTES,
+                idWireBytes,
+                moduleHash?.size ?: 0,
+                genuineLeafDer.size,
+            ) ?: return null
+        if (payloadLength > MAX_ATTEST_KEY_REWRITE_REQUEST_BYTES) return null
+
+        rewriteAttestKeyOverride?.let { override ->
+            val result =
+                override(
+                    callingUid,
+                    RewriteRequest(
+                        genuineLeafDer = genuineLeafDer,
+                        keyId = keyId,
+                        signingAlgorithm = signingAlgorithm,
+                        systemDisposition = systemDisposition,
+                        systemValue = systemValue,
+                        vendorDisposition = vendorDisposition,
+                        vendorValue = vendorValue,
+                        bootDisposition = bootDisposition,
+                        bootValue = bootValue,
+                        idOverrides = idOverrides,
+                        moduleHash = moduleHash,
+                        verifiedBootKey = verifiedBootKey,
+                        verifiedBootHash = verifiedBootHash,
+                    ),
+                )
+            return if (result != null && (result.isEmpty() || result.size > MAX_REWRITTEN_LEAF_BYTES)) null else result
+        }
+
+        val writePayload: (OutputStream) -> Unit = { output ->
+            output.write(REWRITE_WIRE_VERSION)
+            writeI32(output, callingUid)
+            output.write(signingAlgorithm)
+            writePatch(output, systemDisposition, systemValue)
+            writePatch(output, vendorDisposition, vendorValue)
+            writePatch(output, bootDisposition, bootValue)
+            output.write(orderedIds.size)
+            writeU16(output, moduleHash?.size ?: 0)
+            writeI32(output, genuineLeafDer.size)
+            output.write(keyId)
+            output.write(verifiedBootKey)
+            output.write(verifiedBootHash)
+            for ((tag, value) in orderedIds) {
+                writeU16(output, tag)
+                writeU16(output, value.size)
+                output.write(value)
+            }
+            if (moduleHash != null) output.write(moduleHash)
+            output.write(genuineLeafDer)
+        }
+        return NativeBackend.transact(
+            OP_ATTEST_KEY_REWRITE,
+            payloadLength,
+            MAX_REWRITTEN_LEAF_BYTES,
+            propagateTransportFailure = true,
+            writePayload = writePayload,
+        )
+    }
+
+    @JvmStatic
+    fun rewriteChildKey(
+        callingUid: Int,
+        genuineLeafDer: ByteArray,
+        isAttestKey: Boolean,
+        systemDisposition: Int,
+        systemValue: Int,
+        vendorDisposition: Int,
+        vendorValue: Int,
+        bootDisposition: Int,
+        bootValue: Int,
+        idOverrides: Map<Int, ByteArray>,
+        moduleHash: ByteArray?,
+        verifiedBootKey: ByteArray,
+        verifiedBootHash: ByteArray,
+    ): ByteArray? {
+        if (callingUid < 0 || genuineLeafDer.isEmpty() || genuineLeafDer.size > MAX_CERTIFICATE_DER_BYTES ||
+            !validPatch(systemDisposition, systemValue) ||
+            !validPatch(vendorDisposition, vendorValue) ||
+            !validPatch(bootDisposition, bootValue) ||
+            idOverrides.size > MAX_ID_OVERRIDES ||
+            moduleHash?.let { it.isEmpty() || it.size > MAX_MODULE_HASH_BYTES } == true ||
+            verifiedBootKey.size != BOOT_DIGEST_BYTES ||
+            verifiedBootHash.size != BOOT_DIGEST_BYTES ||
+            verifiedBootKey.all { it == 0.toByte() } ||
+            verifiedBootHash.all { it == 0.toByte() }
+        ) {
+            return null
+        }
+
+        val orderedIds = idOverrides.entries.sortedBy { it.key }
+        var idWireBytes = 0
+        for ((tag, value) in orderedIds) {
+            if (tag !in ATTESTATION_ID_TAGS || value.isEmpty() || value.size > MAX_ATTESTATION_ID_BYTES) {
+                return null
+            }
+            idWireBytes = checkedAdd(idWireBytes, ID_HEADER_BYTES, value.size) ?: return null
+        }
+        val payloadLength =
+            checkedAdd(
+                CHILD_KEY_REWRITE_FIXED_BYTES,
+                idWireBytes,
+                moduleHash?.size ?: 0,
+                genuineLeafDer.size,
+            ) ?: return null
+        if (payloadLength > MAX_CHILD_KEY_REWRITE_REQUEST_BYTES) return null
+
+        rewriteChildKeyOverride?.let { override ->
+            val result =
+                override(
+                    callingUid,
+                    isAttestKey,
+                    genuineLeafDer,
+                    verifiedBootKey,
+                    verifiedBootHash,
+                )
+            return if (result != null && (result.isEmpty() || result.size > MAX_REWRITTEN_LEAF_BYTES)) null else result
+        }
+
+        val writePayload: (OutputStream) -> Unit = { output ->
+            output.write(REWRITE_WIRE_VERSION)
+            writeI32(output, callingUid)
+            output.write(if (isAttestKey) 1 else 0)
+            writePatch(output, systemDisposition, systemValue)
+            writePatch(output, vendorDisposition, vendorValue)
+            writePatch(output, bootDisposition, bootValue)
+            output.write(orderedIds.size)
+            writeU16(output, moduleHash?.size ?: 0)
+            writeI32(output, genuineLeafDer.size)
+            output.write(verifiedBootKey)
+            output.write(verifiedBootHash)
+            for ((tag, value) in orderedIds) {
+                writeU16(output, tag)
+                writeU16(output, value.size)
+                output.write(value)
+            }
+            if (moduleHash != null) output.write(moduleHash)
+            output.write(genuineLeafDer)
+        }
+        return NativeBackend.transact(
+            OP_CHILD_KEY_REWRITE,
+            payloadLength,
+            MAX_REWRITTEN_LEAF_BYTES,
+            propagateTransportFailure = true,
+            writePayload = writePayload,
+        )
+    }
+
     @VisibleForTesting
     internal fun resetForTesting() {
         inspectionOverride = null
         rewriteOverride = null
         rewriteTransportOverride = null
+        rewriteAttestKeyOverride = null
+        rewriteChildKeyOverride = null
     }
 
     internal fun decodeInspection(response: ByteArray): Inspection {
@@ -345,6 +544,8 @@ object CertificateBackend {
 
     private const val OP_CERTIFICATE_INSPECT = 25
     private const val OP_CERTIFICATE_REWRITE = 26
+    private const val OP_ATTEST_KEY_REWRITE = 32
+    private const val OP_CHILD_KEY_REWRITE = 33
     private const val INSPECT_WIRE_VERSION = 2
     private const val REWRITE_WIRE_VERSION = 2
     private const val INSPECT_RESPONSE_BYTES = 85
@@ -362,9 +563,21 @@ object CertificateBackend {
     private const val BOOT_DIGEST_BYTES = 32
     private const val ID_HEADER_BYTES = 4
     private const val REWRITE_FIXED_BYTES = 104
+    private const val ATTEST_KEY_REWRITE_FIXED_BYTES = 108
+    private const val CHILD_KEY_REWRITE_FIXED_BYTES = 92
     private const val MAX_ID_WIRE_BYTES = MAX_ID_OVERRIDES * (ID_HEADER_BYTES + MAX_ATTESTATION_ID_BYTES)
     private const val MAX_REWRITE_REQUEST_BYTES =
         REWRITE_FIXED_BYTES +
+            MAX_ID_WIRE_BYTES +
+            MAX_MODULE_HASH_BYTES +
+            MAX_CERTIFICATE_DER_BYTES
+    private const val MAX_ATTEST_KEY_REWRITE_REQUEST_BYTES =
+        ATTEST_KEY_REWRITE_FIXED_BYTES +
+            MAX_ID_WIRE_BYTES +
+            MAX_MODULE_HASH_BYTES +
+            MAX_CERTIFICATE_DER_BYTES
+    private const val MAX_CHILD_KEY_REWRITE_REQUEST_BYTES =
+        CHILD_KEY_REWRITE_FIXED_BYTES +
             MAX_ID_WIRE_BYTES +
             MAX_MODULE_HASH_BYTES +
             MAX_CERTIFICATE_DER_BYTES

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -22,6 +22,13 @@ class SecurityLevelInterceptor : BinderInterceptor() {
             getTransactCode(IKeystoreSecurityLevel.Stub::class.java, "generateKey")
 
         val INTERCEPTED_CODES = validTransactCodes(generateKeyTransaction)
+
+        private class PreTransactContext(
+            val isDefaultAttestationKey: Boolean,
+            val isAttestKeyPurpose: Boolean,
+        )
+
+        private val CURRENT_CONTEXT = ThreadLocal<PreTransactContext?>()
     }
 
     override fun onPreTransact(
@@ -37,9 +44,12 @@ class SecurityLevelInterceptor : BinderInterceptor() {
             CertHack.canHack() &&
             Config.needHack(callingUid)
         ) {
+            val isDefault = Utils.usesDefaultAttestationKey(data)
+            val isAttestKey = Utils.hasAttestKeyPurpose(data)
+            CURRENT_CONTEXT.set(PreTransactContext(isDefault, isAttestKey))
             return Continue
         }
-
+        CURRENT_CONTEXT.remove()
         return Skip
     }
 
@@ -61,8 +71,14 @@ class SecurityLevelInterceptor : BinderInterceptor() {
             reply == null ||
             resultCode != 0
         ) {
+            CURRENT_CONTEXT.remove()
             return Skip
         }
+
+        val context = CURRENT_CONTEXT.get() ?: PreTransactContext(
+            Utils.usesDefaultAttestationKey(data),
+            Utils.hasAttestKeyPurpose(data),
+        )
 
         return try {
             reply.readException()
@@ -77,11 +93,26 @@ class SecurityLevelInterceptor : BinderInterceptor() {
 
                 val originalLeafOnly = arrayOf<Certificate>(originalLeaf)
                 val rewritten =
-                    CertHack.hackCertificateChain(
-                        originalLeafOnly,
-                        callingUid,
-                        true,
-                    )
+                    if (!context.isDefaultAttestationKey) {
+                        CertHack.hackChildKeyCertificate(
+                            originalLeafOnly,
+                            callingUid,
+                            context.isAttestKeyPurpose,
+                            true,
+                        )
+                    } else if (context.isAttestKeyPurpose) {
+                        CertHack.hackAttestKeyCertificateChain(
+                            originalLeafOnly,
+                            callingUid,
+                            true,
+                        )
+                    } else {
+                        CertHack.hackCertificateChain(
+                            originalLeafOnly,
+                            callingUid,
+                            true,
+                        )
+                    }
                 if (rewritten === originalLeafOnly) {
                     return Skip
                 }
@@ -98,7 +129,7 @@ class SecurityLevelInterceptor : BinderInterceptor() {
                 }
 
                 val newLeaf = rewritten[0].encoded
-                val newChain = Utils.encodeIssuerChain(rewritten)
+                val newChain = if (!context.isDefaultAttestationKey) null else Utils.encodeIssuerChain(rewritten)
                 if (!Utils.rewriteKeyMetadataParcel(reply, parsed, newLeaf, newChain)) {
                     return Skip
                 }
@@ -121,17 +152,37 @@ class SecurityLevelInterceptor : BinderInterceptor() {
 
             val originalLeafOnly = arrayOf<Certificate>(originalLeaf)
             val rewritten =
-                CertHack.hackCertificateChain(
-                    originalLeafOnly,
-                    callingUid,
-                    true,
-                )
+                if (!context.isDefaultAttestationKey) {
+                    CertHack.hackChildKeyCertificate(
+                        originalLeafOnly,
+                        callingUid,
+                        context.isAttestKeyPurpose,
+                        true,
+                    )
+                } else if (context.isAttestKeyPurpose) {
+                    CertHack.hackAttestKeyCertificateChain(
+                        originalLeafOnly,
+                        callingUid,
+                        true,
+                    )
+                } else {
+                    CertHack.hackCertificateChain(
+                        originalLeafOnly,
+                        callingUid,
+                        true,
+                    )
+                }
             if (rewritten === originalLeafOnly) {
                 return Skip
             }
 
             if (!CertHack.applyCachedCertificateChain(metadata)) {
-                Utils.putCertificateChain(metadata, rewritten)
+                if (!context.isDefaultAttestationKey) {
+                    metadata.certificate = rewritten[0].encoded
+                    metadata.certificateChain = null
+                } else {
+                    Utils.putCertificateChain(metadata, rewritten)
+                }
             }
             reply.setDataSize(0)
             reply.setDataPosition(0)
@@ -140,6 +191,8 @@ class SecurityLevelInterceptor : BinderInterceptor() {
             OverrideReply(0, reply)
         } catch (_: Throwable) {
             Skip
+        } finally {
+            CURRENT_CONTEXT.remove()
         }
     }
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/CertHack.java
@@ -134,7 +134,7 @@ public final class CertHack {
         ) {
             this.certificates = certificates.clone();
             this.leafEncoded = Objects.requireNonNull(leafEncoded, "leafEncoded");
-            this.issuerChainEncoded = Objects.requireNonNull(issuerChainEncoded, "issuerChainEncoded");
+            this.issuerChainEncoded = issuerChainEncoded;
             this.passthrough = false;
             this.leafOnlySafe = leafOnlySafe;
             this.accountIssuerChainBytes = accountIssuerChainBytes;
@@ -1069,6 +1069,329 @@ public final class CertHack {
         } finally {
             if (keyId != null) Arrays.fill(keyId, (byte) 0);
             if (inspection != null) inspection.wipe();
+            KeyboxActivation.unlockPublishedSnapshot();
+        }
+    }
+
+    public static Certificate[] hackAttestKeyCertificateChain(Certificate[] caList, int uid) {
+        return hackAttestKeyCertificateChain(caList, uid, false);
+    }
+
+    public static Certificate[] hackAttestKeyCertificateChain(
+            Certificate[] caList, int uid, boolean leafOnlySafe) {
+        if (caList == null || caList.length == 0 || caList[0] == null) {
+            throw new UnsupportedOperationException("Certificate chain is empty");
+        }
+        KeyboxActivation.lockPublishedSnapshot();
+        CertificateBackend.Inspection attestInspection = null;
+        byte[] keyId = null;
+        try {
+            State currentState = state;
+            byte[] leafEncoded = caList[0].getEncoded();
+            if (leafEncoded.length == 0 || leafEncoded.length > MAX_LEAF_CERTIFICATE_BYTES) {
+                return caList;
+            }
+            CacheKey cacheKey = new CacheKey(leafEncoded);
+            State.CertificateCache cache = currentState.certificateCache;
+            Object cacheEpoch;
+            synchronized (cache) {
+                CachedCertificateChain cached = cache.get(cacheKey);
+                if (cached != null) {
+                    Certificate[] replacement = cached.certificateCopy();
+                    return replacement == null ? caList : replacement;
+                }
+                cacheEpoch = currentState.certificateCacheEpoch;
+            }
+
+            if (!Utils.hasAndroidAttestationExtension(caList[0])) return caList;
+
+            attestInspection = CertificateBackend.inspect(leafEncoded);
+            if (attestInspection == null) return caList;
+            int attLevel = attestInspection.getAttestationSecurityLevel();
+            int kmLevel = attestInspection.getKeymintSecurityLevel();
+            boolean isTee = attLevel == CertificateBackend.SECURITY_LEVEL_TEE
+                    && kmLevel == CertificateBackend.SECURITY_LEVEL_TEE;
+            boolean isStrongbox =
+                    (attLevel == CertificateBackend.SECURITY_LEVEL_TEE
+                            && kmLevel == CertificateBackend.SECURITY_LEVEL_STRONGBOX)
+                    || (attLevel == CertificateBackend.SECURITY_LEVEL_STRONGBOX
+                            && kmLevel == CertificateBackend.SECURITY_LEVEL_STRONGBOX);
+            boolean isTeeOrStrongbox = isTee || isStrongbox;
+            if (!isTeeOrStrongbox) {
+                synchronized (cache) {
+                    if (state == currentState && currentState.certificateCacheEpoch == cacheEpoch) {
+                        cache.putIfAbsent(cacheKey, CachedCertificateChain.passthrough());
+                    }
+                }
+                return caList;
+            }
+
+            boolean needsCapturedPatchLevels = PolicyState.INSTANCE.isFeatureEnabled(
+                    PolicyState.Feature.SECURITY_PATCH, uid);
+            byte[] originalBootKey = usableBootDigest(attestInspection.getOriginalBootKey());
+            if (originalBootKey != null) {
+                capturedHardwareBootKey = originalBootKey.clone();
+            }
+            byte[] originalBootHash = usableBootDigest(attestInspection.getOriginalBootHash());
+            if (originalBootHash != null) {
+                capturedHardwareBootHash = originalBootHash.clone();
+            }
+            byte[] verifiedBootKey = selectVerifiedBootDigest(
+                    UtilKt.getBootKey(),
+                    originalBootKey != null ? originalBootKey : capturedHardwareBootKey,
+                    UtilKt.getPersistentBootKey());
+            byte[] verifiedBootHash = selectVerifiedBootDigest(
+                    UtilKt.getBootHash(),
+                    originalBootHash != null ? originalBootHash : capturedHardwareBootHash,
+                    UtilKt.getPersistentBootHash());
+            Config.AttestationPatchLevels patchLevels = needsCapturedPatchLevels
+                    ? PolicyState.INSTANCE.resolveAttestationPatchLevels(
+                            uid,
+                            attestInspection.getSystemPatch(),
+                            attestInspection.getVendorPatch(),
+                            attestInspection.getBootPatch())
+                    : keepPatchLevels();
+
+            List<KeyBox> list;
+            var appConfig = Config.INSTANCE.getAppConfig(uid);
+            if (appConfig != null && appConfig.getKeyboxFilename() != null) {
+                List<KeyBox> candidates = currentState.keyboxFiles.get(appConfig.getKeyboxFilename());
+                List<KeyBox> matchingLevel = filterKeyboxesBySecurityLevel(candidates, isStrongbox);
+                if (!matchingLevel.isEmpty()) {
+                    candidates = matchingLevel;
+                } else if (isStrongbox) {
+                    candidates = filterKeyboxesBySecurityLevel(candidates, false);
+                } else {
+                    candidates = Collections.emptyList();
+                }
+                list = selectKeyboxPool(candidates, KeyProperties.KEY_ALGORITHM_EC);
+            } else {
+                if (isStrongbox) {
+                    if (!currentState.globalStrongBoxEc.isEmpty()) {
+                        list = currentState.globalStrongBoxEc;
+                    } else if (!currentState.globalStrongBoxRsa.isEmpty()) {
+                        list = currentState.globalStrongBoxRsa;
+                    } else if (!currentState.globalTeeEc.isEmpty()) {
+                        list = currentState.globalTeeEc;
+                    } else {
+                        list = currentState.globalTeeRsa;
+                    }
+                } else {
+                    if (!currentState.globalTeeEc.isEmpty()) {
+                        list = currentState.globalTeeEc;
+                    } else {
+                        list = currentState.globalTeeRsa;
+                    }
+                }
+            }
+            if (list.isEmpty()) {
+                return caList;
+            }
+
+            KeyBox keybox = list.get(cacheKey.indexForPool(list.size()));
+            PreparedKeyBox prepared = currentState.preparedKeyboxes.get(keybox);
+            if (prepared == null) throw new UnsupportedOperationException("Keybox metadata is unavailable");
+            int signingAlgorithm = signingWireAlgorithm(prepared.signatureAlgorithm);
+            if (signingAlgorithm == 0) return caList;
+
+            if (verifiedBootKey == null || verifiedBootHash == null) {
+                return caList;
+            }
+
+            Map<Integer, byte[]> idOverrides = presentIdOverrides(uid, attestInspection.getPresentIdMask());
+            byte[] moduleHash = attestInspection.getSupportsModuleHash()
+                    ? Config.INSTANCE.getModuleHash()
+                    : null;
+            keyId = keybox.keyPair.getPrivate().getEncoded();
+            if (keyId == null || keyId.length != BACKEND_KEY_ID_BYTES) return caList;
+
+            byte[] rewrittenDer = CertificateBackend.rewriteAttestKey(
+                    uid,
+                    leafEncoded,
+                    keyId,
+                    signingAlgorithm,
+                    patchDisposition(patchLevels.getSystem()), patchLevels.getSystem().getValue(),
+                    patchDisposition(patchLevels.getVendor()), patchLevels.getVendor().getValue(),
+                    patchDisposition(patchLevels.getBoot()), patchLevels.getBoot().getValue(),
+                    idOverrides,
+                    moduleHash,
+                    verifiedBootKey,
+                    verifiedBootHash);
+            if (rewrittenDer == null || rewrittenDer.length == 0 || rewrittenDer.length > MAX_LEAF_CERTIFICATE_BYTES) {
+                return caList;
+            }
+            byte[] encodedIssuerChain = currentState.encodedIssuerChain(prepared);
+            Certificate rewrittenLeaf = new LazyX509Certificate(rewrittenDer, false);
+            Certificate[] result = new Certificate[prepared.issuerChain.length + 1];
+            result[0] = rewrittenLeaf;
+            System.arraycopy(prepared.issuerChain, 0, result, 1, prepared.issuerChain.length);
+            CachedCertificateChain completed = new CachedCertificateChain(
+                    result,
+                    rewrittenDer,
+                    encodedIssuerChain,
+                    leafOnlySafe,
+                    true
+            );
+            synchronized (cache) {
+                if (state != currentState || currentState.certificateCacheEpoch != cacheEpoch) {
+                    return result;
+                }
+                CachedCertificateChain raced = cache.get(cacheKey);
+                if (raced != null) {
+                    Certificate[] replacement = raced.certificateCopy();
+                    return replacement == null ? caList : replacement;
+                }
+                cache.put(cacheKey, completed);
+            }
+            return result;
+        } catch (Throwable t) {
+            return caList;
+        } finally {
+            if (keyId != null) Arrays.fill(keyId, (byte) 0);
+            if (attestInspection != null) attestInspection.wipe();
+            KeyboxActivation.unlockPublishedSnapshot();
+        }
+    }
+
+    public static Certificate[] hackChildKeyCertificate(
+            Certificate[] caList, int uid, boolean isAttestKey) {
+        return hackChildKeyCertificate(caList, uid, isAttestKey, false);
+    }
+
+    public static Certificate[] hackChildKeyCertificate(
+            Certificate[] caList, int uid, boolean isAttestKey, boolean leafOnlySafe) {
+        if (caList == null || caList.length == 0 || caList[0] == null) {
+            return caList;
+        }
+        KeyboxActivation.lockPublishedSnapshot();
+        CertificateBackend.Inspection childInspection = null;
+        try {
+            State currentState = state;
+            byte[] leafEncoded = caList[0].getEncoded();
+            if (leafEncoded.length == 0 || leafEncoded.length > MAX_LEAF_CERTIFICATE_BYTES) {
+                return caList;
+            }
+            CacheKey cacheKey = new CacheKey(leafEncoded);
+            State.CertificateCache cache = currentState.certificateCache;
+            Object cacheEpoch;
+            synchronized (cache) {
+                CachedCertificateChain cached = cache.get(cacheKey);
+                if (cached != null) {
+                    Certificate[] replacement = cached.certificateCopy();
+                    return replacement == null ? caList : replacement;
+                }
+                cacheEpoch = currentState.certificateCacheEpoch;
+            }
+
+            if (!Utils.hasAndroidAttestationExtension(caList[0])) return caList;
+
+            childInspection = CertificateBackend.inspect(leafEncoded);
+            if (childInspection == null) return caList;
+            int attLevel = childInspection.getAttestationSecurityLevel();
+            int kmLevel = childInspection.getKeymintSecurityLevel();
+            boolean isTee = attLevel == CertificateBackend.SECURITY_LEVEL_TEE
+                    && kmLevel == CertificateBackend.SECURITY_LEVEL_TEE;
+            boolean isStrongbox =
+                    (attLevel == CertificateBackend.SECURITY_LEVEL_TEE
+                            && kmLevel == CertificateBackend.SECURITY_LEVEL_STRONGBOX)
+                    || (attLevel == CertificateBackend.SECURITY_LEVEL_STRONGBOX
+                            && kmLevel == CertificateBackend.SECURITY_LEVEL_STRONGBOX);
+            boolean isTeeOrStrongbox = isTee || isStrongbox;
+            if (!isTeeOrStrongbox) {
+                synchronized (cache) {
+                    if (state == currentState && currentState.certificateCacheEpoch == cacheEpoch) {
+                        cache.putIfAbsent(cacheKey, CachedCertificateChain.passthrough());
+                    }
+                }
+                return caList;
+            }
+
+            boolean needsCapturedPatchLevels = PolicyState.INSTANCE.isFeatureEnabled(
+                    PolicyState.Feature.SECURITY_PATCH, uid);
+            byte[] originalBootKey = usableBootDigest(childInspection.getOriginalBootKey());
+            if (originalBootKey != null) {
+                capturedHardwareBootKey = originalBootKey.clone();
+            }
+            byte[] originalBootHash = usableBootDigest(childInspection.getOriginalBootHash());
+            if (originalBootHash != null) {
+                capturedHardwareBootHash = originalBootHash.clone();
+            }
+            byte[] verifiedBootKey = selectVerifiedBootDigest(
+                    UtilKt.getBootKey(),
+                    originalBootKey != null ? originalBootKey : capturedHardwareBootKey,
+                    UtilKt.getPersistentBootKey());
+            byte[] verifiedBootHash = selectVerifiedBootDigest(
+                    UtilKt.getBootHash(),
+                    originalBootHash != null ? originalBootHash : capturedHardwareBootHash,
+                    UtilKt.getPersistentBootHash());
+            if (verifiedBootKey == null || verifiedBootHash == null) {
+                return caList;
+            }
+
+            Config.AttestationPatchLevels patchLevels = needsCapturedPatchLevels
+                    ? PolicyState.INSTANCE.resolveAttestationPatchLevels(
+                            uid,
+                            childInspection.getSystemPatch(),
+                            childInspection.getVendorPatch(),
+                            childInspection.getBootPatch())
+                    : keepPatchLevels();
+
+            Map<Integer, byte[]> idOverrides = presentIdOverrides(uid, childInspection.getPresentIdMask());
+            byte[] moduleHash = childInspection.getSupportsModuleHash()
+                    ? Config.INSTANCE.getModuleHash()
+                    : null;
+
+            byte[] rewrittenDer = CertificateBackend.rewriteChildKey(
+                    uid,
+                    leafEncoded,
+                    isAttestKey,
+                    patchDisposition(patchLevels.getSystem()), patchLevels.getSystem().getValue(),
+                    patchDisposition(patchLevels.getVendor()), patchLevels.getVendor().getValue(),
+                    patchDisposition(patchLevels.getBoot()), patchLevels.getBoot().getValue(),
+                    idOverrides,
+                    moduleHash,
+                    verifiedBootKey,
+                    verifiedBootHash);
+            if (rewrittenDer == null || rewrittenDer.length == 0 || rewrittenDer.length > MAX_LEAF_CERTIFICATE_BYTES) {
+                return caList;
+            }
+
+            Certificate rewrittenLeaf = new LazyX509Certificate(rewrittenDer, false);
+            Certificate[] result = new Certificate[caList.length];
+            result[0] = rewrittenLeaf;
+            if (caList.length > 1) {
+                System.arraycopy(caList, 1, result, 1, caList.length - 1);
+            }
+            byte[] encodedIssuerChain = null;
+            if (caList.length > 1) {
+                try {
+                    encodedIssuerChain = Utils.encodeIssuerChain(caList);
+                } catch (Throwable ignored) {
+                }
+            }
+            CachedCertificateChain completed = new CachedCertificateChain(
+                    result,
+                    rewrittenDer,
+                    encodedIssuerChain,
+                    leafOnlySafe,
+                    false
+            );
+            synchronized (cache) {
+                if (state != currentState || currentState.certificateCacheEpoch != cacheEpoch) {
+                    return result;
+                }
+                CachedCertificateChain raced = cache.get(cacheKey);
+                if (raced != null) {
+                    Certificate[] replacement = raced.certificateCopy();
+                    return replacement == null ? caList : replacement;
+                }
+                cache.put(cacheKey, completed);
+            }
+            return result;
+        } catch (Throwable t) {
+            return caList;
+        } finally {
+            if (childInspection != null) childInspection.wipe();
             KeyboxActivation.unlockPublishedSnapshot();
         }
     }

--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
@@ -26,6 +26,9 @@ public final class Utils {
     private static final int MAX_AUTHORIZATIONS = 256;
     private static final int MAX_REWRITTEN_PARCEL_BYTES = 8 * 1024 * 1024;
     private static final int MAX_RETAINED_SCRATCH_PARCEL_BYTES = 64 * 1024;
+    private static final int TAG_PURPOSE = 0x20000001; // TagType.ENUM_REP | 1
+    private static final int KEY_PARAMETER_VALUE_KEY_PURPOSE = 7;
+    private static final int KEY_PURPOSE_ATTEST_KEY = 7;
 
     private static final ThreadLocal<CertificateFactory> CERTIFICATE_FACTORY =
             new ThreadLocal<CertificateFactory>() {
@@ -56,6 +59,58 @@ public final class Utils {
             // We only need to distinguish the optional attestationKey, so do not instantiate its
             // hidden platform class or depend on a generated CREATOR field that may change by API.
             return request.readInt() == 0;
+        } catch (RuntimeException invalidRequest) {
+            return false;
+        } finally {
+            request.setDataPosition(position);
+        }
+    }
+
+    /**
+     * Inspects the generateKey KeyParameter array to determine if Tag.PURPOSE includes KeyPurpose.ATTEST_KEY.
+     */
+    public static boolean hasAttestKeyPurpose(Parcel request) {
+        if (request == null) return false;
+        int position = request.dataPosition();
+        try {
+            request.enforceInterface(IKeystoreSecurityLevel.DESCRIPTOR);
+            // 1. Skip key: KeyDescriptor
+            if (!skipStableTypedParcelable(request)) return false;
+            // 2. Skip optional attestationKey: KeyDescriptor
+            if (request.dataAvail() < Integer.BYTES) return false;
+            int attestationKeyPresence = request.readInt();
+            if (attestationKeyPresence == 1) {
+                if (!skipStableParcelableBody(request)) return false;
+            } else if (attestationKeyPresence != 0) {
+                return false;
+            }
+            // 3. Inspect params: KeyParameter[]
+            if (request.dataAvail() < Integer.BYTES) return false;
+            int paramCount = request.readInt();
+            if (paramCount <= 0 || paramCount > MAX_AUTHORIZATIONS) return false;
+            for (int i = 0; i < paramCount; i++) {
+                if (request.dataAvail() < Integer.BYTES) return false;
+                int paramPresence = request.readInt();
+                if (paramPresence == 0) continue;
+                if (paramPresence != 1) return false;
+
+                int parcelableStart = request.dataPosition();
+                int parcelableEnd = readStableParcelableEnd(request, request.dataSize());
+                if (parcelableEnd < 0) return false;
+
+                if (hasBytes(request, parcelableEnd, 3 * Integer.BYTES)) {
+                    int tag = request.readInt();
+                    int unionTag = request.readInt();
+                    int unionValue = request.readInt();
+                    if (tag == TAG_PURPOSE &&
+                            unionTag == KEY_PARAMETER_VALUE_KEY_PURPOSE &&
+                            unionValue == KEY_PURPOSE_ATTEST_KEY) {
+                        return true;
+                    }
+                }
+                request.setDataPosition(parcelableEnd);
+            }
+            return false;
         } catch (RuntimeException invalidRequest) {
             return false;
         } finally {
@@ -342,9 +397,9 @@ public final class Utils {
             byte[] newLeaf,
             byte[] newChain
     ) {
-        if (reply == null || parsed == null || newLeaf == null || newChain == null ||
+        if (reply == null || parsed == null || newLeaf == null ||
                 newLeaf.length == 0 || newLeaf.length > MAX_CERTIFICATE_BYTES ||
-                newChain.length > MAX_CHAIN_BYTES ||
+                (newChain != null && newChain.length > MAX_CHAIN_BYTES) ||
                 reply.dataSize() != parsed.sourceDataSize ||
                 parsed.metadataStart < 0 || parsed.certOffset < parsed.metadataStart ||
                 parsed.chainOffset < parsed.certOffset ||
@@ -354,7 +409,7 @@ public final class Utils {
         }
 
         int newCertPaddedLen = Integer.BYTES + paddedByteCount(newLeaf.length);
-        int newChainPaddedLen = Integer.BYTES + paddedByteCount(newChain.length);
+        int newChainPaddedLen = Integer.BYTES + (newChain == null ? 0 : paddedByteCount(newChain.length));
         long sizeDiff = (long) newCertPaddedLen + newChainPaddedLen -
                 parsed.oldCertPaddedLen - parsed.oldChainPaddedLen;
         long newMetadataSize = (long) parsed.metadataSize + sizeDiff;

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationInterceptorContractTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationInterceptorContractTest.java
@@ -66,6 +66,8 @@ public class AttestationInterceptorContractTest {
             Certificate[] rewrittenChain = new Certificate[] {replacementCert};
             backend.when(() -> CertHack.hackCertificateChain(any(), anyInt(), anyBoolean()))
                     .thenReturn(rewrittenChain);
+            backend.when(() -> CertHack.hackChildKeyCertificate(any(), anyInt(), anyBoolean(), anyBoolean()))
+                    .thenReturn(rewrittenChain);
 
             // Test both default RKP request (false) and custom AttestKey request (true)
             for (boolean explicitAttestKey : new boolean[] {false, true}) {
@@ -82,7 +84,54 @@ public class AttestationInterceptorContractTest {
 
             backend.verify(CertHack::canHack, org.mockito.Mockito.times(2));
             backend.verify(() -> CertHack.hackCertificateChain(any(), anyInt(), anyBoolean()),
-                    org.mockito.Mockito.times(2));
+                    org.mockito.Mockito.times(1));
+            backend.verify(() -> CertHack.hackChildKeyCertificate(any(), anyInt(), anyBoolean(), anyBoolean()),
+                    org.mockito.Mockito.times(1));
+        } finally {
+            globalModeField.set(Config.INSTANCE, prevGlobalMode);
+        }
+    }
+
+    @Test
+    public void attestKeyGenerationWithDefaultAttestationKeyRoutesToHackAttestKeyCertificateChain() throws Exception {
+        Binder target = new Binder();
+        int code = field(SecurityLevelInterceptor.class, "generateKeyTransaction").getInt(null);
+        Field globalModeField = field(Config.class, "isGlobalMode");
+        boolean prevGlobalMode = (boolean) globalModeField.get(Config.INSTANCE);
+        globalModeField.set(Config.INSTANCE, true);
+        Config.INSTANCE.setPackagesForTesting(10_001, new String[] {"com.test.app"});
+        try (MockedStatic<CertHack> backend = mockStatic(CertHack.class)) {
+            backend.when(CertHack::canHack).thenReturn(true);
+            backend.when(() -> CertHack.applyCachedCertificateChain(any())).thenReturn(false);
+
+            KeyPair parent = keyPair("EC");
+            KeyPair childKey = keyPair("EC");
+            X509Certificate childCert = certificate(childKey, parent, "child", "parent");
+            KeyMetadata metadata = metadata(childCert, childCert.getEncoded());
+            X509Certificate replacementCert = certificate(childKey, parent, "replacement", "parent");
+            Certificate[] rewrittenChain = new Certificate[] {replacementCert};
+            backend.when(() -> CertHack.hackAttestKeyCertificateChain(any(), anyInt(), anyBoolean()))
+                    .thenReturn(rewrittenChain);
+
+            Parcel request = mock(Parcel.class);
+            when(request.dataPosition()).thenReturn(28, 32, 28, 32, 40, 44);
+            when(request.dataAvail()).thenReturn(128);
+            // 3 ints for usesDefaultAttestationKey (1, 16, 0), then 9 ints for hasAttestKeyPurpose
+            when(request.readInt()).thenReturn(1, 16, 0, 1, 16, 0, 1, 1, 20, 536870913, 7, 7);
+            when(request.dataSize()).thenReturn(128);
+
+            BinderInterceptor.Result preResult = new SecurityLevelInterceptor().onPreTransact(
+                    target, code, 0, 10_001, 42, request);
+            assertSame(BinderInterceptor.Continue.INSTANCE, preResult);
+
+            Parcel reply = generatedReply(metadata);
+            BinderInterceptor.Result postResult = generate(request, reply);
+            assertTrue(postResult instanceof BinderInterceptor.OverrideReply);
+
+            backend.verify(() -> CertHack.hackAttestKeyCertificateChain(any(), anyInt(), anyBoolean()),
+                    org.mockito.Mockito.times(1));
+            backend.verify(() -> CertHack.hackCertificateChain(any(), anyInt(), anyBoolean()), never());
+            backend.verify(() -> CertHack.hackChildKeyCertificate(any(), anyInt(), anyBoolean(), anyBoolean()), never());
         } finally {
             globalModeField.set(Config.INSTANCE, prevGlobalMode);
         }


### PR DESCRIPTION
### Summary
This PR converges the RootOfTrust (deviceLocked=true, verifiedBootState=Verified) and certificate chain verification between default RKP attestation keys, caller-selected attest keys, and child keys minted by them, eliminating attestation detection divergences.

### Key Changes
- **Rust Certificate Core**:
  - Added support for generating bounded EC P-256 keypairs and parsing X.509 Subject/Issuer DER.
  - Added support for SPKI override during certificate rewriting, allowing custom attest keys to be signed by Keybox CAs while retaining genuine hardware keys for cryptographic operations.
  - Verified cryptographic signature verification under the rewritten public key.
- **Rust Backend**:
  - Added thread-safe in-memory cache mapping \(calling_uid, subject_der) -> PreparedIssuer\.
  - Implemented opcodes 32 (\OP_ATTEST_KEY_REWRITE\) and 33 (\OP_CHILD_KEY_REWRITE\).
  - Child keys are rewritten with verified RootOfTrust and resigned by their registered parent attest key, with safe fallback to genuine hardware certificates if not registered.
- **Service & Keystore Interception**:
  - \SecurityLevelInterceptor\: dynamically inspects \generateKey\ request parameters for \ttestationKey\ and \PURPOSE_ATTEST_KEY\, routing requests to default attestation rewrite, attest-key rewrite, or child-key rewrite.
  - \CertHack\: added \hackAttestKeyCertificateChain\ and \hackChildKeyCertificate\.
  - Updated parcel rewrite and cached chain handlers to support leaf-only metadata payloads.
- **Performance & Overhead**:
  - Retains 100% hardware KeyMint key generation without background daemons, polling, or idle CPU/RAM overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for rewriting attestation-key and child-key certificate chains.
  - Added automatic generation and secure handling of attestation keys.
  - Child-key certificates can preserve their original issuer chain while updating certificate details.
  - Added validation and request-size limits for the new certificate operations.
  - Certificate processing now selects the appropriate rewrite flow based on key type and attestation purpose.

- **Tests**
  - Added coverage for attestation-key and child-key certificate generation, routing, signatures, and malformed requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->