### PR TITLE
fix(keystore): rehydrate persistent attest-key signers across backend restarts

### DIFF
--- a/rust/backend/src/certificate_wire.rs
+++ b/rust/backend/src/certificate_wire.rs
@@ -1,10 +1,10 @@
 use crate::attest_key_store;
 use crate::keybox_wire::key_store::{self, KeyId, KEY_ID_BYTES};
 use cleverestricky_certificate_core::{
-    generate_ec_p256_keypair, inspect_certificate, parse_certificate_subject_and_issuer,
-    rewrite_certificate_prepared, AttestationIdOverride, CertificateInspection, PatchComponent,
-    PatchLevels, PreparedCertificateRewriteRequest, PreparedIssuer, SecurityLevel,
-    SigningAlgorithm, MAX_ATTESTATION_ID_BYTES, MAX_CERTIFICATE_DER_BYTES, MAX_MODULE_HASH_BYTES,
+    inspect_certificate, parse_certificate_subject_and_issuer, rewrite_certificate_prepared,
+    AttestationIdOverride, CertificateInspection, PatchComponent, PatchLevels,
+    PreparedCertificateRewriteRequest, PreparedIssuer, SecurityLevel, SigningAlgorithm,
+    MAX_ATTESTATION_ID_BYTES, MAX_CERTIFICATE_DER_BYTES, MAX_MODULE_HASH_BYTES,
 };
 use zeroize::Zeroize;
 
@@ -85,6 +85,26 @@ fn validate_hardware_provenance(provenance: &CertificateInspection) -> Result<()
     Ok(())
 }
 
