### PR TITLE
fix(keystore): canonicalize Domain.APP namespace and converge attest key parent identity

### DIFF
--- a/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
+++ b/service/src/main/java/cleveres/tricky/cleverestech/keystore/Utils.java
@@ -72,11 +72,17 @@ public final class Utils {
     public static byte[] computeKeyDescriptorIdentity(
             int callingUid, int domain, long nspace, String alias, byte[] blob) {
         try {
+            // For Domain.APP (0), Android Keystore2 binds key identity strictly to callingUid
+            // and key alias; client-provided namespace (-1 for KeyProperties.NAMESPACE_APPLICATION,
+            // 0 for default uninitialized parcelables, or callingUid) is ignored by Keystore2 daemon.
+            // Canonicalize namespace to 0L for Domain.APP so generated parent keys and child
+            // parent references produce identical identifiers.
+            long effectiveNspace = (domain == 0) ? 0L : nspace;
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             ByteBuffer buffer = ByteBuffer.allocate(4 + 4 + 8).order(ByteOrder.BIG_ENDIAN);
             buffer.putInt(callingUid);
             buffer.putInt(domain);
-            buffer.putLong(nspace);
+            buffer.putLong(effectiveNspace);
             digest.update(buffer.array());
 
             if (alias == null) {

--- a/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
+++ b/service/src/test/java/cleveres/tricky/cleverestech/keystore/AttestationRequestContractTest.java
@@ -671,6 +671,22 @@ public class AttestationRequestContractTest {
     }
 
     @Test
+    public void computeKeyDescriptorIdentityNormalizesAppDomainNamespace() {
+        int uid = 10001;
+        int domain = 0; // Domain.APP
+        String alias = "my_attest_key";
+        byte[] blob = null;
+
+        byte[] idWithAppNamespace = Utils.computeKeyDescriptorIdentity(uid, domain, -1L, alias, blob);
+        byte[] idWithZeroNamespace = Utils.computeKeyDescriptorIdentity(uid, domain, 0L, alias, blob);
+        byte[] idWithUidNamespace = Utils.computeKeyDescriptorIdentity(uid, domain, (long) uid, alias, blob);
+
+        assertEquals(32, idWithAppNamespace.length);
+        assertArrayEquals(idWithAppNamespace, idWithZeroNamespace);
+        assertArrayEquals(idWithAppNamespace, idWithUidNamespace);
+    }
+
+    @Test
     public void childAttestKeyCannotUseItsOwnDescriptorAsParent() {
         byte[] descriptor = new byte[32];
         descriptor[0] = 1;


### PR DESCRIPTION
### Summary
In Android Keystore 2.0 architecture, keys under \Domain.APP\ (0) are private to the caller UID and key alias. When KeyStore framework generates an attest key, it populates the \KeyDescriptor\ with \
space = KeyProperties.NAMESPACE_APPLICATION\ (\-1\). However, when a client application generates a child key referencing that attest key via \.setAttestKeyAlias(...)\, KeyStore framework constructs the parent \ttestationKey\ descriptor with \domain = Domain.APP\ and leaves \
space\ uninitialized, defaulting to \

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Application-domain key identifiers now remain consistent regardless of the client-provided namespace, improving matching between parent keys and child references.

- **Tests**
  - Added coverage confirming consistent identifiers across supported namespace values for application-domain keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->