+fn derive_attest_issuer(
+    calling_uid: u32,
+    security_level: SecurityLevel,
+    attest_key_id: &[u8; 32],
+    subject_der: Vec<u8>,
+) -> Result<(Vec<u8>, PreparedIssuer), &'static str> {
+    let keypair = key_store::derive_attest_keypair(
+        calling_uid,
+        security_level.wire_value(),
+        attest_key_id,
+    )?;
+    let prepared = PreparedIssuer::from_subject_and_key(
+        subject_der,
+        &keypair.private_key_pkcs8_der,
+        SigningAlgorithm::EcP256Sha256,
+    )
+    .map_err(|_| "failed to prepare derived attest issuer")?;
+    Ok((keypair.public_key_spki_der, prepared))
+}
+
 pub fn rewrite_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'static str> {
     let result = (|| {
         if request.len() < REWRITE_FIXED_BYTES || request.len() > MAX_REWRITE_REQUEST_BYTES {
@@ -146,21 +166,19 @@ pub fn rewrite_attest_key_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'
         let (subject_der, _) = parse_certificate_subject_and_issuer(parsed.genuine_leaf_der)
             .map_err(|_| "invalid attest key certificate")?;
 
-        let keypair =
-            generate_ec_p256_keypair().map_err(|_| "failed to generate attest keypair")?;
-        let prepared_for_children = PreparedIssuer::from_subject_and_key(
-            subject_der,
-            &keypair.private_key_pkcs8_der,
-            SigningAlgorithm::EcP256Sha256,
-        )
-        .map_err(|_| "failed to prepare attest issuer")?;
-
         key_store::with_prepared_key(&parsed.key_id, |stored_algorithm, prepared_issuer| {
             if stored_algorithm != parsed.signing_algorithm
                 || prepared_issuer.algorithm() != stored_algorithm
             {
                 return Err("opaque key algorithm does not match rewrite request");
             }
+
+            let (public_key_spki_der, prepared_for_children) = derive_attest_issuer(
+                parsed.calling_uid,
+                provenance.keymint_security_level,
+                &parsed.attest_key_id,
+                subject_der,
+            )?;
             let rewritten = rewrite_certificate_prepared(&PreparedCertificateRewriteRequest {
                 genuine_leaf_der: parsed.genuine_leaf_der,
                 issuer: prepared_issuer,
@@ -169,7 +187,7 @@ pub fn rewrite_attest_key_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'
                 module_hash: parsed.module_hash,
                 verified_boot_key: parsed.verified_boot_key,
                 verified_boot_hash: parsed.verified_boot_hash,
-                subject_public_key_info: Some(&keypair.public_key_spki_der),
+                subject_public_key_info: Some(&public_key_spki_der),
             })
             .map(|rewritten| rewritten.leaf_der)
             .map_err(|_| "attest key certificate rewrite rejected")?;
@@ -199,9 +217,34 @@ pub fn rewrite_child_key_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'s
             .map_err(|_| "child key rewrite provenance rejected")?;
         validate_hardware_provenance(&provenance)?;
 
+        // A persistent Android attest-key alias can outlive this backend process. Reconstruct its
+        // synthetic signer from backend-only secret material and the canonical descriptor identity
+        // when the in-memory graph is empty after restart. The rewritten parent certificate uses
+        // the genuine subject unchanged, so the child leaf's issuer name is the exact issuer name
+        // required by the reconstructed signer.
         let parent_issuer =
-            attest_key_store::get_attest_key(parsed.calling_uid, &parsed.parent_key_id)
-                .ok_or("attest issuer not found in managed store")?;
+            if let Some(parent) =
+                attest_key_store::get_attest_key(parsed.calling_uid, &parsed.parent_key_id)
+            {
+                parent
+            } else {
+                let (_, parent_subject_der) =
+                    parse_certificate_subject_and_issuer(parsed.genuine_leaf_der)
+                        .map_err(|_| "invalid child certificate issuer")?;
+                let (_, prepared_parent) = derive_attest_issuer(
+                    parsed.calling_uid,
+                    provenance.keymint_security_level,
+                    &parsed.parent_key_id,
+                    parent_subject_der,
+                )?;
+                let prepared_parent = std::sync::Arc::new(prepared_parent);
+                attest_key_store::insert_attest_key(
+                    parsed.calling_uid,
+                    parsed.parent_key_id,
+                    std::sync::Arc::clone(&prepared_parent),
+                );
+                prepared_parent
+            };
 
         let (spki_override, prepared_for_children) = if parsed.is_attest_key {
             if !cleverestricky_certificate_core::is_ec_p256_certificate(parsed.genuine_leaf_der)
@@ -209,17 +252,15 @@ pub fn rewrite_child_key_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'s
             {
                 return Err("child attest key is not EC P-256");
             }
-            let keypair = generate_ec_p256_keypair()
-                .map_err(|_| "failed to generate child attest keypair")?;
             let (subject_der, _) = parse_certificate_subject_and_issuer(parsed.genuine_leaf_der)
                 .map_err(|_| "invalid child certificate")?;
-            let prepared = PreparedIssuer::from_subject_and_key(
+            let (public_key_spki_der, prepared) = derive_attest_issuer(
+                parsed.calling_uid,
+                provenance.keymint_security_level,
+                &parsed.child_key_id,
                 subject_der,
-                &keypair.private_key_pkcs8_der,
-                SigningAlgorithm::EcP256Sha256,
-            )
-            .map_err(|_| "failed to prepare child attest issuer")?;
-            (Some(keypair.public_key_spki_der), Some(prepared))
+            )?;
+            (Some(public_key_spki_der), Some(prepared))
         } else {
             (None, None)
         };

--- a/rust/backend/src/certificate_wire.rs
+++ b/rust/backend/src/certificate_wire.rs
@@ -214,33 +214,14 @@ pub fn rewrite_child_key_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'s
             .map_err(|_| "child key rewrite provenance rejected")?;
         validate_hardware_provenance(&provenance)?;
 
-        // A persistent Android attest-key alias can outlive this backend process. Reconstruct its
-        // synthetic signer from backend-only secret material and the canonical descriptor identity
-        // when the in-memory graph is empty after restart. The rewritten parent certificate uses
-        // the genuine subject unchanged, so the child leaf's issuer name is the exact issuer name
-        // required by the reconstructed signer.
-        let parent_issuer = if let Some(parent) =
+        // Only a parent that was authoritatively rewritten as a supported managed ATTEST_KEY may
+        // sign a synthetic child. Persistent aliases are rehydrated through getKeyEntry readback,
+        // where the real parent metadata and EC P-256 certificate are available for validation.
+        // Never infer parent eligibility from a child's issuer name: Android also supports RSA and
+        // non-P256 EC ATTEST_KEYs, which this synthetic signer path intentionally does not manage.
+        let parent_issuer =
             attest_key_store::get_attest_key(parsed.calling_uid, &parsed.parent_key_id)
-        {
-            parent
-        } else {
-            let (_, parent_subject_der) =
-                parse_certificate_subject_and_issuer(parsed.genuine_leaf_der)
-                    .map_err(|_| "invalid child certificate issuer")?;
-            let (_, prepared_parent) = derive_attest_issuer(
-                parsed.calling_uid,
-                provenance.keymint_security_level,
-                &parsed.parent_key_id,
-                parent_subject_der,
-            )?;
-            let prepared_parent = std::sync::Arc::new(prepared_parent);
-            attest_key_store::insert_attest_key(
-                parsed.calling_uid,
-                parsed.parent_key_id,
-                std::sync::Arc::clone(&prepared_parent),
-            );
-            prepared_parent
-        };
+                .ok_or("attest issuer not found in managed store")?;
 
         let (spki_override, prepared_for_children) = if parsed.is_attest_key {
             if !cleverestricky_certificate_core::is_ec_p256_certificate(parsed.genuine_leaf_der)

--- a/rust/backend/src/certificate_wire.rs
+++ b/rust/backend/src/certificate_wire.rs
@@ -91,11 +91,8 @@ fn derive_attest_issuer(
     attest_key_id: &[u8; 32],
     subject_der: Vec<u8>,
 ) -> Result<(Vec<u8>, PreparedIssuer), &'static str> {
-    let keypair = key_store::derive_attest_keypair(
-        calling_uid,
-        security_level.wire_value(),
-        attest_key_id,
-    )?;
+    let keypair =
+        key_store::derive_attest_keypair(calling_uid, security_level.wire_value(), attest_key_id)?;
     let prepared = PreparedIssuer::from_subject_and_key(
         subject_der,
         &keypair.private_key_pkcs8_der,
@@ -222,29 +219,28 @@ pub fn rewrite_child_key_and_encode(mut request: Vec<u8>) -> Result<Vec<u8>, &'s
         // when the in-memory graph is empty after restart. The rewritten parent certificate uses
         // the genuine subject unchanged, so the child leaf's issuer name is the exact issuer name
         // required by the reconstructed signer.
-        let parent_issuer =
-            if let Some(parent) =
-                attest_key_store::get_attest_key(parsed.calling_uid, &parsed.parent_key_id)
-            {
-                parent
-            } else {
-                let (_, parent_subject_der) =
-                    parse_certificate_subject_and_issuer(parsed.genuine_leaf_der)
-                        .map_err(|_| "invalid child certificate issuer")?;
-                let (_, prepared_parent) = derive_attest_issuer(
-                    parsed.calling_uid,
-                    provenance.keymint_security_level,
-                    &parsed.parent_key_id,
-                    parent_subject_der,
-                )?;
-                let prepared_parent = std::sync::Arc::new(prepared_parent);
-                attest_key_store::insert_attest_key(
-                    parsed.calling_uid,
-                    parsed.parent_key_id,
-                    std::sync::Arc::clone(&prepared_parent),
-                );
-                prepared_parent
-            };
+        let parent_issuer = if let Some(parent) =
+            attest_key_store::get_attest_key(parsed.calling_uid, &parsed.parent_key_id)
+        {
+            parent
+        } else {
+            let (_, parent_subject_der) =
+                parse_certificate_subject_and_issuer(parsed.genuine_leaf_der)
+                    .map_err(|_| "invalid child certificate issuer")?;
+            let (_, prepared_parent) = derive_attest_issuer(
+                parsed.calling_uid,
+                provenance.keymint_security_level,
+                &parsed.parent_key_id,
+                parent_subject_der,
+            )?;
+            let prepared_parent = std::sync::Arc::new(prepared_parent);
+            attest_key_store::insert_attest_key(
+                parsed.calling_uid,
+                parsed.parent_key_id,
+                std::sync::Arc::clone(&prepared_parent),
+            );
+            prepared_parent
+        };
 
         let (spki_override, prepared_for_children) = if parsed.is_attest_key {
             if !cleverestricky_certificate_core::is_ec_p256_certificate(parsed.genuine_leaf_der)

--- a/rust/backend/src/key_store.rs
+++ b/rust/backend/src/key_store.rs
@@ -450,8 +450,14 @@ mod tests {
         let different_level = derive_attest_keypair(10_123, 2, &descriptor).unwrap();
         let different_descriptor = derive_attest_keypair(10_123, 1, &[0x6b; 32]).unwrap();
         assert_ne!(first.public_key_spki_der, different_uid.public_key_spki_der);
-        assert_ne!(first.public_key_spki_der, different_level.public_key_spki_der);
-        assert_ne!(first.public_key_spki_der, different_descriptor.public_key_spki_der);
+        assert_ne!(
+            first.public_key_spki_der,
+            different_level.public_key_spki_der
+        );
+        assert_ne!(
+            first.public_key_spki_der,
+            different_descriptor.public_key_spki_der
+        );
 
         reset_for_testing();
         let document = parse_keybox_xml_bytes(VALID_EC).unwrap();

--- a/rust/backend/src/key_store.rs
+++ b/rust/backend/src/key_store.rs
@@ -2,7 +2,8 @@
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine as _;
 use cleverestricky_certificate_core::{
-    PreparedIssuer, SigningAlgorithm, MAX_CERTIFICATE_DER_BYTES,
+    derive_ec_p256_keypair, GeneratedEcKeypair, PreparedIssuer, SigningAlgorithm,
+    MAX_CERTIFICATE_DER_BYTES,
 };
 use cleverestricky_keybox_core::{normalize_private_key_pkcs8, public_key_spki_from_pkcs8};
 use cleverestricky_xml_core::{KeyboxDocument, MAX_KEYBOXES_PER_FILE, MAX_KEYS_PER_KEYBOX};
@@ -11,7 +12,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::sync::{Arc, Mutex, OnceLock};
 use x509_cert::Certificate;
 use x509_der::{Decode as X509Decode, Encode as X509Encode};
-use zeroize::Zeroizing;
+use zeroize::{Zeroize, Zeroizing};
 
 pub const KEY_ID_BYTES: usize = 16;
 pub const MAX_STORED_KEYS: usize = MAX_KEYBOXES_PER_FILE * MAX_KEYS_PER_KEYBOX;
@@ -141,6 +142,52 @@ pub fn with_prepared_key<T>(
         .as_ref()
         .ok_or("registered key has no prepared issuer")?;
     operation(key.algorithm, prepared)
+}
+
+/// Derives a stable synthetic P-256 signer for an Android attest-key descriptor.
+///
+/// The derivation root is the lexicographically first active keybox secret, so the same active
+/// keybox snapshot produces the same synthetic public key after backend restart without persisting
+/// another private key. The descriptor identity, caller UID and KeyMint security level provide
+/// domain separation. No derived or root private material crosses the Rust backend boundary.
+pub fn derive_attest_keypair(
+    calling_uid: u32,
+    security_level: u8,
+    attest_key_id: &[u8; 32],
+) -> Result<GeneratedEcKeypair, &'static str> {
+    if security_level == 0 || attest_key_id.iter().all(|byte| *byte == 0) {
+        return Err("invalid attest key derivation context");
+    }
+
+    let store = STORE.get_or_init(|| Mutex::new(KeyStore::default()));
+    let guard = store.lock().map_err(|_| "keybox store lock poisoned")?;
+    let root_id = guard
+        .active_ids
+        .iter()
+        .next()
+        .copied()
+        .ok_or("no active keybox secret for attest key derivation")?;
+    let root = guard
+        .keys
+        .get(&root_id)
+        .ok_or("active derivation key is not registered")?;
+    let private_len = u32::try_from(root.private_key_pkcs8.len())
+        .map_err(|_| "active derivation key exceeds length bound")?;
+
+    let mut hash = Sha256::new();
+    hash.update(b"CleveresTricky persistent attest signer seed v1\0");
+    hash.update(root_id);
+    hash.update(private_len.to_be_bytes());
+    hash.update(root.private_key_pkcs8.as_slice());
+    hash.update(calling_uid.to_be_bytes());
+    hash.update([security_level]);
+    hash.update(attest_key_id);
+    let mut seed: [u8; 32] = hash.finalize().into();
+    drop(guard);
+
+    let result = derive_ec_p256_keypair(&seed).map_err(|_| "failed to derive attest keypair");
+    seed.zeroize();
+    result
 }
 
 pub fn retain_only(ids: &[KeyId]) -> Result<(), &'static str> {
@@ -387,6 +434,43 @@ mod tests {
             Ok(())
         })
         .unwrap();
+    }
+
+    #[test]
+    fn deterministic_attest_signer_survives_store_rebuild_and_is_domain_separated() {
+        let _sequence = super::super::isolate_store_sequence();
+        reset_for_testing();
+        let document = parse_keybox_xml_bytes(VALID_EC).unwrap();
+        let root = register_document(&document).unwrap()[0].id;
+        retain_only(&[root]).unwrap();
+
+        let descriptor = [0x5a; 32];
+        let first = derive_attest_keypair(10_123, 1, &descriptor).unwrap();
+        let different_uid = derive_attest_keypair(10_124, 1, &descriptor).unwrap();
+        let different_level = derive_attest_keypair(10_123, 2, &descriptor).unwrap();
+        let different_descriptor = derive_attest_keypair(10_123, 1, &[0x6b; 32]).unwrap();
+        assert_ne!(first.public_key_spki_der, different_uid.public_key_spki_der);
+        assert_ne!(first.public_key_spki_der, different_level.public_key_spki_der);
+        assert_ne!(first.public_key_spki_der, different_descriptor.public_key_spki_der);
+
+        reset_for_testing();
+        let document = parse_keybox_xml_bytes(VALID_EC).unwrap();
+        let rebuilt_root = register_document(&document).unwrap()[0].id;
+        assert_eq!(root, rebuilt_root);
+        retain_only(&[rebuilt_root]).unwrap();
+        let rebuilt = derive_attest_keypair(10_123, 1, &descriptor).unwrap();
+        assert_eq!(first.public_key_spki_der, rebuilt.public_key_spki_der);
+        assert_eq!(
+            first.private_key_pkcs8_der.as_slice(),
+            rebuilt.private_key_pkcs8_der.as_slice()
+        );
+    }
+
+    #[test]
+    fn attest_derivation_requires_an_active_keybox() {
+        let _sequence = super::super::isolate_store_sequence();
+        reset_for_testing();
+        assert!(derive_attest_keypair(10_123, 1, &[0x5a; 32]).is_err());
     }
 
     #[test]

--- a/rust/certificate-core/src/derived_key.rs
+++ b/rust/certificate-core/src/derived_key.rs
@@ -1,0 +1,69 @@
+use crate::core::{Error, GeneratedEcKeypair};
+use p256::pkcs8::{EncodePrivateKey as _, EncodePublicKey as _};
+use p256::SecretKey as P256SecretKey;
+use sha2::{Digest, Sha256};
+use zeroize::{Zeroize, Zeroizing};
+
+const DERIVATION_DOMAIN: &[u8] = b"CleveresTricky deterministic attest signer scalar v1\0";
+const MAX_SCALAR_ATTEMPTS: u32 = 16;
+
+/// Deterministically maps a secret 32-byte seed to a valid P-256 keypair.
+///
+/// The seed is expected to be derived from backend-only secret material. This helper intentionally
+/// performs only the scalar mapping so certificate-policy code never needs direct access to p256
+/// internals. The private key remains wrapped in `Zeroizing` and never crosses the Rust backend
+/// boundary.
+pub fn derive_ec_p256_keypair(seed: &[u8; 32]) -> Result<GeneratedEcKeypair, Error> {
+    for counter in 0..MAX_SCALAR_ATTEMPTS {
+        let mut hash = Sha256::new();
+        hash.update(DERIVATION_DOMAIN);
+        hash.update(seed);
+        hash.update(counter.to_be_bytes());
+        let mut scalar: [u8; 32] = hash.finalize().into();
+
+        let secret_key = match P256SecretKey::from_slice(&scalar) {
+            Ok(secret_key) => secret_key,
+            Err(_) => {
+                scalar.zeroize();
+                continue;
+            }
+        };
+        scalar.zeroize();
+
+        let pkcs8 = secret_key.to_pkcs8_der().map_err(|_| Error::Encoding)?;
+        let spki = secret_key
+            .public_key()
+            .to_public_key_der()
+            .map_err(|_| Error::Encoding)?;
+        return Ok(GeneratedEcKeypair {
+            public_key_spki_der: spki.as_bytes().to_vec(),
+            private_key_pkcs8_der: Zeroizing::new(pkcs8.as_bytes().to_vec()),
+        });
+    }
+
+    Err(Error::Signature)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_seed_derives_same_keypair() {
+        let seed = [0x42; 32];
+        let first = derive_ec_p256_keypair(&seed).unwrap();
+        let second = derive_ec_p256_keypair(&seed).unwrap();
+        assert_eq!(first.public_key_spki_der, second.public_key_spki_der);
+        assert_eq!(
+            first.private_key_pkcs8_der.as_slice(),
+            second.private_key_pkcs8_der.as_slice()
+        );
+    }
+
+    #[test]
+    fn distinct_seeds_derive_distinct_public_keys() {
+        let first = derive_ec_p256_keypair(&[0x11; 32]).unwrap();
+        let second = derive_ec_p256_keypair(&[0x22; 32]).unwrap();
+        assert_ne!(first.public_key_spki_der, second.public_key_spki_der);
+    }
+}

--- a/rust/certificate-core/src/entry.rs
+++ b/rust/certificate-core/src/entry.rs
@@ -3,6 +3,7 @@
 
 #[path = "lib.rs"]
 mod core;
+mod derived_key;
 mod inspection;
 
 pub use cleverestricky_attestation_core::{
@@ -10,4 +11,5 @@ pub use cleverestricky_attestation_core::{
     MAX_ATTESTATION_ID_BYTES, MAX_MODULE_HASH_BYTES,
 };
 pub use core::*;
+pub use derived_key::derive_ec_p256_keypair;
 pub use inspection::{inspect_certificate, CertificateInspection, SecurityLevel};

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeyboxActivation.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeyboxActivation.kt
@@ -80,6 +80,15 @@ internal object KeyboxActivation {
                 Logger.e("Refusing to publish keyboxes because the Rust active-set commit failed")
                 return PublicationResult.FAILED
             }
+
+            // Synthetic attest-key signers are derived from the active backend secret set. Once
+            // that set is committed, no signer prepared under the previous set may survive into the
+            // newly published Java snapshot. clearCertificateCache() is reentrant on this same
+            // publication lock; a transport failure marks the graph unhealthy so child rewrites
+            // fail closed until the backend store can be authoritatively reset.
+            if (!CertHack.clearCertificateCache()) {
+                Logger.w("Active keybox set changed while the attest-key graph could not be reset; graph remains fail-closed")
+            }
             CertHack.setKeyboxes(keyboxes)
             committedIdentity = NativeBackend.currentBackendIdentity()
             PublicationResult.COMMITTED

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -257,6 +257,9 @@ object KeystoreInterceptor : BinderInterceptor() {
                     rewritten.takeUnless { it === chain }
                 }
             if (newChain != null) {
+                if (attestKeyId != null) {
+                    ManagedAttestKeyRegistry.remember(callingUid, attestKeyId)
+                }
                 if (!CertHack.applyCachedCertificateChain(metadata)) {
                     Utils.putCertificateChain(response, newChain)
                 }
@@ -264,9 +267,6 @@ object KeystoreInterceptor : BinderInterceptor() {
                 try {
                     p.writeNoException()
                     p.writeTypedObject(response, 0)
-                    if (attestKeyId != null) {
-                        ManagedAttestKeyRegistry.remember(callingUid, attestKeyId)
-                    }
                     return OverrideReply(0, p)
                 } catch (t: Throwable) {
                     p.recycle()

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -257,9 +257,6 @@ object KeystoreInterceptor : BinderInterceptor() {
                     rewritten.takeUnless { it === chain }
                 }
             if (newChain != null) {
-                if (attestKeyId != null) {
-                    ManagedAttestKeyRegistry.remember(callingUid, attestKeyId)
-                }
                 if (!CertHack.applyCachedCertificateChain(metadata)) {
                     Utils.putCertificateChain(response, newChain)
                 }
@@ -267,6 +264,9 @@ object KeystoreInterceptor : BinderInterceptor() {
                 try {
                     p.writeNoException()
                     p.writeTypedObject(response, 0)
+                    if (attestKeyId != null) {
+                        ManagedAttestKeyRegistry.remember(callingUid, attestKeyId)
+                    }
                     return OverrideReply(0, p)
                 } catch (t: Throwable) {
                     p.recycle()

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -139,7 +139,10 @@ object KeystoreInterceptor : BinderInterceptor() {
         }
         val forceManagedAttestRefresh =
             if (requestedKeyId != null && ManagedAttestKeyRegistry.isKnown(callingUid, requestedKeyId)) {
-                when (CertificateBackend.touchAttestKey(callingUid, requestedKeyId)) {
+                val touchResult =
+                    runCatching { CertificateBackend.touchAttestKey(callingUid, requestedKeyId) }
+                        .getOrElse { return Skip }
+                when (touchResult) {
                     CertificateBackend.AttestKeyTouchResult.PRESENT -> false
                     CertificateBackend.AttestKeyTouchResult.ABSENT -> true
                     CertificateBackend.AttestKeyTouchResult.UNAVAILABLE -> return Skip

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -137,6 +137,16 @@ object KeystoreInterceptor : BinderInterceptor() {
         } catch (e: Exception) {
             return Skip
         }
+        val forceManagedAttestRefresh =
+            if (requestedKeyId != null && ManagedAttestKeyRegistry.isKnown(callingUid, requestedKeyId)) {
+                when (CertificateBackend.touchAttestKey(callingUid, requestedKeyId)) {
+                    CertificateBackend.AttestKeyTouchResult.PRESENT -> false
+                    CertificateBackend.AttestKeyTouchResult.ABSENT -> true
+                    CertificateBackend.AttestKeyTouchResult.UNAVAILABLE -> return Skip
+                }
+            } else {
+                false
+            }
         try {
             // Duck Detector measures repeated service.getKeyEntry calls, not generateKey. Read only
             // the stable-AIDL offsets and genuine leaf bytes on that path. A cache hit rewrites the
@@ -151,11 +161,13 @@ object KeystoreInterceptor : BinderInterceptor() {
                     return Skip
                 }
 
-                when (CertHack.applyCachedCertificateChain(reply, parsed)) {
-                    CertHack.CachedParcelAction.REWRITTEN ->
-                        return OverrideReply(code = 0, reply = reply)
-                    CertHack.CachedParcelAction.PASSTHROUGH -> return Skip
-                    CertHack.CachedParcelAction.MISS -> Unit
+                if (!forceManagedAttestRefresh) {
+                    when (CertHack.applyCachedCertificateChain(reply, parsed)) {
+                        CertHack.CachedParcelAction.REWRITTEN ->
+                            return OverrideReply(code = 0, reply = reply)
+                        CertHack.CachedParcelAction.PASSTHROUGH -> return Skip
+                        CertHack.CachedParcelAction.MISS -> Unit
+                    }
                 }
 
                 // Leaf-only entries must preserve their caller-selected issuer contract. A full
@@ -191,6 +203,7 @@ object KeystoreInterceptor : BinderInterceptor() {
             // A non-standard parcel cannot use the raw fast path, but it may still carry a cacheable
             // platform KeyMetadata object. Keep this path contract-compatible for vendor variants.
             if (
+                !forceManagedAttestRefresh &&
                 (targeted || mayReadGrantedChain) &&
                 CertHack.applyCachedCertificateChain(metadata)
             ) {
@@ -241,6 +254,9 @@ object KeystoreInterceptor : BinderInterceptor() {
                     rewritten.takeUnless { it === chain }
                 }
             if (newChain != null) {
+                if (attestKeyId != null) {
+                    ManagedAttestKeyRegistry.remember(callingUid, attestKeyId)
+                }
                 if (!CertHack.applyCachedCertificateChain(metadata)) {
                     Utils.putCertificateChain(response, newChain)
                 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -144,7 +144,8 @@ object KeystoreInterceptor : BinderInterceptor() {
                         .getOrElse { return Skip }
                 when (touchResult) {
                     CertificateBackend.AttestKeyTouchResult.PRESENT -> false
-                    CertificateBackend.AttestKeyTouchResult.ABSENT -> true
+                    CertificateBackend.AttestKeyTouchResult.ABSENT ->
+                        !ManagedAttestKeyRehydrator.restore(callingUid, requestedKeyId)
                     CertificateBackend.AttestKeyTouchResult.UNAVAILABLE -> return Skip
                 }
             } else {
@@ -258,7 +259,12 @@ object KeystoreInterceptor : BinderInterceptor() {
                 }
             if (newChain != null) {
                 if (attestKeyId != null) {
-                    ManagedAttestKeyRegistry.remember(callingUid, attestKeyId)
+                    ManagedAttestKeyRegistry.remember(
+                        callingUid,
+                        attestKeyId,
+                        null,
+                        metadata.certificate,
+                    )
                 }
                 if (!CertHack.applyCachedCertificateChain(metadata)) {
                     Utils.putCertificateChain(response, newChain)

--- a/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/KeystoreInterceptor.kt
@@ -2,13 +2,17 @@ package cleveres.tricky.cleverestech
 
 import android.annotation.SuppressLint
 import android.hardware.security.keymint.ErrorCode
+import android.hardware.security.keymint.KeyParameterValue
+import android.hardware.security.keymint.KeyPurpose
 import android.hardware.security.keymint.SecurityLevel
+import android.hardware.security.keymint.Tag
 import android.os.IBinder
 import android.os.Parcel
 import android.os.ServiceManager
 import android.os.SystemClock
 import android.system.keystore2.IKeystoreService
 import android.system.keystore2.KeyEntryResponse
+import android.system.keystore2.KeyMetadata
 import cleveres.tricky.cleverestech.binder.BinderInterceptor
 import cleveres.tricky.cleverestech.keystore.CertHack
 import cleveres.tricky.cleverestech.keystore.Utils
@@ -39,6 +43,39 @@ object KeystoreInterceptor : BinderInterceptor() {
 
     @Volatile private var lifecycleEpoch = 0L
 
+    /**
+     * POST request payloads are intentionally omitted by the native hook. Capture only the bounded,
+     * canonical descriptor identity needed to distinguish a persistent ATTEST_KEY readback from an
+     * ordinary full-chain key. The value is removed on every POST/skip path to avoid cross-request
+     * reuse on Binder pool threads.
+     */
+    private val getKeyEntryIdentity = ThreadLocal<ByteArray?>()
+
+    private fun captureGetKeyEntryIdentity(data: Parcel, callingUid: Int): ByteArray? {
+        val position = data.dataPosition()
+        return try {
+            data.enforceInterface(IKeystoreService.DESCRIPTOR)
+            Utils.extractKeyDescriptorIdentity(data, callingUid)
+        } catch (_: RuntimeException) {
+            null
+        } finally {
+            data.setDataPosition(position)
+        }
+    }
+
+    private fun isAttestKeyEntry(metadata: KeyMetadata): Boolean {
+        val authorizations = metadata.authorizations ?: return false
+        for (authorization in authorizations) {
+            val parameter = authorization?.keyParameter ?: continue
+            if (parameter.tag != Tag.PURPOSE) continue
+            val value = parameter.value ?: continue
+            if (value.tag == KeyParameterValue.keyPurpose && value.keyPurpose == KeyPurpose.ATTEST_KEY) {
+                return true
+            }
+        }
+        return false
+    }
+
     override fun onPreTransact(
         target: IBinder,
         code: Int,
@@ -47,19 +84,32 @@ object KeystoreInterceptor : BinderInterceptor() {
         callingPid: Int,
         data: Parcel,
     ): Result {
-        if (target != keystore) return Skip
+        if (target != keystore) {
+            getKeyEntryIdentity.remove()
+            return Skip
+        }
 
         // Security-level discovery remains completely platform-owned. In particular, a StrongBox
         // request must reach Keystore2 unchanged so callers receive the genuine StrongBox child
         // binder when the device provides one. Never substitute TEE and never manufacture an
         // unavailable result for hardware that is actually present.
-        if (!CertHack.canHack()) return Skip
+        if (!CertHack.canHack()) {
+            getKeyEntryIdentity.remove()
+            return Skip
+        }
         if (code == getKeyEntryTransaction) {
             val targeted = Config.needHack(callingUid)
+            if (targeted) {
+                captureGetKeyEntryIdentity(data, callingUid)?.let(getKeyEntryIdentity::set)
+                    ?: getKeyEntryIdentity.remove()
+            } else {
+                getKeyEntryIdentity.remove()
+            }
             val mayReadGrantedChain =
                 callingUid >= FIRST_APPLICATION_UID && CertHack.hasCachedCertificateChains()
             return if (targeted || mayReadGrantedChain) Continue else Skip
         }
+        getKeyEntryIdentity.remove()
         return Skip
     }
 
@@ -73,9 +123,14 @@ object KeystoreInterceptor : BinderInterceptor() {
         reply: Parcel?,
         resultCode: Int,
     ): Result {
-        if (target != keystore || reply == null || resultCode != 0) return Skip
+        if (target != keystore || code != getKeyEntryTransaction) {
+            getKeyEntryIdentity.remove()
+            return Skip
+        }
+        val requestedKeyId = getKeyEntryIdentity.get()
+        getKeyEntryIdentity.remove()
 
-        if (!CertHack.canHack() || code != getKeyEntryTransaction) return Skip
+        if (reply == null || resultCode != 0 || !CertHack.canHack()) return Skip
 
         try {
             reply.readException()
@@ -164,10 +219,26 @@ object KeystoreInterceptor : BinderInterceptor() {
                 return Skip
             }
 
+            val attestKeyId = requestedKeyId?.takeIf { isAttestKeyEntry(metadata) }
             val originalChain = Utils.getCertificateChain(response)
             val newChain =
-                originalChain?.let {
-                    CertHack.hackCertificateChain(it, callingUid, false).takeUnless { rewritten -> rewritten === it }
+                originalChain?.let { chain ->
+                    val rewritten =
+                        if (attestKeyId != null) {
+                            // Persistent Android attest-key aliases survive backend restarts. Re-run
+                            // the attest-key path so Rust derives the same synthetic SPKI from the
+                            // descriptor instead of publishing a generic rewrite with the genuine
+                            // parent public key.
+                            CertHack.hackAttestKeyCertificateChain(
+                                chain,
+                                callingUid,
+                                false,
+                                attestKeyId,
+                            )
+                        } else {
+                            CertHack.hackCertificateChain(chain, callingUid, false)
+                        }
+                    rewritten.takeUnless { it === chain }
                 }
             if (newChain != null) {
                 if (!CertHack.applyCachedCertificateChain(metadata)) {
@@ -610,6 +681,7 @@ object KeystoreInterceptor : BinderInterceptor() {
     }
 
     override fun onInterceptorReplaced() {
+        getKeyEntryIdentity.remove()
         synchronized(this) {
             lifecycleEpoch++
             if (deathRecipientLinked && ::keystore.isInitialized) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistry.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistry.kt
@@ -11,13 +11,22 @@ import java.util.LinkedHashMap
  *
  * This registry is exact eligibility metadata, not a heuristic. It is deliberately larger than the
  * 64-entry certificate cache that can contain stale synthetic parents. Access ordering keeps entries
- * that are actively read hot; evicting an older registry identity is safe once its corresponding
- * certificate-cache entry has already been displaced. Never fall back to treating arbitrary
- * descriptors as managed, because that could convert an unrelated EC P-256 ATTEST_KEY.
+ * that are actively read hot. A bounded copy of the original genuine leaf and parent identity is
+ * retained when available so a nested managed graph can be reconstructed parent-first after a
+ * Rust-only restart without ever inferring eligibility from an arbitrary descriptor.
  */
 internal object ManagedAttestKeyRegistry {
     private const val KEY_ID_BYTES = 32
     private const val MAX_ENTRIES = 256
+    private const val MAX_LEAF_BYTES = 64 * 1024
+    private const val MAX_PROOF_BYTES = 4 * 1024 * 1024
+    private const val MAX_ANCESTRY_DEPTH = 64
+
+    internal data class RehydrationEntry(
+        val keyId: ByteArray,
+        val parentKeyId: ByteArray?,
+        val genuineLeafDer: ByteArray,
+    )
 
     private class Identity private constructor(
         val uid: Int,
@@ -38,22 +47,98 @@ internal object ManagedAttestKeyRegistry {
         }
     }
 
-    private val entries =
-        object : LinkedHashMap<Identity, Unit>(64, 0.75f, true) {
-            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Identity, Unit>?): Boolean =
-                size > MAX_ENTRIES
-        }
+    private class Entry(
+        parentKeyId: ByteArray?,
+        genuineLeafDer: ByteArray?,
+    ) {
+        val parentKeyId = parentKeyId?.clone()
+        var genuineLeafDer = genuineLeafDer?.clone()
+
+        fun proofBytes(): Int = genuineLeafDer?.size ?: 0
+    }
+
+    private val entries = LinkedHashMap<Identity, Entry>(64, 0.75f, true)
+    private var retainedProofBytes = 0
 
     @Synchronized
     fun remember(callingUid: Int, keyId: ByteArray?) {
+        remember(callingUid, keyId, null, null)
+    }
+
+    @Synchronized
+    fun remember(
+        callingUid: Int,
+        keyId: ByteArray?,
+        parentKeyId: ByteArray?,
+        genuineLeafDer: ByteArray?,
+    ) {
         if (!isValid(callingUid, keyId)) return
-        entries[Identity.stored(callingUid, requireNotNull(keyId))] = Unit
+        if (parentKeyId != null && !isValid(callingUid, parentKeyId)) return
+        if (parentKeyId != null && Arrays.equals(keyId, parentKeyId)) return
+        if (genuineLeafDer != null && (genuineLeafDer.isEmpty() || genuineLeafDer.size > MAX_LEAF_BYTES)) return
+
+        val nonNullKeyId = requireNotNull(keyId)
+        val lookup = Identity.lookup(callingUid, nonNullKeyId)
+        val old = entries.remove(lookup)
+        if (old != null) retainedProofBytes -= old.proofBytes()
+
+        val effectiveParent = parentKeyId ?: old?.parentKeyId
+        val effectiveLeaf = genuineLeafDer ?: old?.genuineLeafDer
+        val stored = Entry(effectiveParent, effectiveLeaf)
+        entries[Identity.stored(callingUid, nonNullKeyId)] = stored
+        retainedProofBytes += stored.proofBytes()
+        trimLocked()
     }
 
     @Synchronized
     fun isKnown(callingUid: Int, keyId: ByteArray?): Boolean {
         if (!isValid(callingUid, keyId)) return false
         return entries[Identity.lookup(callingUid, requireNotNull(keyId))] != null
+    }
+
+    @Synchronized
+    fun rehydrationPath(callingUid: Int, keyId: ByteArray?): List<RehydrationEntry>? {
+        if (!isValid(callingUid, keyId)) return null
+        var current = requireNotNull(keyId).clone()
+        val seen = HashSet<Identity>()
+        val reversed = ArrayList<RehydrationEntry>()
+
+        while (true) {
+            if (reversed.size >= MAX_ANCESTRY_DEPTH) return null
+            val lookup = Identity.lookup(callingUid, current)
+            if (!seen.add(Identity.stored(callingUid, current))) return null
+            val entry = entries[lookup] ?: return null
+            val leaf = entry.genuineLeafDer ?: return null
+            reversed.add(
+                RehydrationEntry(
+                    keyId = current.clone(),
+                    parentKeyId = entry.parentKeyId?.clone(),
+                    genuineLeafDer = leaf.clone(),
+                ),
+            )
+            val parent = entry.parentKeyId ?: break
+            current = parent.clone()
+        }
+
+        reversed.reverse()
+        return reversed
+    }
+
+    private fun trimLocked() {
+        val iterator = entries.entries.iterator()
+        while (entries.size > MAX_ENTRIES && iterator.hasNext()) {
+            val removed = iterator.next().value
+            retainedProofBytes -= removed.proofBytes()
+            iterator.remove()
+        }
+        if (retainedProofBytes <= MAX_PROOF_BYTES) return
+        for (entry in entries.values) {
+            if (retainedProofBytes <= MAX_PROOF_BYTES) break
+            val leaf = entry.genuineLeafDer ?: continue
+            retainedProofBytes -= leaf.size
+            entry.genuineLeafDer = null
+        }
+        if (retainedProofBytes < 0) retainedProofBytes = 0
     }
 
     private fun isValid(callingUid: Int, keyId: ByteArray?): Boolean =
@@ -66,5 +151,6 @@ internal object ManagedAttestKeyRegistry {
     @Synchronized
     internal fun resetForTesting() {
         entries.clear()
+        retainedProofBytes = 0
     }
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistry.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistry.kt
@@ -62,7 +62,15 @@ internal object ManagedAttestKeyRegistry {
 
     @Synchronized
     fun remember(callingUid: Int, keyId: ByteArray?) {
-        remember(callingUid, keyId, null, null)
+        if (!isValid(callingUid, keyId)) return
+        val nonNullKeyId = requireNotNull(keyId)
+        val lookup = Identity.lookup(callingUid, nonNullKeyId)
+        val old = entries.remove(lookup)
+        if (old != null) retainedProofBytes -= old.proofBytes()
+        val stored = old ?: Entry(null, null)
+        entries[Identity.stored(callingUid, nonNullKeyId)] = stored
+        retainedProofBytes += stored.proofBytes()
+        trimLocked()
     }
 
     @Synchronized
@@ -82,9 +90,7 @@ internal object ManagedAttestKeyRegistry {
         val old = entries.remove(lookup)
         if (old != null) retainedProofBytes -= old.proofBytes()
 
-        val effectiveParent = parentKeyId ?: old?.parentKeyId
-        val effectiveLeaf = genuineLeafDer ?: old?.genuineLeafDer
-        val stored = Entry(effectiveParent, effectiveLeaf)
+        val stored = Entry(parentKeyId, genuineLeafDer ?: old?.genuineLeafDer)
         entries[Identity.stored(callingUid, nonNullKeyId)] = stored
         retainedProofBytes += stored.proofBytes()
         trimLocked()

--- a/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistry.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistry.kt
@@ -1,0 +1,67 @@
+package cleveres.tricky.cleverestech
+
+import androidx.annotation.VisibleForTesting
+import java.util.Arrays
+import java.util.LinkedHashMap
+
+/**
+ * Process-local knowledge of descriptor identities that have successfully entered the managed
+ * synthetic ATTEST_KEY graph. This survives a Rust-only backend restart while the Java service is
+ * still alive, which lets getKeyEntry distinguish a stale managed cache hit from an ordinary key.
+ *
+ * This is eligibility metadata only; presence in the live Rust graph is always revalidated with
+ * touchAttestKey before a cached managed parent is reused.
+ */
+internal object ManagedAttestKeyRegistry {
+    private const val KEY_ID_BYTES = 32
+    private const val MAX_ENTRIES = 256
+
+    private class Identity private constructor(
+        val uid: Int,
+        val keyId: ByteArray,
+        private val cachedHashCode: Int,
+    ) {
+        override fun equals(other: Any?): Boolean =
+            other is Identity && uid == other.uid && Arrays.equals(keyId, other.keyId)
+
+        override fun hashCode(): Int = cachedHashCode
+
+        companion object {
+            fun stored(uid: Int, keyId: ByteArray): Identity =
+                Identity(uid, keyId.clone(), 31 * uid + Arrays.hashCode(keyId))
+
+            fun lookup(uid: Int, keyId: ByteArray): Identity =
+                Identity(uid, keyId, 31 * uid + Arrays.hashCode(keyId))
+        }
+    }
+
+    private val entries =
+        object : LinkedHashMap<Identity, Unit>(64, 0.75f, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Identity, Unit>?): Boolean =
+                size > MAX_ENTRIES
+        }
+
+    @Synchronized
+    fun remember(callingUid: Int, keyId: ByteArray?) {
+        if (!isValid(callingUid, keyId)) return
+        entries[Identity.stored(callingUid, requireNotNull(keyId))] = Unit
+    }
+
+    @Synchronized
+    fun isKnown(callingUid: Int, keyId: ByteArray?): Boolean {
+        if (!isValid(callingUid, keyId)) return false
+        return entries.containsKey(Identity.lookup(callingUid, requireNotNull(keyId)))
+    }
+
+    private fun isValid(callingUid: Int, keyId: ByteArray?): Boolean =
+        callingUid >= 0 &&
+            keyId != null &&
+            keyId.size == KEY_ID_BYTES &&
+            keyId.any { it != 0.toByte() }
+
+    @VisibleForTesting
+    @Synchronized
+    internal fun resetForTesting() {
+        entries.clear()
+    }
+}

--- a/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistry.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistry.kt
@@ -48,6 +48,12 @@ internal object ManagedAttestKeyRegistry {
     }
 
     @Synchronized
+    fun forget(callingUid: Int, keyId: ByteArray?) {
+        if (!isValid(callingUid, keyId)) return
+        entries.remove(Identity.lookup(callingUid, requireNotNull(keyId)))
+    }
+
+    @Synchronized
     fun isKnown(callingUid: Int, keyId: ByteArray?): Boolean {
         if (!isValid(callingUid, keyId)) return false
         return entries[Identity.lookup(callingUid, requireNotNull(keyId))] != null

--- a/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistry.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistry.kt
@@ -50,7 +50,7 @@ internal object ManagedAttestKeyRegistry {
     @Synchronized
     fun isKnown(callingUid: Int, keyId: ByteArray?): Boolean {
         if (!isValid(callingUid, keyId)) return false
-        return entries.containsKey(Identity.lookup(callingUid, requireNotNull(keyId)))
+        return entries[Identity.lookup(callingUid, requireNotNull(keyId))] != null
     }
 
     private fun isValid(callingUid: Int, keyId: ByteArray?): Boolean =

--- a/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistry.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistry.kt
@@ -9,11 +9,14 @@ import java.util.LinkedHashMap
  * synthetic ATTEST_KEY graph. This survives a Rust-only backend restart while the Java service is
  * still alive, which lets getKeyEntry distinguish a stale managed cache hit from an ordinary key.
  *
- * This registry is exact eligibility metadata, not a heuristic. It is deliberately larger than the
- * 64-entry certificate cache that can contain stale synthetic parents. Access ordering keeps entries
- * that are actively read hot. A bounded copy of the original genuine leaf and parent identity is
- * retained when available so a nested managed graph can be reconstructed parent-first after a
- * Rust-only restart without ever inferring eligibility from an arbitrary descriptor.
+ * This is bounded eligibility metadata, not authority: presence in the live Rust graph is always
+ * revalidated with touchAttestKey before a cached managed parent is reused. A bounded copy of the
+ * original genuine leaf and parent identity is retained when available so a nested managed graph can
+ * be reconstructed parent-first after a Rust-only restart. The registry must never create a false
+ * negative while Java may still hold a synthetic cache entry. If the exact identity bound is
+ * exhausted, it therefore switches to conservative mode and treats valid descriptors as potentially
+ * managed so authoritative KeyMetadata is re-read before cache reuse. Unsupported RSA/non-P256
+ * parents remain fail-closed passthrough in the certificate rewrite path.
  */
 internal object ManagedAttestKeyRegistry {
     private const val KEY_ID_BYTES = 32
@@ -59,6 +62,7 @@ internal object ManagedAttestKeyRegistry {
 
     private val entries = LinkedHashMap<Identity, Entry>(64, 0.75f, true)
     private var retainedProofBytes = 0
+    private var conservativeMode = false
 
     @Synchronized
     fun remember(callingUid: Int, keyId: ByteArray?) {
@@ -66,11 +70,15 @@ internal object ManagedAttestKeyRegistry {
         val nonNullKeyId = requireNotNull(keyId)
         val lookup = Identity.lookup(callingUid, nonNullKeyId)
         val old = entries.remove(lookup)
+        if (old == null && entries.size >= MAX_ENTRIES) {
+            conservativeMode = true
+            return
+        }
         if (old != null) retainedProofBytes -= old.proofBytes()
         val stored = old ?: Entry(null, null)
         entries[Identity.stored(callingUid, nonNullKeyId)] = stored
         retainedProofBytes += stored.proofBytes()
-        trimLocked()
+        trimProofBytesLocked()
     }
 
     @Synchronized
@@ -88,18 +96,22 @@ internal object ManagedAttestKeyRegistry {
         val nonNullKeyId = requireNotNull(keyId)
         val lookup = Identity.lookup(callingUid, nonNullKeyId)
         val old = entries.remove(lookup)
+        if (old == null && entries.size >= MAX_ENTRIES) {
+            conservativeMode = true
+            return
+        }
         if (old != null) retainedProofBytes -= old.proofBytes()
 
         val stored = Entry(parentKeyId, genuineLeafDer ?: old?.genuineLeafDer)
         entries[Identity.stored(callingUid, nonNullKeyId)] = stored
         retainedProofBytes += stored.proofBytes()
-        trimLocked()
+        trimProofBytesLocked()
     }
 
     @Synchronized
     fun isKnown(callingUid: Int, keyId: ByteArray?): Boolean {
         if (!isValid(callingUid, keyId)) return false
-        return entries[Identity.lookup(callingUid, requireNotNull(keyId))] != null
+        return conservativeMode || entries[Identity.lookup(callingUid, requireNotNull(keyId))] != null
     }
 
     @Synchronized
@@ -130,13 +142,7 @@ internal object ManagedAttestKeyRegistry {
         return reversed
     }
 
-    private fun trimLocked() {
-        val iterator = entries.entries.iterator()
-        while (entries.size > MAX_ENTRIES && iterator.hasNext()) {
-            val removed = iterator.next().value
-            retainedProofBytes -= removed.proofBytes()
-            iterator.remove()
-        }
+    private fun trimProofBytesLocked() {
         if (retainedProofBytes <= MAX_PROOF_BYTES) return
         for (entry in entries.values) {
             if (retainedProofBytes <= MAX_PROOF_BYTES) break
@@ -158,5 +164,6 @@ internal object ManagedAttestKeyRegistry {
     internal fun resetForTesting() {
         entries.clear()
         retainedProofBytes = 0
+        conservativeMode = false
     }
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistry.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistry.kt
@@ -2,7 +2,7 @@ package cleveres.tricky.cleverestech
 
 import androidx.annotation.VisibleForTesting
 import java.util.Arrays
-import java.util.LinkedHashMap
+import java.util.HashSet
 
 /**
  * Process-local knowledge of descriptor identities that have successfully entered the managed
@@ -10,11 +10,15 @@ import java.util.LinkedHashMap
  * still alive, which lets getKeyEntry distinguish a stale managed cache hit from an ordinary key.
  *
  * This is eligibility metadata only; presence in the live Rust graph is always revalidated with
- * touchAttestKey before a cached managed parent is reused.
+ * touchAttestKey before a cached managed parent is reused. The registry must never produce a false
+ * negative while the process-local certificate cache may still contain a synthetic parent. Once the
+ * bounded exact set fills, it therefore switches to conservative mode: valid descriptors are treated
+ * as potentially managed. False positives only add a bounded graph touch; false negatives could
+ * incorrectly reuse stale synthetic cache state after a Rust-only restart.
  */
 internal object ManagedAttestKeyRegistry {
     private const val KEY_ID_BYTES = 32
-    private const val MAX_ENTRIES = 256
+    private const val MAX_EXACT_ENTRIES = 256
 
     private class Identity private constructor(
         val uid: Int,
@@ -35,28 +39,33 @@ internal object ManagedAttestKeyRegistry {
         }
     }
 
-    private val entries =
-        object : LinkedHashMap<Identity, Unit>(64, 0.75f, true) {
-            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Identity, Unit>?): Boolean =
-                size > MAX_ENTRIES
-        }
+    private val entries = HashSet<Identity>(MAX_EXACT_ENTRIES)
+    private var conservativeMode = false
 
     @Synchronized
     fun remember(callingUid: Int, keyId: ByteArray?) {
-        if (!isValid(callingUid, keyId)) return
-        entries[Identity.stored(callingUid, requireNotNull(keyId))] = Unit
+        if (!isValid(callingUid, keyId) || conservativeMode) return
+        val nonNullKeyId = requireNotNull(keyId)
+        val lookup = Identity.lookup(callingUid, nonNullKeyId)
+        if (entries.contains(lookup)) return
+        if (entries.size >= MAX_EXACT_ENTRIES) {
+            entries.clear()
+            conservativeMode = true
+            return
+        }
+        entries.add(Identity.stored(callingUid, nonNullKeyId))
     }
 
     @Synchronized
     fun forget(callingUid: Int, keyId: ByteArray?) {
-        if (!isValid(callingUid, keyId)) return
+        if (!isValid(callingUid, keyId) || conservativeMode) return
         entries.remove(Identity.lookup(callingUid, requireNotNull(keyId)))
     }
 
     @Synchronized
     fun isKnown(callingUid: Int, keyId: ByteArray?): Boolean {
         if (!isValid(callingUid, keyId)) return false
-        return entries[Identity.lookup(callingUid, requireNotNull(keyId))] != null
+        return conservativeMode || entries.contains(Identity.lookup(callingUid, requireNotNull(keyId)))
     }
 
     private fun isValid(callingUid: Int, keyId: ByteArray?): Boolean =
@@ -69,5 +78,6 @@ internal object ManagedAttestKeyRegistry {
     @Synchronized
     internal fun resetForTesting() {
         entries.clear()
+        conservativeMode = false
     }
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistry.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistry.kt
@@ -57,12 +57,6 @@ internal object ManagedAttestKeyRegistry {
     }
 
     @Synchronized
-    fun forget(callingUid: Int, keyId: ByteArray?) {
-        if (!isValid(callingUid, keyId) || conservativeMode) return
-        entries.remove(Identity.lookup(callingUid, requireNotNull(keyId)))
-    }
-
-    @Synchronized
     fun isKnown(callingUid: Int, keyId: ByteArray?): Boolean {
         if (!isValid(callingUid, keyId)) return false
         return conservativeMode || entries.contains(Identity.lookup(callingUid, requireNotNull(keyId)))

--- a/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistry.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistry.kt
@@ -2,23 +2,22 @@ package cleveres.tricky.cleverestech
 
 import androidx.annotation.VisibleForTesting
 import java.util.Arrays
-import java.util.HashSet
+import java.util.LinkedHashMap
 
 /**
  * Process-local knowledge of descriptor identities that have successfully entered the managed
  * synthetic ATTEST_KEY graph. This survives a Rust-only backend restart while the Java service is
  * still alive, which lets getKeyEntry distinguish a stale managed cache hit from an ordinary key.
  *
- * This is eligibility metadata only; presence in the live Rust graph is always revalidated with
- * touchAttestKey before a cached managed parent is reused. The registry must never produce a false
- * negative while the process-local certificate cache may still contain a synthetic parent. Once the
- * bounded exact set fills, it therefore switches to conservative mode: valid descriptors are treated
- * as potentially managed. False positives only add a bounded graph touch; false negatives could
- * incorrectly reuse stale synthetic cache state after a Rust-only restart.
+ * This registry is exact eligibility metadata, not a heuristic. It is deliberately larger than the
+ * 64-entry certificate cache that can contain stale synthetic parents. Access ordering keeps entries
+ * that are actively read hot; evicting an older registry identity is safe once its corresponding
+ * certificate-cache entry has already been displaced. Never fall back to treating arbitrary
+ * descriptors as managed, because that could convert an unrelated EC P-256 ATTEST_KEY.
  */
 internal object ManagedAttestKeyRegistry {
     private const val KEY_ID_BYTES = 32
-    private const val MAX_EXACT_ENTRIES = 256
+    private const val MAX_ENTRIES = 256
 
     private class Identity private constructor(
         val uid: Int,
@@ -39,27 +38,22 @@ internal object ManagedAttestKeyRegistry {
         }
     }
 
-    private val entries = HashSet<Identity>(MAX_EXACT_ENTRIES)
-    private var conservativeMode = false
+    private val entries =
+        object : LinkedHashMap<Identity, Unit>(64, 0.75f, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Identity, Unit>?): Boolean =
+                size > MAX_ENTRIES
+        }
 
     @Synchronized
     fun remember(callingUid: Int, keyId: ByteArray?) {
-        if (!isValid(callingUid, keyId) || conservativeMode) return
-        val nonNullKeyId = requireNotNull(keyId)
-        val lookup = Identity.lookup(callingUid, nonNullKeyId)
-        if (entries.contains(lookup)) return
-        if (entries.size >= MAX_EXACT_ENTRIES) {
-            entries.clear()
-            conservativeMode = true
-            return
-        }
-        entries.add(Identity.stored(callingUid, nonNullKeyId))
+        if (!isValid(callingUid, keyId)) return
+        entries[Identity.stored(callingUid, requireNotNull(keyId))] = Unit
     }
 
     @Synchronized
     fun isKnown(callingUid: Int, keyId: ByteArray?): Boolean {
         if (!isValid(callingUid, keyId)) return false
-        return conservativeMode || entries.contains(Identity.lookup(callingUid, requireNotNull(keyId)))
+        return entries[Identity.lookup(callingUid, requireNotNull(keyId))] != null
     }
 
     private fun isValid(callingUid: Int, keyId: ByteArray?): Boolean =
@@ -72,6 +66,5 @@ internal object ManagedAttestKeyRegistry {
     @Synchronized
     internal fun resetForTesting() {
         entries.clear()
-        conservativeMode = false
     }
 }

--- a/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRehydrator.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRehydrator.kt
@@ -25,16 +25,15 @@ internal object ManagedAttestKeyRehydrator {
         val path = ManagedAttestKeyRegistry.rehydrationPath(callingUid, keyId) ?: return false
         if (path.isEmpty()) return false
 
-        for (entry in path) {
-            val presence =
-                runCatching { CertificateBackend.touchAttestKey(callingUid, entry.keyId) }
-                    .getOrElse { return false }
-            when (presence) {
-                CertificateBackend.AttestKeyTouchResult.PRESENT -> continue
-                CertificateBackend.AttestKeyTouchResult.UNAVAILABLE -> return false
-                CertificateBackend.AttestKeyTouchResult.ABSENT -> Unit
-            }
+        // restore() is entered only after the requested signer was authoritatively ABSENT. Rebuild
+        // from one clean graph instead of trying to preserve a partially live ancestry: a stale
+        // Java child cache can otherwise discover its missing Rust entry, clear the graph inside
+        // CertHack validation, and revoke an already-checked parent halfway through reconstruction.
+        // The publication lock above makes this clear -> parent-first rebuild atomic with respect to
+        // certificate generation, cache eviction and active-keybox publication.
+        if (!CertHack.clearCertificateCache()) return false
 
+        for (entry in path) {
             val originalLeaf = LazyX509Certificate(entry.genuineLeafDer, false)
             val original = arrayOf<Certificate>(originalLeaf)
             val rewritten =

--- a/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRehydrator.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRehydrator.kt
@@ -10,6 +10,18 @@ internal object ManagedAttestKeyRehydrator {
         callingUid: Int,
         keyId: ByteArray,
     ): Boolean {
+        KeyboxActivation.lockPublishedSnapshot()
+        return try {
+            restoreLocked(callingUid, keyId)
+        } finally {
+            KeyboxActivation.unlockPublishedSnapshot()
+        }
+    }
+
+    private fun restoreLocked(
+        callingUid: Int,
+        keyId: ByteArray,
+    ): Boolean {
         val path = ManagedAttestKeyRegistry.rehydrationPath(callingUid, keyId) ?: return false
         if (path.isEmpty()) return false
 

--- a/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRehydrator.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/ManagedAttestKeyRehydrator.kt
@@ -1,0 +1,55 @@
+package cleveres.tricky.cleverestech
+
+import cleveres.tricky.cleverestech.keystore.CertHack
+import cleveres.tricky.cleverestech.keystore.LazyX509Certificate
+import java.security.cert.Certificate
+
+/** Rebuilds a previously managed attest-key ancestry after a Rust-only backend restart. */
+internal object ManagedAttestKeyRehydrator {
+    fun restore(
+        callingUid: Int,
+        keyId: ByteArray,
+    ): Boolean {
+        val path = ManagedAttestKeyRegistry.rehydrationPath(callingUid, keyId) ?: return false
+        if (path.isEmpty()) return false
+
+        for (entry in path) {
+            val presence =
+                runCatching { CertificateBackend.touchAttestKey(callingUid, entry.keyId) }
+                    .getOrElse { return false }
+            when (presence) {
+                CertificateBackend.AttestKeyTouchResult.PRESENT -> continue
+                CertificateBackend.AttestKeyTouchResult.UNAVAILABLE -> return false
+                CertificateBackend.AttestKeyTouchResult.ABSENT -> Unit
+            }
+
+            val originalLeaf = LazyX509Certificate(entry.genuineLeafDer, false)
+            val original = arrayOf<Certificate>(originalLeaf)
+            val rewritten =
+                if (entry.parentKeyId == null) {
+                    CertHack.hackAttestKeyCertificateChain(
+                        original,
+                        callingUid,
+                        false,
+                        entry.keyId,
+                    )
+                } else {
+                    CertHack.hackChildKeyCertificate(
+                        original,
+                        callingUid,
+                        true,
+                        true,
+                        entry.parentKeyId,
+                        entry.keyId,
+                    )
+                }
+            if (rewritten === original) return false
+
+            val confirmed =
+                runCatching { CertificateBackend.touchAttestKey(callingUid, entry.keyId) }
+                    .getOrElse { return false }
+            if (confirmed != CertificateBackend.AttestKeyTouchResult.PRESENT) return false
+        }
+        return true
+    }
+}

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -174,7 +174,12 @@ class SecurityLevelInterceptor : BinderInterceptor() {
                     return Skip
                 }
                 if (context.isAttestKeyPurpose) {
-                    ManagedAttestKeyRegistry.remember(callingUid, context.generatedKeyId)
+                    ManagedAttestKeyRegistry.remember(
+                        callingUid,
+                        context.generatedKeyId,
+                        context.parentKeyId,
+                        parsed.leafEncoded,
+                    )
                 }
 
                 // hackCertificateChain publishes the completed rewrite bytes in its epoch-protected
@@ -258,7 +263,12 @@ class SecurityLevelInterceptor : BinderInterceptor() {
                 return Skip
             }
             if (context.isAttestKeyPurpose) {
-                ManagedAttestKeyRegistry.remember(callingUid, context.generatedKeyId)
+                ManagedAttestKeyRegistry.remember(
+                    callingUid,
+                    context.generatedKeyId,
+                    context.parentKeyId,
+                    metadata.certificate,
+                )
             }
 
             if (!CertHack.applyCachedCertificateChain(metadata)) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -173,6 +173,9 @@ class SecurityLevelInterceptor : BinderInterceptor() {
                 if (rewritten === originalLeafOnly) {
                     return Skip
                 }
+                if (context.isAttestKeyPurpose) {
+                    ManagedAttestKeyRegistry.remember(callingUid, context.generatedKeyId)
+                }
 
                 // hackCertificateChain publishes the completed rewrite bytes in its epoch-protected
                 // cache before returning. Reuse those exact bytes here instead of calling getEncoded()
@@ -253,6 +256,9 @@ class SecurityLevelInterceptor : BinderInterceptor() {
                 }
             if (rewritten === originalLeafOnly) {
                 return Skip
+            }
+            if (context.isAttestKeyPurpose) {
+                ManagedAttestKeyRegistry.remember(callingUid, context.generatedKeyId)
             }
 
             if (!CertHack.applyCachedCertificateChain(metadata)) {

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -74,6 +74,47 @@ class SecurityLevelInterceptor : BinderInterceptor() {
         return Skip
     }
 
+    private fun rewriteChildWithParentRecovery(
+        original: Array<Certificate>,
+        callingUid: Int,
+        isAttestKey: Boolean,
+        parentKeyId: ByteArray,
+        childKeyId: ByteArray?,
+    ): Array<Certificate> {
+        KeyboxActivation.lockPublishedSnapshot()
+        return try {
+            val first =
+                CertHack.hackChildKeyCertificate(
+                    original,
+                    callingUid,
+                    isAttestKey,
+                    true,
+                    parentKeyId,
+                    childKeyId,
+                )
+            if (first !== original || !ManagedAttestKeyRegistry.isKnown(callingUid, parentKeyId)) {
+                return first
+            }
+
+            val presence =
+                runCatching { CertificateBackend.touchAttestKey(callingUid, parentKeyId) }
+                    .getOrElse { return first }
+            if (presence != CertificateBackend.AttestKeyTouchResult.ABSENT) return first
+            if (!ManagedAttestKeyRehydrator.restore(callingUid, parentKeyId)) return first
+
+            CertHack.hackChildKeyCertificate(
+                original,
+                callingUid,
+                isAttestKey,
+                true,
+                parentKeyId,
+                childKeyId,
+            )
+        } finally {
+            KeyboxActivation.unlockPublishedSnapshot()
+        }
+    }
+
     override fun onPostTransact(
         target: IBinder,
         code: Int,
@@ -138,11 +179,10 @@ class SecurityLevelInterceptor : BinderInterceptor() {
                                 true,
                             )
                         } else {
-                            CertHack.hackChildKeyCertificate(
+                            rewriteChildWithParentRecovery(
                                 originalLeafOnly,
                                 callingUid,
                                 context.isAttestKeyPurpose,
-                                true,
                                 parentId,
                                 context.generatedKeyId,
                             )
@@ -227,11 +267,10 @@ class SecurityLevelInterceptor : BinderInterceptor() {
                             true,
                         )
                     } else {
-                        CertHack.hackChildKeyCertificate(
+                        rewriteChildWithParentRecovery(
                             originalLeafOnly,
                             callingUid,
                             context.isAttestKeyPurpose,
-                            true,
                             parentId,
                             context.generatedKeyId,
                         )

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -173,6 +173,9 @@ class SecurityLevelInterceptor : BinderInterceptor() {
                 if (rewritten === originalLeafOnly) {
                     return Skip
                 }
+                if (context.isAttestKeyPurpose) {
+                    ManagedAttestKeyRegistry.remember(callingUid, context.generatedKeyId)
+                }
 
                 // hackCertificateChain publishes the completed rewrite bytes in its epoch-protected
                 // cache before returning. Reuse those exact bytes here instead of calling getEncoded()
@@ -182,9 +185,6 @@ class SecurityLevelInterceptor : BinderInterceptor() {
                     CertHack.applyCachedCertificateChain(reply, parsed) ==
                         CertHack.CachedParcelAction.REWRITTEN
                 ) {
-                    if (context.isAttestKeyPurpose) {
-                        ManagedAttestKeyRegistry.remember(callingUid, context.generatedKeyId)
-                    }
                     return OverrideReply(code = 0, reply = reply)
                 }
 
@@ -192,9 +192,6 @@ class SecurityLevelInterceptor : BinderInterceptor() {
                 val newChain = if (!context.isDefaultAttestationKey) null else Utils.encodeIssuerChain(rewritten)
                 if (!Utils.rewriteKeyMetadataParcel(reply, parsed, newLeaf, newChain)) {
                     return Skip
-                }
-                if (context.isAttestKeyPurpose) {
-                    ManagedAttestKeyRegistry.remember(callingUid, context.generatedKeyId)
                 }
                 return OverrideReply(code = 0, reply = reply)
             }
@@ -260,6 +257,9 @@ class SecurityLevelInterceptor : BinderInterceptor() {
             if (rewritten === originalLeafOnly) {
                 return Skip
             }
+            if (context.isAttestKeyPurpose) {
+                ManagedAttestKeyRegistry.remember(callingUid, context.generatedKeyId)
+            }
 
             if (!CertHack.applyCachedCertificateChain(metadata)) {
                 if (!context.isDefaultAttestationKey) {
@@ -273,9 +273,6 @@ class SecurityLevelInterceptor : BinderInterceptor() {
             reply.setDataPosition(0)
             reply.writeNoException()
             reply.writeTypedObject(metadata, 0)
-            if (context.isAttestKeyPurpose) {
-                ManagedAttestKeyRegistry.remember(callingUid, context.generatedKeyId)
-            }
             OverrideReply(0, reply)
         } catch (_: Throwable) {
             Skip

--- a/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
+++ b/service/src/main/java/cleveres/tricky/cleverestech/SecurityLevelInterceptor.kt
@@ -173,9 +173,6 @@ class SecurityLevelInterceptor : BinderInterceptor() {
                 if (rewritten === originalLeafOnly) {
                     return Skip
                 }
-                if (context.isAttestKeyPurpose) {
-                    ManagedAttestKeyRegistry.remember(callingUid, context.generatedKeyId)
-                }
 
                 // hackCertificateChain publishes the completed rewrite bytes in its epoch-protected
                 // cache before returning. Reuse those exact bytes here instead of calling getEncoded()
@@ -185,6 +182,9 @@ class SecurityLevelInterceptor : BinderInterceptor() {
                     CertHack.applyCachedCertificateChain(reply, parsed) ==
                         CertHack.CachedParcelAction.REWRITTEN
                 ) {
+                    if (context.isAttestKeyPurpose) {
+                        ManagedAttestKeyRegistry.remember(callingUid, context.generatedKeyId)
+                    }
                     return OverrideReply(code = 0, reply = reply)
                 }
 
@@ -192,6 +192,9 @@ class SecurityLevelInterceptor : BinderInterceptor() {
                 val newChain = if (!context.isDefaultAttestationKey) null else Utils.encodeIssuerChain(rewritten)
                 if (!Utils.rewriteKeyMetadataParcel(reply, parsed, newLeaf, newChain)) {
                     return Skip
+                }
+                if (context.isAttestKeyPurpose) {
+                    ManagedAttestKeyRegistry.remember(callingUid, context.generatedKeyId)
                 }
                 return OverrideReply(code = 0, reply = reply)
             }
@@ -257,9 +260,6 @@ class SecurityLevelInterceptor : BinderInterceptor() {
             if (rewritten === originalLeafOnly) {
                 return Skip
             }
-            if (context.isAttestKeyPurpose) {
-                ManagedAttestKeyRegistry.remember(callingUid, context.generatedKeyId)
-            }
 
             if (!CertHack.applyCachedCertificateChain(metadata)) {
                 if (!context.isDefaultAttestationKey) {
@@ -273,6 +273,9 @@ class SecurityLevelInterceptor : BinderInterceptor() {
             reply.setDataPosition(0)
             reply.writeNoException()
             reply.writeTypedObject(metadata, 0)
+            if (context.isAttestKeyPurpose) {
+                ManagedAttestKeyRegistry.remember(callingUid, context.generatedKeyId)
+            }
             OverrideReply(0, reply)
         } catch (_: Throwable) {
             Skip

--- a/service/src/test/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistryTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistryTest.kt
@@ -2,6 +2,7 @@ package cleveres.tricky.cleverestech
 
 import org.junit.After
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -34,7 +35,7 @@ class ManagedAttestKeyRegistryTest {
     }
 
     @Test
-    fun `registry stays exact and access ordered at bound`() {
+    fun `registry saturation never creates a managed cache false negative`() {
         val uid = 10_123
         fun descriptor(index: Int): ByteArray =
             ByteArray(32).also {
@@ -46,16 +47,16 @@ class ManagedAttestKeyRegistryTest {
         for (index in 1..256) {
             ManagedAttestKeyRegistry.remember(uid, descriptor(index))
         }
-        val first = descriptor(1)
-        val second = descriptor(2)
-        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, first))
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(1)))
         assertFalse(ManagedAttestKeyRegistry.isKnown(uid, descriptor(999)))
 
         ManagedAttestKeyRegistry.remember(uid, descriptor(257))
 
-        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, first))
-        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, second))
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(1)))
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(256)))
         assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(257)))
-        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, descriptor(999)))
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(999)))
+        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, ByteArray(32)))
+        assertNull(ManagedAttestKeyRegistry.rehydrationPath(uid, descriptor(257)))
     }
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistryTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistryTest.kt
@@ -31,9 +31,6 @@ class ManagedAttestKeyRegistryTest {
         assertFalse(ManagedAttestKeyRegistry.isKnown(uid, ByteArray(32) { 0x6b.toByte() }))
         assertFalse(ManagedAttestKeyRegistry.isKnown(uid, ByteArray(32)))
         assertFalse(ManagedAttestKeyRegistry.isKnown(uid, ByteArray(31) { 1 }))
-
-        ManagedAttestKeyRegistry.forget(uid, lookup)
-        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, lookup))
     }
 
     @Test

--- a/service/src/test/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistryTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistryTest.kt
@@ -34,7 +34,7 @@ class ManagedAttestKeyRegistryTest {
     }
 
     @Test
-    fun `registry becomes conservative at bound instead of producing false negatives`() {
+    fun `registry stays exact and access ordered at bound`() {
         val uid = 10_123
         fun descriptor(index: Int): ByteArray =
             ByteArray(32).also {
@@ -46,16 +46,16 @@ class ManagedAttestKeyRegistryTest {
         for (index in 1..256) {
             ManagedAttestKeyRegistry.remember(uid, descriptor(index))
         }
-        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(1)))
-        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(256)))
+        val first = descriptor(1)
+        val second = descriptor(2)
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, first))
         assertFalse(ManagedAttestKeyRegistry.isKnown(uid, descriptor(999)))
 
         ManagedAttestKeyRegistry.remember(uid, descriptor(257))
 
-        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(1)))
-        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(256)))
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, first))
+        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, second))
         assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(257)))
-        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(999)))
-        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, ByteArray(32)))
+        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, descriptor(999)))
     }
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistryTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistryTest.kt
@@ -31,10 +31,13 @@ class ManagedAttestKeyRegistryTest {
         assertFalse(ManagedAttestKeyRegistry.isKnown(uid, ByteArray(32) { 0x6b.toByte() }))
         assertFalse(ManagedAttestKeyRegistry.isKnown(uid, ByteArray(32)))
         assertFalse(ManagedAttestKeyRegistry.isKnown(uid, ByteArray(31) { 1 }))
+
+        ManagedAttestKeyRegistry.forget(uid, lookup)
+        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, lookup))
     }
 
     @Test
-    fun `registry remains bounded and evicts least recently used identity`() {
+    fun `registry becomes conservative at bound instead of producing false negatives`() {
         val uid = 10_123
         fun descriptor(index: Int): ByteArray =
             ByteArray(32).also {
@@ -46,14 +49,16 @@ class ManagedAttestKeyRegistryTest {
         for (index in 1..256) {
             ManagedAttestKeyRegistry.remember(uid, descriptor(index))
         }
-        val first = descriptor(1)
-        val second = descriptor(2)
-        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, first))
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(1)))
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(256)))
+        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, descriptor(999)))
 
         ManagedAttestKeyRegistry.remember(uid, descriptor(257))
 
-        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, first))
-        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, second))
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(1)))
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(256)))
         assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(257)))
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(999)))
+        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, ByteArray(32)))
     }
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistryTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistryTest.kt
@@ -1,6 +1,8 @@
 package cleveres.tricky.cleverestech
 
 import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -35,7 +37,7 @@ class ManagedAttestKeyRegistryTest {
     }
 
     @Test
-    fun `registry saturation never creates a managed cache false negative`() {
+    fun `registry stays exact and access ordered at bound`() {
         val uid = 10_123
         fun descriptor(index: Int): ByteArray =
             ByteArray(32).also {
@@ -47,16 +49,72 @@ class ManagedAttestKeyRegistryTest {
         for (index in 1..256) {
             ManagedAttestKeyRegistry.remember(uid, descriptor(index))
         }
-        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(1)))
+        val first = descriptor(1)
+        val second = descriptor(2)
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, first))
         assertFalse(ManagedAttestKeyRegistry.isKnown(uid, descriptor(999)))
 
         ManagedAttestKeyRegistry.remember(uid, descriptor(257))
 
-        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(1)))
-        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(256)))
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, first))
+        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, second))
         assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(257)))
-        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(999)))
-        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, ByteArray(32)))
+        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, descriptor(999)))
         assertNull(ManagedAttestKeyRegistry.rehydrationPath(uid, descriptor(257)))
+    }
+
+    @Test
+    fun `rehydration path is parent first bounded and defensively copied`() {
+        val uid = 10_123
+        val root = ByteArray(32) { 0x11 }
+        val child = ByteArray(32) { 0x22 }
+        val rootLeaf = byteArrayOf(1, 2, 3)
+        val childLeaf = byteArrayOf(4, 5, 6)
+
+        ManagedAttestKeyRegistry.remember(uid, root, null, rootLeaf)
+        ManagedAttestKeyRegistry.remember(uid, child, root, childLeaf)
+        rootLeaf.fill(0)
+        childLeaf.fill(0)
+
+        val path = requireNotNull(ManagedAttestKeyRegistry.rehydrationPath(uid, child))
+        assertEquals(2, path.size)
+        assertArrayEquals(root, path[0].keyId)
+        assertNull(path[0].parentKeyId)
+        assertArrayEquals(byteArrayOf(1, 2, 3), path[0].genuineLeafDer)
+        assertArrayEquals(child, path[1].keyId)
+        assertArrayEquals(root, path[1].parentKeyId)
+        assertArrayEquals(byteArrayOf(4, 5, 6), path[1].genuineLeafDer)
+
+        path[0].keyId.fill(0)
+        path[0].genuineLeafDer.fill(0)
+        val secondRead = requireNotNull(ManagedAttestKeyRegistry.rehydrationPath(uid, child))
+        assertArrayEquals(root, secondRead[0].keyId)
+        assertArrayEquals(byteArrayOf(1, 2, 3), secondRead[0].genuineLeafDer)
+    }
+
+    @Test
+    fun `explicit top level regeneration clears old parent relation`() {
+        val uid = 10_123
+        val parent = ByteArray(32) { 0x31 }
+        val key = ByteArray(32) { 0x41 }
+
+        ManagedAttestKeyRegistry.remember(uid, parent, null, byteArrayOf(1))
+        ManagedAttestKeyRegistry.remember(uid, key, parent, byteArrayOf(2))
+        assertEquals(2, requireNotNull(ManagedAttestKeyRegistry.rehydrationPath(uid, key)).size)
+
+        ManagedAttestKeyRegistry.remember(uid, key, null, byteArrayOf(3))
+        val path = requireNotNull(ManagedAttestKeyRegistry.rehydrationPath(uid, key))
+        assertEquals(1, path.size)
+        assertNull(path[0].parentKeyId)
+        assertArrayEquals(byteArrayOf(3), path[0].genuineLeafDer)
+    }
+
+    @Test
+    fun `missing ancestor fails closed`() {
+        val uid = 10_123
+        val missingParent = ByteArray(32) { 0x51 }
+        val child = ByteArray(32) { 0x61 }
+        ManagedAttestKeyRegistry.remember(uid, child, missingParent, byteArrayOf(9))
+        assertNull(ManagedAttestKeyRegistry.rehydrationPath(uid, child))
     }
 }

--- a/service/src/test/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistryTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistryTest.kt
@@ -1,0 +1,59 @@
+package cleveres.tricky.cleverestech
+
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ManagedAttestKeyRegistryTest {
+    @Before
+    fun setUp() {
+        ManagedAttestKeyRegistry.resetForTesting()
+    }
+
+    @After
+    fun tearDown() {
+        ManagedAttestKeyRegistry.resetForTesting()
+    }
+
+    @Test
+    fun `known identity is separated by uid and descriptor and stored defensively`() {
+        val uid = 10_123
+        val original = ByteArray(32) { 0x5a.toByte() }
+        val lookup = original.copyOf()
+
+        ManagedAttestKeyRegistry.remember(uid, original)
+        original.fill(0)
+
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, lookup))
+        assertFalse(ManagedAttestKeyRegistry.isKnown(uid + 1, lookup))
+        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, ByteArray(32) { 0x6b.toByte() }))
+        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, ByteArray(32)))
+        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, ByteArray(31) { 1 }))
+    }
+
+    @Test
+    fun `registry remains bounded and evicts least recently used identity`() {
+        val uid = 10_123
+        fun descriptor(index: Int): ByteArray =
+            ByteArray(32).also {
+                it[0] = ((index ushr 8) and 0xff).toByte()
+                it[1] = (index and 0xff).toByte()
+                it[2] = 1
+            }
+
+        for (index in 1..256) {
+            ManagedAttestKeyRegistry.remember(uid, descriptor(index))
+        }
+        val first = descriptor(1)
+        val second = descriptor(2)
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, first))
+
+        ManagedAttestKeyRegistry.remember(uid, descriptor(257))
+
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, first))
+        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, second))
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(257)))
+    }
+}

--- a/service/src/test/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistryTest.kt
+++ b/service/src/test/java/cleveres/tricky/cleverestech/ManagedAttestKeyRegistryTest.kt
@@ -37,7 +37,7 @@ class ManagedAttestKeyRegistryTest {
     }
 
     @Test
-    fun `registry stays exact and access ordered at bound`() {
+    fun `registry saturation never creates a managed cache false negative`() {
         val uid = 10_123
         fun descriptor(index: Int): ByteArray =
             ByteArray(32).also {
@@ -49,17 +49,16 @@ class ManagedAttestKeyRegistryTest {
         for (index in 1..256) {
             ManagedAttestKeyRegistry.remember(uid, descriptor(index))
         }
-        val first = descriptor(1)
-        val second = descriptor(2)
-        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, first))
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(1)))
         assertFalse(ManagedAttestKeyRegistry.isKnown(uid, descriptor(999)))
 
         ManagedAttestKeyRegistry.remember(uid, descriptor(257))
 
-        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, first))
-        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, second))
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(1)))
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(256)))
         assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(257)))
-        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, descriptor(999)))
+        assertTrue(ManagedAttestKeyRegistry.isKnown(uid, descriptor(999)))
+        assertFalse(ManagedAttestKeyRegistry.isKnown(uid, ByteArray(32)))
         assertNull(ManagedAttestKeyRegistry.rehydrationPath(uid, descriptor(257)))
     }
 


### PR DESCRIPTION
## Summary

Fix persistent Android `PURPOSE_ATTEST_KEY` aliases losing their synthetic signer when the unprivileged Rust backend is restarted or rebuilt.

Key Attestation and similar clients intentionally keep a persistent attest-key alias and only generate it when the alias is absent. CleveresTricky previously generated a random synthetic P-256 signer and retained it only in the Rust in-memory attest graph. After backend restart the Android alias survived, but the synthetic signer did not, so a fresh child using that alias fell back to the genuine certificate path and exposed the device RootOfTrust.

### Changes

- derive synthetic EC P-256 attest signers deterministically from backend-only active keybox secret material plus caller/descriptor identity;
- keep derived private material inside the Rust backend and zeroize intermediate derivation state;
- capture the bounded `getKeyEntry` descriptor identity in PRE and detect `PURPOSE_ATTEST_KEY` from returned metadata so a persistent parent readback re-runs the authoritative attest-key rewrite, restores the same synthetic SPKI, and repopulates the Rust signer graph;
- require child rewrites to find an already-authoritatively managed parent in that graph instead of inferring parent eligibility from the child issuer name;
- derive nested EC P-256 attest-key child signers with the same stable identity scheme;
- reset the Rust attest graph whenever a new active keybox secret set is committed, preventing prepared signers from crossing keybox publication epochs;
- add deterministic derivation tests covering restart stability and UID/security-level/descriptor separation.

## Why readback is authoritative

AndroidKeyStore `containsAlias()` resolves the alias through key metadata (`getKeyMetadata` / `getKeyEntry`). Key Attestation performs that existence check before reusing its persistent attest-key alias. The readback path therefore has the actual parent metadata and certificate available, so CleveresTricky can verify `PURPOSE_ATTEST_KEY`, hardware provenance, and the currently supported EC P-256 shape before reconstructing the deterministic signer.

The child path deliberately does **not** synthesize a missing parent from a descriptor alone. Android KeyMint also supports RSA and non-P256 EC attestation keys; accepting an unknown descriptor as synthetic P-256 would create a mismatched parent/child chain.

## Security / lifecycle properties

- no new private key or seed is persisted to disk;
- no keybox private material leaves the unprivileged Rust backend;
- software-provenance certificates remain rejected before derivation/rewrite;
- unsupported/unmanaged RSA or non-P256 attest parents remain passthrough rather than being silently converted to an EC synthetic signer;
- caller-selected leaf-only child readback remains untouched;
- backend/keybox publication continues to fail closed when authoritative graph reset is unavailable.

## Reproduction addressed

1. Enable `Use attest key` in Key Attestation.
2. Generate the persistent EC P-256 attest key once.
3. Restart/rebuild the CleveresTricky backend or reboot while the Android alias remains.
4. Key Attestation checks/reuses the persistent alias; its `getKeyEntry` readback reconstructs and registers the same deterministic synthetic signer.
5. Generate a child using the persistent alias.

Before this change the parent signer was absent from Rust and the child remained on the genuine `deviceLocked=false / Unverified` RootOfTrust path. After readback, the same descriptor and active secret set reconstruct the same synthetic parent identity, so the child rewrite can remain on the converged RootOfTrust path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic attestation key handling for consistent certificate identities.
  * Improved certificate rewriting for managed attestation keys and child keys.
  * Added automatic recovery of managed attestation-key chains after backend restarts.
  * Added support for restoring missing attestation keys and retrying dependent certificate operations.

* **Bug Fixes**
  * Certificate caches are now cleared after keybox updates to prevent stale certificate data.
  * Improved handling of certificate readbacks and cache misses for managed attestation keys.
  * Unsupported key types continue to fail safely without certificate rewriting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->